### PR TITLE
Preserve target focus during capture on macOS

### DIFF
--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -51,6 +51,20 @@ pub(crate) enum UserEvent {
 	OverlayWorkerResponse,
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlayCancelHotkeyRegistrationState {
+	Unregistered,
+	Registered,
+	Blocked,
+}
+#[cfg(target_os = "macos")]
+impl OverlayCancelHotkeyRegistrationState {
+	fn allows_register_attempt(self) -> bool {
+		matches!(self, Self::Unregistered)
+	}
+}
+
 struct App {
 	capture_hotkey: HotKey,
 	capture_hotkey_id: u32,
@@ -62,7 +76,7 @@ struct App {
 	#[cfg(target_os = "macos")]
 	overlay_cancel_hotkey_id: u32,
 	#[cfg(target_os = "macos")]
-	overlay_cancel_hotkey_registered: bool,
+	overlay_cancel_hotkey_registration_state: OverlayCancelHotkeyRegistrationState,
 	capture_hotkey_recording_suspended: bool,
 	tray_icon: Option<TrayIcon>,
 	#[cfg(target_os = "macos")]
@@ -133,7 +147,8 @@ impl App {
 			#[cfg(target_os = "macos")]
 			overlay_cancel_hotkey_id: Self::overlay_cancel_hotkey().id(),
 			#[cfg(target_os = "macos")]
-			overlay_cancel_hotkey_registered: false,
+			overlay_cancel_hotkey_registration_state:
+				OverlayCancelHotkeyRegistrationState::Unregistered,
 			capture_hotkey_recording_suspended: false,
 			_hotkey_manager: hotkey_manager,
 			tray_icon: None,
@@ -258,6 +273,8 @@ fn settings_window_entry(requested_by: &'static str) -> SettingsWindowEntry {
 
 #[cfg(test)]
 mod tests {
+	#[cfg(target_os = "macos")]
+	use crate::app::OverlayCancelHotkeyRegistrationState;
 	use crate::app::{self, SettingsWindowEntry};
 	#[cfg(target_os = "macos")]
 	use global_hotkey::hotkey::{Code, Modifiers};
@@ -290,5 +307,13 @@ mod tests {
 
 		assert_eq!(hotkey.key, Code::Escape);
 		assert_eq!(hotkey.mods, Modifiers::empty());
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn blocked_overlay_cancel_hotkey_registration_skips_retries_until_reset() {
+		assert!(OverlayCancelHotkeyRegistrationState::Unregistered.allows_register_attempt());
+		assert!(!OverlayCancelHotkeyRegistrationState::Registered.allows_register_attempt());
+		assert!(!OverlayCancelHotkeyRegistrationState::Blocked.allows_register_attempt());
 	}
 }

--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -15,6 +15,8 @@ use std::time::Instant;
 
 use color_eyre::eyre::Result;
 #[cfg(target_os = "macos")]
+use global_hotkey::Error as GlobalHotKeyError;
+#[cfg(target_os = "macos")]
 use global_hotkey::hotkey::Code;
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, hotkey::HotKey};
 #[cfg(target_os = "macos")]
@@ -62,6 +64,13 @@ enum OverlayCancelHotkeyRegistrationState {
 impl OverlayCancelHotkeyRegistrationState {
 	fn allows_register_attempt(self) -> bool {
 		matches!(self, Self::Unregistered)
+	}
+
+	fn next_state_after_register_error(error: &GlobalHotKeyError) -> Self {
+		match error {
+			GlobalHotKeyError::AlreadyRegistered(_) => Self::Registered,
+			_ => Self::Blocked,
+		}
 	}
 }
 
@@ -274,7 +283,7 @@ fn settings_window_entry(requested_by: &'static str) -> SettingsWindowEntry {
 #[cfg(test)]
 mod tests {
 	#[cfg(target_os = "macos")]
-	use crate::app::OverlayCancelHotkeyRegistrationState;
+	use crate::app::{GlobalHotKeyError, OverlayCancelHotkeyRegistrationState};
 	use crate::app::{self, SettingsWindowEntry};
 	#[cfg(target_os = "macos")]
 	use global_hotkey::hotkey::{Code, Modifiers};
@@ -315,5 +324,16 @@ mod tests {
 		assert!(OverlayCancelHotkeyRegistrationState::Unregistered.allows_register_attempt());
 		assert!(!OverlayCancelHotkeyRegistrationState::Registered.allows_register_attempt());
 		assert!(!OverlayCancelHotkeyRegistrationState::Blocked.allows_register_attempt());
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn already_registered_overlay_cancel_hotkey_error_keeps_registered_state() {
+		let error = GlobalHotKeyError::AlreadyRegistered(app::App::overlay_cancel_hotkey());
+
+		assert_eq!(
+			OverlayCancelHotkeyRegistrationState::next_state_after_register_error(&error),
+			OverlayCancelHotkeyRegistrationState::Registered
+		);
 	}
 }

--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use color_eyre::eyre::Result;
 #[cfg(target_os = "macos")]
-use global_hotkey::Error as GlobalHotKeyError;
+use global_hotkey::Error;
 #[cfg(target_os = "macos")]
 use global_hotkey::hotkey::Code;
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, hotkey::HotKey};
@@ -66,9 +66,9 @@ impl OverlayCancelHotkeyRegistrationState {
 		matches!(self, Self::Unregistered)
 	}
 
-	fn next_state_after_register_error(error: &GlobalHotKeyError) -> Self {
+	fn next_state_after_register_error(error: &Error) -> Self {
 		match error {
-			GlobalHotKeyError::AlreadyRegistered(_) => Self::Registered,
+			Error::AlreadyRegistered(_) => Self::Registered,
 			_ => Self::Blocked,
 		}
 	}
@@ -283,10 +283,11 @@ fn settings_window_entry(requested_by: &'static str) -> SettingsWindowEntry {
 #[cfg(test)]
 mod tests {
 	#[cfg(target_os = "macos")]
-	use crate::app::{GlobalHotKeyError, OverlayCancelHotkeyRegistrationState};
-	use crate::app::{self, SettingsWindowEntry};
-	#[cfg(target_os = "macos")]
 	use global_hotkey::hotkey::{Code, Modifiers};
+
+	#[cfg(target_os = "macos")]
+	use crate::app::OverlayCancelHotkeyRegistrationState;
+	use crate::app::{self, SettingsWindowEntry};
 
 	#[test]
 	fn startup_permission_check_uses_permissions_entry() {
@@ -329,7 +330,7 @@ mod tests {
 	#[cfg(target_os = "macos")]
 	#[test]
 	fn already_registered_overlay_cancel_hotkey_error_keeps_registered_state() {
-		let error = GlobalHotKeyError::AlreadyRegistered(app::App::overlay_cancel_hotkey());
+		let error = global_hotkey::Error::AlreadyRegistered(app::App::overlay_cancel_hotkey());
 
 		assert_eq!(
 			OverlayCancelHotkeyRegistrationState::next_state_after_register_error(&error),

--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -14,6 +14,8 @@ use std::sync::{
 use std::time::Instant;
 
 use color_eyre::eyre::Result;
+#[cfg(target_os = "macos")]
+use global_hotkey::hotkey::Code;
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, hotkey::HotKey};
 #[cfg(target_os = "macos")]
 use tray_icon::menu::Menu;
@@ -55,6 +57,12 @@ struct App {
 	settings_hotkey: Option<HotKey>,
 	settings_hotkey_id: Option<u32>,
 	_hotkey_manager: Option<GlobalHotKeyManager>,
+	#[cfg(target_os = "macos")]
+	overlay_cancel_hotkey: HotKey,
+	#[cfg(target_os = "macos")]
+	overlay_cancel_hotkey_id: u32,
+	#[cfg(target_os = "macos")]
+	overlay_cancel_hotkey_registered: bool,
 	capture_hotkey_recording_suspended: bool,
 	tray_icon: Option<TrayIcon>,
 	#[cfg(target_os = "macos")]
@@ -98,6 +106,11 @@ struct App {
 	startup_permissions_checked: bool,
 }
 impl App {
+	#[cfg(target_os = "macos")]
+	fn overlay_cancel_hotkey() -> HotKey {
+		HotKey::new(None, Code::Escape)
+	}
+
 	#[allow(clippy::too_many_arguments)]
 	fn new(
 		capture_hotkey: HotKey,
@@ -115,6 +128,12 @@ impl App {
 			capture_hotkey,
 			settings_hotkey,
 			settings_hotkey_id: settings_hotkey.as_ref().map(HotKey::id),
+			#[cfg(target_os = "macos")]
+			overlay_cancel_hotkey: Self::overlay_cancel_hotkey(),
+			#[cfg(target_os = "macos")]
+			overlay_cancel_hotkey_id: Self::overlay_cancel_hotkey().id(),
+			#[cfg(target_os = "macos")]
+			overlay_cancel_hotkey_registered: false,
 			capture_hotkey_recording_suspended: false,
 			_hotkey_manager: hotkey_manager,
 			tray_icon: None,
@@ -240,6 +259,8 @@ fn settings_window_entry(requested_by: &'static str) -> SettingsWindowEntry {
 #[cfg(test)]
 mod tests {
 	use crate::app::{self, SettingsWindowEntry};
+	#[cfg(target_os = "macos")]
+	use global_hotkey::hotkey::{Code, Modifiers};
 
 	#[test]
 	fn startup_permission_check_uses_permissions_entry() {
@@ -260,5 +281,14 @@ mod tests {
 			SettingsWindowEntry::Standard
 		);
 		assert_eq!(app::settings_window_entry("tray-settings-menu"), SettingsWindowEntry::Standard);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn overlay_cancel_hotkey_is_plain_escape() {
+		let hotkey = app::App::overlay_cancel_hotkey();
+
+		assert_eq!(hotkey.key, Code::Escape);
+		assert_eq!(hotkey.mods, Modifiers::empty());
 	}
 }

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -37,11 +37,13 @@ const OVERLAY_SESSION_PREWARM_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 impl App {
 	#[cfg(target_os = "macos")]
 	fn register_overlay_cancel_hotkey(&mut self) {
-		if self.overlay_cancel_hotkey_registered {
+		if !self.overlay_cancel_hotkey_registration_state.allows_register_attempt() {
 			return;
 		}
 
 		let Some(manager) = self._hotkey_manager.as_mut() else {
+			self.overlay_cancel_hotkey_registration_state =
+				super::OverlayCancelHotkeyRegistrationState::Blocked;
 			tracing::warn!(
 				hotkey = "Esc",
 				"Capture cancel hotkey is unavailable because the global hotkey manager is missing."
@@ -51,6 +53,8 @@ impl App {
 		};
 
 		if let Err(err) = manager.register(self.overlay_cancel_hotkey) {
+			self.overlay_cancel_hotkey_registration_state =
+				super::OverlayCancelHotkeyRegistrationState::Blocked;
 			tracing::warn!(
 				error = ?err,
 				hotkey = "Esc",
@@ -58,7 +62,8 @@ impl App {
 				"Failed to register the capture cancel hotkey."
 			);
 		} else {
-			self.overlay_cancel_hotkey_registered = true;
+			self.overlay_cancel_hotkey_registration_state =
+				super::OverlayCancelHotkeyRegistrationState::Registered;
 			tracing::info!(
 				hotkey = "Esc",
 				hotkey_id = %self.overlay_cancel_hotkey_id,
@@ -69,12 +74,25 @@ impl App {
 
 	#[cfg(target_os = "macos")]
 	fn unregister_overlay_cancel_hotkey(&mut self) {
-		if !self.overlay_cancel_hotkey_registered {
+		if matches!(
+			self.overlay_cancel_hotkey_registration_state,
+			super::OverlayCancelHotkeyRegistrationState::Unregistered
+		) {
+			return;
+		}
+		if matches!(
+			self.overlay_cancel_hotkey_registration_state,
+			super::OverlayCancelHotkeyRegistrationState::Blocked
+		) {
+			self.overlay_cancel_hotkey_registration_state =
+				super::OverlayCancelHotkeyRegistrationState::Unregistered;
+
 			return;
 		}
 
 		let Some(manager) = self._hotkey_manager.as_mut() else {
-			self.overlay_cancel_hotkey_registered = false;
+			self.overlay_cancel_hotkey_registration_state =
+				super::OverlayCancelHotkeyRegistrationState::Unregistered;
 
 			return;
 		};
@@ -87,7 +105,8 @@ impl App {
 				"Failed to unregister the capture cancel hotkey."
 			);
 		} else {
-			self.overlay_cancel_hotkey_registered = false;
+			self.overlay_cancel_hotkey_registration_state =
+				super::OverlayCancelHotkeyRegistrationState::Unregistered;
 			tracing::info!(
 				hotkey = "Esc",
 				hotkey_id = %self.overlay_cancel_hotkey_id,

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -17,6 +17,7 @@ use color_eyre::eyre::Result;
 use winit::event_loop::ActiveEventLoop;
 
 use crate::app::App;
+#[cfg(target_os = "macos")]
 use crate::app::OverlayCancelHotkeyRegistrationState;
 #[cfg(target_os = "macos")]
 use crate::app::UserEvent;

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -54,7 +54,7 @@ impl App {
 
 		if let Err(err) = manager.register(self.overlay_cancel_hotkey) {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::Blocked;
+				super::OverlayCancelHotkeyRegistrationState::next_state_after_register_error(&err);
 			tracing::warn!(
 				error = ?err,
 				hotkey = "Esc",
@@ -98,6 +98,8 @@ impl App {
 		};
 
 		if let Err(err) = manager.unregister(self.overlay_cancel_hotkey) {
+			self.overlay_cancel_hotkey_registration_state =
+				super::OverlayCancelHotkeyRegistrationState::Unregistered;
 			tracing::warn!(
 				error = ?err,
 				hotkey = "Esc",

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -35,6 +35,79 @@ const SCROLL_INPUT_OBSERVER_READY_TIMEOUT: Duration = Duration::from_millis(250)
 const OVERLAY_SESSION_PREWARM_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 
 impl App {
+	#[cfg(target_os = "macos")]
+	fn register_overlay_cancel_hotkey(&mut self) {
+		if self.overlay_cancel_hotkey_registered {
+			return;
+		}
+
+		let Some(manager) = self._hotkey_manager.as_mut() else {
+			tracing::warn!(
+				hotkey = "Esc",
+				"Capture cancel hotkey is unavailable because the global hotkey manager is missing."
+			);
+
+			return;
+		};
+
+		if let Err(err) = manager.register(self.overlay_cancel_hotkey) {
+			tracing::warn!(
+				error = ?err,
+				hotkey = "Esc",
+				hotkey_id = %self.overlay_cancel_hotkey_id,
+				"Failed to register the capture cancel hotkey."
+			);
+		} else {
+			self.overlay_cancel_hotkey_registered = true;
+			tracing::info!(
+				hotkey = "Esc",
+				hotkey_id = %self.overlay_cancel_hotkey_id,
+				"Registered the capture cancel hotkey."
+			);
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn unregister_overlay_cancel_hotkey(&mut self) {
+		if !self.overlay_cancel_hotkey_registered {
+			return;
+		}
+
+		let Some(manager) = self._hotkey_manager.as_mut() else {
+			self.overlay_cancel_hotkey_registered = false;
+
+			return;
+		};
+
+		if let Err(err) = manager.unregister(self.overlay_cancel_hotkey) {
+			tracing::warn!(
+				error = ?err,
+				hotkey = "Esc",
+				hotkey_id = %self.overlay_cancel_hotkey_id,
+				"Failed to unregister the capture cancel hotkey."
+			);
+		} else {
+			self.overlay_cancel_hotkey_registered = false;
+			tracing::info!(
+				hotkey = "Esc",
+				hotkey_id = %self.overlay_cancel_hotkey_id,
+				"Unregistered the capture cancel hotkey."
+			);
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn sync_overlay_cancel_hotkey_registration(&mut self) {
+		let should_register =
+			self.overlay_session.as_ref().is_some_and(OverlaySession::wants_global_cancel_hotkey);
+
+		if should_register {
+			self.register_overlay_cancel_hotkey();
+		} else {
+			self.unregister_overlay_cancel_hotkey();
+		}
+	}
+
 	fn self_capture_exception_window_ids(&self) -> Vec<u32> {
 		self_capture_exception_window_ids_from_sources(
 			self.settings_window.as_ref().and_then(|window| window.capture_window_id()),
@@ -182,6 +255,8 @@ impl App {
 				);
 
 				self.overlay_session = Some(overlay_session);
+				#[cfg(target_os = "macos")]
+				self.sync_overlay_cancel_hotkey_registration();
 			},
 			Err(err) => {
 				let overlay_start_ms = overlay_start_started_at.elapsed().as_millis();
@@ -418,6 +493,8 @@ impl App {
 		let Some(_session) = self.overlay_session.take() else {
 			return;
 		};
+		#[cfg(target_os = "macos")]
+		self.unregister_overlay_cancel_hotkey();
 
 		#[cfg(target_os = "macos")]
 		{
@@ -623,11 +700,11 @@ impl App {
 	}
 
 	pub(super) fn handle_overlay_control(&mut self, control: OverlayControl) {
-		let OverlayControl::Exit(exit) = control else {
-			return;
-		};
-
-		self.end_overlay_session(exit);
+		if let OverlayControl::Exit(exit) = control {
+			self.end_overlay_session(exit);
+		}
+		#[cfg(target_os = "macos")]
+		self.sync_overlay_cancel_hotkey_registration();
 	}
 }
 

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -17,6 +17,7 @@ use color_eyre::eyre::Result;
 use winit::event_loop::ActiveEventLoop;
 
 use crate::app::App;
+use crate::app::OverlayCancelHotkeyRegistrationState;
 #[cfg(target_os = "macos")]
 use crate::app::UserEvent;
 #[cfg(target_os = "macos")]
@@ -43,7 +44,8 @@ impl App {
 
 		let Some(manager) = self._hotkey_manager.as_mut() else {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::Blocked;
+				OverlayCancelHotkeyRegistrationState::Blocked;
+
 			tracing::warn!(
 				hotkey = "Esc",
 				"Capture cancel hotkey is unavailable because the global hotkey manager is missing."
@@ -54,7 +56,8 @@ impl App {
 
 		if let Err(err) = manager.register(self.overlay_cancel_hotkey) {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::next_state_after_register_error(&err);
+				OverlayCancelHotkeyRegistrationState::next_state_after_register_error(&err);
+
 			tracing::warn!(
 				error = ?err,
 				hotkey = "Esc",
@@ -63,7 +66,8 @@ impl App {
 			);
 		} else {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::Registered;
+				OverlayCancelHotkeyRegistrationState::Registered;
+
 			tracing::info!(
 				hotkey = "Esc",
 				hotkey_id = %self.overlay_cancel_hotkey_id,
@@ -85,21 +89,22 @@ impl App {
 			super::OverlayCancelHotkeyRegistrationState::Blocked
 		) {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::Unregistered;
+				OverlayCancelHotkeyRegistrationState::Unregistered;
 
 			return;
 		}
 
 		let Some(manager) = self._hotkey_manager.as_mut() else {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::Unregistered;
+				OverlayCancelHotkeyRegistrationState::Unregistered;
 
 			return;
 		};
 
 		if let Err(err) = manager.unregister(self.overlay_cancel_hotkey) {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::Unregistered;
+				OverlayCancelHotkeyRegistrationState::Unregistered;
+
 			tracing::warn!(
 				error = ?err,
 				hotkey = "Esc",
@@ -108,7 +113,8 @@ impl App {
 			);
 		} else {
 			self.overlay_cancel_hotkey_registration_state =
-				super::OverlayCancelHotkeyRegistrationState::Unregistered;
+				OverlayCancelHotkeyRegistrationState::Unregistered;
+
 			tracing::info!(
 				hotkey = "Esc",
 				hotkey_id = %self.overlay_cancel_hotkey_id,
@@ -276,6 +282,7 @@ impl App {
 				);
 
 				self.overlay_session = Some(overlay_session);
+
 				#[cfg(target_os = "macos")]
 				self.sync_overlay_cancel_hotkey_registration();
 			},
@@ -514,6 +521,7 @@ impl App {
 		let Some(_session) = self.overlay_session.take() else {
 			return;
 		};
+
 		#[cfg(target_os = "macos")]
 		self.unregister_overlay_cancel_hotkey();
 
@@ -724,6 +732,7 @@ impl App {
 		if let OverlayControl::Exit(exit) = control {
 			self.end_overlay_session(exit);
 		}
+
 		#[cfg(target_os = "macos")]
 		self.sync_overlay_cancel_hotkey_registration();
 	}

--- a/apps/rsnap/src/app/shell.rs
+++ b/apps/rsnap/src/app/shell.rs
@@ -233,6 +233,18 @@ impl App {
 		if event.state() != HotKeyState::Pressed {
 			return;
 		}
+		#[cfg(target_os = "macos")]
+		if self.overlay_session.is_some() && event.id() == self.overlay_cancel_hotkey_id {
+			tracing::info!(hotkey = "Esc", "Capture cancel requested from hotkey.");
+
+			if let Some(session) = self.overlay_session.as_mut() {
+				let control = session.handle_global_escape_hotkey();
+
+				self.handle_overlay_control(control);
+			}
+
+			return;
+		}
 		if event.id() == self.capture_hotkey_id {
 			tracing::info!(
 				hotkey = %self.capture_key_label(),

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -27,6 +27,7 @@ use std::env;
 use std::ffi::c_void;
 use std::mem;
 use std::panic;
+#[cfg(target_os = "macos")]
 use std::process;
 use std::ptr;
 use std::slice;

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -27,6 +27,7 @@ use std::env;
 use std::ffi::c_void;
 use std::mem;
 use std::panic;
+use std::process;
 use std::ptr;
 use std::slice;
 #[cfg(target_os = "macos")]
@@ -220,12 +221,6 @@ type ExternalScrollInputDrainReader =
 	Arc<dyn Fn(u64, Instant) -> Vec<ExternalScrollInputEvent> + Send + Sync>;
 
 #[cfg(target_os = "macos")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct MacOSFrontmostApplication {
-	process_id: i32,
-}
-
-#[cfg(target_os = "macos")]
 type ScrollCaptureStartGuard = Arc<dyn Fn() -> color_eyre::eyre::Result<bool> + Send + Sync>;
 
 #[cfg(target_os = "macos")]
@@ -400,325 +395,6 @@ const SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE: Duration = Duration::from_mil
 const SCROLL_CAPTURE_PREVIEW_WIDTH_PX: u32 = 320;
 #[cfg(target_os = "macos")]
 const KCG_EVENT_SOURCE_STATE_HID_SYSTEM_STATE: u32 = 0;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-/// Selects how the live HUD should be positioned.
-pub enum HudAnchor {
-	/// Pin the HUD cluster to the current cursor position.
-	Cursor,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Chooses the requested HUD and chrome theme.
-pub enum ThemeMode {
-	#[default]
-	/// Follow the host window or operating-system theme.
-	System,
-	/// Force the dark theme variant.
-	Dark,
-	/// Force the light theme variant.
-	Light,
-}
-
-#[derive(Debug)]
-/// Describes how an overlay session finished.
-pub enum OverlayExit {
-	/// The user cancelled the session without producing output.
-	Cancelled,
-	/// The session completed by copying PNG bytes to the caller.
-	PngBytes(Vec<u8>),
-	/// The session completed by copying recognized text to the clipboard.
-	TextCopied(usize),
-	/// The session completed by handing OCR work to a background task.
-	#[cfg(target_os = "macos")]
-	DeferredTextRecognition(DeferredTextRecognitionRequest),
-	/// The session completed by saving a file to disk.
-	Saved(PathBuf),
-	/// The session failed with a user-visible error message.
-	Error(String),
-}
-
-#[derive(Debug)]
-/// Signals whether the caller should keep driving the overlay event loop.
-pub enum OverlayControl {
-	/// Keep the session alive and continue processing events.
-	Continue,
-	/// Exit the session with the provided terminal outcome.
-	Exit(OverlayExit),
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Controls how the Tab-triggered loupe interaction is activated.
-pub enum AltActivationMode {
-	#[default]
-	/// Enable the loupe only while Tab is held.
-	Hold,
-	/// Toggle the loupe on and off with Tab presses.
-	Toggle,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Chooses where the frozen toolbar is anchored relative to the capture.
-pub enum ToolbarPlacement {
-	/// Render the toolbar above the frozen capture.
-	Top,
-	#[default]
-	/// Render the toolbar below the frozen capture.
-	Bottom,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Selects how saved captures are named on disk.
-pub enum OutputNaming {
-	#[default]
-	/// Use the current Unix timestamp in milliseconds.
-	Timestamp,
-	/// Use a zero-padded incrementing sequence number.
-	Sequence,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Controls how transparent window captures are composited before export.
-pub enum WindowCaptureAlphaMode {
-	#[default]
-	/// Preserve the observed screen background behind transparent pixels.
-	Background,
-	/// Composite transparency against a light matte color.
-	MatteLight,
-	/// Composite transparency against a dark matte color.
-	MatteDark,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum OverlayEventLoopPhase {
-	Idle,
-	WindowEvent,
-	AboutToWait,
-	RedrawDispatch,
-	HudRedraw,
-	LoupeRedraw,
-	ToolbarRedraw,
-	OverlayRedraw,
-}
-impl OverlayEventLoopPhase {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Idle => "idle",
-			Self::WindowEvent => "window_event",
-			Self::AboutToWait => "about_to_wait",
-			Self::RedrawDispatch => "redraw_dispatch",
-			Self::HudRedraw => "hud_redraw",
-			Self::LoupeRedraw => "loupe_redraw",
-			Self::ToolbarRedraw => "toolbar_redraw",
-			Self::OverlayRedraw => "overlay_window_redraw",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum HudTheme {
-	Dark,
-	Light,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenToolbarTool {
-	Pointer,
-	Pen,
-	Text,
-	Mosaic,
-	Undo,
-	Redo,
-	AutoCenter,
-	Scroll,
-	#[cfg(target_os = "macos")]
-	Ocr,
-	Copy,
-	Save,
-}
-impl FrozenToolbarTool {
-	const fn label(self) -> &'static str {
-		match self {
-			Self::Pointer => "Pointer",
-			Self::Pen => "Pen",
-			Self::Text => "Text",
-			Self::Mosaic => "Mosaic",
-			Self::Undo => "Undo",
-			Self::Redo => "Redo",
-			Self::AutoCenter => "Auto-center (C)",
-			Self::Scroll => "Scroll Capture",
-			#[cfg(target_os = "macos")]
-			Self::Ocr => "Recognize Text",
-			Self::Copy => "Copy",
-			Self::Save => "Save",
-		}
-	}
-
-	const fn icon(self) -> &'static str {
-		match self {
-			Self::Pointer => regular::CURSOR,
-			Self::Pen => regular::PENCIL_SIMPLE,
-			Self::Text => regular::TEXT_T,
-			Self::Mosaic => regular::CHECKERBOARD,
-			Self::Undo => regular::ARROW_COUNTER_CLOCKWISE,
-			Self::Redo => regular::ARROW_CLOCKWISE,
-			Self::AutoCenter => regular::ARROWS_IN_CARDINAL,
-			Self::Scroll => regular::ARROWS_DOWN_UP,
-			#[cfg(target_os = "macos")]
-			Self::Ocr => regular::FILE_TEXT,
-			Self::Copy => regular::COPY,
-			Self::Save => regular::FLOPPY_DISK,
-		}
-	}
-
-	const fn is_mode_tool(self) -> bool {
-		matches!(self, Self::Pointer | Self::Pen | Self::Text | Self::Mosaic)
-	}
-
-	const fn requires_final_capture(self) -> bool {
-		match self {
-			Self::Pointer | Self::Pen | Self::Text | Self::AutoCenter => false,
-			Self::Mosaic | Self::Undo | Self::Redo => true,
-			Self::Scroll | Self::Copy | Self::Save => true,
-			#[cfg(target_os = "macos")]
-			Self::Ocr => true,
-		}
-	}
-
-	fn is_available(self, toolbar_state: &FrozenToolbarState) -> bool {
-		match self {
-			Self::Undo => toolbar_state.undo_available,
-			Self::Redo => toolbar_state.redo_available,
-			_ => true,
-		}
-	}
-
-	fn unavailable_label(self, toolbar_state: &FrozenToolbarState) -> &'static str {
-		if self.requires_final_capture() && !toolbar_state.final_capture_ready {
-			return "Preparing capture...";
-		}
-
-		match self {
-			Self::Undo => "Nothing to undo",
-			Self::Redo => "Nothing to redo",
-			_ => "Preparing capture...",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ScrollCaptureFrameSource {
-	Worker { request_id: u64 },
-	LiveStream { frame_seq: u64 },
-}
-impl ScrollCaptureFrameSource {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Worker { .. } => "worker",
-			Self::LiveStream { .. } => "live_stream",
-		}
-	}
-
-	const fn worker_request_id(self) -> Option<u64> {
-		match self {
-			Self::Worker { request_id } => Some(request_id),
-			Self::LiveStream { .. } => None,
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum PngAction {
-	Copy,
-	Save,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-enum FrozenCaptureSource {
-	#[default]
-	None,
-	DragRegion,
-	Window,
-	FullscreenFallback,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenSelectionCorner {
-	TopLeft,
-	TopRight,
-	BottomLeft,
-	BottomRight,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-enum FrozenSelectionInteractionKind {
-	#[default]
-	Move,
-	Resize(FrozenSelectionCorner),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum DeviceCursorPointSource {
-	DevicePoints,
-	DevicePixelsFallback,
-	EventRecentFallback,
-}
-impl DeviceCursorPointSource {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::DevicePoints => "device_points",
-			Self::DevicePixelsFallback => "device_pixels_fallback",
-			Self::EventRecentFallback => "event_recent_fallback",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SelectionFlowStyle {
-	Band,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum WindowRendererPath {
-	Overlay,
-	LoupeTile,
-}
-impl WindowRendererPath {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Overlay => "overlay",
-			Self::LoupeTile => "loupe_tile",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SurfaceFrameSkipReason {
-	Timeout,
-	Occluded,
-}
-impl SurfaceFrameSkipReason {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Timeout => "timeout",
-			Self::Occluded => "occluded",
-		}
-	}
-
-	const fn should_request_redraw(self) -> bool {
-		matches!(self, Self::Timeout)
-	}
-}
-
-enum AcquiredSurfaceFrame {
-	Ready(SurfaceTexture),
-	Skipped(SurfaceFrameSkipReason),
-}
 
 #[cfg(target_os = "macos")]
 pub(super) struct MacOSOverlayCursorRectSupport {
@@ -1241,7 +917,6 @@ impl OverlaySession {
 
 			return;
 		};
-
 		let restored = macos_restore_frontmost_application(target);
 
 		tracing::info!(
@@ -1259,6 +934,8 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	/// Returns whether the host should keep the global Escape hotkey registered
+	/// for the current overlay mode.
 	#[must_use]
 	pub fn wants_global_cancel_hotkey(&self) -> bool {
 		matches!(self.state.mode, OverlayMode::Live)
@@ -6765,6 +6442,7 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	/// Handles a host-level Escape hotkey press when the overlay is active.
 	pub fn handle_global_escape_hotkey(&mut self) -> OverlayControl {
 		if self.frozen_text_edit.is_some() {
 			let changed = self.handle_frozen_text_pressed_key(&Key::Named(NamedKey::Escape), None);
@@ -8180,8 +7858,10 @@ impl OverlaySession {
 
 		self.log_exit_begin(&exit_metadata);
 		self.finalize_scroll_capture_for_exit();
+
 		#[cfg(target_os = "macos")]
 		let frontmost_application_before_start = self.frontmost_application_before_start.take();
+
 		self.reset_runtime_for_exit();
 		#[cfg(target_os = "macos")]
 		self.restore_frontmost_application_after_exit(frontmost_application_before_start);
@@ -8368,6 +8048,12 @@ impl Default for OverlaySession {
 }
 
 #[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MacOSFrontmostApplication {
+	process_id: i32,
+}
+
+#[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct OverlayCursorRect {
 	rect: Rect,
@@ -8393,30 +8079,11 @@ struct FrozenMosaicEdit {
 	window_patch: Option<FrozenImagePatch>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenTextInputSource {
-	Key,
-	Ime,
-}
-
 #[derive(Clone, Debug, PartialEq)]
 struct FrozenTextRecentInput {
 	source: FrozenTextInputSource,
 	text: String,
 	generation: u64,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenEditKind {
-	BrushStroke,
-	MosaicEdit,
-	TextAnnotation,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum FrozenCommittedOverlay<'a> {
-	Brush(&'a FrozenBrushStroke),
-	Text(&'a FrozenTextAnnotation),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -8526,6 +8193,344 @@ unsafe impl Encode for MacOSOverlayPoint {
 	fn encode() -> Encoding {
 		unsafe { Encoding::from_str("{CGPoint=dd}") }
 	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Selects how the live HUD should be positioned.
+pub enum HudAnchor {
+	/// Pin the HUD cluster to the current cursor position.
+	Cursor,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Chooses the requested HUD and chrome theme.
+pub enum ThemeMode {
+	#[default]
+	/// Follow the host window or operating-system theme.
+	System,
+	/// Force the dark theme variant.
+	Dark,
+	/// Force the light theme variant.
+	Light,
+}
+
+#[derive(Debug)]
+/// Describes how an overlay session finished.
+pub enum OverlayExit {
+	/// The user cancelled the session without producing output.
+	Cancelled,
+	/// The session completed by copying PNG bytes to the caller.
+	PngBytes(Vec<u8>),
+	/// The session completed by copying recognized text to the clipboard.
+	TextCopied(usize),
+	/// The session completed by handing OCR work to a background task.
+	#[cfg(target_os = "macos")]
+	DeferredTextRecognition(DeferredTextRecognitionRequest),
+	/// The session completed by saving a file to disk.
+	Saved(PathBuf),
+	/// The session failed with a user-visible error message.
+	Error(String),
+}
+
+#[derive(Debug)]
+/// Signals whether the caller should keep driving the overlay event loop.
+pub enum OverlayControl {
+	/// Keep the session alive and continue processing events.
+	Continue,
+	/// Exit the session with the provided terminal outcome.
+	Exit(OverlayExit),
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Controls how the Tab-triggered loupe interaction is activated.
+pub enum AltActivationMode {
+	#[default]
+	/// Enable the loupe only while Tab is held.
+	Hold,
+	/// Toggle the loupe on and off with Tab presses.
+	Toggle,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Chooses where the frozen toolbar is anchored relative to the capture.
+pub enum ToolbarPlacement {
+	/// Render the toolbar above the frozen capture.
+	Top,
+	#[default]
+	/// Render the toolbar below the frozen capture.
+	Bottom,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Selects how saved captures are named on disk.
+pub enum OutputNaming {
+	#[default]
+	/// Use the current Unix timestamp in milliseconds.
+	Timestamp,
+	/// Use a zero-padded incrementing sequence number.
+	Sequence,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Controls how transparent window captures are composited before export.
+pub enum WindowCaptureAlphaMode {
+	#[default]
+	/// Preserve the observed screen background behind transparent pixels.
+	Background,
+	/// Composite transparency against a light matte color.
+	MatteLight,
+	/// Composite transparency against a dark matte color.
+	MatteDark,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlayEventLoopPhase {
+	Idle,
+	WindowEvent,
+	AboutToWait,
+	RedrawDispatch,
+	HudRedraw,
+	LoupeRedraw,
+	ToolbarRedraw,
+	OverlayRedraw,
+}
+impl OverlayEventLoopPhase {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Idle => "idle",
+			Self::WindowEvent => "window_event",
+			Self::AboutToWait => "about_to_wait",
+			Self::RedrawDispatch => "redraw_dispatch",
+			Self::HudRedraw => "hud_redraw",
+			Self::LoupeRedraw => "loupe_redraw",
+			Self::ToolbarRedraw => "toolbar_redraw",
+			Self::OverlayRedraw => "overlay_window_redraw",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HudTheme {
+	Dark,
+	Light,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FrozenToolbarTool {
+	Pointer,
+	Pen,
+	Text,
+	Mosaic,
+	Undo,
+	Redo,
+	AutoCenter,
+	Scroll,
+	#[cfg(target_os = "macos")]
+	Ocr,
+	Copy,
+	Save,
+}
+impl FrozenToolbarTool {
+	const fn label(self) -> &'static str {
+		match self {
+			Self::Pointer => "Pointer",
+			Self::Pen => "Pen",
+			Self::Text => "Text",
+			Self::Mosaic => "Mosaic",
+			Self::Undo => "Undo",
+			Self::Redo => "Redo",
+			Self::AutoCenter => "Auto-center (C)",
+			Self::Scroll => "Scroll Capture",
+			#[cfg(target_os = "macos")]
+			Self::Ocr => "Recognize Text",
+			Self::Copy => "Copy",
+			Self::Save => "Save",
+		}
+	}
+
+	const fn icon(self) -> &'static str {
+		match self {
+			Self::Pointer => regular::CURSOR,
+			Self::Pen => regular::PENCIL_SIMPLE,
+			Self::Text => regular::TEXT_T,
+			Self::Mosaic => regular::CHECKERBOARD,
+			Self::Undo => regular::ARROW_COUNTER_CLOCKWISE,
+			Self::Redo => regular::ARROW_CLOCKWISE,
+			Self::AutoCenter => regular::ARROWS_IN_CARDINAL,
+			Self::Scroll => regular::ARROWS_DOWN_UP,
+			#[cfg(target_os = "macos")]
+			Self::Ocr => regular::FILE_TEXT,
+			Self::Copy => regular::COPY,
+			Self::Save => regular::FLOPPY_DISK,
+		}
+	}
+
+	const fn is_mode_tool(self) -> bool {
+		matches!(self, Self::Pointer | Self::Pen | Self::Text | Self::Mosaic)
+	}
+
+	const fn requires_final_capture(self) -> bool {
+		match self {
+			Self::Pointer | Self::Pen | Self::Text | Self::AutoCenter => false,
+			Self::Mosaic | Self::Undo | Self::Redo => true,
+			Self::Scroll | Self::Copy | Self::Save => true,
+			#[cfg(target_os = "macos")]
+			Self::Ocr => true,
+		}
+	}
+
+	fn is_available(self, toolbar_state: &FrozenToolbarState) -> bool {
+		match self {
+			Self::Undo => toolbar_state.undo_available,
+			Self::Redo => toolbar_state.redo_available,
+			_ => true,
+		}
+	}
+
+	fn unavailable_label(self, toolbar_state: &FrozenToolbarState) -> &'static str {
+		if self.requires_final_capture() && !toolbar_state.final_capture_ready {
+			return "Preparing capture...";
+		}
+
+		match self {
+			Self::Undo => "Nothing to undo",
+			Self::Redo => "Nothing to redo",
+			_ => "Preparing capture...",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScrollCaptureFrameSource {
+	Worker { request_id: u64 },
+	LiveStream { frame_seq: u64 },
+}
+impl ScrollCaptureFrameSource {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Worker { .. } => "worker",
+			Self::LiveStream { .. } => "live_stream",
+		}
+	}
+
+	const fn worker_request_id(self) -> Option<u64> {
+		match self {
+			Self::Worker { request_id } => Some(request_id),
+			Self::LiveStream { .. } => None,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PngAction {
+	Copy,
+	Save,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum FrozenCaptureSource {
+	#[default]
+	None,
+	DragRegion,
+	Window,
+	FullscreenFallback,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FrozenSelectionCorner {
+	TopLeft,
+	TopRight,
+	BottomLeft,
+	BottomRight,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum FrozenSelectionInteractionKind {
+	#[default]
+	Move,
+	Resize(FrozenSelectionCorner),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeviceCursorPointSource {
+	DevicePoints,
+	DevicePixelsFallback,
+	EventRecentFallback,
+}
+impl DeviceCursorPointSource {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::DevicePoints => "device_points",
+			Self::DevicePixelsFallback => "device_pixels_fallback",
+			Self::EventRecentFallback => "event_recent_fallback",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SelectionFlowStyle {
+	Band,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum WindowRendererPath {
+	Overlay,
+	LoupeTile,
+}
+impl WindowRendererPath {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Overlay => "overlay",
+			Self::LoupeTile => "loupe_tile",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SurfaceFrameSkipReason {
+	Timeout,
+	Occluded,
+}
+impl SurfaceFrameSkipReason {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Timeout => "timeout",
+			Self::Occluded => "occluded",
+		}
+	}
+
+	const fn should_request_redraw(self) -> bool {
+		matches!(self, Self::Timeout)
+	}
+}
+
+enum AcquiredSurfaceFrame {
+	Ready(SurfaceTexture),
+	Skipped(SurfaceFrameSkipReason),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FrozenTextInputSource {
+	Key,
+	Ime,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FrozenEditKind {
+	BrushStroke,
+	MosaicEdit,
+	TextAnnotation,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FrozenCommittedOverlay<'a> {
+	Brush(&'a FrozenBrushStroke),
+	Text(&'a FrozenTextAnnotation),
 }
 
 fn frozen_toolbar_window_startup_size_points() -> Vec2 {
@@ -9088,7 +9093,7 @@ fn macos_frontmost_application() -> Option<MacOSFrontmostApplication> {
 
 #[cfg(target_os = "macos")]
 fn macos_restore_frontmost_application(target: MacOSFrontmostApplication) -> bool {
-	if target.process_id == std::process::id() as i32 {
+	if target.process_id == process::id() as i32 {
 		macos_activate_app();
 
 		return true;

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -220,6 +220,12 @@ type ExternalScrollInputDrainReader =
 	Arc<dyn Fn(u64, Instant) -> Vec<ExternalScrollInputEvent> + Send + Sync>;
 
 #[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MacOSFrontmostApplication {
+	process_id: i32,
+}
+
+#[cfg(target_os = "macos")]
 type ScrollCaptureStartGuard = Arc<dyn Fn() -> color_eyre::eyre::Result<bool> + Send + Sync>;
 
 #[cfg(target_os = "macos")]
@@ -955,6 +961,8 @@ pub struct OverlaySession {
 	startup_aux_window_creation_scheduled: bool,
 	#[cfg(target_os = "macos")]
 	pending_startup_aux_live_stream_filter_upgrade: bool,
+	#[cfg(target_os = "macos")]
+	frontmost_application_before_start: Option<MacOSFrontmostApplication>,
 	response_waker: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 impl OverlaySession {
@@ -1166,6 +1174,8 @@ impl OverlaySession {
 			startup_aux_window_creation_scheduled: false,
 			#[cfg(target_os = "macos")]
 			pending_startup_aux_live_stream_filter_upgrade: false,
+			#[cfg(target_os = "macos")]
+			frontmost_application_before_start: None,
 			response_waker: None,
 		}
 	}
@@ -1209,9 +1219,49 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn capture_frontmost_application_for_exit_restore(&mut self) {
+		self.frontmost_application_before_start = macos_frontmost_application();
+
+		tracing::info!(
+			op = "overlay.frontmost_app_captured",
+			target_process_id =
+				self.frontmost_application_before_start.map(|target| target.process_id),
+			"Captured the pre-capture frontmost application for later restore."
+		);
+	}
+
+	#[cfg(target_os = "macos")]
+	fn restore_frontmost_application_after_exit(&self, target: Option<MacOSFrontmostApplication>) {
+		let Some(target) = target else {
+			tracing::info!(
+				op = "overlay.frontmost_app_restore_attempted",
+				target = "none",
+				"Skipped restoring the pre-capture frontmost application because none was recorded."
+			);
+
+			return;
+		};
+
+		let restored = macos_restore_frontmost_application(target);
+
+		tracing::info!(
+			op = "overlay.frontmost_app_restore_attempted",
+			target_process_id = target.process_id,
+			restored,
+			"Attempted to restore the pre-capture frontmost application."
+		);
+	}
+
+	#[cfg(target_os = "macos")]
 	/// Registers a wake callback for macOS live-stream frame notifications.
 	pub fn set_scroll_frame_waker(&mut self, waker: Arc<dyn Fn() + Send + Sync>) {
 		self.scroll_frame_waker = Some(waker);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[must_use]
+	pub fn wants_global_cancel_hotkey(&self) -> bool {
+		matches!(self.state.mode, OverlayMode::Live)
 	}
 
 	#[cfg(target_os = "macos")]
@@ -6714,6 +6764,29 @@ impl OverlaySession {
 		}
 	}
 
+	#[cfg(target_os = "macos")]
+	pub fn handle_global_escape_hotkey(&mut self) -> OverlayControl {
+		if self.frozen_text_edit.is_some() {
+			let changed = self.handle_frozen_text_pressed_key(&Key::Named(NamedKey::Escape), None);
+
+			if changed {
+				self.sync_text_input_ime_state();
+
+				if let Some(monitor) = self.state.monitor {
+					self.sync_frozen_text_ime_cursor_area(monitor);
+					self.request_redraw_for_monitor(monitor);
+				}
+			}
+
+			return OverlayControl::Continue;
+		}
+		if self.scroll_capture.active {
+			return self.cancel_overlay("global_escape_hotkey_scroll_capture");
+		}
+
+		self.cancel_overlay("global_escape_hotkey")
+	}
+
 	fn handle_key_event(&mut self, event: &KeyEvent) -> OverlayControl {
 		if matches!(self.state.mode, OverlayMode::Frozen)
 			&& let Some(control) = self.handle_frozen_text_key_event(event)
@@ -8107,7 +8180,11 @@ impl OverlaySession {
 
 		self.log_exit_begin(&exit_metadata);
 		self.finalize_scroll_capture_for_exit();
+		#[cfg(target_os = "macos")]
+		let frontmost_application_before_start = self.frontmost_application_before_start.take();
 		self.reset_runtime_for_exit();
+		#[cfg(target_os = "macos")]
+		self.restore_frontmost_application_after_exit(frontmost_application_before_start);
 		self.log_exit_end(&exit_metadata);
 
 		OverlayControl::Exit(exit)
@@ -8215,6 +8292,10 @@ impl OverlaySession {
 		self.loupe_window_visible = false;
 		self.loupe_window_warmup_redraws_remaining = 0;
 		self.scroll_capture = ScrollCaptureState::default();
+		#[cfg(target_os = "macos")]
+		{
+			self.frontmost_application_before_start = None;
+		}
 		self.frozen_capture_source = FrozenCaptureSource::None;
 		self.cursor_monitor = None;
 		self.gpu = None;
@@ -8981,6 +9062,53 @@ fn macos_activate_app() {
 		}
 
 		let _: () = objc::msg_send![app, activateIgnoringOtherApps: YES];
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn macos_frontmost_application() -> Option<MacOSFrontmostApplication> {
+	unsafe {
+		let workspace: *mut Object = objc::msg_send![objc::class!(NSWorkspace), sharedWorkspace];
+
+		if workspace.is_null() {
+			return None;
+		}
+
+		let app: *mut Object = objc::msg_send![workspace, frontmostApplication];
+
+		if app.is_null() {
+			return None;
+		}
+
+		let process_id: i32 = objc::msg_send![app, processIdentifier];
+
+		(process_id > 0).then_some(MacOSFrontmostApplication { process_id })
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn macos_restore_frontmost_application(target: MacOSFrontmostApplication) -> bool {
+	if target.process_id == std::process::id() as i32 {
+		macos_activate_app();
+
+		return true;
+	}
+
+	unsafe {
+		let running_application_class = objc::class!(NSRunningApplication);
+		let app: *mut Object = objc::msg_send![
+			running_application_class,
+			runningApplicationWithProcessIdentifier: target.process_id
+		];
+
+		if app.is_null() {
+			return false;
+		}
+
+		let options: usize = 1 << 1;
+		let activated: BOOL = objc::msg_send![app, activateWithOptions: options];
+
+		activated == YES
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/cursor_context_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/cursor_context_runtime.rs
@@ -72,7 +72,7 @@ impl OverlaySession {
 	pub(super) fn startup_live_rgb_plan(
 		startup_monitor: Option<MonitorRect>,
 	) -> StartupLiveRgbPlan {
-		StartupLiveRgbPlan { focus_window: true, seed_monitor: startup_monitor }
+		StartupLiveRgbPlan { focus_window: false, seed_monitor: startup_monitor }
 	}
 
 	#[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -786,9 +786,11 @@ fn wants_global_cancel_hotkey_only_in_live_mode() {
 	let mut session = OverlaySession::new();
 
 	session.state.mode = OverlayMode::Live;
+
 	assert!(session.wants_global_cancel_hotkey());
 
 	session.state.mode = OverlayMode::Frozen;
+
 	assert!(!session.wants_global_cancel_hotkey());
 }
 

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -21,7 +21,7 @@ use crate::overlay::tests::{
 #[allow(unused_imports)]
 use crate::overlay::tests::{
 	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, LiveCursorSample,
-	LiveSampleApplyResult, ModifiersState, StartupLiveRgbPlan, WindowId,
+	LiveSampleApplyResult, ModifiersState, OverlayExit, StartupLiveRgbPlan, WindowId,
 };
 
 #[cfg(target_os = "macos")]
@@ -772,12 +772,37 @@ fn startup_live_rgb_plan_keeps_focus_independent_from_seed_monitor() {
 
 	assert_eq!(
 		OverlaySession::startup_live_rgb_plan(None),
-		StartupLiveRgbPlan { focus_window: true, seed_monitor: None }
+		StartupLiveRgbPlan { focus_window: false, seed_monitor: None }
 	);
 	assert_eq!(
 		OverlaySession::startup_live_rgb_plan(Some(monitor)),
-		StartupLiveRgbPlan { focus_window: true, seed_monitor: Some(monitor) }
+		StartupLiveRgbPlan { focus_window: false, seed_monitor: Some(monitor) }
 	);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn wants_global_cancel_hotkey_only_in_live_mode() {
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	assert!(session.wants_global_cancel_hotkey());
+
+	session.state.mode = OverlayMode::Frozen;
+	assert!(!session.wants_global_cancel_hotkey());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn global_escape_hotkey_cancels_live_capture() {
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+
+	assert!(matches!(
+		session.handle_global_escape_hotkey(),
+		OverlayControl::Exit(OverlayExit::Cancelled)
+	));
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -33,6 +33,8 @@ impl OverlaySession {
 		let reset_started_at = Instant::now();
 
 		self.reset_for_start();
+		#[cfg(target_os = "macos")]
+		self.capture_frontmost_application_for_exit_restore();
 
 		let reset_ms = reset_started_at.elapsed().as_millis();
 		let worker_setup_ms = self.setup_startup_worker();
@@ -604,6 +606,7 @@ impl OverlaySession {
 
 			if visible {
 				window.request_redraw();
+				#[cfg(not(target_os = "macos"))]
 				window.focus_window();
 			}
 


### PR DESCRIPTION
## Summary
- avoid forcing the live capture overlay window to become key on macOS so the target app/window stays active during selection
- record the pre-capture frontmost application and restore it when the overlay exits
- register a global Escape hotkey only while the overlay is in live mode so cancel still works without re-stealing focus

## Verification
- cargo make check
- cargo test -p rsnap overlay_cancel_hotkey_is_plain_escape
- cargo test -p rsnap-overlay wants_global_cancel_hotkey_only_in_live_mode
- cargo test -p rsnap-overlay global_escape_hotkey_cancels_live_capture
- cargo test -p rsnap-overlay startup_live_rgb_plan

Linear: XY-241