### PR TITLE
Add audible success feedback when rsnap screenshot capture completes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,6 +3888,7 @@ dependencies = [
  "image",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "pollster",
  "rsnap-overlay",
  "serde",

--- a/apps/rsnap/Cargo.toml
+++ b/apps/rsnap/Cargo.toml
@@ -43,8 +43,8 @@ winit              = { workspace = true }
 criterion = { version = "0.8", features = ["html_reports"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2         = { workspace = true }
-objc2-app-kit = { workspace = true, features = ["NSScreen", "NSSound", "NSView", "NSWindow"] }
+objc2            = { workspace = true }
+objc2-app-kit    = { workspace = true, features = ["NSScreen", "NSSound", "NSView", "NSWindow"] }
 objc2-foundation = { workspace = true, features = ["NSString"] }
 
 [[bench]]

--- a/apps/rsnap/Cargo.toml
+++ b/apps/rsnap/Cargo.toml
@@ -44,7 +44,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2         = { workspace = true }
-objc2-app-kit = { workspace = true, features = ["NSScreen", "NSView", "NSWindow"] }
+objc2-app-kit = { workspace = true, features = ["NSGraphics", "NSScreen", "NSView", "NSWindow"] }
 
 [[bench]]
 harness = false

--- a/apps/rsnap/Cargo.toml
+++ b/apps/rsnap/Cargo.toml
@@ -44,7 +44,8 @@ criterion = { version = "0.8", features = ["html_reports"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2         = { workspace = true }
-objc2-app-kit = { workspace = true, features = ["NSGraphics", "NSScreen", "NSView", "NSWindow"] }
+objc2-app-kit = { workspace = true, features = ["NSScreen", "NSSound", "NSView", "NSWindow"] }
+objc2-foundation = { workspace = true, features = ["NSString"] }
 
 [[bench]]
 harness = false

--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -20,6 +20,10 @@ use global_hotkey::Error;
 use global_hotkey::hotkey::Code;
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, hotkey::HotKey};
 #[cfg(target_os = "macos")]
+use objc2::rc::Retained;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::NSSound;
+#[cfg(target_os = "macos")]
 use tray_icon::menu::Menu;
 use tray_icon::{
 	TrayIcon,
@@ -108,6 +112,8 @@ struct App {
 	settings_window_capture_window_id: Option<u32>,
 	settings: AppSettings,
 	#[cfg(target_os = "macos")]
+	capture_success_sound: Option<Retained<NSSound>>,
+	#[cfg(target_os = "macos")]
 	overlay_proxy: EventLoopProxy<UserEvent>,
 	#[cfg(target_os = "macos")]
 	scroll_input_observer_lifecycle: Arc<ScrollInputObserverLifecycle>,
@@ -180,6 +186,8 @@ impl App {
 			settings_window: None,
 			settings_window_capture_window_id: None,
 			settings,
+			#[cfg(target_os = "macos")]
+			capture_success_sound: Self::load_capture_success_sound(),
 			#[cfg(target_os = "macos")]
 			overlay_proxy,
 			#[cfg(target_os = "macos")]

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -58,7 +58,7 @@ impl App {
 			if let Some(sound) =
 				NSSound::initWithContentsOfFile_byReference(NSSound::alloc(), &ns_path, true)
 			{
-				tracing::info!(path, "Loaded native capture success sound.");
+				tracing::info!(path, sound_path = path, "Loaded native capture success sound.");
 
 				return Some(sound);
 			}
@@ -176,8 +176,8 @@ impl App {
 		let Some(sound) = self.capture_success_sound.as_ref() else {
 			return;
 		};
-
 		let _ = sound.stop();
+
 		sound.setCurrentTime(0.0);
 
 		if !sound.play() {
@@ -593,6 +593,7 @@ impl App {
 			OverlayExit::Cancelled => tracing::info!("Capture cancelled."),
 			OverlayExit::PngBytes(png_bytes) => {
 				tracing::info!(bytes = png_bytes.len(), "Capture copied to clipboard.");
+
 				self.play_capture_success_feedback();
 			},
 			OverlayExit::TextCopied(character_count) => {
@@ -670,6 +671,7 @@ impl App {
 			},
 			OverlayExit::Saved(path) => {
 				tracing::info!(path = %path.display(), "Capture saved to file.");
+
 				self.play_capture_success_feedback();
 			},
 			OverlayExit::Error(message) => tracing::warn!(error = %message, "Capture failed."),

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -14,6 +14,8 @@ use std::time::Instant;
 use color_eyre::eyre;
 #[cfg(target_os = "macos")]
 use color_eyre::eyre::Result;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::NSBeep;
 use winit::event_loop::ActiveEventLoop;
 
 use crate::app::App;
@@ -135,6 +137,14 @@ impl App {
 			self.unregister_overlay_cancel_hotkey();
 		}
 	}
+
+	#[cfg(target_os = "macos")]
+	fn play_capture_success_feedback(&self) {
+		NSBeep();
+	}
+
+	#[cfg(not(target_os = "macos"))]
+	fn play_capture_success_feedback(&self) {}
 
 	fn self_capture_exception_window_ids(&self) -> Vec<u32> {
 		self_capture_exception_window_ids_from_sources(
@@ -541,6 +551,7 @@ impl App {
 			OverlayExit::Cancelled => tracing::info!("Capture cancelled."),
 			OverlayExit::PngBytes(png_bytes) => {
 				tracing::info!(bytes = png_bytes.len(), "Capture copied to clipboard.");
+				self.play_capture_success_feedback();
 			},
 			OverlayExit::TextCopied(character_count) => {
 				tracing::info!(
@@ -617,6 +628,7 @@ impl App {
 			},
 			OverlayExit::Saved(path) => {
 				tracing::info!(path = %path.display(), "Capture saved to file.");
+				self.play_capture_success_feedback();
 			},
 			OverlayExit::Error(message) => tracing::warn!(error = %message, "Capture failed."),
 		};

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -15,7 +15,13 @@ use color_eyre::eyre;
 #[cfg(target_os = "macos")]
 use color_eyre::eyre::Result;
 #[cfg(target_os = "macos")]
-use objc2_app_kit::NSBeep;
+use objc2::AnyThread;
+#[cfg(target_os = "macos")]
+use objc2::rc::Retained;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::NSSound;
+#[cfg(target_os = "macos")]
+use objc2_foundation::NSString;
 use winit::event_loop::ActiveEventLoop;
 
 use crate::app::App;
@@ -37,8 +43,35 @@ use rsnap_overlay::{HudAnchor, OverlayConfig, OverlayControl, OverlayExit, Overl
 const SCROLL_INPUT_OBSERVER_READY_TIMEOUT: Duration = Duration::from_millis(250);
 #[cfg(target_os = "macos")]
 const OVERLAY_SESSION_PREWARM_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+#[cfg(target_os = "macos")]
+const CAPTURE_SUCCESS_SOUND_CANDIDATE_PATHS: [&str; 2] = [
+	"/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/system/Screen Capture.aif",
+	"/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/system/Shutter.aif",
+];
 
 impl App {
+	#[cfg(target_os = "macos")]
+	pub(super) fn load_capture_success_sound() -> Option<Retained<NSSound>> {
+		for path in CAPTURE_SUCCESS_SOUND_CANDIDATE_PATHS {
+			let ns_path = NSString::from_str(path);
+
+			if let Some(sound) =
+				NSSound::initWithContentsOfFile_byReference(NSSound::alloc(), &ns_path, true)
+			{
+				tracing::info!(path, "Loaded native capture success sound.");
+
+				return Some(sound);
+			}
+		}
+
+		tracing::warn!(
+			candidates = ?CAPTURE_SUCCESS_SOUND_CANDIDATE_PATHS,
+			"Failed to load a native capture success sound; capture completion audio is unavailable."
+		);
+
+		None
+	}
+
 	#[cfg(target_os = "macos")]
 	fn register_overlay_cancel_hotkey(&mut self) {
 		if !self.overlay_cancel_hotkey_registration_state.allows_register_attempt() {
@@ -140,7 +173,16 @@ impl App {
 
 	#[cfg(target_os = "macos")]
 	fn play_capture_success_feedback(&self) {
-		NSBeep();
+		let Some(sound) = self.capture_success_sound.as_ref() else {
+			return;
+		};
+
+		let _ = sound.stop();
+		sound.setCurrentTime(0.0);
+
+		if !sound.play() {
+			tracing::warn!("Failed to play the native capture success sound.");
+		}
 	}
 
 	#[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Summary
- play a native macOS success cue when screenshot capture completes by copying PNG bytes to the clipboard
- play the same cue when screenshot capture successfully saves to disk
- keep cancel, failure, and text-copy-only exits silent

## Verification
- cargo fmt --all
- cargo make lint-rust
- cargo make test-rust

Linear: https://linear.app/hack-ink/issue/XY-231/add-audible-success-feedback-when-rsnap-screenshot-capture-completes