### PR TITLE
Extract overlay frozen text editing and IME runtime module

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -10,6 +10,7 @@ mod frozen_brush_runtime;
 mod frozen_export_runtime;
 mod frozen_mosaic_runtime;
 mod frozen_selection_runtime;
+mod frozen_text_runtime;
 mod hud_helpers;
 mod hud_runtime;
 mod image_helpers;
@@ -147,6 +148,7 @@ use winit::{
 	window::{CursorIcon, WindowId, WindowLevel},
 };
 
+use self::frozen_text_runtime::{FrozenTextInputSource, FrozenTextRecentInput};
 #[cfg(target_os = "macos")]
 use self::rendering::StartupLiveRgbPlan;
 use self::rendering::{
@@ -1198,15 +1200,6 @@ impl OverlaySession {
 		self.request_redraw_toolbar_window();
 	}
 
-	fn reset_frozen_text_state(&mut self) {
-		self.frozen_text_annotations.clear();
-		self.frozen_text_redo_annotations.clear();
-
-		self.frozen_text_edit = None;
-
-		self.sync_text_input_ime_state();
-	}
-
 	fn reset_frozen_annotation_state(&mut self) {
 		self.frozen_brush = FrozenBrushState::default();
 		self.frozen_selection_drag = FrozenSelectionDragState::default();
@@ -1458,374 +1451,6 @@ impl OverlaySession {
 		self.sync_frozen_toolbar_state();
 
 		redone
-	}
-
-	fn frozen_text_tool_active(&self) -> bool {
-		!self.scroll_capture.active && self.toolbar_state.selected_tool == FrozenToolbarTool::Text
-	}
-
-	fn sync_text_input_ime_state(&self) {
-		let ime_allowed = self.frozen_text_tool_active() && self.frozen_text_edit.is_some();
-
-		for overlay_window in self.windows.values() {
-			overlay_window.window.set_ime_allowed(ime_allowed);
-		}
-
-		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			toolbar_window.window.set_ime_allowed(ime_allowed);
-		}
-	}
-
-	fn sync_frozen_text_ime_cursor_area(&self, monitor: MonitorRect) {
-		let Some(edit_state) = self.frozen_text_edit.as_ref() else {
-			return;
-		};
-		let Some(overlay_window) = self.windows.values().find(|window| window.monitor == monitor)
-		else {
-			return;
-		};
-		let (visible_text, caret_char_index) = edit_state.visible_text_and_caret_char_index();
-		let caret_rect = overlay_window.renderer.frozen_text_edit_caret_rect_for_window(
-			edit_state.anchor,
-			visible_text.as_str(),
-			&FontId::proportional(self.toolbar_state.text_style.font_size_points),
-			caret_char_index.unwrap_or_else(|| visible_text.chars().count()),
-		);
-
-		overlay_window.window.set_ime_cursor_area(
-			LogicalPosition::new(
-				f64::from(caret_rect.min.x.max(0.0)),
-				f64::from(caret_rect.min.y.max(0.0)),
-			),
-			LogicalSize::new(
-				f64::from(caret_rect.width().max(1.0)),
-				f64::from(caret_rect.height().max(self.toolbar_state.text_style.font_size_points)),
-			),
-		);
-	}
-
-	fn should_refresh_frozen_text_ime_cursor_area_for_text_style_change(
-		&self,
-		monitor: MonitorRect,
-	) -> bool {
-		self.state.monitor == Some(monitor)
-			&& self.frozen_text_tool_active()
-			&& self.frozen_text_edit.as_ref().is_some_and(FrozenTextEditState::has_ime_preedit)
-	}
-
-	fn refresh_frozen_text_ime_cursor_area_for_text_style_change(&self, monitor: MonitorRect) {
-		if self.should_refresh_frozen_text_ime_cursor_area_for_text_style_change(monitor) {
-			self.sync_frozen_text_ime_cursor_area(monitor);
-		}
-	}
-
-	fn finish_frozen_text_editing(&mut self, commit: bool) -> bool {
-		let Some(edit_state) = self.frozen_text_edit.take() else {
-			self.sync_text_input_ime_state();
-
-			return false;
-		};
-		let committed_text = edit_state.visible_text();
-		let had_visible_text = !committed_text.trim().is_empty();
-
-		if commit && had_visible_text {
-			self.frozen_text_annotations.push(FrozenTextAnnotation {
-				anchor: edit_state.anchor,
-				text: committed_text,
-				style: self.toolbar_state.text_style,
-			});
-			self.push_frozen_edit_to_undo_history(FrozenEditKind::TextAnnotation);
-			self.sync_frozen_toolbar_state();
-		}
-
-		self.frozen_text_recent_input = None;
-
-		self.sync_text_input_ime_state();
-
-		had_visible_text
-	}
-
-	fn note_frozen_text_input_event(&mut self) -> u64 {
-		self.frozen_text_input_generation = self.frozen_text_input_generation.wrapping_add(1);
-
-		self.frozen_text_input_generation
-	}
-
-	fn append_text_to_frozen_edit_for_input_event(
-		&mut self,
-		source: FrozenTextInputSource,
-		generation: u64,
-		text: &str,
-	) -> bool {
-		let text = text.replace('\r', "");
-
-		if text.is_empty() {
-			return false;
-		}
-		if self.frozen_text_recent_input.as_ref().is_some_and(|recent| {
-			recent.source != source
-				&& recent.text == text
-				&& generation == recent.generation.saturating_add(1)
-		}) {
-			self.frozen_text_recent_input = None;
-
-			return false;
-		}
-
-		let changed = self.append_text_to_frozen_edit(text.as_str());
-
-		if changed {
-			self.frozen_text_recent_input =
-				Some(FrozenTextRecentInput { source, text, generation });
-		}
-
-		changed
-	}
-
-	fn append_text_to_frozen_edit(&mut self, text: &str) -> bool {
-		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
-			return false;
-		};
-		let text = text.replace('\r', "");
-
-		if text.is_empty() {
-			return false;
-		}
-
-		edit_state.text.push_str(&text);
-
-		edit_state.ime_preedit = None;
-		edit_state.ime_preedit_cursor_char_range = None;
-
-		edit_state.reset_caret_blink();
-
-		self.frozen_text_recent_input = None;
-
-		true
-	}
-
-	fn backspace_frozen_text_edit(&mut self) -> bool {
-		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
-			return false;
-		};
-		let had_preedit = edit_state.has_ime_preedit();
-
-		edit_state.ime_preedit = None;
-		edit_state.ime_preedit_cursor_char_range = None;
-
-		let changed = had_preedit || edit_state.text.pop().is_some();
-
-		if changed {
-			edit_state.reset_caret_blink();
-
-			self.frozen_text_recent_input = None;
-		}
-
-		changed
-	}
-
-	fn undo_frozen_text_annotation(&mut self) -> bool {
-		let Some(annotation) = self.frozen_text_annotations.pop() else {
-			return false;
-		};
-
-		self.frozen_text_redo_annotations.push(annotation);
-
-		self.toolbar_state.needs_redraw = true;
-
-		self.request_redraw_toolbar_window();
-
-		if let Some(monitor) = self.state.monitor {
-			self.request_redraw_for_monitor(monitor);
-		}
-
-		true
-	}
-
-	fn redo_frozen_text_annotation(&mut self) -> bool {
-		let Some(annotation) = self.frozen_text_redo_annotations.pop() else {
-			return false;
-		};
-
-		self.frozen_text_annotations.push(annotation);
-
-		self.toolbar_state.needs_redraw = true;
-
-		self.request_redraw_toolbar_window();
-
-		if let Some(monitor) = self.state.monitor {
-			self.request_redraw_for_monitor(monitor);
-		}
-
-		true
-	}
-
-	fn set_frozen_text_ime_preedit(
-		&mut self,
-		preedit: Option<String>,
-		cursor_range: Option<(usize, usize)>,
-	) -> bool {
-		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
-			return false;
-		};
-		let normalized = preedit.filter(|text| !text.is_empty());
-		let normalized_cursor_range = normalized.as_deref().and_then(|text| {
-			FrozenTextEditState::normalize_ime_preedit_cursor_char_range(text, cursor_range)
-		});
-
-		if edit_state.ime_preedit == normalized
-			&& edit_state.ime_preedit_cursor_char_range == normalized_cursor_range
-		{
-			return false;
-		}
-
-		edit_state.ime_preedit = normalized;
-		edit_state.ime_preedit_cursor_char_range = normalized_cursor_range;
-
-		edit_state.reset_caret_blink();
-
-		true
-	}
-
-	fn begin_frozen_text_edit_at(&mut self, monitor: MonitorRect, cursor: GlobalPoint) -> bool {
-		if self.state.monitor != Some(monitor) {
-			return false;
-		}
-
-		let Some((local_x, local_y)) = monitor.local_u32(cursor) else {
-			return false;
-		};
-		let Some(capture_rect) = self.state.frozen_capture_rect else {
-			return false;
-		};
-
-		if !capture_rect.contains((local_x, local_y)) {
-			return false;
-		}
-
-		let _ = self.finish_frozen_text_editing(true);
-
-		self.frozen_text_edit =
-			Some(FrozenTextEditState::new(Pos2::new(local_x as f32, local_y as f32)));
-		self.frozen_text_recent_input = None;
-
-		self.sync_text_input_ime_state();
-		self.sync_frozen_text_ime_cursor_area(monitor);
-		#[cfg(target_os = "macos")]
-		self.focus_frozen_text_input_window(Some(monitor));
-
-		true
-	}
-
-	fn frozen_text_edit_hit_rect_for_monitor(&self, monitor: MonitorRect) -> Option<Rect> {
-		if self.state.monitor != Some(monitor) {
-			return None;
-		}
-
-		let edit_state = self.frozen_text_edit.as_ref()?;
-		let visible_text = edit_state.visible_text();
-
-		Some(WindowRenderer::frozen_text_edit_interaction_rect(
-			edit_state.anchor,
-			visible_text.as_str(),
-			&FontId::proportional(self.toolbar_state.text_style.font_size_points),
-		))
-	}
-
-	fn begin_frozen_text_edit_drag_at(
-		&mut self,
-		monitor: MonitorRect,
-		cursor: GlobalPoint,
-	) -> bool {
-		let Some((local_x, local_y)) = monitor.local_u32(cursor) else {
-			return false;
-		};
-		let Some(hit_rect) = self.frozen_text_edit_hit_rect_for_monitor(monitor) else {
-			return false;
-		};
-		let pointer = Pos2::new(local_x as f32, local_y as f32);
-
-		if !hit_rect.contains(pointer) {
-			return false;
-		}
-
-		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
-			return false;
-		};
-
-		edit_state.dragging = true;
-		edit_state.drag_offset = pointer - edit_state.anchor;
-
-		true
-	}
-
-	fn stop_frozen_text_edit_drag(&mut self) -> bool {
-		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
-			return false;
-		};
-		let was_dragging = edit_state.dragging;
-
-		edit_state.dragging = false;
-		edit_state.drag_offset = Vec2::ZERO;
-
-		was_dragging
-	}
-
-	fn update_frozen_text_edit_drag_anchor(&mut self, global: GlobalPoint) -> bool {
-		let Some(monitor) = self.state.monitor else {
-			let _ = self.stop_frozen_text_edit_drag();
-
-			return false;
-		};
-		let Some(capture_rect) = self.state.frozen_capture_rect else {
-			let _ = self.stop_frozen_text_edit_drag();
-
-			return false;
-		};
-		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
-			return false;
-		};
-
-		if !edit_state.dragging {
-			return false;
-		}
-
-		let (cursor_x, cursor_y) = Self::clamped_local_point_in_monitor(monitor, global);
-		let max_x = capture_rect.x.saturating_add(capture_rect.width.saturating_sub(1)) as f32;
-		let max_y = capture_rect.y.saturating_add(capture_rect.height.saturating_sub(1)) as f32;
-		let changed = {
-			let next_anchor = Pos2::new(
-				(cursor_x as f32 - edit_state.drag_offset.x).clamp(capture_rect.x as f32, max_x),
-				(cursor_y as f32 - edit_state.drag_offset.y).clamp(capture_rect.y as f32, max_y),
-			);
-
-			if next_anchor == edit_state.anchor {
-				false
-			} else {
-				edit_state.anchor = next_anchor;
-
-				true
-			}
-		};
-
-		if !changed {
-			return false;
-		}
-
-		self.sync_frozen_text_ime_cursor_area(monitor);
-		self.request_redraw_for_monitor(monitor);
-
-		true
-	}
-
-	fn sync_frozen_text_edit_for_selected_tool(&mut self) -> bool {
-		if self.frozen_text_tool_active() {
-			self.sync_text_input_ime_state();
-
-			return false;
-		}
-
-		self.finish_frozen_text_editing(true)
 	}
 
 	fn handle_captured_freeze_response(
@@ -2234,16 +1859,6 @@ impl OverlaySession {
 		})
 	}
 
-	#[cfg(test)]
-	fn visible_frozen_text_annotations(&self) -> &[FrozenTextAnnotation] {
-		if self.scroll_capture.active { &[] } else { &self.frozen_text_annotations }
-	}
-
-	#[cfg(test)]
-	fn visible_frozen_text_edit(&self) -> Option<&FrozenTextEditState> {
-		if self.scroll_capture.active { None } else { self.frozen_text_edit.as_ref() }
-	}
-
 	#[cfg(target_os = "macos")]
 	fn current_deferred_text_recognition_request(
 		&mut self,
@@ -2437,93 +2052,6 @@ impl OverlaySession {
 		}
 
 		self.handle_overlay_window_redraw(window_id)
-	}
-
-	#[cfg(target_os = "macos")]
-	fn frozen_text_input_overlay_window(&self, monitor: Option<MonitorRect>) -> Option<&Window> {
-		monitor
-			.and_then(|target| self.windows.values().find(|window| window.monitor == target))
-			.or_else(|| self.windows.values().next())
-			.map(|overlay_window| overlay_window.window.as_ref())
-	}
-
-	#[cfg(target_os = "macos")]
-	fn focus_frozen_text_input_window(&self, monitor: Option<MonitorRect>) {
-		macos_activate_app();
-
-		let Some(target_window) = self.frozen_text_input_overlay_window(monitor) else {
-			tracing::info!(
-				op = "overlay.frozen_text_focus_requested",
-				target = "missing_window",
-				monitor_id = ?monitor.map(|target| target.id),
-				"Requested frozen text input focus, but no overlay window was available."
-			);
-
-			return;
-		};
-
-		tracing::info!(
-			op = "overlay.frozen_text_focus_requested",
-			target = "overlay_window",
-			monitor_id = ?monitor.map(|target| target.id),
-			"Requested frozen text input focus."
-		);
-
-		macos_make_window_key(target_window);
-	}
-
-	#[cfg(target_os = "macos")]
-	fn focus_frozen_keyboard_window(&self) {
-		macos_activate_app();
-
-		if self.frozen_text_edit.is_some()
-			&& let Some(target_window) = self.frozen_text_input_overlay_window(self.state.monitor)
-		{
-			tracing::info!(
-				op = "scroll_capture.frozen_focus_requested",
-				target = "overlay_window",
-				state_mode = ?self.state.mode,
-				toolbar_window_visible = self.toolbar_window_visible,
-				monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
-				"Requested frozen keyboard focus for text editing."
-			);
-
-			macos_make_window_key(target_window);
-
-			return;
-		}
-
-		let target_window = if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			Some(toolbar_window.window.as_ref())
-		} else {
-			self.windows
-				.values()
-				.find(|overlay_window| Some(overlay_window.monitor) == self.state.monitor)
-				.map(|overlay_window| overlay_window.window.as_ref())
-		};
-		let Some(target_window) = target_window else {
-			tracing::info!(
-				op = "scroll_capture.frozen_focus_requested",
-				target = "missing_window",
-				state_mode = ?self.state.mode,
-				toolbar_window_present = self.toolbar_window.is_some(),
-				monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
-				"Requested frozen keyboard focus, but no target window was available."
-			);
-
-			return;
-		};
-
-		tracing::info!(
-			op = "scroll_capture.frozen_focus_requested",
-			target = if self.toolbar_window.is_some() { "toolbar_window" } else { "overlay_window" },
-			state_mode = ?self.state.mode,
-			toolbar_window_visible = self.toolbar_window_visible,
-			monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
-			"Requested frozen keyboard focus."
-		);
-
-		macos_make_window_key(target_window);
 	}
 
 	#[cfg(target_os = "macos")]
@@ -3118,13 +2646,6 @@ struct FrozenMosaicEdit {
 	window_patch: Option<FrozenImagePatch>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-struct FrozenTextRecentInput {
-	source: FrozenTextInputSource,
-	text: String,
-	generation: u64,
-}
-
 #[derive(Clone, Copy, Debug)]
 struct FrozenExportTransform {
 	capture_rect: RectPoints,
@@ -3551,12 +3072,6 @@ impl SurfaceFrameSkipReason {
 enum AcquiredSurfaceFrame {
 	Ready(SurfaceTexture),
 	Skipped(SurfaceFrameSkipReason),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenTextInputSource {
-	Key,
-	Ime,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
@@ -10,7 +10,6 @@ use crate::overlay::{
 	MonitorRect, OverlaySession, Pos2, RectPoints, WINDOW_CAPTURE_MATTE_DARK_RGBA,
 	WINDOW_CAPTURE_MATTE_LIGHT_RGBA, WindowCaptureAlphaMode,
 };
-use crate::text_rendering::{self, RasterTextAnnotation};
 
 impl OverlaySession {
 	pub(super) fn cropped_frozen_capture_image(&self) -> Option<RgbaImage> {
@@ -360,21 +359,6 @@ impl OverlaySession {
 
 			pixel[3] = (out_a * 255.0).round().clamp(0.0, 255.0) as u8;
 		}
-	}
-
-	fn render_frozen_text_annotation_into_image(
-		image: &mut RgbaImage,
-		export_transform: FrozenExportTransform,
-		annotation: &FrozenTextAnnotation,
-	) {
-		let raster_annotation = RasterTextAnnotation {
-			anchor_px: export_transform.point_to_pixels(annotation.anchor),
-			font_size_px: annotation.style.font_size_points * export_transform.scalar_scale(),
-			fill_rgba: annotation.style.color.export_rgba(),
-			text: annotation.text.as_str(),
-		};
-
-		text_rendering::render_text_annotations(image, &[raster_annotation]);
 	}
 
 	pub(super) fn current_export_image(&self) -> Option<RgbaImage> {

--- a/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
@@ -1,0 +1,525 @@
+use egui::{FontId, Pos2, Rect, Vec2};
+use image::RgbaImage;
+use winit::dpi::{LogicalPosition, LogicalSize};
+
+use crate::overlay::{
+	FrozenEditKind, FrozenExportTransform, FrozenTextAnnotation, FrozenTextEditState,
+	FrozenToolbarTool, GlobalPoint, MonitorRect, OverlaySession, WindowRenderer,
+};
+#[cfg(target_os = "macos")]
+use crate::overlay::{Window, macos_activate_app, macos_make_window_key};
+use crate::text_rendering::{self, RasterTextAnnotation};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct FrozenTextRecentInput {
+	pub(super) source: FrozenTextInputSource,
+	pub(super) text: String,
+	pub(super) generation: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FrozenTextInputSource {
+	Key,
+	Ime,
+}
+
+impl OverlaySession {
+	pub(super) fn reset_frozen_text_state(&mut self) {
+		self.frozen_text_annotations.clear();
+		self.frozen_text_redo_annotations.clear();
+
+		self.frozen_text_edit = None;
+
+		self.sync_text_input_ime_state();
+	}
+
+	pub(super) fn frozen_text_tool_active(&self) -> bool {
+		!self.scroll_capture.active && self.toolbar_state.selected_tool == FrozenToolbarTool::Text
+	}
+
+	pub(super) fn sync_text_input_ime_state(&self) {
+		let ime_allowed = self.frozen_text_tool_active() && self.frozen_text_edit.is_some();
+
+		for overlay_window in self.windows.values() {
+			overlay_window.window.set_ime_allowed(ime_allowed);
+		}
+
+		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+			toolbar_window.window.set_ime_allowed(ime_allowed);
+		}
+	}
+
+	pub(super) fn sync_frozen_text_ime_cursor_area(&self, monitor: MonitorRect) {
+		let Some(edit_state) = self.frozen_text_edit.as_ref() else {
+			return;
+		};
+		let Some(overlay_window) = self.windows.values().find(|window| window.monitor == monitor)
+		else {
+			return;
+		};
+		let (visible_text, caret_char_index) = edit_state.visible_text_and_caret_char_index();
+		let caret_rect = overlay_window.renderer.frozen_text_edit_caret_rect_for_window(
+			edit_state.anchor,
+			visible_text.as_str(),
+			&FontId::proportional(self.toolbar_state.text_style.font_size_points),
+			caret_char_index.unwrap_or_else(|| visible_text.chars().count()),
+		);
+
+		overlay_window.window.set_ime_cursor_area(
+			LogicalPosition::new(
+				f64::from(caret_rect.min.x.max(0.0)),
+				f64::from(caret_rect.min.y.max(0.0)),
+			),
+			LogicalSize::new(
+				f64::from(caret_rect.width().max(1.0)),
+				f64::from(caret_rect.height().max(self.toolbar_state.text_style.font_size_points)),
+			),
+		);
+	}
+
+	pub(super) fn should_refresh_frozen_text_ime_cursor_area_for_text_style_change(
+		&self,
+		monitor: MonitorRect,
+	) -> bool {
+		self.state.monitor == Some(monitor)
+			&& self.frozen_text_tool_active()
+			&& self.frozen_text_edit.as_ref().is_some_and(FrozenTextEditState::has_ime_preedit)
+	}
+
+	pub(super) fn refresh_frozen_text_ime_cursor_area_for_text_style_change(
+		&self,
+		monitor: MonitorRect,
+	) {
+		if self.should_refresh_frozen_text_ime_cursor_area_for_text_style_change(monitor) {
+			self.sync_frozen_text_ime_cursor_area(monitor);
+		}
+	}
+
+	pub(super) fn finish_frozen_text_editing(&mut self, commit: bool) -> bool {
+		let Some(edit_state) = self.frozen_text_edit.take() else {
+			self.sync_text_input_ime_state();
+
+			return false;
+		};
+		let committed_text = edit_state.visible_text();
+		let had_visible_text = !committed_text.trim().is_empty();
+
+		if commit && had_visible_text {
+			self.frozen_text_annotations.push(FrozenTextAnnotation {
+				anchor: edit_state.anchor,
+				text: committed_text,
+				style: self.toolbar_state.text_style,
+			});
+			self.push_frozen_edit_to_undo_history(FrozenEditKind::TextAnnotation);
+			self.sync_frozen_toolbar_state();
+		}
+
+		self.frozen_text_recent_input = None;
+
+		self.sync_text_input_ime_state();
+
+		had_visible_text
+	}
+
+	pub(super) fn note_frozen_text_input_event(&mut self) -> u64 {
+		self.frozen_text_input_generation = self.frozen_text_input_generation.wrapping_add(1);
+
+		self.frozen_text_input_generation
+	}
+
+	pub(super) fn append_text_to_frozen_edit_for_input_event(
+		&mut self,
+		source: FrozenTextInputSource,
+		generation: u64,
+		text: &str,
+	) -> bool {
+		let text = text.replace('\r', "");
+
+		if text.is_empty() {
+			return false;
+		}
+		if self.frozen_text_recent_input.as_ref().is_some_and(|recent| {
+			recent.source != source
+				&& recent.text == text
+				&& generation == recent.generation.saturating_add(1)
+		}) {
+			self.frozen_text_recent_input = None;
+
+			return false;
+		}
+
+		let changed = self.append_text_to_frozen_edit(text.as_str());
+
+		if changed {
+			self.frozen_text_recent_input =
+				Some(FrozenTextRecentInput { source, text, generation });
+		}
+
+		changed
+	}
+
+	pub(super) fn append_text_to_frozen_edit(&mut self, text: &str) -> bool {
+		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
+			return false;
+		};
+		let text = text.replace('\r', "");
+
+		if text.is_empty() {
+			return false;
+		}
+
+		edit_state.text.push_str(&text);
+
+		edit_state.ime_preedit = None;
+		edit_state.ime_preedit_cursor_char_range = None;
+
+		edit_state.reset_caret_blink();
+
+		self.frozen_text_recent_input = None;
+
+		true
+	}
+
+	pub(super) fn backspace_frozen_text_edit(&mut self) -> bool {
+		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
+			return false;
+		};
+		let had_preedit = edit_state.has_ime_preedit();
+
+		edit_state.ime_preedit = None;
+		edit_state.ime_preedit_cursor_char_range = None;
+
+		let changed = had_preedit || edit_state.text.pop().is_some();
+
+		if changed {
+			edit_state.reset_caret_blink();
+
+			self.frozen_text_recent_input = None;
+		}
+
+		changed
+	}
+
+	pub(super) fn undo_frozen_text_annotation(&mut self) -> bool {
+		let Some(annotation) = self.frozen_text_annotations.pop() else {
+			return false;
+		};
+
+		self.frozen_text_redo_annotations.push(annotation);
+
+		self.toolbar_state.needs_redraw = true;
+
+		self.request_redraw_toolbar_window();
+
+		if let Some(monitor) = self.state.monitor {
+			self.request_redraw_for_monitor(monitor);
+		}
+
+		true
+	}
+
+	pub(super) fn redo_frozen_text_annotation(&mut self) -> bool {
+		let Some(annotation) = self.frozen_text_redo_annotations.pop() else {
+			return false;
+		};
+
+		self.frozen_text_annotations.push(annotation);
+
+		self.toolbar_state.needs_redraw = true;
+
+		self.request_redraw_toolbar_window();
+
+		if let Some(monitor) = self.state.monitor {
+			self.request_redraw_for_monitor(monitor);
+		}
+
+		true
+	}
+
+	pub(super) fn set_frozen_text_ime_preedit(
+		&mut self,
+		preedit: Option<String>,
+		cursor_range: Option<(usize, usize)>,
+	) -> bool {
+		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
+			return false;
+		};
+		let normalized = preedit.filter(|text| !text.is_empty());
+		let normalized_cursor_range = normalized.as_deref().and_then(|text| {
+			FrozenTextEditState::normalize_ime_preedit_cursor_char_range(text, cursor_range)
+		});
+
+		if edit_state.ime_preedit == normalized
+			&& edit_state.ime_preedit_cursor_char_range == normalized_cursor_range
+		{
+			return false;
+		}
+
+		edit_state.ime_preedit = normalized;
+		edit_state.ime_preedit_cursor_char_range = normalized_cursor_range;
+
+		edit_state.reset_caret_blink();
+
+		true
+	}
+
+	pub(super) fn begin_frozen_text_edit_at(
+		&mut self,
+		monitor: MonitorRect,
+		cursor: GlobalPoint,
+	) -> bool {
+		if self.state.monitor != Some(monitor) {
+			return false;
+		}
+
+		let Some((local_x, local_y)) = monitor.local_u32(cursor) else {
+			return false;
+		};
+		let Some(capture_rect) = self.state.frozen_capture_rect else {
+			return false;
+		};
+
+		if !capture_rect.contains((local_x, local_y)) {
+			return false;
+		}
+
+		let _ = self.finish_frozen_text_editing(true);
+
+		self.frozen_text_edit =
+			Some(FrozenTextEditState::new(Pos2::new(local_x as f32, local_y as f32)));
+		self.frozen_text_recent_input = None;
+
+		self.sync_text_input_ime_state();
+		self.sync_frozen_text_ime_cursor_area(monitor);
+		#[cfg(target_os = "macos")]
+		self.focus_frozen_text_input_window(Some(monitor));
+
+		true
+	}
+
+	pub(super) fn frozen_text_edit_hit_rect_for_monitor(
+		&self,
+		monitor: MonitorRect,
+	) -> Option<Rect> {
+		if self.state.monitor != Some(monitor) {
+			return None;
+		}
+
+		let edit_state = self.frozen_text_edit.as_ref()?;
+		let visible_text = edit_state.visible_text();
+
+		Some(WindowRenderer::frozen_text_edit_interaction_rect(
+			edit_state.anchor,
+			visible_text.as_str(),
+			&FontId::proportional(self.toolbar_state.text_style.font_size_points),
+		))
+	}
+
+	pub(super) fn begin_frozen_text_edit_drag_at(
+		&mut self,
+		monitor: MonitorRect,
+		cursor: GlobalPoint,
+	) -> bool {
+		let Some((local_x, local_y)) = monitor.local_u32(cursor) else {
+			return false;
+		};
+		let Some(hit_rect) = self.frozen_text_edit_hit_rect_for_monitor(monitor) else {
+			return false;
+		};
+		let pointer = Pos2::new(local_x as f32, local_y as f32);
+
+		if !hit_rect.contains(pointer) {
+			return false;
+		}
+
+		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
+			return false;
+		};
+
+		edit_state.dragging = true;
+		edit_state.drag_offset = pointer - edit_state.anchor;
+
+		true
+	}
+
+	pub(super) fn stop_frozen_text_edit_drag(&mut self) -> bool {
+		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
+			return false;
+		};
+		let was_dragging = edit_state.dragging;
+
+		edit_state.dragging = false;
+		edit_state.drag_offset = Vec2::ZERO;
+
+		was_dragging
+	}
+
+	pub(super) fn update_frozen_text_edit_drag_anchor(&mut self, global: GlobalPoint) -> bool {
+		let Some(monitor) = self.state.monitor else {
+			let _ = self.stop_frozen_text_edit_drag();
+
+			return false;
+		};
+		let Some(capture_rect) = self.state.frozen_capture_rect else {
+			let _ = self.stop_frozen_text_edit_drag();
+
+			return false;
+		};
+		let Some(edit_state) = self.frozen_text_edit.as_mut() else {
+			return false;
+		};
+
+		if !edit_state.dragging {
+			return false;
+		}
+
+		let (cursor_x, cursor_y) = Self::clamped_local_point_in_monitor(monitor, global);
+		let max_x = capture_rect.x.saturating_add(capture_rect.width.saturating_sub(1)) as f32;
+		let max_y = capture_rect.y.saturating_add(capture_rect.height.saturating_sub(1)) as f32;
+		let changed = {
+			let next_anchor = Pos2::new(
+				(cursor_x as f32 - edit_state.drag_offset.x).clamp(capture_rect.x as f32, max_x),
+				(cursor_y as f32 - edit_state.drag_offset.y).clamp(capture_rect.y as f32, max_y),
+			);
+
+			if next_anchor == edit_state.anchor {
+				false
+			} else {
+				edit_state.anchor = next_anchor;
+
+				true
+			}
+		};
+
+		if !changed {
+			return false;
+		}
+
+		self.sync_frozen_text_ime_cursor_area(monitor);
+		self.request_redraw_for_monitor(monitor);
+
+		true
+	}
+
+	pub(super) fn sync_frozen_text_edit_for_selected_tool(&mut self) -> bool {
+		if self.frozen_text_tool_active() {
+			self.sync_text_input_ime_state();
+
+			return false;
+		}
+
+		self.finish_frozen_text_editing(true)
+	}
+
+	#[cfg(test)]
+	pub(super) fn visible_frozen_text_annotations(&self) -> &[FrozenTextAnnotation] {
+		if self.scroll_capture.active { &[] } else { &self.frozen_text_annotations }
+	}
+
+	#[cfg(test)]
+	pub(super) fn visible_frozen_text_edit(&self) -> Option<&FrozenTextEditState> {
+		if self.scroll_capture.active { None } else { self.frozen_text_edit.as_ref() }
+	}
+
+	pub(super) fn render_frozen_text_annotation_into_image(
+		image: &mut RgbaImage,
+		export_transform: FrozenExportTransform,
+		annotation: &FrozenTextAnnotation,
+	) {
+		let raster_annotation = RasterTextAnnotation {
+			anchor_px: export_transform.point_to_pixels(annotation.anchor),
+			font_size_px: annotation.style.font_size_points * export_transform.scalar_scale(),
+			fill_rgba: annotation.style.color.export_rgba(),
+			text: annotation.text.as_str(),
+		};
+
+		text_rendering::render_text_annotations(image, &[raster_annotation]);
+	}
+
+	#[cfg(target_os = "macos")]
+	fn frozen_text_input_overlay_window(&self, monitor: Option<MonitorRect>) -> Option<&Window> {
+		monitor
+			.and_then(|target| self.windows.values().find(|window| window.monitor == target))
+			.or_else(|| self.windows.values().next())
+			.map(|overlay_window| overlay_window.window.as_ref())
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn focus_frozen_text_input_window(&self, monitor: Option<MonitorRect>) {
+		macos_activate_app();
+
+		let Some(target_window) = self.frozen_text_input_overlay_window(monitor) else {
+			tracing::info!(
+				op = "overlay.frozen_text_focus_requested",
+				target = "missing_window",
+				monitor_id = ?monitor.map(|target| target.id),
+				"Requested frozen text input focus, but no overlay window was available."
+			);
+
+			return;
+		};
+
+		tracing::info!(
+			op = "overlay.frozen_text_focus_requested",
+			target = "overlay_window",
+			monitor_id = ?monitor.map(|target| target.id),
+			"Requested frozen text input focus."
+		);
+
+		macos_make_window_key(target_window);
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn focus_frozen_keyboard_window(&self) {
+		macos_activate_app();
+
+		if self.frozen_text_edit.is_some()
+			&& let Some(target_window) = self.frozen_text_input_overlay_window(self.state.monitor)
+		{
+			tracing::info!(
+				op = "scroll_capture.frozen_focus_requested",
+				target = "overlay_window",
+				state_mode = ?self.state.mode,
+				toolbar_window_visible = self.toolbar_window_visible,
+				monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
+				"Requested frozen keyboard focus for text editing."
+			);
+
+			macos_make_window_key(target_window);
+
+			return;
+		}
+
+		let target_window = if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+			Some(toolbar_window.window.as_ref())
+		} else {
+			self.windows
+				.values()
+				.find(|overlay_window| Some(overlay_window.monitor) == self.state.monitor)
+				.map(|overlay_window| overlay_window.window.as_ref())
+		};
+		let Some(target_window) = target_window else {
+			tracing::info!(
+				op = "scroll_capture.frozen_focus_requested",
+				target = "missing_window",
+				state_mode = ?self.state.mode,
+				toolbar_window_present = self.toolbar_window.is_some(),
+				monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
+				"Requested frozen keyboard focus, but no target window was available."
+			);
+
+			return;
+		};
+
+		tracing::info!(
+			op = "scroll_capture.frozen_focus_requested",
+			target = if self.toolbar_window.is_some() { "toolbar_window" } else { "overlay_window" },
+			state_mode = ?self.state.mode,
+			toolbar_window_visible = self.toolbar_window_visible,
+			monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
+			"Requested frozen keyboard focus."
+		);
+
+		macos_make_window_key(target_window);
+	}
+}

--- a/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
@@ -2,12 +2,12 @@ use egui::{FontId, Pos2, Rect, Vec2};
 use image::RgbaImage;
 use winit::dpi::{LogicalPosition, LogicalSize};
 
+#[cfg(target_os = "macos")]
+use crate::overlay::Window;
 use crate::overlay::{
 	FrozenEditKind, FrozenExportTransform, FrozenTextAnnotation, FrozenTextEditState,
 	FrozenToolbarTool, GlobalPoint, MonitorRect, OverlaySession, WindowRenderer,
 };
-#[cfg(target_os = "macos")]
-use crate::overlay::{Window, macos_activate_app, macos_make_window_key};
 use crate::text_rendering::{self, RasterTextAnnotation};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -446,7 +446,7 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	pub(super) fn focus_frozen_text_input_window(&self, monitor: Option<MonitorRect>) {
-		macos_activate_app();
+		super::macos_activate_app();
 
 		let Some(target_window) = self.frozen_text_input_overlay_window(monitor) else {
 			tracing::info!(
@@ -466,12 +466,12 @@ impl OverlaySession {
 			"Requested frozen text input focus."
 		);
 
-		macos_make_window_key(target_window);
+		super::macos_make_window_key(target_window);
 	}
 
 	#[cfg(target_os = "macos")]
 	pub(super) fn focus_frozen_keyboard_window(&self) {
-		macos_activate_app();
+		super::macos_activate_app();
 
 		if self.frozen_text_edit.is_some()
 			&& let Some(target_window) = self.frozen_text_input_overlay_window(self.state.monitor)
@@ -485,7 +485,7 @@ impl OverlaySession {
 				"Requested frozen keyboard focus for text editing."
 			);
 
-			macos_make_window_key(target_window);
+			super::macos_make_window_key(target_window);
 
 			return;
 		}
@@ -520,6 +520,6 @@ impl OverlaySession {
 			"Requested frozen keyboard focus."
 		);
 
-		macos_make_window_key(target_window);
+		super::macos_make_window_key(target_window);
 	}
 }


### PR DESCRIPTION
## Summary
- extract frozen text editing, IME coordination, text drag, and macOS focus helpers into `frozen_text_runtime.rs`
- move committed frozen text annotation export rendering into the text runtime module
- reduce `overlay.rs` to orchestration for frozen text paths while keeping the module boundary scoped to `overlay`

## Testing
- cargo fmt --all
- cargo test -p rsnap-overlay --lib
- cargo make lint-rust
- cargo make fmt-rust-check
- cargo make lint
