### PR TITLE
Speed up frozen transition preview and stabilize overlay handoff

### DIFF
--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -2249,7 +2249,7 @@ fn log_missing_current_process_fallback(
 	excepting_window_count: usize,
 	fallback_excluded_window_count: usize,
 ) {
-	tracing::info!(
+	tracing::debug!(
 		op = "live_frame_stream.setup_filter_fallback_missing_current_process",
 		monitor_id,
 		pid = process::id(),

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -110,12 +110,13 @@ objc2::define_class!(
 	}
 );
 
+pub(crate) const STREAM_REGION_FRAME_MAX_AGE: Duration = Duration::from_millis(90);
+
 const STREAM_RPC_TIMEOUT: Duration = Duration::from_secs(3);
 const STREAM_SETUP_BACKOFF: Duration = Duration::from_millis(300);
 const STREAM_INCOMPLETE_EXCEPTION_UPGRADE_BACKOFF: Duration = Duration::from_secs(3);
 const STREAM_FRAME_QUEUE_CAPACITY: usize = 16;
 const STREAM_CONFIG_QUEUE_DEPTH: usize = 8;
-const STREAM_REGION_FRAME_MAX_AGE: Duration = Duration::from_millis(90);
 const STREAM_ACTIVE_GESTURE_FORCE_REFRESH_MIN_AGE: Duration = Duration::from_millis(60);
 const STREAM_REGION_FRAME_REFRESH_TIMEOUT: Duration = Duration::from_millis(180);
 const STREAM_REGION_FRAME_REFRESH_POLL_INTERVAL: Duration = Duration::from_millis(4);

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -271,6 +271,11 @@ impl MacLiveFrameStream {
 	}
 
 	#[cfg(test)]
+	pub(crate) fn debug_set_self_capture_filter_complete(&self, monitor_id: u32, complete: bool) {
+		self.shared_latest_frame.set_stream_filter_status(monitor_id, complete);
+	}
+
+	#[cfg(test)]
 	fn record_debug_request_kind(&self, kind: &'static str) {
 		match self.debug_last_request_kind.lock() {
 			Ok(mut guard) => {
@@ -367,6 +372,10 @@ impl MacLiveFrameStream {
 			monitor,
 			image: Arc::new(image),
 		}))
+	}
+
+	pub(crate) fn self_capture_filter_complete_for_monitor(&self, monitor: MonitorRect) -> bool {
+		self.shared_latest_frame.self_capture_filter_complete_for_monitor(monitor.id)
 	}
 
 	pub(crate) fn latest_rgba_region(
@@ -592,6 +601,7 @@ struct SharedLatestFrame {
 	pending_monitor: Mutex<Option<u32>>,
 	pending_refresh_monitor: Mutex<Option<PendingMonitorRequest>>,
 	waiting_for_frame_until: Mutex<Option<(u32, Instant)>>,
+	stream_filter_status: Mutex<Option<StreamFilterStatus>>,
 }
 impl SharedLatestFrame {
 	fn store(&self, monitor_id: u32, frame: &QueuedPixelBufferFrame) -> StoreFrameOutcome {
@@ -943,6 +953,30 @@ impl SharedLatestFrame {
 
 		false
 	}
+
+	fn set_stream_filter_status(&self, monitor_id: u32, self_capture_filter_complete: bool) {
+		match self.stream_filter_status.lock() {
+			Ok(mut guard) => {
+				*guard = Some(StreamFilterStatus { monitor_id, self_capture_filter_complete });
+			},
+			Err(poisoned) => {
+				let mut guard = poisoned.into_inner();
+
+				*guard = Some(StreamFilterStatus { monitor_id, self_capture_filter_complete });
+			},
+		}
+	}
+
+	fn self_capture_filter_complete_for_monitor(&self, monitor_id: u32) -> bool {
+		match self.stream_filter_status.lock() {
+			Ok(guard) => guard.as_ref().is_some_and(|status| {
+				status.monitor_id == monitor_id && status.self_capture_filter_complete
+			}),
+			Err(poisoned) => poisoned.into_inner().as_ref().is_some_and(|status| {
+				status.monitor_id == monitor_id && status.self_capture_filter_complete
+			}),
+		}
+	}
 }
 
 #[derive(Clone, Copy)]
@@ -950,6 +984,12 @@ struct PendingMonitorRequest {
 	monitor_id: u32,
 	stalled_after_frame_seq: u64,
 	started_at: Instant,
+}
+
+#[derive(Clone, Copy)]
+struct StreamFilterStatus {
+	monitor_id: u32,
+	self_capture_filter_complete: bool,
 }
 
 struct StoreFrameOutcome {
@@ -1716,6 +1756,7 @@ fn ensure_stream(
 		}
 
 		let mut previous_state = state.replace(next_state);
+		shared_latest_frame.set_stream_filter_status(monitor.id, true);
 
 		teardown_stream(&mut previous_state);
 
@@ -1738,6 +1779,7 @@ fn ensure_stream(
 	let self_capture_filter_complete = next_state.self_capture_filter_complete;
 
 	*state = Some(next_state);
+	shared_latest_frame.set_stream_filter_status(monitor.id, self_capture_filter_complete);
 
 	shared_latest_frame.mark_waiting_for_frame(monitor.id);
 
@@ -1955,6 +1997,7 @@ fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgress {
 	let self_capture_filter_complete = next_state.self_capture_filter_complete;
 	let replaced_existing_state = state.is_some();
 	let mut previous_state = state.replace(next_state);
+	shared_latest_frame.set_stream_filter_status(monitor.id, self_capture_filter_complete);
 
 	teardown_stream(&mut previous_state);
 
@@ -2965,6 +3008,38 @@ mod tests {
 		assert!(shared.waiting_for_frame_after_setup_at(7, now + Duration::from_millis(25)));
 		assert!(!shared.waiting_for_frame_after_setup_at(7, now + Duration::from_millis(60)));
 		assert!(!shared.waiting_for_frame_after_setup_at(7, now + Duration::from_millis(61)));
+	}
+
+	#[test]
+	fn shared_latest_frame_tracks_self_capture_filter_completeness_per_monitor() {
+		let shared = live_frame_stream_macos::SharedLatestFrame::default();
+
+		assert!(!shared.self_capture_filter_complete_for_monitor(7));
+
+		shared.set_stream_filter_status(7, false);
+		assert!(!shared.self_capture_filter_complete_for_monitor(7));
+
+		shared.set_stream_filter_status(7, true);
+		assert!(shared.self_capture_filter_complete_for_monitor(7));
+		assert!(!shared.self_capture_filter_complete_for_monitor(9));
+	}
+
+	#[test]
+	fn mac_live_frame_stream_reports_self_capture_filter_completeness_from_shared_status() {
+		let stream = live_frame_stream_macos::MacLiveFrameStream::with_waker(None);
+		let monitor = crate::state::MonitorRect {
+			id: 7,
+			origin: crate::state::GlobalPoint::new(0, 0),
+			width: 1_440,
+			height: 900,
+			scale_factor_x1000: 2_000,
+		};
+
+		assert!(!stream.self_capture_filter_complete_for_monitor(monitor));
+
+		stream.debug_set_self_capture_filter_complete(monitor.id, true);
+
+		assert!(stream.self_capture_filter_complete_for_monitor(monitor));
 	}
 
 	#[test]

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -77,6 +77,7 @@ objc2::define_class!(
 				self.ivars().frame_seq_counter.fetch_add(1, Ordering::AcqRel).wrapping_add(1);
 			let frame = QueuedPixelBufferFrame {
 				frame_seq,
+				stream_generation: self.ivars().stream_generation,
 				captured_at: Instant::now(),
 				pixel_buffer: SharedPixelBuffer(image_buffer),
 			};
@@ -586,6 +587,7 @@ unsafe impl Sync for SharedPixelBuffer {}
 #[derive(Clone)]
 struct QueuedPixelBufferFrame {
 	frame_seq: u64,
+	stream_generation: u64,
 	captured_at: Instant,
 	pixel_buffer: SharedPixelBuffer,
 }
@@ -602,11 +604,16 @@ struct SharedLatestFrame {
 	pending_monitor: Mutex<Option<u32>>,
 	pending_refresh_monitor: Mutex<Option<PendingMonitorRequest>>,
 	waiting_for_frame_until: Mutex<Option<(u32, Instant)>>,
+	active_stream_generation: Mutex<Option<StreamGenerationStatus>>,
 	stream_filter_status: Mutex<Option<StreamFilterStatus>>,
-	pending_stream_filter_complete_monitor: Mutex<Option<u32>>,
+	pending_stream_filter_complete_monitor: Mutex<Option<StreamGenerationStatus>>,
 }
 impl SharedLatestFrame {
 	fn store(&self, monitor_id: u32, frame: &QueuedPixelBufferFrame) -> StoreFrameOutcome {
+		if !self.stream_generation_is_active_for_monitor(monitor_id, frame.stream_generation) {
+			return StoreFrameOutcome { completed_ensure: false, completed_refresh: false };
+		}
+
 		match self.frames.lock() {
 			Ok(mut guard) => {
 				let shared = guard.get_or_insert_with(|| SharedQueuedPixelBufferFrames {
@@ -645,11 +652,15 @@ impl SharedLatestFrame {
 			},
 		}
 
-		self.complete_pending_requests_for_stored_frame(monitor_id)
+		self.complete_pending_requests_for_stored_frame(monitor_id, frame.stream_generation)
 	}
 
-	fn complete_pending_requests_for_stored_frame(&self, monitor_id: u32) -> StoreFrameOutcome {
-		self.complete_pending_stream_filter_status(monitor_id);
+	fn complete_pending_requests_for_stored_frame(
+		&self,
+		monitor_id: u32,
+		stream_generation: u64,
+	) -> StoreFrameOutcome {
+		self.complete_pending_stream_filter_status(monitor_id, stream_generation);
 		self.clear_waiting_for_frame(monitor_id);
 		StoreFrameOutcome {
 			completed_ensure: self.finish_ensure_monitor(monitor_id),
@@ -658,18 +669,40 @@ impl SharedLatestFrame {
 	}
 
 	fn latest_frame_for_monitor(&self, monitor_id: u32) -> Option<QueuedPixelBufferFrame> {
+		let active_stream_generation = self.active_stream_generation_for_monitor(monitor_id);
+
 		match self.frames.lock() {
 			Ok(guard) => guard
 				.as_ref()
 				.and_then(|latest| {
-					(latest.monitor_id == monitor_id).then(|| latest.frames.back().cloned())
+					(latest.monitor_id == monitor_id).then(|| {
+						latest
+							.frames
+							.iter()
+							.rev()
+							.find(|frame| {
+								active_stream_generation
+									.is_none_or(|generation| frame.stream_generation == generation)
+							})
+							.cloned()
+					})
 				})
 				.flatten(),
 			Err(poisoned) => poisoned
 				.into_inner()
 				.as_ref()
 				.and_then(|latest| {
-					(latest.monitor_id == monitor_id).then(|| latest.frames.back().cloned())
+					(latest.monitor_id == monitor_id).then(|| {
+						latest
+							.frames
+							.iter()
+							.rev()
+							.find(|frame| {
+								active_stream_generation
+									.is_none_or(|generation| frame.stream_generation == generation)
+							})
+							.cloned()
+					})
 				})
 				.flatten(),
 		}
@@ -680,6 +713,8 @@ impl SharedLatestFrame {
 		monitor_id: u32,
 		after_frame_seq: u64,
 	) -> Vec<QueuedPixelBufferFrame> {
+		let active_stream_generation = self.active_stream_generation_for_monitor(monitor_id);
+
 		match self.frames.lock() {
 			Ok(guard) => guard
 				.as_ref()
@@ -688,7 +723,11 @@ impl SharedLatestFrame {
 					shared
 						.frames
 						.iter()
-						.filter(|frame| frame.frame_seq > after_frame_seq)
+						.filter(|frame| {
+							frame.frame_seq > after_frame_seq
+								&& active_stream_generation
+									.is_none_or(|generation| frame.stream_generation == generation)
+						})
 						.cloned()
 						.collect()
 				})
@@ -701,7 +740,11 @@ impl SharedLatestFrame {
 					shared
 						.frames
 						.iter()
-						.filter(|frame| frame.frame_seq > after_frame_seq)
+						.filter(|frame| {
+							frame.frame_seq > after_frame_seq
+								&& active_stream_generation
+									.is_none_or(|generation| frame.stream_generation == generation)
+						})
 						.cloned()
 						.collect()
 				})
@@ -981,29 +1024,68 @@ impl SharedLatestFrame {
 		}
 	}
 
+	fn activate_stream_generation(&self, monitor_id: u32, stream_generation: u64) {
+		match self.active_stream_generation.lock() {
+			Ok(mut guard) => {
+				*guard = Some(StreamGenerationStatus { monitor_id, stream_generation });
+			},
+			Err(poisoned) => {
+				let mut guard = poisoned.into_inner();
+
+				*guard = Some(StreamGenerationStatus { monitor_id, stream_generation });
+			},
+		}
+	}
+
+	fn active_stream_generation_for_monitor(&self, monitor_id: u32) -> Option<u64> {
+		match self.active_stream_generation.lock() {
+			Ok(guard) => guard.as_ref().and_then(|status| {
+				(status.monitor_id == monitor_id).then_some(status.stream_generation)
+			}),
+			Err(poisoned) => poisoned.into_inner().as_ref().and_then(|status| {
+				(status.monitor_id == monitor_id).then_some(status.stream_generation)
+			}),
+		}
+	}
+
+	fn stream_generation_is_active_for_monitor(
+		&self,
+		monitor_id: u32,
+		stream_generation: u64,
+	) -> bool {
+		self.active_stream_generation_for_monitor(monitor_id)
+			.is_none_or(|active_generation| active_generation == stream_generation)
+	}
+
 	fn defer_stream_filter_complete_until_next_frame(
 		&self,
 		monitor_id: u32,
+		stream_generation: u64,
 		self_capture_filter_complete: bool,
 	) {
 		self.set_stream_filter_status(monitor_id, false);
 
 		match self.pending_stream_filter_complete_monitor.lock() {
 			Ok(mut guard) => {
-				*guard = self_capture_filter_complete.then_some(monitor_id);
+				*guard = self_capture_filter_complete
+					.then_some(StreamGenerationStatus { monitor_id, stream_generation });
 			},
 			Err(poisoned) => {
 				let mut guard = poisoned.into_inner();
 
-				*guard = self_capture_filter_complete.then_some(monitor_id);
+				*guard = self_capture_filter_complete
+					.then_some(StreamGenerationStatus { monitor_id, stream_generation });
 			},
 		}
 	}
 
-	fn complete_pending_stream_filter_status(&self, monitor_id: u32) {
+	fn complete_pending_stream_filter_status(&self, monitor_id: u32, stream_generation: u64) {
 		let should_mark_complete = match self.pending_stream_filter_complete_monitor.lock() {
 			Ok(mut guard) => {
-				if guard.is_some_and(|pending_monitor_id| pending_monitor_id == monitor_id) {
+				if guard.is_some_and(|pending| {
+					pending.monitor_id == monitor_id
+						&& pending.stream_generation == stream_generation
+				}) {
 					*guard = None;
 
 					true
@@ -1014,7 +1096,10 @@ impl SharedLatestFrame {
 			Err(poisoned) => {
 				let mut guard = poisoned.into_inner();
 
-				if guard.is_some_and(|pending_monitor_id| pending_monitor_id == monitor_id) {
+				if guard.is_some_and(|pending| {
+					pending.monitor_id == monitor_id
+						&& pending.stream_generation == stream_generation
+				}) {
 					*guard = None;
 
 					true
@@ -1043,6 +1128,12 @@ struct StreamFilterStatus {
 	self_capture_filter_complete: bool,
 }
 
+#[derive(Clone, Copy)]
+struct StreamGenerationStatus {
+	monitor_id: u32,
+	stream_generation: u64,
+}
+
 struct StoreFrameOutcome {
 	completed_ensure: bool,
 	completed_refresh: bool,
@@ -1050,6 +1141,7 @@ struct StoreFrameOutcome {
 
 struct StreamOutputIvars {
 	monitor_id: u32,
+	stream_generation: u64,
 	frames: Mutex<VecDeque<QueuedPixelBufferFrame>>,
 	frame_seq_counter: Arc<AtomicU64>,
 	frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
@@ -1058,12 +1150,14 @@ struct StreamOutputIvars {
 impl StreamOutputIvars {
 	fn new(
 		monitor_id: u32,
+		stream_generation: u64,
 		frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
 		frame_seq_counter: Arc<AtomicU64>,
 		shared_latest_frame: Arc<SharedLatestFrame>,
 	) -> Self {
 		Self {
 			monitor_id,
+			stream_generation,
 			frames: Mutex::new(VecDeque::with_capacity(STREAM_FRAME_QUEUE_CAPACITY)),
 			frame_seq_counter,
 			frame_waker,
@@ -1074,6 +1168,7 @@ impl StreamOutputIvars {
 
 struct StreamState {
 	monitor_id: u32,
+	stream_generation: u64,
 	self_capture_filter_complete: bool,
 	stream: Retained<SCStream>,
 	output: Retained<StreamOutput>,
@@ -1129,6 +1224,7 @@ struct PreparedStreamFilter {
 }
 
 struct StartedStreamArtifacts {
+	stream_generation: u64,
 	stream: Retained<SCStream>,
 	output: Retained<StreamOutput>,
 	sample_handler_queue: DispatchRetained<DispatchQueue>,
@@ -1191,12 +1287,14 @@ enum StreamReuseDecision {
 impl StreamOutput {
 	fn new(
 		monitor_id: u32,
+		stream_generation: u64,
 		frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
 		frame_seq_counter: Arc<AtomicU64>,
 		shared_latest_frame: Arc<SharedLatestFrame>,
 	) -> Retained<Self> {
 		let this = Self::alloc().set_ivars(StreamOutputIvars::new(
 			monitor_id,
+			stream_generation,
 			frame_waker,
 			frame_seq_counter,
 			shared_latest_frame,
@@ -1806,9 +1904,17 @@ fn ensure_stream(
 			return StreamRequestProgress::Settled;
 		}
 
+		let stream_generation = next_state.stream_generation;
+
+		shared_latest_frame.activate_stream_generation(monitor.id, stream_generation);
+
 		let mut previous_state = state.replace(next_state);
 
-		shared_latest_frame.defer_stream_filter_complete_until_next_frame(monitor.id, true);
+		shared_latest_frame.defer_stream_filter_complete_until_next_frame(
+			monitor.id,
+			stream_generation,
+			true,
+		);
 
 		teardown_stream(&mut previous_state);
 
@@ -1829,11 +1935,17 @@ fn ensure_stream(
 	teardown_stream(state);
 
 	let self_capture_filter_complete = next_state.self_capture_filter_complete;
+	let stream_generation = next_state.stream_generation;
+
+	shared_latest_frame.activate_stream_generation(monitor.id, stream_generation);
 
 	*state = Some(next_state);
 
-	shared_latest_frame
-		.defer_stream_filter_complete_until_next_frame(monitor.id, self_capture_filter_complete);
+	shared_latest_frame.defer_stream_filter_complete_until_next_frame(
+		monitor.id,
+		stream_generation,
+		self_capture_filter_complete,
+	);
 	shared_latest_frame.mark_waiting_for_frame(monitor.id);
 
 	tracing::debug!(
@@ -2048,11 +2160,18 @@ fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgress {
 		return StreamRequestProgress::Settled;
 	};
 	let self_capture_filter_complete = next_state.self_capture_filter_complete;
+	let stream_generation = next_state.stream_generation;
 	let replaced_existing_state = state.is_some();
+
+	shared_latest_frame.activate_stream_generation(monitor.id, stream_generation);
+
 	let mut previous_state = state.replace(next_state);
 
-	shared_latest_frame
-		.defer_stream_filter_complete_until_next_frame(monitor.id, self_capture_filter_complete);
+	shared_latest_frame.defer_stream_filter_complete_until_next_frame(
+		monitor.id,
+		stream_generation,
+		self_capture_filter_complete,
+	);
 
 	teardown_stream(&mut previous_state);
 
@@ -2133,6 +2252,7 @@ fn setup_stream_for_monitor(
 
 	Some(StreamState {
 		monitor_id: monitor.id,
+		stream_generation: started_stream.stream_generation,
 		self_capture_filter_complete: prepared_filter.self_capture_filter_complete,
 		stream: started_stream.stream,
 		output: started_stream.output,
@@ -2330,7 +2450,14 @@ fn build_and_start_stream_artifacts(
 	let sample_handler_queue = build_sample_handler_queue_for_monitor(monitor.id);
 	let queue_build_ms = queue_build_started_at.elapsed().as_millis();
 	let output_build_started_at = Instant::now();
-	let output = StreamOutput::new(monitor.id, frame_waker, frame_seq_counter, shared_latest_frame);
+	let stream_generation = frame_seq_counter.fetch_add(1, Ordering::AcqRel).wrapping_add(1);
+	let output = StreamOutput::new(
+		monitor.id,
+		stream_generation,
+		frame_waker,
+		frame_seq_counter,
+		shared_latest_frame,
+	);
 	let output_build_ms = output_build_started_at.elapsed().as_millis();
 	let stream_init_started_at = Instant::now();
 	let delegate_proto = ProtocolObject::from_ref(&*output);
@@ -2370,6 +2497,7 @@ fn build_and_start_stream_artifacts(
 	}
 
 	Some(StartedStreamArtifacts {
+		stream_generation,
 		stream,
 		output,
 		sample_handler_queue,
@@ -3087,16 +3215,19 @@ mod tests {
 		let pixel_buffer = test_pixel_buffer();
 		let other_monitor_frame = live_frame_stream_macos::QueuedPixelBufferFrame {
 			frame_seq: 1,
+			stream_generation: 1,
 			captured_at: std::time::Instant::now(),
 			pixel_buffer: pixel_buffer.clone(),
 		};
 		let matching_monitor_frame = live_frame_stream_macos::QueuedPixelBufferFrame {
 			frame_seq: 2,
+			stream_generation: 1,
 			captured_at: std::time::Instant::now(),
 			pixel_buffer,
 		};
 
-		shared.defer_stream_filter_complete_until_next_frame(7, true);
+		shared.activate_stream_generation(7, 1);
+		shared.defer_stream_filter_complete_until_next_frame(7, 1, true);
 
 		assert!(!shared.self_capture_filter_complete_for_monitor(7));
 
@@ -3110,15 +3241,51 @@ mod tests {
 	}
 
 	#[test]
+	fn deferred_filter_complete_ignores_stale_generation_frames() {
+		let shared = live_frame_stream_macos::SharedLatestFrame::default();
+		let pixel_buffer = test_pixel_buffer();
+		let stale_frame = live_frame_stream_macos::QueuedPixelBufferFrame {
+			frame_seq: 1,
+			stream_generation: 1,
+			captured_at: std::time::Instant::now(),
+			pixel_buffer: pixel_buffer.clone(),
+		};
+		let current_frame = live_frame_stream_macos::QueuedPixelBufferFrame {
+			frame_seq: 2,
+			stream_generation: 2,
+			captured_at: std::time::Instant::now(),
+			pixel_buffer,
+		};
+
+		shared.activate_stream_generation(7, 2);
+		shared.defer_stream_filter_complete_until_next_frame(7, 2, true);
+
+		let _ = shared.store(7, &stale_frame);
+
+		assert!(!shared.self_capture_filter_complete_for_monitor(7));
+		assert!(shared.latest_frame_for_monitor(7).is_none());
+
+		let _ = shared.store(7, &current_frame);
+
+		assert!(shared.self_capture_filter_complete_for_monitor(7));
+		assert_eq!(
+			shared.latest_frame_for_monitor(7).map(|frame| frame.stream_generation),
+			Some(2)
+		);
+	}
+
+	#[test]
 	fn incomplete_filter_never_flips_complete_after_first_frame() {
 		let shared = live_frame_stream_macos::SharedLatestFrame::default();
 		let frame = live_frame_stream_macos::QueuedPixelBufferFrame {
 			frame_seq: 1,
+			stream_generation: 1,
 			captured_at: std::time::Instant::now(),
 			pixel_buffer: test_pixel_buffer(),
 		};
 
-		shared.defer_stream_filter_complete_until_next_frame(7, false);
+		shared.activate_stream_generation(7, 1);
+		shared.defer_stream_filter_complete_until_next_frame(7, 1, false);
 
 		let _ = shared.store(7, &frame);
 
@@ -3152,7 +3319,7 @@ mod tests {
 
 		shared.mark_waiting_for_frame_until(7, now + Duration::from_secs(1));
 
-		let outcome = shared.complete_pending_requests_for_stored_frame(7);
+		let outcome = shared.complete_pending_requests_for_stored_frame(7, 1);
 
 		assert!(outcome.completed_ensure);
 		assert!(!outcome.completed_refresh);
@@ -3169,7 +3336,7 @@ mod tests {
 
 		shared.mark_waiting_for_frame_until(7, now + Duration::from_secs(1));
 
-		let outcome = shared.complete_pending_requests_for_stored_frame(9);
+		let outcome = shared.complete_pending_requests_for_stored_frame(9, 1);
 
 		assert!(!outcome.completed_ensure);
 		assert!(!outcome.completed_refresh);
@@ -3186,7 +3353,7 @@ mod tests {
 
 		shared.mark_waiting_for_frame_until(7, now + Duration::from_secs(1));
 
-		let outcome = shared.complete_pending_requests_for_stored_frame(7);
+		let outcome = shared.complete_pending_requests_for_stored_frame(7, 1);
 
 		assert!(!outcome.completed_ensure);
 		assert!(outcome.completed_refresh);
@@ -3275,6 +3442,7 @@ mod tests {
 		let pixel_buffer = test_pixel_buffer();
 		let make_frame = |frame_seq| live_frame_stream_macos::QueuedPixelBufferFrame {
 			frame_seq,
+			stream_generation: 1,
 			captured_at: std::time::Instant::now(),
 			pixel_buffer: pixel_buffer.clone(),
 		};
@@ -3303,6 +3471,7 @@ mod tests {
 		let rect = crate::state::RectPoints::new(0, 0, 1, 1);
 		let frame = live_frame_stream_macos::QueuedPixelBufferFrame {
 			frame_seq: 4,
+			stream_generation: 1,
 			captured_at: std::time::Instant::now(),
 			pixel_buffer: test_pixel_buffer(),
 		};

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -603,6 +603,7 @@ struct SharedLatestFrame {
 	pending_refresh_monitor: Mutex<Option<PendingMonitorRequest>>,
 	waiting_for_frame_until: Mutex<Option<(u32, Instant)>>,
 	stream_filter_status: Mutex<Option<StreamFilterStatus>>,
+	pending_stream_filter_complete_monitor: Mutex<Option<u32>>,
 }
 impl SharedLatestFrame {
 	fn store(&self, monitor_id: u32, frame: &QueuedPixelBufferFrame) -> StoreFrameOutcome {
@@ -648,6 +649,7 @@ impl SharedLatestFrame {
 	}
 
 	fn complete_pending_requests_for_stored_frame(&self, monitor_id: u32) -> StoreFrameOutcome {
+		self.complete_pending_stream_filter_status(monitor_id);
 		self.clear_waiting_for_frame(monitor_id);
 		StoreFrameOutcome {
 			completed_ensure: self.finish_ensure_monitor(monitor_id),
@@ -976,6 +978,54 @@ impl SharedLatestFrame {
 			Err(poisoned) => poisoned.into_inner().as_ref().is_some_and(|status| {
 				status.monitor_id == monitor_id && status.self_capture_filter_complete
 			}),
+		}
+	}
+
+	fn defer_stream_filter_complete_until_next_frame(
+		&self,
+		monitor_id: u32,
+		self_capture_filter_complete: bool,
+	) {
+		self.set_stream_filter_status(monitor_id, false);
+
+		match self.pending_stream_filter_complete_monitor.lock() {
+			Ok(mut guard) => {
+				*guard = self_capture_filter_complete.then_some(monitor_id);
+			},
+			Err(poisoned) => {
+				let mut guard = poisoned.into_inner();
+
+				*guard = self_capture_filter_complete.then_some(monitor_id);
+			},
+		}
+	}
+
+	fn complete_pending_stream_filter_status(&self, monitor_id: u32) {
+		let should_mark_complete = match self.pending_stream_filter_complete_monitor.lock() {
+			Ok(mut guard) => {
+				if guard.is_some_and(|pending_monitor_id| pending_monitor_id == monitor_id) {
+					*guard = None;
+
+					true
+				} else {
+					false
+				}
+			},
+			Err(poisoned) => {
+				let mut guard = poisoned.into_inner();
+
+				if guard.is_some_and(|pending_monitor_id| pending_monitor_id == monitor_id) {
+					*guard = None;
+
+					true
+				} else {
+					false
+				}
+			},
+		};
+
+		if should_mark_complete {
+			self.set_stream_filter_status(monitor_id, true);
 		}
 	}
 }
@@ -1758,7 +1808,7 @@ fn ensure_stream(
 
 		let mut previous_state = state.replace(next_state);
 
-		shared_latest_frame.set_stream_filter_status(monitor.id, true);
+		shared_latest_frame.defer_stream_filter_complete_until_next_frame(monitor.id, true);
 
 		teardown_stream(&mut previous_state);
 
@@ -1782,7 +1832,8 @@ fn ensure_stream(
 
 	*state = Some(next_state);
 
-	shared_latest_frame.set_stream_filter_status(monitor.id, self_capture_filter_complete);
+	shared_latest_frame
+		.defer_stream_filter_complete_until_next_frame(monitor.id, self_capture_filter_complete);
 	shared_latest_frame.mark_waiting_for_frame(monitor.id);
 
 	tracing::debug!(
@@ -2000,7 +2051,8 @@ fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgress {
 	let replaced_existing_state = state.is_some();
 	let mut previous_state = state.replace(next_state);
 
-	shared_latest_frame.set_stream_filter_status(monitor.id, self_capture_filter_complete);
+	shared_latest_frame
+		.defer_stream_filter_complete_until_next_frame(monitor.id, self_capture_filter_complete);
 
 	teardown_stream(&mut previous_state);
 
@@ -3027,6 +3079,50 @@ mod tests {
 
 		assert!(shared.self_capture_filter_complete_for_monitor(7));
 		assert!(!shared.self_capture_filter_complete_for_monitor(9));
+	}
+
+	#[test]
+	fn deferred_filter_complete_waits_for_matching_first_frame() {
+		let shared = live_frame_stream_macos::SharedLatestFrame::default();
+		let pixel_buffer = test_pixel_buffer();
+		let other_monitor_frame = live_frame_stream_macos::QueuedPixelBufferFrame {
+			frame_seq: 1,
+			captured_at: std::time::Instant::now(),
+			pixel_buffer: pixel_buffer.clone(),
+		};
+		let matching_monitor_frame = live_frame_stream_macos::QueuedPixelBufferFrame {
+			frame_seq: 2,
+			captured_at: std::time::Instant::now(),
+			pixel_buffer,
+		};
+
+		shared.defer_stream_filter_complete_until_next_frame(7, true);
+
+		assert!(!shared.self_capture_filter_complete_for_monitor(7));
+
+		let _ = shared.store(9, &other_monitor_frame);
+
+		assert!(!shared.self_capture_filter_complete_for_monitor(7));
+
+		let _ = shared.store(7, &matching_monitor_frame);
+
+		assert!(shared.self_capture_filter_complete_for_monitor(7));
+	}
+
+	#[test]
+	fn incomplete_filter_never_flips_complete_after_first_frame() {
+		let shared = live_frame_stream_macos::SharedLatestFrame::default();
+		let frame = live_frame_stream_macos::QueuedPixelBufferFrame {
+			frame_seq: 1,
+			captured_at: std::time::Instant::now(),
+			pixel_buffer: test_pixel_buffer(),
+		};
+
+		shared.defer_stream_filter_complete_until_next_frame(7, false);
+
+		let _ = shared.store(7, &frame);
+
+		assert!(!shared.self_capture_filter_complete_for_monitor(7));
 	}
 
 	#[test]

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -1756,6 +1756,7 @@ fn ensure_stream(
 		}
 
 		let mut previous_state = state.replace(next_state);
+
 		shared_latest_frame.set_stream_filter_status(monitor.id, true);
 
 		teardown_stream(&mut previous_state);
@@ -1779,8 +1780,8 @@ fn ensure_stream(
 	let self_capture_filter_complete = next_state.self_capture_filter_complete;
 
 	*state = Some(next_state);
-	shared_latest_frame.set_stream_filter_status(monitor.id, self_capture_filter_complete);
 
+	shared_latest_frame.set_stream_filter_status(monitor.id, self_capture_filter_complete);
 	shared_latest_frame.mark_waiting_for_frame(monitor.id);
 
 	tracing::debug!(
@@ -1997,6 +1998,7 @@ fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgress {
 	let self_capture_filter_complete = next_state.self_capture_filter_complete;
 	let replaced_existing_state = state.is_some();
 	let mut previous_state = state.replace(next_state);
+
 	shared_latest_frame.set_stream_filter_status(monitor.id, self_capture_filter_complete);
 
 	teardown_stream(&mut previous_state);
@@ -3017,9 +3019,11 @@ mod tests {
 		assert!(!shared.self_capture_filter_complete_for_monitor(7));
 
 		shared.set_stream_filter_status(7, false);
+
 		assert!(!shared.self_capture_filter_complete_for_monitor(7));
 
 		shared.set_stream_filter_status(7, true);
+
 		assert!(shared.self_capture_filter_complete_for_monitor(7));
 		assert!(!shared.self_capture_filter_complete_for_monitor(9));
 	}

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -182,7 +182,9 @@ use self::trace_recording::{
 #[cfg(target_os = "macos")]
 use crate::deferred_text_recognition::DeferredTextRecognitionRequest;
 #[cfg(target_os = "macos")]
-use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
+use crate::live_frame_stream_macos::{
+	CursorSampleRequest, MacLiveFrameStream, STREAM_REGION_FRAME_MAX_AGE,
+};
 use crate::scroll_capture::{self, ScrollDirection, ScrollObserveOutcome, ScrollSession};
 use crate::state::LiveCursorSample;
 #[cfg(target_os = "macos")]
@@ -1368,7 +1370,13 @@ impl OverlaySession {
 		let Some(snapshot) = snapshot.filter(|snapshot| snapshot.monitor == monitor) else {
 			return false;
 		};
-		let snapshot_age_ms = snapshot.captured_at.elapsed().as_millis();
+		let snapshot_age = snapshot.captured_at.elapsed();
+
+		if snapshot_age > STREAM_REGION_FRAME_MAX_AGE {
+			return false;
+		}
+
+		let snapshot_age_ms = snapshot_age.as_millis();
 		let snapshot_image = snapshot.image.as_ref().clone();
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1355,6 +1355,22 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn usable_frozen_capture_snapshot(
+		&self,
+		monitor: MonitorRect,
+		snapshot: Option<Arc<MonitorImageSnapshot>>,
+	) -> Option<(Arc<MonitorImageSnapshot>, u128)> {
+		let snapshot = snapshot.filter(|snapshot| snapshot.monitor == monitor)?;
+		let snapshot_age = snapshot.captured_at.elapsed();
+
+		if snapshot_age > STREAM_REGION_FRAME_MAX_AGE {
+			return None;
+		}
+
+		Some((snapshot, snapshot_age.as_millis()))
+	}
+
+	#[cfg(target_os = "macos")]
 	fn maybe_finish_frozen_capture_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1367,16 +1383,11 @@ impl OverlaySession {
 			return false;
 		}
 
-		let Some(snapshot) = snapshot.filter(|snapshot| snapshot.monitor == monitor) else {
+		let Some((snapshot, snapshot_age_ms)) =
+			self.usable_frozen_capture_snapshot(monitor, snapshot)
+		else {
 			return false;
 		};
-		let snapshot_age = snapshot.captured_at.elapsed();
-
-		if snapshot_age > STREAM_REGION_FRAME_MAX_AGE {
-			return false;
-		}
-
-		let snapshot_age_ms = snapshot_age.as_millis();
 		let snapshot_image = snapshot.image.as_ref().clone();
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);
@@ -1428,10 +1439,11 @@ impl OverlaySession {
 		snapshot: Option<Arc<MonitorImageSnapshot>>,
 		source: &'static str,
 	) -> bool {
-		let Some(snapshot) = snapshot.filter(|snapshot| snapshot.monitor == monitor) else {
+		let Some((snapshot, snapshot_age_ms)) =
+			self.usable_frozen_capture_snapshot(monitor, snapshot)
+		else {
 			return false;
 		};
-		let snapshot_age_ms = snapshot.captured_at.elapsed().as_millis();
 		let snapshot_image = snapshot.image.as_ref().clone();
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -185,7 +185,7 @@ use crate::deferred_text_recognition::DeferredTextRecognitionRequest;
 use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
 use crate::scroll_capture::{self, ScrollDirection, ScrollObserveOutcome, ScrollSession};
 use crate::state::LiveCursorSample;
-#[cfg(any(target_os = "macos", test))]
+#[cfg(target_os = "macos")]
 use crate::state::MonitorImageSnapshot;
 use crate::worker::CapturedMonitorRegionResult;
 use crate::{
@@ -1177,7 +1177,7 @@ impl OverlaySession {
 		);
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(target_os = "macos")]
 	fn note_frozen_transition_preview_deferred(
 		&self,
 		monitor: MonitorRect,
@@ -1287,7 +1287,7 @@ impl OverlaySession {
 		);
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(target_os = "macos")]
 	fn note_frozen_transition_toolbar_visible(&mut self, monitor: MonitorRect) {
 		if self.frozen_transition_toolbar_visible_at.is_some() {
 			return;
@@ -1332,7 +1332,7 @@ impl OverlaySession {
 		);
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(target_os = "macos")]
 	fn commit_frozen_preview(
 		&mut self,
 		monitor: MonitorRect,
@@ -1346,7 +1346,7 @@ impl OverlaySession {
 		}
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(target_os = "macos")]
 	fn snapshot_can_finish_frozen_capture(
 		&self,
 		window_target: Option<WindowFreezeCaptureTarget>,
@@ -1355,7 +1355,7 @@ impl OverlaySession {
 			|| self.config.window_capture_alpha_mode == WindowCaptureAlphaMode::Background
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(target_os = "macos")]
 	fn maybe_finish_frozen_capture_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1403,7 +1403,7 @@ impl OverlaySession {
 		true
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(target_os = "macos")]
 	fn can_finish_frozen_capture_from_unverified_snapshot(
 		&self,
 		window_target: Option<WindowFreezeCaptureTarget>,
@@ -1412,7 +1412,7 @@ impl OverlaySession {
 			&& self.config.self_capture_exception_window_ids.is_empty()
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(target_os = "macos")]
 	fn maybe_seed_frozen_capture_preview_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -773,8 +773,7 @@ impl OverlaySession {
 			macos_hud_window_config_cache: HashMap::new(),
 			hud_outer_pos: None, pending_hud_outer_pos: None, hud_inner_size_points: None,
 			loupe_outer_pos: None, pending_loupe_outer_pos: None, loupe_inner_size_points: None,
-			toolbar_outer_pos: None, pending_toolbar_outer_pos: None,
-			toolbar_inner_size_points: None,
+			toolbar_outer_pos: None, pending_toolbar_outer_pos: None, toolbar_inner_size_points: None,
 			gpu: None,
 			last_hud_window_move_at: Instant::now(),
 			last_loupe_window_move_at: Instant::now(),
@@ -832,11 +831,8 @@ impl OverlaySession {
 			png_encode_inflight: false,
 			#[cfg(target_os = "macos")]
 			pending_self_capture_exception_window_ids_worker_refresh: false,
-			frozen_text_annotations: Vec::new(),
-			frozen_text_redo_annotations: Vec::new(),
-			frozen_text_edit: None,
-			frozen_text_input_generation: 0,
-			frozen_text_recent_input: None,
+			frozen_text_annotations: Vec::new(), frozen_text_redo_annotations: Vec::new(),
+			frozen_text_edit: None, frozen_text_input_generation: 0, frozen_text_recent_input: None,
 			toolbar_state: FrozenToolbarState::default(),
 			toolbar_left_button_down: false, toolbar_left_button_went_down: false, toolbar_left_button_went_up: false,
 			toolbar_pointer_local: None,
@@ -1163,6 +1159,7 @@ impl OverlaySession {
 		let now = Instant::now();
 
 		self.reset_frozen_transition_timing();
+
 		self.frozen_transition_started_at = Some(now);
 		self.frozen_transition_target_window_id = window_target.map(|target| target.window_id);
 
@@ -1371,27 +1368,30 @@ impl OverlaySession {
 		let Some(snapshot) = snapshot.filter(|snapshot| snapshot.monitor == monitor) else {
 			return false;
 		};
-
 		let snapshot_age_ms = snapshot.captured_at.elapsed().as_millis();
 		let snapshot_image = snapshot.image.as_ref().clone();
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);
 		self.note_frozen_transition_preview_committed(monitor, source, Some(snapshot_age_ms));
+
 		self.pending_freeze_capture = None;
 		self.inflight_freeze_capture = None;
 		self.pending_freeze_capture_armed = false;
 		self.pending_window_freeze_capture = None;
 		self.inflight_window_freeze_capture = None;
 		self.authoritative_frozen_capture_ready = true;
+
 		self.note_frozen_transition_final_ready(
 			monitor,
 			source,
 			window_target.map(|target| target.window_id),
 		);
+
 		self.freeze_capture_send_full_count = 0;
 		self.frozen_window_image = None;
 		self.capture_windows_hidden = false;
 		self.toolbar_state.needs_redraw = true;
+
 		self.sync_frozen_toolbar_state();
 		self.request_redraw_for_monitor(monitor);
 		#[cfg(target_os = "macos")]
@@ -1423,13 +1423,14 @@ impl OverlaySession {
 		let Some(snapshot) = snapshot.filter(|snapshot| snapshot.monitor == monitor) else {
 			return false;
 		};
-
 		let snapshot_age_ms = snapshot.captured_at.elapsed().as_millis();
 		let snapshot_image = snapshot.image.as_ref().clone();
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);
 		self.note_frozen_transition_preview_committed(monitor, source, Some(snapshot_age_ms));
+
 		self.toolbar_state.needs_redraw = true;
+
 		self.sync_frozen_toolbar_state();
 		self.request_redraw_for_monitor(monitor);
 
@@ -1470,7 +1471,6 @@ impl OverlaySession {
 			) {
 			return true;
 		}
-
 		if !self_capture_filter_complete
 			&& self.can_finish_frozen_capture_from_unverified_snapshot(window_target)
 			&& self.maybe_finish_frozen_capture_from_snapshot(
@@ -1579,6 +1579,28 @@ impl OverlaySession {
 		self.request_redraw_toolbar_window();
 	}
 
+	fn prepare_toolbar_for_frozen_capture_transition(
+		&mut self,
+		monitor: MonitorRect,
+		capture_rect: RectPoints,
+	) {
+		self.toolbar_state.floating_position = None;
+		self.toolbar_state.default_slot_position = None;
+		self.toolbar_state.dragging = false;
+		self.toolbar_state.needs_redraw = true;
+		self.toolbar_state.pill_height_points = None;
+		self.toolbar_state.layout_last_screen_size_points = None;
+		self.toolbar_state.layout_stable_frames = 0;
+
+		self.reset_frozen_text_state();
+		self.sync_frozen_toolbar_state();
+		// Spawn the toolbar immediately at the default position (capture aware). This avoids any
+		// dependency on egui viewport stabilization or additional input events (mouse move) to
+		// finish the initial layout.
+		self.seed_frozen_toolbar_default_position(monitor, capture_rect);
+		self.request_redraw_toolbar_window();
+	}
+
 	fn reset_frozen_annotation_state(&mut self) {
 		self.frozen_brush = FrozenBrushState::default();
 		self.frozen_selection_drag = FrozenSelectionDragState::default();
@@ -1635,21 +1657,7 @@ impl OverlaySession {
 			"Freeze begin."
 		);
 
-		self.toolbar_state.floating_position = None;
-		self.toolbar_state.default_slot_position = None;
-		self.toolbar_state.dragging = false;
-		self.toolbar_state.needs_redraw = true;
-		self.toolbar_state.pill_height_points = None;
-		self.toolbar_state.layout_last_screen_size_points = None;
-		self.toolbar_state.layout_stable_frames = 0;
-
-		self.reset_frozen_text_state();
-		self.sync_frozen_toolbar_state();
-		// Spawn the toolbar immediately at the default position (capture aware). This avoids any
-		// dependency on egui viewport stabilization or additional input events (mouse move) to
-		// finish the initial layout.
-		self.seed_frozen_toolbar_default_position(monitor, capture_rect);
-		self.request_redraw_toolbar_window();
+		self.prepare_toolbar_for_frozen_capture_transition(monitor, capture_rect);
 
 		self.pending_freeze_capture = Some(monitor);
 		self.pending_freeze_capture_armed = false;
@@ -1703,6 +1711,7 @@ impl OverlaySession {
 				self.pending_freeze_capture = None;
 				self.pending_freeze_capture_armed = false;
 				self.authoritative_frozen_capture_ready = true;
+
 				self.note_frozen_transition_final_ready(monitor, "cached_live_background", None);
 
 				if let Some(cursor) = cursor {
@@ -2974,8 +2983,8 @@ impl OverlaySession {
 
 		self.frozen_text_edit = None;
 		self.frozen_text_recent_input = None;
-		self.reset_frozen_transition_timing();
 
+		self.reset_frozen_transition_timing();
 		self.sync_text_input_ime_state();
 		self.stop_frozen_selection_drag();
 		self.stop_frozen_mosaic_drag();

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -185,6 +185,8 @@ use crate::deferred_text_recognition::DeferredTextRecognitionRequest;
 use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
 use crate::scroll_capture::{self, ScrollDirection, ScrollObserveOutcome, ScrollSession};
 use crate::state::LiveCursorSample;
+#[cfg(any(target_os = "macos", test))]
+use crate::state::MonitorImageSnapshot;
 use crate::worker::CapturedMonitorRegionResult;
 use crate::{
 	state::{
@@ -588,6 +590,12 @@ pub struct OverlaySession {
 	inflight_freeze_capture: Option<MonitorRect>,
 	pending_freeze_capture_armed: bool,
 	authoritative_frozen_capture_ready: bool,
+	frozen_transition_started_at: Option<Instant>,
+	frozen_transition_preview_committed_at: Option<Instant>,
+	frozen_transition_preview_source: Option<&'static str>,
+	frozen_transition_final_ready_at: Option<Instant>,
+	frozen_transition_toolbar_visible_at: Option<Instant>,
+	frozen_transition_target_window_id: Option<u32>,
 	pending_window_freeze_capture: Option<WindowFreezeCaptureTarget>,
 	inflight_window_freeze_capture: Option<WindowFreezeCaptureTarget>,
 	frozen_window_image: Option<RgbaImage>,
@@ -810,6 +818,9 @@ impl OverlaySession {
 			egui_repaint_deadline: Arc::new(Mutex::new(None)),
 			pending_freeze_capture: None, inflight_freeze_capture: None, pending_freeze_capture_armed: false,
 			authoritative_frozen_capture_ready: false,
+			frozen_transition_started_at: None, frozen_transition_preview_committed_at: None,
+			frozen_transition_preview_source: None, frozen_transition_final_ready_at: None,
+			frozen_transition_toolbar_visible_at: None, frozen_transition_target_window_id: None,
 			pending_window_freeze_capture: None, inflight_window_freeze_capture: None, frozen_window_image: None,
 			frozen_capture_source: FrozenCaptureSource::None,
 			capture_windows_hidden: false,
@@ -1124,6 +1135,201 @@ impl OverlaySession {
 			&& self.inflight_freeze_capture.is_none()
 	}
 
+	fn frozen_transition_elapsed_ms_since(
+		&self,
+		started_at: Option<Instant>,
+		now: Instant,
+	) -> Option<u128> {
+		started_at
+			.and_then(|started_at| now.checked_duration_since(started_at))
+			.map(|elapsed| elapsed.as_millis())
+	}
+
+	fn reset_frozen_transition_timing(&mut self) {
+		self.frozen_transition_started_at = None;
+		self.frozen_transition_preview_committed_at = None;
+		self.frozen_transition_preview_source = None;
+		self.frozen_transition_final_ready_at = None;
+		self.frozen_transition_toolbar_visible_at = None;
+		self.frozen_transition_target_window_id = None;
+	}
+
+	fn begin_frozen_transition_timing(
+		&mut self,
+		monitor: MonitorRect,
+		capture_rect: RectPoints,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	) {
+		let now = Instant::now();
+
+		self.reset_frozen_transition_timing();
+		self.frozen_transition_started_at = Some(now);
+		self.frozen_transition_target_window_id = window_target.map(|target| target.window_id);
+
+		tracing::info!(
+			op = "overlay.freeze_transition_begin",
+			monitor_id = monitor.id,
+			frozen_capture_source = ?self.frozen_capture_source,
+			alpha_mode = ?self.config.window_capture_alpha_mode,
+			capture_rect = ?capture_rect,
+			target_window_id = self.frozen_transition_target_window_id,
+			"Frozen transition started."
+		);
+	}
+
+	fn note_frozen_transition_preview_deferred(
+		&self,
+		monitor: MonitorRect,
+		reason: &'static str,
+		snapshot_age_ms: Option<u128>,
+	) {
+		let now = Instant::now();
+
+		tracing::info!(
+			op = "overlay.freeze_transition_preview_deferred",
+			monitor_id = monitor.id,
+			frozen_capture_source = ?self.frozen_capture_source,
+			alpha_mode = ?self.config.window_capture_alpha_mode,
+			target_window_id = self.frozen_transition_target_window_id,
+			reason,
+			snapshot_age_ms,
+			since_begin_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now),
+			"Frozen transition preview will wait for authoritative capture."
+		);
+	}
+
+	fn note_frozen_transition_preview_committed(
+		&mut self,
+		monitor: MonitorRect,
+		source: &'static str,
+		snapshot_age_ms: Option<u128>,
+	) {
+		if self.frozen_transition_preview_committed_at.is_some() {
+			return;
+		}
+
+		let now = Instant::now();
+
+		self.frozen_transition_preview_committed_at = Some(now);
+		self.frozen_transition_preview_source = Some(source);
+
+		tracing::info!(
+			op = "overlay.freeze_transition_preview_committed",
+			monitor_id = monitor.id,
+			frozen_capture_source = ?self.frozen_capture_source,
+			alpha_mode = ?self.config.window_capture_alpha_mode,
+			target_window_id = self.frozen_transition_target_window_id,
+			source,
+			snapshot_age_ms,
+			since_begin_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now),
+			"Frozen transition preview became visible."
+		);
+	}
+
+	fn note_frozen_transition_worker_requested(
+		&mut self,
+		monitor: MonitorRect,
+		pending_window_target: Option<WindowFreezeCaptureTarget>,
+	) {
+		let now = Instant::now();
+
+		if self.frozen_transition_target_window_id.is_none() {
+			self.frozen_transition_target_window_id =
+				pending_window_target.map(|target| target.window_id);
+		}
+
+		tracing::info!(
+			op = "overlay.freeze_transition_worker_requested",
+			monitor_id = monitor.id,
+			frozen_capture_source = ?self.frozen_capture_source,
+			alpha_mode = ?self.config.window_capture_alpha_mode,
+			target_window_id = self.frozen_transition_target_window_id,
+			capture_windows_hidden = self.capture_windows_hidden,
+			since_begin_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now),
+			since_preview_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_preview_committed_at, now),
+			"Authoritative frozen capture was requested from the worker."
+		);
+	}
+
+	fn note_frozen_transition_final_ready(
+		&mut self,
+		monitor: MonitorRect,
+		source: &'static str,
+		captured_window_id: Option<u32>,
+	) {
+		if self.frozen_transition_final_ready_at.is_some() {
+			return;
+		}
+
+		let now = Instant::now();
+
+		self.frozen_transition_final_ready_at = Some(now);
+
+		tracing::info!(
+			op = "overlay.freeze_transition_final_ready",
+			monitor_id = monitor.id,
+			frozen_capture_source = ?self.frozen_capture_source,
+			alpha_mode = ?self.config.window_capture_alpha_mode,
+			target_window_id = self.frozen_transition_target_window_id,
+			captured_window_id,
+			source,
+			preview_source = self.frozen_transition_preview_source,
+			since_begin_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now),
+			since_preview_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_preview_committed_at, now),
+			"Frozen transition final capture is ready."
+		);
+	}
+
+	fn note_frozen_transition_toolbar_visible(&mut self, monitor: MonitorRect) {
+		if self.frozen_transition_toolbar_visible_at.is_some() {
+			return;
+		}
+
+		let now = Instant::now();
+
+		self.frozen_transition_toolbar_visible_at = Some(now);
+
+		tracing::info!(
+			op = "overlay.freeze_transition_toolbar_visible",
+			monitor_id = monitor.id,
+			frozen_capture_source = ?self.frozen_capture_source,
+			alpha_mode = ?self.config.window_capture_alpha_mode,
+			target_window_id = self.frozen_transition_target_window_id,
+			preview_source = self.frozen_transition_preview_source,
+			since_begin_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now),
+			since_preview_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_preview_committed_at, now),
+			since_final_ready_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_final_ready_at, now),
+			"Frozen transition toolbar became visible."
+		);
+	}
+
+	fn note_frozen_transition_aborted(&self, message: &str) {
+		let now = Instant::now();
+
+		tracing::info!(
+			op = "overlay.freeze_transition_aborted",
+			frozen_capture_source = ?self.frozen_capture_source,
+			alpha_mode = ?self.config.window_capture_alpha_mode,
+			target_window_id = self.frozen_transition_target_window_id,
+			preview_source = self.frozen_transition_preview_source,
+			message,
+			since_begin_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now),
+			since_preview_ms =
+				self.frozen_transition_elapsed_ms_since(self.frozen_transition_preview_committed_at, now),
+			"Frozen transition was aborted before completion."
+		);
+	}
+
 	#[cfg(target_os = "macos")]
 	#[allow(dead_code)]
 	fn commit_frozen_preview(
@@ -1137,6 +1343,170 @@ impl OverlaySession {
 		if let Some(cursor) = cursor {
 			self.update_cursor_state(monitor, cursor);
 		}
+	}
+
+	#[cfg(any(target_os = "macos", test))]
+	fn snapshot_can_finish_frozen_capture(
+		&self,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	) -> bool {
+		window_target.is_none()
+			|| self.config.window_capture_alpha_mode == WindowCaptureAlphaMode::Background
+	}
+
+	#[cfg(any(target_os = "macos", test))]
+	fn maybe_finish_frozen_capture_from_snapshot(
+		&mut self,
+		monitor: MonitorRect,
+		window_target: Option<WindowFreezeCaptureTarget>,
+		cursor: Option<GlobalPoint>,
+		snapshot: Option<Arc<MonitorImageSnapshot>>,
+	) -> bool {
+		if !self.snapshot_can_finish_frozen_capture(window_target) {
+			return false;
+		}
+
+		let Some(snapshot) = snapshot.filter(|snapshot| snapshot.monitor == monitor) else {
+			return false;
+		};
+
+		let snapshot_age_ms = snapshot.captured_at.elapsed().as_millis();
+		let snapshot_image = snapshot.image.as_ref().clone();
+
+		self.commit_frozen_preview(monitor, snapshot_image, cursor);
+		self.note_frozen_transition_preview_committed(
+			monitor,
+			"live_stream_snapshot",
+			Some(snapshot_age_ms),
+		);
+		self.pending_freeze_capture = None;
+		self.inflight_freeze_capture = None;
+		self.pending_freeze_capture_armed = false;
+		self.pending_window_freeze_capture = None;
+		self.inflight_window_freeze_capture = None;
+		self.authoritative_frozen_capture_ready = true;
+		self.note_frozen_transition_final_ready(
+			monitor,
+			"live_stream_snapshot",
+			window_target.map(|target| target.window_id),
+		);
+		self.freeze_capture_send_full_count = 0;
+		self.frozen_window_image = None;
+		self.capture_windows_hidden = false;
+		self.toolbar_state.needs_redraw = true;
+		self.sync_frozen_toolbar_state();
+		self.request_redraw_for_monitor(monitor);
+		#[cfg(target_os = "macos")]
+		{
+			self.request_aux_window_creation_if_needed();
+			self.request_redraw_toolbar_window();
+		}
+
+		tracing::debug!(
+			monitor_id = monitor.id,
+			window_target = window_target.map(|target| target.window_id),
+			snapshot_age_ms,
+			"Frozen capture finished immediately from the latest live-stream snapshot."
+		);
+
+		true
+	}
+
+	#[cfg(any(target_os = "macos", test))]
+	fn maybe_seed_frozen_capture_preview_from_snapshot(
+		&mut self,
+		monitor: MonitorRect,
+		cursor: Option<GlobalPoint>,
+		snapshot: Option<Arc<MonitorImageSnapshot>>,
+		source: &'static str,
+	) -> bool {
+		let Some(snapshot) = snapshot.filter(|snapshot| snapshot.monitor == monitor) else {
+			return false;
+		};
+
+		let snapshot_age_ms = snapshot.captured_at.elapsed().as_millis();
+		let snapshot_image = snapshot.image.as_ref().clone();
+
+		self.commit_frozen_preview(monitor, snapshot_image, cursor);
+		self.note_frozen_transition_preview_committed(monitor, source, Some(snapshot_age_ms));
+		self.toolbar_state.needs_redraw = true;
+		self.sync_frozen_toolbar_state();
+		self.request_redraw_for_monitor(monitor);
+
+		tracing::debug!(
+			monitor_id = monitor.id,
+			snapshot_age_ms,
+			source,
+			"Frozen capture preview was seeded from the latest live-stream snapshot while authoritative capture remains pending."
+		);
+
+		true
+	}
+
+	#[cfg(target_os = "macos")]
+	fn maybe_finish_frozen_capture_from_live_stream_snapshot(
+		&mut self,
+		monitor: MonitorRect,
+		window_target: Option<WindowFreezeCaptureTarget>,
+		cursor: Option<GlobalPoint>,
+	) -> bool {
+		let Some(stream) = self.live_sample_stream.as_ref() else {
+			self.note_frozen_transition_preview_deferred(
+				monitor,
+				"live_stream_snapshot_unavailable",
+				None,
+			);
+
+			return false;
+		};
+		let snapshot = stream.peek_latest_rgba_snapshot(monitor);
+		let self_capture_filter_complete = stream.self_capture_filter_complete_for_monitor(monitor);
+		let can_finish_from_snapshot = self.snapshot_can_finish_frozen_capture(window_target);
+		let snapshot_age_ms =
+			snapshot.as_ref().map(|snapshot| snapshot.captured_at.elapsed().as_millis());
+		let snapshot_monitor = snapshot.as_ref().map(|snapshot| snapshot.monitor);
+
+		if self_capture_filter_complete
+			&& can_finish_from_snapshot
+			&& self.maybe_finish_frozen_capture_from_snapshot(
+				monitor,
+				window_target,
+				cursor,
+				snapshot.clone(),
+			) {
+			return true;
+		}
+
+		let seeded_preview = self.maybe_seed_frozen_capture_preview_from_snapshot(
+			monitor,
+			cursor,
+			snapshot.clone(),
+			if self_capture_filter_complete {
+				"live_stream_snapshot_seeded"
+			} else {
+				"live_stream_snapshot_seeded_unverified"
+			},
+		);
+
+		if seeded_preview {
+			return false;
+		}
+
+		let reason = if !can_finish_from_snapshot {
+			"matte_window_capture_requires_authoritative_composite"
+		} else if snapshot_monitor.is_none() {
+			"live_stream_snapshot_unavailable"
+		} else if !self_capture_filter_complete {
+			"live_stream_self_capture_filter_incomplete"
+		} else if snapshot_monitor != Some(monitor) {
+			"live_stream_snapshot_monitor_mismatch"
+		} else {
+			"live_stream_snapshot_not_usable"
+		};
+
+		self.note_frozen_transition_preview_deferred(monitor, reason, snapshot_age_ms);
+
+		false
 	}
 
 	fn seed_frozen_toolbar_default_position(
@@ -1239,6 +1609,7 @@ impl OverlaySession {
 		self.set_alt_loupe_window_visible(None, false);
 		self.state.clear_error();
 		self.state.begin_freeze(monitor);
+		self.begin_frozen_transition_timing(monitor, capture_rect, window_target);
 
 		self.state.frozen_capture_rect = Some(capture_rect);
 		self.state.frozen_mosaic_preview_rect = None;
@@ -1292,7 +1663,13 @@ impl OverlaySession {
 
 		#[cfg(target_os = "macos")]
 		{
-			let _ = cursor;
+			if self.maybe_finish_frozen_capture_from_live_stream_snapshot(
+				monitor,
+				window_target,
+				cursor,
+			) {
+				return;
+			}
 
 			self.state.live_bg_monitor = None;
 			self.state.live_bg_image = None;
@@ -1311,10 +1688,16 @@ impl OverlaySession {
 				self.state.live_bg_monitor = None;
 
 				self.state.finish_freeze(monitor, image);
+				self.note_frozen_transition_preview_committed(
+					monitor,
+					"cached_live_background",
+					None,
+				);
 
 				self.pending_freeze_capture = None;
 				self.pending_freeze_capture_armed = false;
 				self.authoritative_frozen_capture_ready = true;
+				self.note_frozen_transition_final_ready(monitor, "cached_live_background", None);
 
 				if let Some(cursor) = cursor {
 					self.update_cursor_state(monitor, cursor);
@@ -1499,6 +1882,12 @@ impl OverlaySession {
 			}
 
 			self.state.finish_freeze(monitor, frozen_preview_image);
+			self.note_frozen_transition_preview_committed(monitor, "authoritative_capture", None);
+			self.note_frozen_transition_final_ready(
+				monitor,
+				"authoritative_capture",
+				captured_window_id,
+			);
 			#[cfg(target_os = "macos")]
 			self.destroy_live_only_aux_windows();
 			self.restore_capture_windows_visibility();
@@ -2579,6 +2968,7 @@ impl OverlaySession {
 
 		self.frozen_text_edit = None;
 		self.frozen_text_recent_input = None;
+		self.reset_frozen_transition_timing();
 
 		self.sync_text_input_ime_state();
 		self.stop_frozen_selection_drag();

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1166,7 +1166,7 @@ impl OverlaySession {
 		self.frozen_transition_started_at = Some(now);
 		self.frozen_transition_target_window_id = window_target.map(|target| target.window_id);
 
-		tracing::info!(
+		tracing::debug!(
 			op = "overlay.freeze_transition_begin",
 			monitor_id = monitor.id,
 			frozen_capture_source = ?self.frozen_capture_source,
@@ -1185,7 +1185,7 @@ impl OverlaySession {
 	) {
 		let now = Instant::now();
 
-		tracing::info!(
+		tracing::debug!(
 			op = "overlay.freeze_transition_preview_deferred",
 			monitor_id = monitor.id,
 			frozen_capture_source = ?self.frozen_capture_source,
@@ -1214,7 +1214,7 @@ impl OverlaySession {
 		self.frozen_transition_preview_committed_at = Some(now);
 		self.frozen_transition_preview_source = Some(source);
 
-		tracing::info!(
+		tracing::debug!(
 			op = "overlay.freeze_transition_preview_committed",
 			monitor_id = monitor.id,
 			frozen_capture_source = ?self.frozen_capture_source,
@@ -1240,7 +1240,7 @@ impl OverlaySession {
 				pending_window_target.map(|target| target.window_id);
 		}
 
-		tracing::info!(
+		tracing::debug!(
 			op = "overlay.freeze_transition_worker_requested",
 			monitor_id = monitor.id,
 			frozen_capture_source = ?self.frozen_capture_source,
@@ -1269,7 +1269,7 @@ impl OverlaySession {
 
 		self.frozen_transition_final_ready_at = Some(now);
 
-		tracing::info!(
+		tracing::debug!(
 			op = "overlay.freeze_transition_final_ready",
 			monitor_id = monitor.id,
 			frozen_capture_source = ?self.frozen_capture_source,
@@ -1295,7 +1295,7 @@ impl OverlaySession {
 
 		self.frozen_transition_toolbar_visible_at = Some(now);
 
-		tracing::info!(
+		tracing::debug!(
 			op = "overlay.freeze_transition_toolbar_visible",
 			monitor_id = monitor.id,
 			frozen_capture_source = ?self.frozen_capture_source,
@@ -1315,7 +1315,7 @@ impl OverlaySession {
 	fn note_frozen_transition_aborted(&self, message: &str) {
 		let now = Instant::now();
 
-		tracing::info!(
+		tracing::debug!(
 			op = "overlay.freeze_transition_aborted",
 			frozen_capture_source = ?self.frozen_capture_source,
 			alpha_mode = ?self.config.window_capture_alpha_mode,
@@ -1361,6 +1361,7 @@ impl OverlaySession {
 		window_target: Option<WindowFreezeCaptureTarget>,
 		cursor: Option<GlobalPoint>,
 		snapshot: Option<Arc<MonitorImageSnapshot>>,
+		source: &'static str,
 	) -> bool {
 		if !self.snapshot_can_finish_frozen_capture(window_target) {
 			return false;
@@ -1374,11 +1375,7 @@ impl OverlaySession {
 		let snapshot_image = snapshot.image.as_ref().clone();
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);
-		self.note_frozen_transition_preview_committed(
-			monitor,
-			"live_stream_snapshot",
-			Some(snapshot_age_ms),
-		);
+		self.note_frozen_transition_preview_committed(monitor, source, Some(snapshot_age_ms));
 		self.pending_freeze_capture = None;
 		self.inflight_freeze_capture = None;
 		self.pending_freeze_capture_armed = false;
@@ -1387,7 +1384,7 @@ impl OverlaySession {
 		self.authoritative_frozen_capture_ready = true;
 		self.note_frozen_transition_final_ready(
 			monitor,
-			"live_stream_snapshot",
+			source,
 			window_target.map(|target| target.window_id),
 		);
 		self.freeze_capture_send_full_count = 0;
@@ -1402,14 +1399,16 @@ impl OverlaySession {
 			self.request_redraw_toolbar_window();
 		}
 
-		tracing::debug!(
-			monitor_id = monitor.id,
-			window_target = window_target.map(|target| target.window_id),
-			snapshot_age_ms,
-			"Frozen capture finished immediately from the latest live-stream snapshot."
-		);
-
 		true
+	}
+
+	#[cfg(any(target_os = "macos", test))]
+	fn can_finish_frozen_capture_from_unverified_snapshot(
+		&self,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	) -> bool {
+		self.snapshot_can_finish_frozen_capture(window_target)
+			&& self.config.self_capture_exception_window_ids.is_empty()
 	}
 
 	#[cfg(any(target_os = "macos", test))]
@@ -1432,13 +1431,6 @@ impl OverlaySession {
 		self.toolbar_state.needs_redraw = true;
 		self.sync_frozen_toolbar_state();
 		self.request_redraw_for_monitor(monitor);
-
-		tracing::debug!(
-			monitor_id = monitor.id,
-			snapshot_age_ms,
-			source,
-			"Frozen capture preview was seeded from the latest live-stream snapshot while authoritative capture remains pending."
-		);
 
 		true
 	}
@@ -1473,6 +1465,19 @@ impl OverlaySession {
 				window_target,
 				cursor,
 				snapshot.clone(),
+				"live_stream_snapshot",
+			) {
+			return true;
+		}
+
+		if !self_capture_filter_complete
+			&& self.can_finish_frozen_capture_from_unverified_snapshot(window_target)
+			&& self.maybe_finish_frozen_capture_from_snapshot(
+				monitor,
+				window_target,
+				cursor,
+				snapshot.clone(),
+				"live_stream_snapshot_unverified_final",
 			) {
 			return true;
 		}

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1423,15 +1423,6 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
-	fn can_finish_frozen_capture_from_unverified_snapshot(
-		&self,
-		window_target: Option<WindowFreezeCaptureTarget>,
-	) -> bool {
-		self.snapshot_can_finish_frozen_capture(window_target)
-			&& self.config.self_capture_exception_window_ids.is_empty()
-	}
-
-	#[cfg(target_os = "macos")]
 	fn maybe_seed_frozen_capture_preview_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1488,17 +1479,6 @@ impl OverlaySession {
 				cursor,
 				snapshot.clone(),
 				"live_stream_snapshot",
-			) {
-			return true;
-		}
-		if !self_capture_filter_complete
-			&& self.can_finish_frozen_capture_from_unverified_snapshot(window_target)
-			&& self.maybe_finish_frozen_capture_from_snapshot(
-				monitor,
-				window_target,
-				cursor,
-				snapshot.clone(),
-				"live_stream_snapshot_unverified_final",
 			) {
 			return true;
 		}

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1177,6 +1177,7 @@ impl OverlaySession {
 		);
 	}
 
+	#[cfg(any(target_os = "macos", test))]
 	fn note_frozen_transition_preview_deferred(
 		&self,
 		monitor: MonitorRect,
@@ -1286,6 +1287,7 @@ impl OverlaySession {
 		);
 	}
 
+	#[cfg(any(target_os = "macos", test))]
 	fn note_frozen_transition_toolbar_visible(&mut self, monitor: MonitorRect) {
 		if self.frozen_transition_toolbar_visible_at.is_some() {
 			return;
@@ -1330,8 +1332,7 @@ impl OverlaySession {
 		);
 	}
 
-	#[cfg(target_os = "macos")]
-	#[allow(dead_code)]
+	#[cfg(any(target_os = "macos", test))]
 	fn commit_frozen_preview(
 		&mut self,
 		monitor: MonitorRect,

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -3,6 +3,11 @@ use crate::overlay::Instant;
 use crate::overlay::{GlobalPoint, MonitorRect, OverlayMode, OverlaySession};
 
 impl OverlaySession {
+	#[cfg(target_os = "macos")]
+	pub(super) const fn should_hide_overlay_windows_during_capture(&self) -> bool {
+		false
+	}
+
 	pub(super) fn update_cursor_state(&mut self, monitor: MonitorRect, cursor: GlobalPoint) {
 		self.cursor_monitor = Some(monitor);
 		self.state.cursor = Some(cursor);
@@ -12,8 +17,12 @@ impl OverlaySession {
 	pub(super) fn hide_capture_windows(&mut self) {
 		self.capture_windows_hidden = true;
 
-		for overlay_window in self.windows.values() {
-			overlay_window.window.set_visible(false);
+		let hide_overlay_windows = self.should_hide_overlay_windows_during_capture();
+
+		if hide_overlay_windows {
+			for overlay_window in self.windows.values() {
+				overlay_window.window.set_visible(false);
+			}
 		}
 
 		if let Some(hud_window) = &self.hud_window {
@@ -40,6 +49,11 @@ impl OverlaySession {
 		if let Some(preview_window) = &self.scroll_preview_window {
 			preview_window.window.set_visible(false);
 		}
+
+		tracing::debug!(
+			hide_overlay_windows,
+			"Capture windows hidden for authoritative freeze capture."
+		);
 
 		self.last_present_at = Instant::now();
 	}

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -50,11 +50,6 @@ impl OverlaySession {
 			preview_window.window.set_visible(false);
 		}
 
-		tracing::debug!(
-			hide_overlay_windows,
-			"Capture windows hidden for authoritative freeze capture."
-		);
-
 		self.last_present_at = Instant::now();
 	}
 

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -5,7 +5,9 @@ use crate::overlay::{GlobalPoint, MonitorRect, OverlayMode, OverlaySession};
 impl OverlaySession {
 	#[cfg(target_os = "macos")]
 	pub(super) const fn should_hide_overlay_windows_during_capture(&self) -> bool {
-		false
+		// Authoritative freeze capture still falls back to CoreGraphics monitor capture.
+		// Keep overlays hidden until XY-74/XY-75 replace that path with a verified exclusion contract.
+		true
 	}
 
 	pub(super) fn update_cursor_state(&mut self, monitor: MonitorRect, cursor: GlobalPoint) {

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -45,6 +45,9 @@ impl OverlaySession {
 		}
 
 		self.state.drag_rect = Some(MonitorRectPoints { monitor_id: monitor.id, rect });
+		if self.state.hovered_window_rect.is_some_and(|hovered| hovered.monitor_id == monitor.id) {
+			self.state.hovered_window_rect = None;
+		}
 
 		if !was_active {
 			self.hide_auxiliary_windows_for_live_drag();
@@ -471,6 +474,21 @@ impl OverlaySession {
 
 	pub(super) fn frozen_selection_drag_hides_auxiliary_windows(&self) -> bool {
 		matches!(self.state.mode, OverlayMode::Frozen) && self.frozen_selection_drag.active
+	}
+
+	pub(super) fn live_press_active_for_monitor(&self, monitor: MonitorRect) -> bool {
+		matches!(self.state.mode, OverlayMode::Live)
+			&& self.left_mouse_button_down
+			&& self.left_mouse_button_down_monitor == Some(monitor)
+	}
+
+	pub(super) fn live_drag_active_for_monitor(&self, monitor: MonitorRect) -> bool {
+		matches!(self.state.mode, OverlayMode::Live)
+			&& self.state.drag_rect.is_some_and(|drag_rect| drag_rect.monitor_id == monitor.id)
+	}
+
+	pub(super) fn live_press_pending_for_monitor(&self, monitor: MonitorRect) -> bool {
+		self.live_press_active_for_monitor(monitor) && !self.live_drag_active_for_monitor(monitor)
 	}
 
 	pub(super) fn live_drag_hides_auxiliary_windows(&self) -> bool {

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -45,10 +45,10 @@ impl OverlaySession {
 		}
 
 		self.state.drag_rect = Some(MonitorRectPoints { monitor_id: monitor.id, rect });
+
 		if self.state.hovered_window_rect.is_some_and(|hovered| hovered.monitor_id == monitor.id) {
 			self.state.hovered_window_rect = None;
 		}
-
 		if !was_active {
 			self.hide_auxiliary_windows_for_live_drag();
 		}

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -835,10 +835,9 @@ impl OverlaySession {
 			return;
 		}
 
-		let is_dragging_window = matches!(self.state.mode, OverlayMode::Live)
-			&& self.left_mouse_button_down
-			&& self.left_mouse_button_down_monitor == Some(monitor);
-		let had_snapshot_update = if is_dragging_window || self.state.alt_held {
+		let press_pending = self.live_press_pending_for_monitor(monitor);
+		let is_dragging_window = self.live_drag_active_for_monitor(monitor);
+		let had_snapshot_update = if press_pending || is_dragging_window || self.state.alt_held {
 			false
 		} else {
 			self.apply_live_hover_cache_state(monitor, global)
@@ -846,7 +845,7 @@ impl OverlaySession {
 		let sample_requested =
 			self.request_live_cursor_sample(monitor, global, self.state.alt_held);
 
-		if !is_dragging_window && !self.state.alt_held {
+		if !press_pending && !is_dragging_window && !self.state.alt_held {
 			let _ = self.request_live_window_list_refresh_if_needed();
 		}
 
@@ -897,7 +896,6 @@ impl OverlaySession {
 					self.left_mouse_button_down_monitor = Some(monitor);
 					self.left_mouse_button_down_global = Some(raw_cursor);
 					self.state.drag_rect = None;
-					self.state.hovered_window_rect = None;
 
 					self.reset_toolbar_pointer_state();
 					self.request_redraw_for_monitor(monitor);
@@ -909,7 +907,6 @@ impl OverlaySession {
 				self.left_mouse_button_down_monitor = Some(press_monitor);
 				self.left_mouse_button_down_global = Some(press_global);
 				self.state.drag_rect = None;
-				self.state.hovered_window_rect = None;
 
 				self.reset_toolbar_pointer_state();
 				self.update_cursor_state(press_monitor, press_global);

--- a/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
@@ -33,6 +33,7 @@ impl ScrollPreviewWindow {
 			.with_visible(false)
 			.with_resizable(false)
 			.with_decorations(false)
+			.with_content_protected(cfg!(target_os = "macos"))
 			.with_transparent(true)
 			.with_inner_size(LogicalSize::new(
 				SCROLL_PREVIEW_WINDOW_WIDTH_POINTS,

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -1,3 +1,6 @@
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
+
 use image::RgbaImage;
 #[cfg(target_os = "macos")]
 use winit::dpi::{PhysicalPosition, PhysicalSize};
@@ -12,9 +15,12 @@ use crate::overlay::DeviceCursorPointSource;
 use crate::overlay::FrozenCaptureSource;
 use crate::overlay::OverlayControl;
 #[cfg(target_os = "macos")]
+use crate::overlay::tests::WorkerResponse;
+#[cfg(target_os = "macos")]
 use crate::overlay::tests::{
 	self, AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, LiveCursorSample,
 	LiveSampleApplyResult, ModifiersState, OverlayExit, StartupLiveRgbPlan, WindowId,
+	WindowListSnapshot,
 };
 use crate::overlay::tests::{
 	Duration, GlobalPoint, HudRedrawSummary, Instant, LoupeSample, MonitorRect, MonitorRectPoints,
@@ -552,6 +558,97 @@ fn live_drag_rect_activation_hides_auxiliary_windows() {
 	);
 	assert!(!session.hud_window_visible);
 	assert!(!session.loupe_window_visible);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn live_mouse_press_keeps_hovered_window_affordance_until_drag_or_release() {
+	let monitor = tests::test_monitor();
+	let hovered =
+		MonitorRectPoints { monitor_id: monitor.id, rect: RectPoints::new(100, 120, 240, 320) };
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.state.monitor = Some(monitor);
+	session.state.hovered_window_rect = Some(hovered);
+
+	assert!(matches!(
+		session.handle_left_mouse_input(WindowId::from(1), ElementState::Pressed),
+		OverlayControl::Continue
+	));
+	assert_eq!(session.state.hovered_window_rect, Some(hovered));
+	assert!(session.left_mouse_button_down);
+	assert_eq!(session.left_mouse_button_down_monitor, Some(monitor));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn live_press_pending_keeps_hovered_window_across_worker_updates() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(180, 220);
+	let hovered =
+		MonitorRectPoints { monitor_id: monitor.id, rect: RectPoints::new(100, 120, 240, 320) };
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.cursor_monitor = Some(monitor);
+	session.state.cursor = Some(cursor);
+	session.left_mouse_button_down = true;
+	session.left_mouse_button_down_monitor = Some(monitor);
+	session.left_mouse_button_down_global = Some(cursor);
+	session.state.hovered_window_rect = Some(hovered);
+
+	let apply = session.apply_live_cursor_sample_detail(
+		monitor,
+		cursor,
+		LiveCursorSample { rgb: None, patch: None },
+	);
+
+	assert!(!apply.overlay_changed);
+	assert_eq!(session.state.hovered_window_rect, Some(hovered));
+
+	let control = session.maybe_tick_worker_response_limiter(WorkerResponse::RefreshedWindowList {
+		snapshot: Arc::new(WindowListSnapshot {
+			captured_at: Instant::now(),
+			windows: Arc::new(vec![]),
+		}),
+	});
+
+	assert!(matches!(control, OverlayControl::Continue));
+	assert_eq!(session.state.hovered_window_rect, Some(hovered));
+}
+
+#[test]
+fn live_drag_activation_clears_hovered_window_affordance() {
+	let monitor = MonitorRect {
+		id: 1,
+		origin: GlobalPoint::new(0, 0),
+		width: 1_000,
+		height: 800,
+		scale_factor_x1000: 1_000,
+	};
+	let start = GlobalPoint::new(120, 180);
+	let end = GlobalPoint::new(280, 360);
+	let hovered =
+		MonitorRectPoints { monitor_id: monitor.id, rect: RectPoints::new(100, 120, 240, 320) };
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.left_mouse_button_down = true;
+	session.left_mouse_button_down_monitor = Some(monitor);
+	session.left_mouse_button_down_global = Some(start);
+	session.state.hovered_window_rect = Some(hovered);
+
+	session.update_live_drag_rect(monitor, end);
+
+	assert_eq!(
+		session.state.drag_rect,
+		Some(MonitorRectPoints {
+			monitor_id: monitor.id,
+			rect: RectPoints::new(120, 180, 160, 180),
+		})
+	);
+	assert!(session.state.hovered_window_rect.is_none());
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -153,6 +153,41 @@ fn snapshot_matte_window_capture_keeps_authoritative_handoff_pending() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn stale_snapshot_does_not_finish_frozen_transition_immediately() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(120, 160, 320, 240);
+	let snapshot = Arc::new(MonitorImageSnapshot {
+		captured_at: Instant::now()
+			- crate::live_frame_stream_macos::STREAM_REGION_FRAME_MAX_AGE
+			- Duration::from_millis(1),
+		monitor,
+		image: Arc::new(tests::test_frozen_image()),
+	});
+	let window_target =
+		crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 11, rect: capture_rect };
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	session.state.frozen_capture_rect = Some(capture_rect);
+	session.pending_freeze_capture = Some(monitor);
+	session.pending_window_freeze_capture = Some(window_target);
+
+	assert!(!session.maybe_finish_frozen_capture_from_snapshot(
+		monitor,
+		Some(window_target),
+		None,
+		Some(snapshot),
+		"live_stream_snapshot",
+	));
+	assert!(!session.authoritative_frozen_capture_ready);
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert_eq!(session.pending_window_freeze_capture, Some(window_target));
+	assert!(session.state.frozen_image.is_none());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn unverified_snapshot_can_finish_without_self_capture_exceptions() {
 	let monitor = tests::test_monitor();
 	let capture_rect = RectPoints::new(120, 160, 320, 240);

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -242,6 +242,37 @@ fn snapshot_seeded_preview_keeps_authoritative_handoff_pending() {
 	assert!(!session.toolbar_state.final_capture_ready);
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn stale_snapshot_does_not_seed_frozen_preview() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(120, 160, 320, 240);
+	let snapshot = Arc::new(MonitorImageSnapshot {
+		captured_at: Instant::now()
+			- crate::live_frame_stream_macos::STREAM_REGION_FRAME_MAX_AGE
+			- Duration::from_millis(1),
+		monitor,
+		image: Arc::new(tests::test_frozen_image()),
+	});
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	session.state.frozen_capture_rect = Some(capture_rect);
+	session.pending_freeze_capture = Some(monitor);
+
+	assert!(!session.maybe_seed_frozen_capture_preview_from_snapshot(
+		monitor,
+		None,
+		Some(snapshot),
+		"live_stream_snapshot_seeded_unverified",
+	));
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(!session.authoritative_frozen_capture_ready);
+	assert!(session.state.frozen_image.is_none());
+	assert!(!session.toolbar_state.final_capture_ready);
+}
+
 #[cfg(not(target_os = "macos"))]
 #[test]
 fn pending_freeze_capture_waits_for_empty_frozen_image_off_macos() {

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -106,6 +106,7 @@ fn snapshot_background_capture_finishes_frozen_transition_immediately() {
 		session.pending_window_freeze_capture,
 		None,
 		Some(snapshot),
+		"live_stream_snapshot",
 	));
 	assert!(session.authoritative_frozen_capture_ready);
 	assert!(session.pending_freeze_capture.is_none());
@@ -139,11 +140,38 @@ fn snapshot_matte_window_capture_keeps_authoritative_handoff_pending() {
 		Some(window_target),
 		None,
 		Some(snapshot),
+		"live_stream_snapshot",
 	));
 	assert!(!session.authoritative_frozen_capture_ready);
 	assert_eq!(session.pending_freeze_capture, Some(monitor));
 	assert_eq!(session.pending_window_freeze_capture, Some(window_target));
 	assert!(session.state.frozen_image.is_none());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn unverified_snapshot_can_finish_without_self_capture_exceptions() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(120, 160, 320, 240);
+	let window_target =
+		crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 11, rect: capture_rect };
+	let session = OverlaySession::new();
+
+	assert!(session.can_finish_frozen_capture_from_unverified_snapshot(Some(window_target)));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn unverified_snapshot_respects_self_capture_exception_windows() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(120, 160, 320, 240);
+	let window_target =
+		crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 11, rect: capture_rect };
+	let mut session = OverlaySession::new();
+
+	session.config.self_capture_exception_window_ids = vec![17];
+
+	assert!(!session.can_finish_frozen_capture_from_unverified_snapshot(Some(window_target)));
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -93,6 +93,7 @@ fn snapshot_background_capture_finishes_frozen_transition_immediately() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
+
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.pending_freeze_capture = Some(monitor);
 	session.pending_window_freeze_capture = Some(crate::overlay::WindowFreezeCaptureTarget {
@@ -130,7 +131,9 @@ fn snapshot_matte_window_capture_keeps_authoritative_handoff_pending() {
 	let mut session = OverlaySession::new();
 
 	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+
 	session.state.begin_freeze(monitor);
+
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.pending_freeze_capture = Some(monitor);
 	session.pending_window_freeze_capture = Some(window_target);
@@ -188,6 +191,7 @@ fn snapshot_seeded_preview_keeps_authoritative_handoff_pending() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
+
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.pending_freeze_capture = Some(monitor);
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -188,32 +188,6 @@ fn stale_snapshot_does_not_finish_frozen_transition_immediately() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn unverified_snapshot_can_finish_without_self_capture_exceptions() {
-	let monitor = tests::test_monitor();
-	let capture_rect = RectPoints::new(120, 160, 320, 240);
-	let window_target =
-		crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 11, rect: capture_rect };
-	let session = OverlaySession::new();
-
-	assert!(session.can_finish_frozen_capture_from_unverified_snapshot(Some(window_target)));
-}
-
-#[cfg(target_os = "macos")]
-#[test]
-fn unverified_snapshot_respects_self_capture_exception_windows() {
-	let monitor = tests::test_monitor();
-	let capture_rect = RectPoints::new(120, 160, 320, 240);
-	let window_target =
-		crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 11, rect: capture_rect };
-	let mut session = OverlaySession::new();
-
-	session.config.self_capture_exception_window_ids = vec![17];
-
-	assert!(!session.can_finish_frozen_capture_from_unverified_snapshot(Some(window_target)));
-}
-
-#[cfg(target_os = "macos")]
-#[test]
 fn snapshot_seeded_preview_keeps_authoritative_handoff_pending() {
 	let monitor = tests::test_monitor();
 	let capture_rect = RectPoints::new(120, 160, 320, 240);

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -1,4 +1,8 @@
 use std::slice;
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use std::time::Instant;
 
 use egui::Id;
 use egui::LayerId;
@@ -10,6 +14,8 @@ use objc::runtime::Object;
 use winit::window::CursorIcon;
 
 use crate::OverlayControl;
+#[cfg(target_os = "macos")]
+use crate::overlay::WindowCaptureAlphaMode;
 use crate::overlay::tests::{
 	self, Duration, ElementState, FrozenCaptureSource, FrozenSelectionDragState,
 	FrozenToolbarState, FrozenToolbarTool, GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, HudTheme,
@@ -25,6 +31,8 @@ use crate::overlay::{
 	FrozenAnnotationColor, FrozenEditKind, FrozenSelectionCorner, FrozenSelectionInteractionKind,
 	FrozenTextAnnotation, FrozenTextEditState,
 };
+#[cfg(target_os = "macos")]
+use crate::state::MonitorImageSnapshot;
 use crate::worker::{WorkerErrorSource, WorkerResponse};
 
 fn test_mosaic_source_image() -> RgbaImage {
@@ -69,6 +77,102 @@ fn pending_freeze_capture_dispatches_even_with_seeded_preview() {
 	session.pending_freeze_capture = Some(monitor);
 
 	assert!(session.should_dispatch_pending_freeze_capture(monitor));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn snapshot_background_capture_finishes_frozen_transition_immediately() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(120, 160, 320, 240);
+	let frozen_image = tests::test_frozen_image();
+	let snapshot = Arc::new(MonitorImageSnapshot {
+		captured_at: Instant::now(),
+		monitor,
+		image: Arc::new(frozen_image.clone()),
+	});
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+	session.state.frozen_capture_rect = Some(capture_rect);
+	session.pending_freeze_capture = Some(monitor);
+	session.pending_window_freeze_capture = Some(crate::overlay::WindowFreezeCaptureTarget {
+		monitor,
+		window_id: 11,
+		rect: capture_rect,
+	});
+
+	assert!(session.maybe_finish_frozen_capture_from_snapshot(
+		monitor,
+		session.pending_window_freeze_capture,
+		None,
+		Some(snapshot),
+	));
+	assert!(session.authoritative_frozen_capture_ready);
+	assert!(session.pending_freeze_capture.is_none());
+	assert!(session.pending_window_freeze_capture.is_none());
+	assert_eq!(session.state.frozen_image.as_ref(), Some(&frozen_image));
+	assert!(session.toolbar_state.final_capture_ready);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn snapshot_matte_window_capture_keeps_authoritative_handoff_pending() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(120, 160, 320, 240);
+	let snapshot = Arc::new(MonitorImageSnapshot {
+		captured_at: Instant::now(),
+		monitor,
+		image: Arc::new(tests::test_frozen_image()),
+	});
+	let window_target =
+		crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 11, rect: capture_rect };
+	let mut session = OverlaySession::new();
+
+	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+	session.state.begin_freeze(monitor);
+	session.state.frozen_capture_rect = Some(capture_rect);
+	session.pending_freeze_capture = Some(monitor);
+	session.pending_window_freeze_capture = Some(window_target);
+
+	assert!(!session.maybe_finish_frozen_capture_from_snapshot(
+		monitor,
+		Some(window_target),
+		None,
+		Some(snapshot),
+	));
+	assert!(!session.authoritative_frozen_capture_ready);
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert_eq!(session.pending_window_freeze_capture, Some(window_target));
+	assert!(session.state.frozen_image.is_none());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn snapshot_seeded_preview_keeps_authoritative_handoff_pending() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(120, 160, 320, 240);
+	let frozen_image = tests::test_frozen_image();
+	let snapshot = Arc::new(MonitorImageSnapshot {
+		captured_at: Instant::now(),
+		monitor,
+		image: Arc::new(frozen_image.clone()),
+	});
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+	session.state.frozen_capture_rect = Some(capture_rect);
+	session.pending_freeze_capture = Some(monitor);
+
+	assert!(session.maybe_seed_frozen_capture_preview_from_snapshot(
+		monitor,
+		None,
+		Some(snapshot),
+		"live_stream_snapshot_seeded_unverified",
+	));
+	assert!(!session.authoritative_frozen_capture_ready);
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert_eq!(session.state.frozen_image.as_ref(), Some(&frozen_image));
+	assert!(!session.toolbar_state.final_capture_ready);
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -225,6 +225,14 @@ fn armed_freeze_capture_without_worker_restores_visibility_and_surfaces_error() 
 
 #[cfg(target_os = "macos")]
 #[test]
+fn authoritative_freeze_capture_keeps_overlay_windows_visible_on_macos() {
+	let session = OverlaySession::new();
+
+	assert!(!session.should_hide_overlay_windows_during_capture());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn repeated_freeze_capture_send_full_aborts_and_restores_hidden_windows() {
 	let monitor = tests::test_monitor();
 	let mut session = OverlaySession::new();

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -225,10 +225,10 @@ fn armed_freeze_capture_without_worker_restores_visibility_and_surfaces_error() 
 
 #[cfg(target_os = "macos")]
 #[test]
-fn authoritative_freeze_capture_keeps_overlay_windows_visible_on_macos() {
+fn authoritative_freeze_capture_hides_overlay_windows_on_macos() {
 	let session = OverlaySession::new();
 
-	assert!(!session.should_hide_overlay_windows_during_capture());
+	assert!(session.should_hide_overlay_windows_during_capture());
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -476,6 +476,7 @@ impl OverlaySession {
 			};
 
 			toolbar_window.window.set_visible(true);
+
 			let mut toolbar_became_visible = false;
 
 			if !self.toolbar_window_visible {

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -462,33 +462,12 @@ impl OverlaySession {
 		}
 		#[cfg(target_os = "macos")]
 		{
-			let should_focus_frozen_keyboard = self.should_focus_frozen_toolbar_window_on_show();
-
-			if !self.toolbar_window_visible {
-				self.maybe_apply_pending_startup_aux_live_stream_filter_upgrade(monitor);
-			}
-
+			let Some(toolbar_became_visible) = self.prepare_toolbar_window_for_draw(monitor) else {
+				return Ok(());
+			};
 			let Some(gpu) = self.gpu.as_ref() else {
 				return Ok(());
 			};
-			let Some(toolbar_window) = self.toolbar_window.as_ref() else {
-				return Ok(());
-			};
-
-			toolbar_window.window.set_visible(true);
-
-			let mut toolbar_became_visible = false;
-
-			if !self.toolbar_window_visible {
-				self.toolbar_window_visible = true;
-				self.skip_toolbar_focus_on_next_show = false;
-				self.toolbar_window_warmup_redraws_remaining = TOOLBAR_WINDOW_WARMUP_REDRAWS;
-				toolbar_became_visible = true;
-			}
-			if should_focus_frozen_keyboard {
-				self.focus_frozen_keyboard_window();
-			}
-
 			let previous_floating_position = self.toolbar_state.floating_position;
 
 			self.toolbar_state.floating_position = Some(Pos2::ZERO);
@@ -564,6 +543,33 @@ impl OverlaySession {
 
 			Ok(())
 		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn prepare_toolbar_window_for_draw(&mut self, monitor: MonitorRect) -> Option<bool> {
+		let should_focus_frozen_keyboard = self.should_focus_frozen_toolbar_window_on_show();
+
+		if !self.toolbar_window_visible {
+			self.maybe_apply_pending_startup_aux_live_stream_filter_upgrade(monitor);
+		}
+
+		let toolbar_window = self.toolbar_window.as_ref()?;
+
+		toolbar_window.window.set_visible(true);
+
+		let mut toolbar_became_visible = false;
+
+		if !self.toolbar_window_visible {
+			self.toolbar_window_visible = true;
+			self.skip_toolbar_focus_on_next_show = false;
+			self.toolbar_window_warmup_redraws_remaining = TOOLBAR_WINDOW_WARMUP_REDRAWS;
+			toolbar_became_visible = true;
+		}
+		if should_focus_frozen_keyboard {
+			self.focus_frozen_keyboard_window();
+		}
+
+		Some(toolbar_became_visible)
 	}
 
 	pub(super) fn handle_toolbar_window_redraw_requested(&mut self) -> OverlayControl {

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -1,6 +1,6 @@
 use crate::overlay::{
-	self, Arc, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant, MonitorRect,
-	OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
+	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
+	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
 	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
 	WindowRenderer,
 };
@@ -581,7 +581,6 @@ impl OverlaySession {
 		};
 		let toolbar_input = self.toolbar_pointer_state(monitor, self.toolbar_pointer_local);
 		let should_hide_toolbar_window = self.should_hide_toolbar_window(monitor);
-		let mut position_update_elapsed = None;
 
 		if should_hide_toolbar_window {
 			self.set_toolbar_window_hidden();
@@ -605,14 +604,8 @@ impl OverlaySession {
 
 		self.update_scroll_toolbar_default_position(monitor);
 
-		if let Some(toolbar_pos) = self.toolbar_state.floating_position {
-			let position_update_started_at = Instant::now();
-			let _ = self.update_toolbar_outer_position(monitor, toolbar_pos);
+		let position_update_elapsed = self.update_toolbar_position_after_redraw(monitor);
 
-			self.force_apply_pending_toolbar_window_move();
-
-			position_update_elapsed = Some(position_update_started_at.elapsed());
-		}
 		if let Some(action) = self.toolbar_state.pending_action.take() {
 			let control = self.handle_toolbar_action(action);
 
@@ -630,22 +623,51 @@ impl OverlaySession {
 			self.request_redraw_for_monitor(monitor);
 			self.request_redraw_toolbar_window();
 		}
-		if tracing::enabled!(tracing::Level::TRACE)
-			&& matches!(self.state.mode, OverlayMode::Frozen)
-		{
-			tracing::trace!(
-				op = "overlay.toolbar_redraw_phase_timing",
-				monitor_id = monitor.id,
-				total_us = redraw_started_at.elapsed().as_micros(),
-				draw_frame_us = draw_frame_elapsed.as_micros(),
-				position_update_us =
-					position_update_elapsed.map_or(0, |elapsed| elapsed.as_micros()),
-				hidden = should_hide_toolbar_window,
-				frozen_selection_drag_active = self.frozen_selection_drag.active,
-				"Toolbar redraw phase timing."
-			);
-		}
+
+		self.log_toolbar_redraw_phase_timing(
+			monitor,
+			redraw_started_at,
+			draw_frame_elapsed,
+			position_update_elapsed,
+			should_hide_toolbar_window,
+		);
 
 		OverlayControl::Continue
+	}
+
+	fn update_toolbar_position_after_redraw(&mut self, monitor: MonitorRect) -> Option<Duration> {
+		let toolbar_pos = self.toolbar_state.floating_position?;
+		let position_update_started_at = Instant::now();
+		let _ = self.update_toolbar_outer_position(monitor, toolbar_pos);
+
+		self.force_apply_pending_toolbar_window_move();
+
+		Some(position_update_started_at.elapsed())
+	}
+
+	fn log_toolbar_redraw_phase_timing(
+		&self,
+		monitor: MonitorRect,
+		redraw_started_at: Instant,
+		draw_frame_elapsed: Duration,
+		position_update_elapsed: Option<Duration>,
+		should_hide_toolbar_window: bool,
+	) {
+		if !tracing::enabled!(tracing::Level::TRACE)
+			|| !matches!(self.state.mode, OverlayMode::Frozen)
+		{
+			return;
+		}
+
+		tracing::trace!(
+			op = "overlay.toolbar_redraw_phase_timing",
+			monitor_id = monitor.id,
+			total_us = redraw_started_at.elapsed().as_micros(),
+			draw_frame_us = draw_frame_elapsed.as_micros(),
+			position_update_us = position_update_elapsed.map_or(0, |elapsed| elapsed.as_micros()),
+			hidden = should_hide_toolbar_window,
+			frozen_selection_drag_active = self.frozen_selection_drag.active,
+			"Toolbar redraw phase timing."
+		);
 	}
 }

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -476,11 +476,13 @@ impl OverlaySession {
 			};
 
 			toolbar_window.window.set_visible(true);
+			let mut toolbar_became_visible = false;
 
 			if !self.toolbar_window_visible {
 				self.toolbar_window_visible = true;
 				self.skip_toolbar_focus_on_next_show = false;
 				self.toolbar_window_warmup_redraws_remaining = TOOLBAR_WINDOW_WARMUP_REDRAWS;
+				toolbar_became_visible = true;
 			}
 			if should_focus_frozen_keyboard {
 				self.focus_frozen_keyboard_window();
@@ -553,6 +555,10 @@ impl OverlaySession {
 					f64::from(desired.0),
 					f64::from(desired.1),
 				));
+			}
+
+			if toolbar_became_visible {
+				self.note_frozen_transition_toolbar_visible(monitor);
 			}
 
 			Ok(())

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -628,6 +628,7 @@ impl OverlaySession {
 				.with_title("rsnap-overlay")
 				.with_decorations(false)
 				.with_resizable(false)
+				.with_content_protected(cfg!(target_os = "macos"))
 				.with_transparent(true)
 				.with_window_level(WindowLevel::AlwaysOnTop)
 				.with_inner_size(LogicalSize::new(
@@ -768,6 +769,7 @@ impl OverlaySession {
 			.with_title("rsnap-hud")
 			.with_decorations(false)
 			.with_resizable(false)
+			.with_content_protected(cfg!(target_os = "macos"))
 			.with_transparent(true)
 			.with_visible(false)
 			.with_window_level(WindowLevel::AlwaysOnTop)
@@ -801,6 +803,7 @@ impl OverlaySession {
 			.with_title("rsnap-loupe")
 			.with_decorations(false)
 			.with_resizable(false)
+			.with_content_protected(cfg!(target_os = "macos"))
 			.with_transparent(true)
 			.with_visible(false)
 			.with_window_level(WindowLevel::AlwaysOnTop)
@@ -837,6 +840,7 @@ impl OverlaySession {
 			.with_title("rsnap-toolbar")
 			.with_decorations(false)
 			.with_resizable(false)
+			.with_content_protected(cfg!(target_os = "macos"))
 			.with_inner_size(LogicalSize::new(
 				startup_size.x as f64,
 				f64::from(startup_size.y.max(TOOLBAR_EXPANDED_HEIGHT_PX)),

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -22,6 +22,7 @@ impl OverlaySession {
 	pub(super) fn abort_pending_freeze_capture(&mut self, message: impl Into<String>) {
 		let message = message.into();
 
+		self.note_frozen_transition_aborted(message.as_str());
 		self.clear_freeze_capture_tracking();
 		self.restore_capture_windows_visibility();
 		self.state.set_error(message);
@@ -39,6 +40,7 @@ impl OverlaySession {
 		self.inflight_window_freeze_capture = pending_window_target;
 		self.pending_window_freeze_capture = None;
 		self.freeze_capture_send_full_count = 0;
+		self.note_frozen_transition_worker_requested(overlay_monitor, pending_window_target);
 	}
 
 	pub(super) fn handle_freeze_capture_request_send_error(
@@ -187,17 +189,16 @@ impl OverlaySession {
 			return false;
 		}
 
-		let is_dragging_window = matches!(self.state.mode, OverlayMode::Live)
-			&& self.left_mouse_button_down
-			&& self.left_mouse_button_down_monitor == Some(monitor);
-		let had_snapshot_update = if is_dragging_window || self.state.alt_held {
+		let press_pending = self.live_press_pending_for_monitor(monitor);
+		let is_dragging_window = self.live_drag_active_for_monitor(monitor);
+		let had_snapshot_update = if press_pending || is_dragging_window || self.state.alt_held {
 			false
 		} else {
 			self.apply_live_hover_cache_state(monitor, cursor)
 		};
 		let sample_updated = self.request_live_cursor_sample(monitor, cursor, self.state.alt_held);
 
-		if !is_dragging_window && !self.state.alt_held {
+		if !press_pending && !is_dragging_window && !self.state.alt_held {
 			let _ = self.request_live_window_list_refresh_if_needed();
 		}
 
@@ -415,9 +416,8 @@ impl OverlaySession {
 			return LiveSampleApplyResult::default();
 		}
 
-		let is_dragging_window = self.left_mouse_button_down
-			&& self.left_mouse_button_down_monitor == Some(monitor)
-			&& matches!(self.state.mode, OverlayMode::Live);
+		let press_pending = self.live_press_pending_for_monitor(monitor);
+		let is_dragging_window = self.live_drag_active_for_monitor(monitor);
 		let mut changed = LiveSampleApplyResult::default();
 
 		if is_dragging_window {
@@ -426,7 +426,7 @@ impl OverlaySession {
 				changed.overlay_changed = true;
 				changed.hud_changed = true;
 			}
-		} else if self.apply_live_hover_cache_state(monitor, point) {
+		} else if !press_pending && self.apply_live_hover_cache_state(monitor, point) {
 			changed.overlay_changed = true;
 			changed.hud_changed = true;
 		}
@@ -728,9 +728,8 @@ impl OverlaySession {
 		let Some(monitor) = self.active_cursor_monitor() else {
 			return;
 		};
-		let is_dragging_window = self.left_mouse_button_down
-			&& self.left_mouse_button_down_monitor == Some(monitor)
-			&& matches!(self.state.mode, OverlayMode::Live);
+		let press_pending = self.live_press_pending_for_monitor(monitor);
+		let is_dragging_window = self.live_drag_active_for_monitor(monitor);
 
 		if is_dragging_window {
 			if self.state.hovered_window_rect.is_some() {
@@ -746,6 +745,9 @@ impl OverlaySession {
 				);
 			}
 
+			return;
+		}
+		if press_pending {
 			return;
 		}
 		if self.apply_live_hover_cache_state(monitor, cursor) {

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -40,6 +40,7 @@ impl OverlaySession {
 		self.inflight_window_freeze_capture = pending_window_target;
 		self.pending_window_freeze_capture = None;
 		self.freeze_capture_send_full_count = 0;
+
 		self.note_frozen_transition_worker_requested(overlay_monitor, pending_window_target);
 	}
 


### PR DESCRIPTION
## Summary
- speed up the macOS transition from live capture into frozen mode by committing a live-stream snapshot immediately when it can safely stand in for the final frozen image
- keep overlay scrim and hover affordances stable during press, drag, and authoritative capture handoff so the transition no longer flashes or brightens unexpectedly
- harden self-capture handling with content-protected windows, stream filter state tracking, and regression tests for verified, preview-seeded, and unverified-final paths

## Testing
- cargo make fmt-rust
- cargo test -p rsnap-overlay rendering_behaviors --lib
- cargo test -p rsnap-overlay self_capture_runtime --lib
- cargo test -p rsnap-overlay live_runtime --lib
- cargo test -p rsnap-overlay live_frame_stream_macos --lib
- cargo make lint-rust
