### PR TITLE
XY-247 Split frozen annotation style controls into a separate capsule

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -753,6 +753,7 @@ impl OverlaySession {
 		}
 	}
 
+	#[allow(clippy::too_many_lines)]
 	#[rustfmt::skip]
 	fn build_base_session_defaults() -> Self {
 		Self {
@@ -1531,6 +1532,8 @@ impl OverlaySession {
 		tracing::debug!(
 			monitor_id = monitor.id,
 			frozen_generation = self.state.frozen_generation,
+			toolbar_primary_size_points =
+				?WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state),
 			toolbar_size_points =
 				?WindowRenderer::frozen_toolbar_size(&self.toolbar_state),
 			default_pos = ?default_pos,
@@ -1549,12 +1552,14 @@ impl OverlaySession {
 			Pos2::new(capture_rect_points.x as f32, capture_rect_points.y as f32),
 			Vec2::new(capture_rect_points.width as f32, capture_rect_points.height as f32),
 		);
-		let toolbar_size = WindowRenderer::frozen_toolbar_size(&self.toolbar_state);
+		let toolbar_primary_size = WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state);
+		let toolbar_window_size = WindowRenderer::frozen_toolbar_size(&self.toolbar_state);
 
-		WindowRenderer::frozen_toolbar_default_pos(
+		WindowRenderer::frozen_toolbar_default_window_pos(
 			screen_rect,
 			capture_rect,
-			toolbar_size,
+			toolbar_primary_size,
+			toolbar_window_size,
 			self.config.toolbar_placement,
 		)
 	}
@@ -2016,6 +2021,7 @@ impl OverlaySession {
 	}
 
 	/// Handles a winit window event for one of the overlay-owned windows.
+	#[allow(clippy::too_many_lines)]
 	pub fn handle_window_event(
 		&mut self,
 		window_id: WindowId,
@@ -2547,20 +2553,21 @@ impl OverlaySession {
 		self.maybe_log_event_loop_stall(Instant::now());
 		self.mark_progress(OverlayEventLoopPhase::OverlayRedraw);
 
-		// On macOS the frozen toolbar is now rendered in its own native HUD window; keep this
-		// fullscreen overlay free of toolbar UI so shader-backed blur and monitor-aligned offsets
-		// do not conflict with native-window positioning.
-		let draw_toolbar = !cfg!(target_os = "macos")
-			&& matches!(self.state.mode, OverlayMode::Frozen)
+		let overlay_screen_rect = self.overlay_window_screen_rect(window_id, overlay_monitor);
+		#[cfg(target_os = "macos")]
+		let draw_toolbar = false;
+		#[cfg(not(target_os = "macos"))]
+		let draw_toolbar = matches!(self.state.mode, OverlayMode::Frozen)
 			&& self.toolbar_state.visible
 			&& self.state.monitor == Some(overlay_monitor)
 			&& self.frozen_final_capture_ready();
+		#[cfg(not(target_os = "macos"))]
 		let toolbar_input =
 			if draw_toolbar { self.toolbar_pointer_state(overlay_monitor, None) } else { None };
+		#[cfg(target_os = "macos")]
+		let toolbar_input = None;
 
 		self.log_frozen_overlay_redraw_trace(window_id, overlay_monitor, draw_toolbar);
-
-		let overlay_screen_rect = self.overlay_window_screen_rect(window_id, overlay_monitor);
 		let toolbar_visible_for_badge = if cfg!(target_os = "macos") {
 			!self.should_hide_toolbar_window(overlay_monitor)
 		} else {

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1553,7 +1553,7 @@ impl OverlaySession {
 			Vec2::new(capture_rect_points.width as f32, capture_rect_points.height as f32),
 		);
 		let toolbar_primary_size = WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state);
-		let toolbar_window_size = WindowRenderer::frozen_toolbar_size(&self.toolbar_state);
+		let toolbar_window_size = self.toolbar_positioning_size();
 
 		WindowRenderer::frozen_toolbar_default_window_pos(
 			screen_rect,

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -621,6 +621,8 @@ pub struct OverlaySession {
 	toolbar_left_button_went_down: bool,
 	toolbar_left_button_went_up: bool,
 	toolbar_pointer_local: Option<Pos2>,
+	#[cfg(target_os = "macos")]
+	toolbar_window_cursor_hittest_enabled: bool,
 	left_mouse_button_down: bool,
 	left_mouse_button_down_monitor: Option<MonitorRect>,
 	left_mouse_button_down_global: Option<GlobalPoint>,
@@ -837,9 +839,11 @@ impl OverlaySession {
 			frozen_text_annotations: Vec::new(), frozen_text_redo_annotations: Vec::new(),
 			frozen_text_edit: None, frozen_text_input_generation: 0, frozen_text_recent_input: None,
 			toolbar_state: FrozenToolbarState::default(),
-			toolbar_left_button_down: false, toolbar_left_button_went_down: false, toolbar_left_button_went_up: false,
-			toolbar_pointer_local: None,
-			left_mouse_button_down: false, left_mouse_button_down_monitor: None, left_mouse_button_down_global: None,
+				toolbar_left_button_down: false, toolbar_left_button_went_down: false, toolbar_left_button_went_up: false,
+				toolbar_pointer_local: None,
+				#[cfg(target_os = "macos")]
+				toolbar_window_cursor_hittest_enabled: false,
+				left_mouse_button_down: false, left_mouse_button_down_monitor: None, left_mouse_button_down_global: None,
 			frozen_brush: FrozenBrushState::default(),
 			frozen_selection_drag: FrozenSelectionDragState::default(),
 			frozen_mosaic_drag: FrozenMosaicDragState::default(),
@@ -2952,6 +2956,10 @@ impl OverlaySession {
 		self.pending_toolbar_outer_pos = None;
 		self.hud_window_visible = false;
 		self.toolbar_window_visible = false;
+		#[cfg(target_os = "macos")]
+		{
+			self.toolbar_window_cursor_hittest_enabled = false;
+		}
 		self.skip_toolbar_focus_on_next_show = false;
 		self.toolbar_window_warmup_redraws_remaining = 0;
 		self.loupe_window_visible = false;

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -2568,6 +2568,7 @@ impl OverlaySession {
 		let toolbar_input = None;
 
 		self.log_frozen_overlay_redraw_trace(window_id, overlay_monitor, draw_toolbar);
+
 		let toolbar_visible_for_badge = if cfg!(target_os = "macos") {
 			!self.should_hide_toolbar_window(overlay_monitor)
 		} else {

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -13,6 +13,9 @@ impl OverlaySession {
 	pub(super) fn update_cursor_state(&mut self, monitor: MonitorRect, cursor: GlobalPoint) {
 		self.cursor_monitor = Some(monitor);
 		self.state.cursor = Some(cursor);
+
+		#[cfg(target_os = "macos")]
+		self.sync_toolbar_window_cursor_hittest(Some(cursor));
 	}
 
 	#[cfg(target_os = "macos")]
@@ -42,10 +45,17 @@ impl OverlaySession {
 		self.reset_loupe_window_warmup_redraws();
 
 		if let Some(toolbar_window) = &self.toolbar_window {
+			#[cfg(target_os = "macos")]
+			let _ = toolbar_window.window.set_cursor_hittest(false);
+
 			toolbar_window.window.set_visible(false);
 		}
 
 		self.toolbar_window_visible = false;
+		#[cfg(target_os = "macos")]
+		{
+			self.toolbar_window_cursor_hittest_enabled = false;
+		}
 		self.toolbar_window_warmup_redraws_remaining = 0;
 
 		if let Some(preview_window) = &self.scroll_preview_window {

--- a/packages/rsnap-overlay/src/overlay/config_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/config_runtime.rs
@@ -9,7 +9,6 @@ use crate::overlay;
 use crate::overlay::OverlayWorker;
 use crate::overlay::{
 	Arc, Instant, LOUPE_TILE_CORNER_RADIUS_POINTS, OverlayConfig, OverlayMode, OverlaySession,
-	WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{MacLiveFrameStream, MacOSHudWindowConfigState, SLOW_OP_WARN_HUD_CONFIG};
@@ -176,12 +175,14 @@ impl OverlaySession {
 		}
 		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
 			let window = Arc::clone(&toolbar_window.window);
+			let toolbar_height_points = self
+				.toolbar_inner_size_points
+				.map(|(_, height)| height as f32)
+				.unwrap_or_else(|| overlay::frozen_toolbar_window_startup_size_points().y);
 
 			self.configure_hud_window_common(
 				window.as_ref(),
-				Some(overlay::frozen_toolbar_corner_radius_points(
-					WindowRenderer::frozen_toolbar_size(&self.toolbar_state).y,
-				)),
+				Some(overlay::frozen_toolbar_corner_radius_points(toolbar_height_points)),
 			);
 		}
 	}

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -8,7 +8,7 @@ use crate::overlay::{
 	ElementState, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
 	FrozenToolbarTool, GlobalPoint, Ime, Key, KeyEvent, LIVE_DRAG_START_THRESHOLD_PX, Modifiers,
 	MonitorRect, MouseScrollDelta, NamedKey, OverlayControl, OverlayMode, OverlaySession,
-	PhysicalPosition, PhysicalSize, PngAction, Vec2, WindowId,
+	PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId, WindowRenderer,
 };
 
 impl OverlaySession {
@@ -59,12 +59,18 @@ impl OverlaySession {
 			let _ = self.stop_frozen_text_edit_drag();
 
 			self.toolbar_state.dragging = false;
+			self.toolbar_state.drag_start_eligible = false;
 			self.toolbar_state.drag_offset = Vec2::ZERO;
 			self.toolbar_state.drag_anchor = None;
 		} else {
 			self.toolbar_state.drag_offset = Vec2::ZERO;
 			self.toolbar_state.dragging = false;
 			self.toolbar_state.drag_anchor = None;
+			self.toolbar_state.drag_start_eligible =
+				self.toolbar_pointer_local.is_some_and(|cursor_local| {
+					WindowRenderer::frozen_toolbar_primary_rect(&self.toolbar_state, Pos2::ZERO)
+						.contains(cursor_local)
+				});
 		}
 
 		#[cfg(target_os = "macos")]
@@ -111,6 +117,7 @@ impl OverlaySession {
 		self.toolbar_pointer_local = None;
 		self.toolbar_state.annotation_size_control_hovered = false;
 		self.toolbar_state.annotation_size_wheel_accumulator = 0.0;
+		self.toolbar_state.drag_start_eligible = false;
 		self.toolbar_state.drag_anchor = None;
 	}
 

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -66,11 +66,11 @@ impl OverlaySession {
 			self.toolbar_state.drag_offset = Vec2::ZERO;
 			self.toolbar_state.dragging = false;
 			self.toolbar_state.drag_anchor = None;
+
+			let current_cursor_local = self.current_toolbar_cursor_local();
+
 			self.toolbar_state.drag_start_eligible =
-				self.toolbar_pointer_local.is_some_and(|cursor_local| {
-					WindowRenderer::frozen_toolbar_primary_rect(&self.toolbar_state, Pos2::ZERO)
-						.contains(cursor_local)
-				});
+				self.resolve_toolbar_drag_start_eligibility(current_cursor_local);
 		}
 
 		#[cfg(target_os = "macos")]
@@ -119,6 +119,38 @@ impl OverlaySession {
 		self.toolbar_state.annotation_size_wheel_accumulator = 0.0;
 		self.toolbar_state.drag_start_eligible = false;
 		self.toolbar_state.drag_anchor = None;
+	}
+
+	pub(super) fn resolve_toolbar_drag_start_eligibility(
+		&self,
+		current_cursor_local: Option<Pos2>,
+	) -> bool {
+		current_cursor_local
+			.or(self.toolbar_pointer_local)
+			.is_some_and(|cursor_local| self.toolbar_primary_rect_contains(cursor_local))
+	}
+
+	fn current_toolbar_cursor_local(&mut self) -> Option<Pos2> {
+		let toolbar_window = self.toolbar_window.as_ref()?;
+		let outer_position = Self::toolbar_window_outer_position(toolbar_window)?;
+		let cursor_global = self.sample_mouse_location();
+
+		Some(Self::toolbar_cursor_local_position_from_outer(outer_position, cursor_global))
+	}
+
+	fn toolbar_primary_rect_contains(&self, cursor_local: Pos2) -> bool {
+		WindowRenderer::frozen_toolbar_primary_rect(&self.toolbar_state, Pos2::ZERO)
+			.contains(cursor_local)
+	}
+
+	pub(super) fn toolbar_cursor_local_position_from_outer(
+		outer_position: GlobalPoint,
+		global_cursor: GlobalPoint,
+	) -> Pos2 {
+		Pos2::new(
+			global_cursor.x as f32 - outer_position.x as f32,
+			global_cursor.y as f32 - outer_position.y as f32,
+		)
 	}
 
 	pub(super) fn handle_modifiers_changed(&mut self, modifiers: &Modifiers) -> OverlayControl {

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -133,9 +133,12 @@ impl OverlaySession {
 	fn current_toolbar_cursor_local(&mut self) -> Option<Pos2> {
 		let toolbar_window = self.toolbar_window.as_ref()?;
 		let outer_position = Self::toolbar_window_outer_position(toolbar_window)?;
+		#[cfg(target_os = "macos")]
+		let cursor_global = super::macos_mouse_location()?;
+		#[cfg(not(target_os = "macos"))]
 		let cursor_global = self.sample_mouse_location();
 
-		Some(Self::toolbar_cursor_local_position_from_outer(outer_position, cursor_global))
+		Self::toolbar_cursor_local_from_sampled_global(outer_position, Some(cursor_global))
 	}
 
 	fn toolbar_primary_rect_contains(&self, cursor_local: Pos2) -> bool {
@@ -151,6 +154,15 @@ impl OverlaySession {
 			global_cursor.x as f32 - outer_position.x as f32,
 			global_cursor.y as f32 - outer_position.y as f32,
 		)
+	}
+
+	pub(super) fn toolbar_cursor_local_from_sampled_global(
+		outer_position: GlobalPoint,
+		sampled_cursor: Option<GlobalPoint>,
+	) -> Option<Pos2> {
+		sampled_cursor.map(|global_cursor| {
+			Self::toolbar_cursor_local_position_from_outer(outer_position, global_cursor)
+		})
 	}
 
 	pub(super) fn handle_modifiers_changed(&mut self, modifiers: &Modifiers) -> OverlayControl {

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -690,6 +690,7 @@ impl WindowRenderer {
 	}
 
 	#[allow(clippy::too_many_arguments)]
+	#[allow(clippy::too_many_lines)]
 	fn run_egui(
 		&mut self,
 		raw_input: egui::RawInput,

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -2779,9 +2779,9 @@ impl WindowRenderer {
 			}
 
 			*hud_pill_out = Some(HudPillGeometry {
-				rect: toolbar_rect,
+				rect: window_rect,
 				radius_points: f32::from(overlay::frozen_toolbar_corner_radius_u8(
-					toolbar_rect.height(),
+					window_rect.height(),
 				)),
 			});
 		});

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -2720,7 +2720,6 @@ impl WindowRenderer {
 				cursor,
 				left_button_down,
 			);
-
 			Self::paint_frozen_toolbar_capsule(
 				ui,
 				toolbar_rect,
@@ -2731,6 +2730,7 @@ impl WindowRenderer {
 				hud_milk_amount,
 				hud_tint_hue,
 			);
+
 			let toolbar_inner_rect = toolbar_rect.shrink2(egui::vec2(
 				HUD_PILL_INNER_MARGIN_X_POINTS,
 				TOOLBAR_PILL_INNER_MARGIN_Y_POINTS,
@@ -2755,6 +2755,7 @@ impl WindowRenderer {
 					hud_milk_amount,
 					hud_tint_hue,
 				);
+
 				let style_inner_rect = style_rect.shrink2(egui::vec2(
 					HUD_PILL_INNER_MARGIN_X_POINTS,
 					TOOLBAR_PILL_INNER_MARGIN_Y_POINTS,

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -47,8 +47,6 @@ use crate::overlay::{
 
 const FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS: f32 = 4.0;
 const FROZEN_ANNOTATION_TOOLBAR_SECTION_HEIGHT_POINTS: f32 = 24.0;
-const FROZEN_ANNOTATION_TOOLBAR_SECTION_DIVIDER_ALPHA_DARK: u8 = 60;
-const FROZEN_ANNOTATION_TOOLBAR_SECTION_DIVIDER_ALPHA_LIGHT: u8 = 72;
 const FROZEN_ANNOTATION_TOOLBAR_SWATCH_SIZE_POINTS: f32 = 16.0;
 const FROZEN_ANNOTATION_TOOLBAR_SWATCH_GAP_POINTS: f32 = 6.0;
 const FROZEN_ANNOTATION_TOOLBAR_SIZE_BUTTON_WIDTH_POINTS: f32 = 20.0;
@@ -81,13 +79,6 @@ impl FrozenAnnotationStyleToolbarKind {
 		}
 	}
 
-	const fn size_hover_text(self) -> &'static str {
-		match self {
-			Self::Pen => "Scroll or use +/- to adjust stroke size",
-			Self::Text => "Scroll or use +/- to adjust text size",
-		}
-	}
-
 	const fn size_display_width(self) -> f32 {
 		match self {
 			Self::Pen => FROZEN_ANNOTATION_TOOLBAR_PEN_SIZE_DISPLAY_WIDTH_POINTS,
@@ -97,20 +88,6 @@ impl FrozenAnnotationStyleToolbarKind {
 
 	const fn size_control_width(self) -> f32 {
 		self.size_display_width() + FROZEN_ANNOTATION_TOOLBAR_SIZE_BUTTON_WIDTH_POINTS * 2.0
-	}
-
-	const fn decrease_hover_text(self) -> &'static str {
-		match self {
-			Self::Pen => "Smaller stroke",
-			Self::Text => "Smaller text",
-		}
-	}
-
-	const fn increase_hover_text(self) -> &'static str {
-		match self {
-			Self::Pen => "Larger stroke",
-			Self::Text => "Larger text",
-		}
 	}
 
 	fn size_value(self, toolbar_state: &FrozenToolbarState) -> f64 {
@@ -944,11 +921,13 @@ impl WindowRenderer {
 		}
 
 		let capture_rect = Self::frozen_toolbar_capture_rect(state, monitor, screen_rect);
-		let toolbar_size = Self::frozen_toolbar_size(toolbar_state);
-		let default_pos = Self::frozen_toolbar_default_pos(
+		let toolbar_primary_size = Self::frozen_toolbar_primary_size(toolbar_state);
+		let toolbar_window_size = Self::frozen_toolbar_size(toolbar_state);
+		let default_pos = Self::frozen_toolbar_default_window_pos(
 			screen_rect,
 			capture_rect,
-			toolbar_size,
+			toolbar_primary_size,
+			toolbar_window_size,
 			toolbar_placement,
 		);
 		let toolbar_pos = toolbar_state.floating_position.unwrap_or(default_pos);
@@ -957,7 +936,7 @@ impl WindowRenderer {
 			return None;
 		}
 
-		Some(Rect::from_min_size(toolbar_pos, toolbar_size))
+		Some(Self::frozen_toolbar_window_rect(toolbar_state, toolbar_pos))
 	}
 
 	pub(in crate::overlay) fn selection_size_badge_text(
@@ -2304,6 +2283,7 @@ impl WindowRenderer {
 		} else {
 			(Pos2::new(-1.0, -1.0), false)
 		};
+		let toolbar_primary_size = Self::frozen_toolbar_primary_size(toolbar_state);
 		let toolbar_size = Self::frozen_toolbar_size(toolbar_state);
 		let screen_rect = ctx.input(|i| i.viewport_rect());
 		let capture_rect = Self::frozen_toolbar_capture_rect(state, monitor, screen_rect);
@@ -2314,6 +2294,7 @@ impl WindowRenderer {
 			toolbar_state,
 			screen_rect,
 			capture_rect,
+			toolbar_primary_size,
 			toolbar_size,
 			toolbar_placement,
 		) else {
@@ -2473,21 +2454,68 @@ impl WindowRenderer {
 		}
 	}
 
-	pub(in crate::overlay) fn frozen_toolbar_size(toolbar_state: &FrozenToolbarState) -> Vec2 {
+	pub(in crate::overlay) fn frozen_toolbar_primary_size(
+		toolbar_state: &FrozenToolbarState,
+	) -> Vec2 {
 		let tool_count = Self::frozen_toolbar_tools(toolbar_state).len() as f32;
 		let spacing_count = (tool_count - 1.0).max(0.0);
 		let width = tool_count * FROZEN_TOOLBAR_BUTTON_SIZE_POINTS
 			+ spacing_count * FROZEN_TOOLBAR_ITEM_SPACING_POINTS
 			+ 2.0 * HUD_PILL_INNER_MARGIN_X_POINTS
 			+ 2.0 * HUD_PILL_STROKE_WIDTH_POINTS;
-		let mut height = toolbar_state.pill_height_points.unwrap_or(TOOLBAR_EXPANDED_HEIGHT_PX);
-
-		if Self::frozen_annotation_style_toolbar_visible(toolbar_state) {
-			height += FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS
-				+ FROZEN_ANNOTATION_TOOLBAR_SECTION_HEIGHT_POINTS;
-		}
+		let height = toolbar_state.pill_height_points.unwrap_or(TOOLBAR_EXPANDED_HEIGHT_PX);
 
 		Vec2::new(width, height)
+	}
+
+	pub(in crate::overlay) fn frozen_toolbar_primary_rect(
+		toolbar_state: &FrozenToolbarState,
+		toolbar_pos: Pos2,
+	) -> Rect {
+		Rect::from_min_size(toolbar_pos, Self::frozen_toolbar_primary_size(toolbar_state))
+	}
+
+	pub(in crate::overlay) fn frozen_annotation_style_capsule_size(
+		toolbar_state: &FrozenToolbarState,
+	) -> Option<Vec2> {
+		let style_kind = FrozenAnnotationStyleToolbarKind::from_toolbar_state(toolbar_state)?;
+		let swatch_count = FrozenAnnotationColor::ALL.len() as f32;
+		let swatches_width = swatch_count * FROZEN_ANNOTATION_TOOLBAR_SWATCH_SIZE_POINTS
+			+ (swatch_count - 1.0).max(0.0) * FROZEN_ANNOTATION_TOOLBAR_SWATCH_GAP_POINTS;
+		let content_width = style_kind.size_control_width() + 4.0 + swatches_width;
+		let width = content_width
+			+ 2.0 * HUD_PILL_INNER_MARGIN_X_POINTS
+			+ 2.0 * HUD_PILL_STROKE_WIDTH_POINTS;
+		let height = toolbar_state.pill_height_points.unwrap_or(TOOLBAR_EXPANDED_HEIGHT_PX);
+
+		Some(Vec2::new(width, height))
+	}
+
+	fn frozen_annotation_style_capsule_rect(
+		toolbar_state: &FrozenToolbarState,
+		toolbar_rect: Rect,
+	) -> Option<Rect> {
+		let style_size = Self::frozen_annotation_style_capsule_size(toolbar_state)?;
+		let min_x = toolbar_rect.left();
+		let max_x = (toolbar_rect.right() - style_size.x).max(min_x);
+		let x = (toolbar_rect.center().x - style_size.x * 0.5).clamp(min_x, max_x);
+		let y = toolbar_rect.max.y + FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS;
+
+		Some(Rect::from_min_size(Pos2::new(x, y), style_size))
+	}
+
+	pub(in crate::overlay) fn frozen_toolbar_window_rect(
+		toolbar_state: &FrozenToolbarState,
+		toolbar_pos: Pos2,
+	) -> Rect {
+		let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, toolbar_pos);
+
+		Self::frozen_annotation_style_capsule_rect(toolbar_state, toolbar_rect)
+			.map_or(toolbar_rect, |style_rect| toolbar_rect.union(style_rect))
+	}
+
+	pub(in crate::overlay) fn frozen_toolbar_size(toolbar_state: &FrozenToolbarState) -> Vec2 {
+		Self::frozen_toolbar_window_rect(toolbar_state, Pos2::ZERO).size()
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -2498,6 +2526,7 @@ impl WindowRenderer {
 		toolbar_state: &mut FrozenToolbarState,
 		screen_rect: Rect,
 		capture_rect: Rect,
+		toolbar_primary_size: Vec2,
 		toolbar_size: Vec2,
 		toolbar_placement: ToolbarPlacement,
 	) -> Option<Pos2> {
@@ -2557,9 +2586,10 @@ impl WindowRenderer {
 			return None;
 		}
 
-		let default_pos = Self::frozen_toolbar_default_pos(
+		let default_pos = Self::frozen_toolbar_default_window_pos(
 			screen_rect,
 			capture_rect,
+			toolbar_primary_size,
 			toolbar_size,
 			toolbar_placement,
 		);
@@ -2567,6 +2597,7 @@ impl WindowRenderer {
 		tracing::debug!(
 			monitor_id = monitor.id,
 			frozen_generation = state.frozen_generation,
+			toolbar_primary_size_points = ?toolbar_primary_size,
 			toolbar_size_points = ?toolbar_size,
 			default_pos = ?default_pos,
 			"Frozen toolbar birth resolved."
@@ -2602,48 +2633,43 @@ impl WindowRenderer {
 		capture_rect.intersect(screen_rect)
 	}
 
-	pub(in crate::overlay) fn frozen_toolbar_default_pos(
+	pub(in crate::overlay) fn frozen_toolbar_default_window_pos(
 		screen_rect: Rect,
 		capture_rect: Rect,
-		toolbar_size: Vec2,
+		toolbar_primary_size: Vec2,
+		toolbar_window_size: Vec2,
 		toolbar_placement: ToolbarPlacement,
 	) -> Pos2 {
 		let y = match toolbar_placement {
 			ToolbarPlacement::Bottom => {
 				let below_y = capture_rect.max.y + TOOLBAR_CAPTURE_GAP_PX;
-				let within_screen =
-					below_y + toolbar_size.y + TOOLBAR_SCREEN_MARGIN_PX <= screen_rect.max.y;
+				let within_screen = below_y + toolbar_primary_size.y + TOOLBAR_SCREEN_MARGIN_PX
+					<= screen_rect.max.y;
 
 				if within_screen {
 					below_y
 				} else {
-					capture_rect.max.y - TOOLBAR_SCREEN_MARGIN_PX - toolbar_size.y
+					capture_rect.max.y - TOOLBAR_SCREEN_MARGIN_PX - toolbar_primary_size.y
 				}
 			},
 			ToolbarPlacement::Top => {
-				let above_y = capture_rect.min.y - TOOLBAR_CAPTURE_GAP_PX - toolbar_size.y;
+				let above_y = capture_rect.min.y - TOOLBAR_CAPTURE_GAP_PX - toolbar_primary_size.y;
 				let within_screen = above_y >= screen_rect.min.y + TOOLBAR_SCREEN_MARGIN_PX;
 
 				if within_screen { above_y } else { capture_rect.min.y + TOOLBAR_SCREEN_MARGIN_PX }
 			},
 		};
 		let min_y = screen_rect.min.y + TOOLBAR_SCREEN_MARGIN_PX;
-		let max_y = (screen_rect.max.y - toolbar_size.y - TOOLBAR_SCREEN_MARGIN_PX).max(min_y);
-		let x = Self::frozen_toolbar_default_x(screen_rect, toolbar_size, capture_rect.center().x);
+		let max_y =
+			(screen_rect.max.y - toolbar_window_size.y - TOOLBAR_SCREEN_MARGIN_PX).max(min_y);
+		let ideal_x = capture_rect.center().x - toolbar_primary_size.x / 2.0;
+		let min_x = screen_rect.min.x + TOOLBAR_SCREEN_MARGIN_PX;
+		let max_x =
+			(screen_rect.max.x - toolbar_window_size.x - TOOLBAR_SCREEN_MARGIN_PX).max(min_x);
+		let x = ideal_x.clamp(min_x, max_x);
 		let y = y.max(min_y).min(max_y);
 
 		Pos2::new(x, y)
-	}
-
-	pub(in crate::overlay) fn frozen_toolbar_default_x(
-		screen_rect: Rect,
-		toolbar_size: Vec2,
-		anchor_center_x: f32,
-	) -> f32 {
-		let min_x = screen_rect.min.x + TOOLBAR_SCREEN_MARGIN_PX;
-		let max_x = (screen_rect.max.x - toolbar_size.x - TOOLBAR_SCREEN_MARGIN_PX).max(min_x);
-
-		(anchor_center_x - toolbar_size.x / 2.0).clamp(min_x, max_x)
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -2666,23 +2692,62 @@ impl WindowRenderer {
 	) {
 		#[cfg(target_os = "macos")]
 		let _ = screen_rect;
+		let area_id = Id::new(format!("frozen-toolbar-{}", monitor.id));
 
-		Area::new(Id::new(format!("frozen-toolbar-{}", monitor.id)))
-			.order(Order::Foreground)
-			.fixed_pos(toolbar_pos)
-			.show(ctx, |ui| {
-				let (rect, response) = ui.allocate_exact_size(
-					toolbar_size,
-					if cfg!(target_os = "macos") {
-						Sense::hover()
-					} else {
-						Sense::click_and_drag()
-					},
+		Area::new(area_id).order(Order::Foreground).fixed_pos(toolbar_pos).show(ctx, |ui| {
+			let (window_rect, _window_response) =
+				ui.allocate_exact_size(toolbar_size, Sense::hover());
+			let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, window_rect.min);
+			let style_rect =
+				Self::frozen_annotation_style_capsule_rect(toolbar_state, toolbar_rect);
+			let toolbar_response = ui.interact(
+				toolbar_rect,
+				area_id.with("primary-capsule"),
+				if cfg!(target_os = "macos") { Sense::hover() } else { Sense::click_and_drag() },
+			);
+			#[cfg(target_os = "macos")]
+			let _ = &toolbar_response;
+
+			toolbar_state.annotation_size_control_hovered = false;
+
+			#[cfg(not(target_os = "macos"))]
+			Self::update_frozen_toolbar_drag_state(
+				toolbar_state,
+				toolbar_response.drag_started(),
+				toolbar_pos,
+				screen_rect,
+				toolbar_size,
+				cursor,
+				left_button_down,
+			);
+
+			Self::paint_frozen_toolbar_capsule(
+				ui,
+				toolbar_rect,
+				theme,
+				hud_blur_active,
+				hud_opaque,
+				hud_opacity,
+				hud_milk_amount,
+				hud_tint_hue,
+			);
+			let toolbar_inner_rect = toolbar_rect.shrink2(egui::vec2(
+				HUD_PILL_INNER_MARGIN_X_POINTS,
+				TOOLBAR_PILL_INNER_MARGIN_Y_POINTS,
+			));
+			let _ = ui.scope_builder(UiBuilder::new().max_rect(toolbar_inner_rect), |ui| {
+				Self::render_frozen_toolbar_primary_row(
+					ui,
+					toolbar_inner_rect.width(),
+					toolbar_state,
+					theme,
 				);
-				#[cfg(target_os = "macos")]
-				let _ = &response;
-				let corner_radius = overlay::frozen_toolbar_corner_radius_u8(rect.height());
-				let body_fill = Self::tinted_hud_body_fill(
+			});
+
+			if let Some(style_rect) = style_rect {
+				Self::paint_frozen_toolbar_capsule(
+					ui,
+					style_rect,
 					theme,
 					hud_blur_active,
 					hud_opaque,
@@ -2690,56 +2755,79 @@ impl WindowRenderer {
 					hud_milk_amount,
 					hud_tint_hue,
 				);
-				let toolbar_frame =
-					Self::hud_pill_frame(theme, hud_opaque, hud_opacity, body_fill, false);
-
-				toolbar_state.annotation_size_control_hovered = false;
-
-				#[cfg(not(target_os = "macos"))]
-				Self::update_frozen_toolbar_drag_state(
-					toolbar_state,
-					response.drag_started(),
-					toolbar_pos,
-					screen_rect,
-					toolbar_size,
-					cursor,
-					left_button_down,
-				);
-
-				// Draw the capsule ourselves at the exact allocated rect. This keeps the visible pill
-				// and the blur rect perfectly aligned (no shrink-to-content surprises on first frame).
-				ui.painter().rect_filled(rect, f32::from(corner_radius), toolbar_frame.fill);
-				ui.painter().rect_stroke(
-					rect.shrink(0.5),
-					CornerRadius::same(corner_radius),
-					toolbar_frame.stroke,
-					StrokeKind::Inside,
-				);
-
-				let inner_stroke_color = match theme {
-					HudTheme::Dark => Color32::from_rgba_unmultiplied(0, 0, 0, 44),
-					HudTheme::Light => Color32::from_rgba_unmultiplied(255, 255, 255, 140),
-				};
-				let inner_stroke = Stroke::new(1.0, inner_stroke_color);
-				let inner_rect = rect.shrink(1.0);
-
-				ui.painter().rect_stroke(
-					inner_rect,
-					CornerRadius::same(corner_radius.saturating_sub(1)),
-					inner_stroke,
-					StrokeKind::Inside,
-				);
-
-				let inner_rect = rect.shrink2(egui::vec2(
+				let style_inner_rect = style_rect.shrink2(egui::vec2(
 					HUD_PILL_INNER_MARGIN_X_POINTS,
 					TOOLBAR_PILL_INNER_MARGIN_Y_POINTS,
 				));
+				let _ = ui.scope_builder(UiBuilder::new().max_rect(style_inner_rect), |ui| {
+					let _ = ui.allocate_ui_with_layout(
+						Vec2::new(
+							style_inner_rect.width(),
+							FROZEN_ANNOTATION_TOOLBAR_SECTION_HEIGHT_POINTS,
+						),
+						Layout::left_to_right(Align::Center),
+						|ui| {
+							Self::render_frozen_annotation_toolbar_controls(
+								ui,
+								toolbar_state,
+								theme,
+							)
+						},
+					);
+				});
+			}
 
-				Self::render_frozen_toolbar_body(ui, inner_rect, toolbar_state, theme);
-
-				*hud_pill_out =
-					Some(HudPillGeometry { rect, radius_points: f32::from(corner_radius) });
+			*hud_pill_out = Some(HudPillGeometry {
+				rect: toolbar_rect,
+				radius_points: f32::from(overlay::frozen_toolbar_corner_radius_u8(
+					toolbar_rect.height(),
+				)),
 			});
+		});
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	fn paint_frozen_toolbar_capsule(
+		ui: &Ui,
+		rect: Rect,
+		theme: HudTheme,
+		hud_blur_active: bool,
+		hud_opaque: bool,
+		hud_opacity: f32,
+		hud_milk_amount: f32,
+		hud_tint_hue: f32,
+	) {
+		let corner_radius = overlay::frozen_toolbar_corner_radius_u8(rect.height());
+		let body_fill = Self::tinted_hud_body_fill(
+			theme,
+			hud_blur_active,
+			hud_opaque,
+			hud_opacity,
+			hud_milk_amount,
+			hud_tint_hue,
+		);
+		let toolbar_frame = Self::hud_pill_frame(theme, hud_opaque, hud_opacity, body_fill, false);
+
+		ui.painter().rect_filled(rect, f32::from(corner_radius), toolbar_frame.fill);
+		ui.painter().rect_stroke(
+			rect.shrink(0.5),
+			CornerRadius::same(corner_radius),
+			toolbar_frame.stroke,
+			StrokeKind::Inside,
+		);
+
+		let inner_stroke_color = match theme {
+			HudTheme::Dark => Color32::from_rgba_unmultiplied(0, 0, 0, 44),
+			HudTheme::Light => Color32::from_rgba_unmultiplied(255, 255, 255, 140),
+		};
+		let inner_rect = rect.shrink(1.0);
+
+		ui.painter().rect_stroke(
+			inner_rect,
+			CornerRadius::same(corner_radius.saturating_sub(1)),
+			Stroke::new(1.0, inner_stroke_color),
+			StrokeKind::Inside,
+		);
 	}
 
 	#[cfg(not(target_os = "macos"))]
@@ -2770,33 +2858,6 @@ impl WindowRenderer {
 		}
 	}
 
-	fn render_frozen_toolbar_body(
-		ui: &mut Ui,
-		inner_rect: Rect,
-		toolbar_state: &mut FrozenToolbarState,
-		theme: HudTheme,
-	) {
-		let _ = ui.scope_builder(UiBuilder::new().max_rect(inner_rect), |ui| {
-			ui.with_layout(Layout::top_down(Align::Center), |ui| {
-				Self::render_frozen_toolbar_primary_row(
-					ui,
-					inner_rect.width(),
-					toolbar_state,
-					theme,
-				);
-
-				if Self::frozen_annotation_style_toolbar_visible(toolbar_state) {
-					Self::render_frozen_annotation_toolbar_section(
-						ui,
-						inner_rect,
-						toolbar_state,
-						theme,
-					);
-				}
-			});
-		});
-	}
-
 	fn render_frozen_toolbar_primary_row(
 		ui: &mut Ui,
 		width: f32,
@@ -2811,46 +2872,6 @@ impl WindowRenderer {
 
 				Self::render_frozen_toolbar_controls(ui, toolbar_state, theme);
 			},
-		);
-	}
-
-	fn paint_frozen_annotation_toolbar_spacing(ui: &mut Ui, inner_rect: Rect, theme: HudTheme) {
-		ui.add_space(FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS * 0.5);
-
-		Self::paint_frozen_annotation_toolbar_divider(ui, inner_rect, theme);
-
-		ui.add_space(FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS * 0.5);
-	}
-
-	fn render_frozen_annotation_toolbar_section(
-		ui: &mut Ui,
-		inner_rect: Rect,
-		toolbar_state: &mut FrozenToolbarState,
-		theme: HudTheme,
-	) {
-		Self::paint_frozen_annotation_toolbar_spacing(ui, inner_rect, theme);
-
-		let _ = ui.allocate_ui_with_layout(
-			Vec2::new(inner_rect.width(), FROZEN_ANNOTATION_TOOLBAR_SECTION_HEIGHT_POINTS),
-			Layout::left_to_right(Align::Center),
-			|ui| Self::render_frozen_annotation_toolbar_controls(ui, toolbar_state, theme),
-		);
-	}
-
-	fn paint_frozen_annotation_toolbar_divider(ui: &Ui, inner_rect: Rect, theme: HudTheme) {
-		let divider_color = match theme {
-			HudTheme::Dark => {
-				Color32::from_white_alpha(FROZEN_ANNOTATION_TOOLBAR_SECTION_DIVIDER_ALPHA_DARK)
-			},
-			HudTheme::Light => {
-				Color32::from_black_alpha(FROZEN_ANNOTATION_TOOLBAR_SECTION_DIVIDER_ALPHA_LIGHT)
-			},
-		};
-		let divider_y = ui.cursor().min.y;
-
-		ui.painter().line_segment(
-			[Pos2::new(inner_rect.left(), divider_y), Pos2::new(inner_rect.right(), divider_y)],
-			Stroke::new(1.0, divider_color),
 		);
 	}
 
@@ -2936,10 +2957,6 @@ impl WindowRenderer {
 		});
 	}
 
-	fn frozen_annotation_style_toolbar_visible(toolbar_state: &FrozenToolbarState) -> bool {
-		FrozenAnnotationStyleToolbarKind::from_toolbar_state(toolbar_state).is_some()
-	}
-
 	fn render_frozen_annotation_toolbar_controls(
 		ui: &mut Ui,
 		toolbar_state: &mut FrozenToolbarState,
@@ -3003,7 +3020,6 @@ impl WindowRenderer {
 			),
 			Sense::hover(),
 		);
-		let size_response = size_response.on_hover_text(style_kind.size_hover_text());
 		let minus_rect = Rect::from_min_max(
 			size_rect.min,
 			Pos2::new(
@@ -3022,20 +3038,16 @@ impl WindowRenderer {
 			Pos2::new(minus_rect.max.x, size_rect.min.y),
 			Pos2::new(plus_rect.min.x, size_rect.max.y),
 		);
-		let minus_response = ui
-			.interact(
-				minus_rect,
-				ui.id().with(("annotation-size-decrease", style_kind)),
-				Sense::click(),
-			)
-			.on_hover_text(style_kind.decrease_hover_text());
-		let plus_response = ui
-			.interact(
-				plus_rect,
-				ui.id().with(("annotation-size-increase", style_kind)),
-				Sense::click(),
-			)
-			.on_hover_text(style_kind.increase_hover_text());
+		let minus_response = ui.interact(
+			minus_rect,
+			ui.id().with(("annotation-size-decrease", style_kind)),
+			Sense::click(),
+		);
+		let plus_response = ui.interact(
+			plus_rect,
+			ui.id().with(("annotation-size-increase", style_kind)),
+			Sense::click(),
+		);
 		let hovered =
 			size_response.hovered() || minus_response.hovered() || plus_response.hovered();
 		let capsule_rect = size_rect.shrink2(egui::vec2(1.0, 3.0));
@@ -3279,7 +3291,7 @@ impl WindowRenderer {
 			Stroke::new(if selected { 2.0 } else { 1.0 }, stroke_color),
 		);
 
-		response.on_hover_text("Annotation color").clicked()
+		response.clicked()
 	}
 
 	pub(in crate::overlay) fn frozen_toolbar_button_style(

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -2514,6 +2514,20 @@ impl WindowRenderer {
 			.map_or(toolbar_rect, |style_rect| toolbar_rect.union(style_rect))
 	}
 
+	pub(in crate::overlay) fn frozen_toolbar_visible_capsules_contain(
+		toolbar_state: &FrozenToolbarState,
+		cursor_local: Pos2,
+	) -> bool {
+		let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, Pos2::ZERO);
+
+		if toolbar_rect.contains(cursor_local) {
+			return true;
+		}
+
+		Self::frozen_annotation_style_capsule_rect(toolbar_state, toolbar_rect)
+			.is_some_and(|style_rect| style_rect.contains(cursor_local))
+	}
+
 	pub(in crate::overlay) fn frozen_toolbar_size(toolbar_state: &FrozenToolbarState) -> Vec2 {
 		Self::frozen_toolbar_window_rect(toolbar_state, Pos2::ZERO).size()
 	}

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -2514,6 +2514,7 @@ impl WindowRenderer {
 			.map_or(toolbar_rect, |style_rect| toolbar_rect.union(style_rect))
 	}
 
+	#[cfg(any(target_os = "macos", test))]
 	pub(in crate::overlay) fn frozen_toolbar_visible_capsules_contain(
 		toolbar_state: &FrozenToolbarState,
 		cursor_local: Pos2,

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -583,7 +583,7 @@ impl OverlaySession {
 			Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
 		let preview_rect = self.scroll_preview_local_rect(monitor);
 		let toolbar_primary_size = WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state);
-		let toolbar_window_size = WindowRenderer::frozen_toolbar_size(&self.toolbar_state);
+		let toolbar_window_size = self.toolbar_positioning_size();
 		let toolbar_pos = WindowRenderer::frozen_toolbar_default_window_pos(
 			screen_rect,
 			preview_rect,

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -582,11 +582,13 @@ impl OverlaySession {
 		let screen_rect =
 			Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
 		let preview_rect = self.scroll_preview_local_rect(monitor);
-		let toolbar_size = WindowRenderer::frozen_toolbar_size(&self.toolbar_state);
-		let toolbar_pos = WindowRenderer::frozen_toolbar_default_pos(
+		let toolbar_primary_size = WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state);
+		let toolbar_window_size = WindowRenderer::frozen_toolbar_size(&self.toolbar_state);
+		let toolbar_pos = WindowRenderer::frozen_toolbar_default_window_pos(
 			screen_rect,
 			preview_rect,
-			toolbar_size,
+			toolbar_primary_size,
+			toolbar_window_size,
 			self.config.toolbar_placement,
 		);
 

--- a/packages/rsnap-overlay/src/overlay/session_state.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state.rs
@@ -144,6 +144,7 @@ pub(super) struct HudDrawConfig {
 pub(super) struct FrozenToolbarState {
 	pub(super) visible: bool,
 	pub(super) dragging: bool,
+	pub(super) drag_start_eligible: bool,
 	pub(super) annotation_size_control_hovered: bool,
 	pub(super) annotation_size_wheel_accumulator: f32,
 	pub(super) selected_tool: FrozenToolbarTool,
@@ -271,6 +272,7 @@ impl Default for FrozenToolbarState {
 		Self {
 			visible: true,
 			dragging: false,
+			drag_start_eligible: false,
 			annotation_size_control_hovered: false,
 			annotation_size_wheel_accumulator: 0.0,
 			selected_tool: FrozenToolbarTool::Pointer,
@@ -350,7 +352,7 @@ impl Default for FrozenBrushStyle {
 	fn default() -> Self {
 		Self {
 			stroke_width_points: FROZEN_BRUSH_STROKE_WIDTH_POINTS,
-			color: FrozenAnnotationColor::Red,
+			color: FrozenAnnotationColor::Blue,
 		}
 	}
 }

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -1407,6 +1407,36 @@ fn toolbar_cursor_left_during_drag_keeps_drag_session_alive() {
 }
 
 #[test]
+fn toolbar_drag_start_eligibility_prefers_live_cursor_over_stale_cache() {
+	let mut session = OverlaySession::new();
+	let primary_rect =
+		WindowRenderer::frozen_toolbar_primary_rect(&session.toolbar_state, Pos2::ZERO);
+	let stale_cursor = Pos2::new(primary_rect.right() + 12.0, primary_rect.center().y);
+	let live_cursor = primary_rect.center();
+
+	assert!(!primary_rect.contains(stale_cursor));
+	assert!(primary_rect.contains(live_cursor));
+
+	session.toolbar_pointer_local = Some(stale_cursor);
+
+	assert!(session.resolve_toolbar_drag_start_eligibility(Some(live_cursor)));
+}
+
+#[test]
+fn toolbar_drag_start_eligibility_falls_back_to_cached_pointer_when_live_cursor_is_missing() {
+	let mut session = OverlaySession::new();
+	let primary_rect =
+		WindowRenderer::frozen_toolbar_primary_rect(&session.toolbar_state, Pos2::ZERO);
+	let cached_cursor = primary_rect.center();
+
+	assert!(primary_rect.contains(cached_cursor));
+
+	session.toolbar_pointer_local = Some(cached_cursor);
+
+	assert!(session.resolve_toolbar_drag_start_eligibility(None));
+}
+
+#[test]
 fn toolbar_cursor_left_while_idle_clears_pointer_state() {
 	let mut session = OverlaySession::new();
 

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -386,7 +386,10 @@ fn current_export_image_includes_frozen_brush_strokes() {
 	let export_image = session.current_export_image().expect("annotated export image");
 
 	assert_eq!(export_image.get_pixel(7, 7), &Rgba([12, 34, 56, 255]));
-	assert_eq!(export_image.get_pixel(2, 2), &Rgba(FrozenAnnotationColor::Red.export_rgba()));
+	assert_eq!(
+		export_image.get_pixel(2, 2),
+		&Rgba(session.toolbar_state.brush_style.color.export_rgba())
+	);
 }
 
 #[test]
@@ -440,7 +443,10 @@ fn frozen_brush_undo_and_redo_update_export_image() {
 
 	let redone = session.current_export_image().expect("redo export image");
 
-	assert_eq!(redone.get_pixel(3, 3), &Rgba(FrozenAnnotationColor::Red.export_rgba()));
+	assert_eq!(
+		redone.get_pixel(3, 3),
+		&Rgba(session.toolbar_state.brush_style.color.export_rgba())
+	);
 }
 
 #[test]
@@ -462,7 +468,8 @@ fn current_export_image_antialiases_frozen_brush_edges() {
 
 	let export_image = session.current_export_image().expect("annotated export image");
 	let has_antialiased_edge = export_image.pixels().any(|pixel| {
-		pixel != &background && pixel != &Rgba(FrozenAnnotationColor::Red.export_rgba())
+		pixel != &background
+			&& pixel != &Rgba(session.toolbar_state.brush_style.color.export_rgba())
 	});
 
 	assert!(has_antialiased_edge, "expected blended edge pixels around the exported brush");
@@ -484,7 +491,10 @@ fn rasterizing_frozen_brush_clears_reused_coverage_mask() {
 	);
 
 	assert_eq!(export_image.get_pixel(7, 7), &Rgba([12, 34, 56, 255]));
-	assert_eq!(export_image.get_pixel(2, 2), &Rgba(FrozenAnnotationColor::Red.export_rgba()));
+	assert_eq!(
+		export_image.get_pixel(2, 2),
+		&Rgba(FrozenBrushStyle::default().color.export_rgba())
+	);
 }
 
 fn significant_y_direction_reversals(points: &[Pos2], min_delta: f32) -> usize {
@@ -1112,7 +1122,7 @@ fn default_frozen_brush_style_uses_existing_width_and_color() {
 		session.toolbar_state.brush_style.stroke_width_points,
 		overlay::FROZEN_BRUSH_STROKE_WIDTH_POINTS
 	);
-	assert_eq!(session.toolbar_state.brush_style.color, FrozenAnnotationColor::Red);
+	assert_eq!(session.toolbar_state.brush_style.color, FrozenAnnotationColor::Blue);
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -1437,6 +1437,45 @@ fn toolbar_drag_start_eligibility_falls_back_to_cached_pointer_when_live_cursor_
 }
 
 #[test]
+fn toolbar_cursor_local_from_sampled_global_returns_none_when_sampling_fails() {
+	let outer_position = GlobalPoint::new(320, 140);
+
+	assert_eq!(
+		OverlaySession::toolbar_cursor_local_from_sampled_global(outer_position, None),
+		None
+	);
+}
+
+#[test]
+fn toolbar_visible_capsule_hit_test_excludes_gap_between_capsules() {
+	let mut session = OverlaySession::new();
+
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	let primary_rect =
+		WindowRenderer::frozen_toolbar_primary_rect(&session.toolbar_state, Pos2::ZERO);
+	let window_rect =
+		WindowRenderer::frozen_toolbar_window_rect(&session.toolbar_state, Pos2::ZERO);
+	let primary_point = primary_rect.center();
+	let gap_point = Pos2::new(primary_rect.center().x, primary_rect.max.y + 1.0);
+	let style_point = Pos2::new(primary_rect.center().x, window_rect.max.y - 1.0);
+
+	assert!(WindowRenderer::frozen_toolbar_visible_capsules_contain(
+		&session.toolbar_state,
+		primary_point
+	));
+	assert!(window_rect.contains(gap_point));
+	assert!(!WindowRenderer::frozen_toolbar_visible_capsules_contain(
+		&session.toolbar_state,
+		gap_point
+	));
+	assert!(WindowRenderer::frozen_toolbar_visible_capsules_contain(
+		&session.toolbar_state,
+		style_point
+	));
+}
+
+#[test]
 fn toolbar_cursor_left_while_idle_clears_pointer_state() {
 	let mut session = OverlaySession::new();
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -671,6 +671,109 @@ fn toolbar_window_position_sync_updates_runtime_state_without_requeueing_in_boun
 }
 
 #[test]
+fn toolbar_position_update_near_edge_clamps_with_runtime_positioning_geometry() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+	let desired = Pos2::new(900.0, 760.0);
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
+	let rendered_toolbar_size = WindowRenderer::frozen_toolbar_size(&session.toolbar_state);
+
+	session.toolbar_inner_size_points = Some((
+		startup_size.x.ceil().max(1.0) as u32,
+		startup_size.y.ceil().max(1.0) as u32,
+	));
+
+	let expected_toolbar_size = if cfg!(target_os = "macos") {
+		startup_window_size
+	} else {
+		rendered_toolbar_size
+	};
+	let expected = WindowRenderer::clamp_toolbar_position(
+		screen_rect,
+		expected_toolbar_size,
+		desired,
+		TOOLBAR_SCREEN_MARGIN_PX,
+		TOOLBAR_SCREEN_MARGIN_PX,
+	);
+
+	#[cfg(not(target_os = "macos"))]
+	assert_ne!(
+		expected,
+		WindowRenderer::clamp_toolbar_position(
+			screen_rect,
+			startup_window_size,
+			desired,
+			TOOLBAR_SCREEN_MARGIN_PX,
+			TOOLBAR_SCREEN_MARGIN_PX,
+		)
+	);
+	assert!(session.update_toolbar_outer_position(monitor, desired));
+	assert_eq!(session.toolbar_state.floating_position, Some(expected));
+	assert_eq!(
+		session.toolbar_outer_pos,
+		Some(GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32))
+	);
+}
+
+#[test]
+fn toolbar_window_position_sync_near_edge_clamps_with_runtime_positioning_geometry() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+	let desired_outer = GlobalPoint::new(900, 760);
+	let desired_local = Pos2::new(desired_outer.x as f32, desired_outer.y as f32);
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
+	let rendered_toolbar_size = WindowRenderer::frozen_toolbar_size(&session.toolbar_state);
+
+	session.toolbar_inner_size_points = Some((
+		startup_size.x.ceil().max(1.0) as u32,
+		startup_size.y.ceil().max(1.0) as u32,
+	));
+
+	let expected_toolbar_size = if cfg!(target_os = "macos") {
+		startup_window_size
+	} else {
+		rendered_toolbar_size
+	};
+	let expected = WindowRenderer::clamp_toolbar_position(
+		screen_rect,
+		expected_toolbar_size,
+		desired_local,
+		TOOLBAR_SCREEN_MARGIN_PX,
+		TOOLBAR_SCREEN_MARGIN_PX,
+	);
+
+	#[cfg(not(target_os = "macos"))]
+	assert_ne!(
+		expected,
+		WindowRenderer::clamp_toolbar_position(
+			screen_rect,
+			startup_window_size,
+			desired_local,
+			TOOLBAR_SCREEN_MARGIN_PX,
+			TOOLBAR_SCREEN_MARGIN_PX,
+		)
+	);
+	assert!(session.sync_toolbar_outer_position_from_window(monitor, desired_outer));
+	assert_eq!(session.toolbar_state.floating_position, Some(expected));
+	assert_eq!(
+		session.toolbar_outer_pos,
+		Some(GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32))
+	);
+	assert_eq!(
+		session.pending_toolbar_outer_pos,
+		(session.toolbar_outer_pos != Some(desired_outer)).then_some(
+			GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32)
+		)
+	);
+}
+
+#[test]
 fn toolbar_cursor_global_position_from_outer_uses_cached_toolbar_origin() {
 	let outer_position = GlobalPoint::new(220, 260);
 	let cursor_local = Pos2::new(18.25, 12.75);

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -1236,23 +1236,29 @@ fn frozen_text_caret_visible_blinks_on_half_periods() {
 }
 
 #[test]
-fn frozen_toolbar_size_expands_for_annotation_style_toolbar() {
+fn frozen_toolbar_primary_size_stays_stable_when_annotation_style_capsule_appears() {
 	let mut toolbar_state = FrozenToolbarState::default();
-	let base_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
+	let base_primary_size = WindowRenderer::frozen_toolbar_primary_size(&toolbar_state);
+	let base_window_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
 
 	toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
-	let pen_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
+	let pen_primary_size = WindowRenderer::frozen_toolbar_primary_size(&toolbar_state);
+	let pen_window_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
 
-	assert!(pen_size.y > base_size.y);
-	assert_eq!(pen_size.x, base_size.x);
+	assert_eq!(pen_primary_size, base_primary_size);
+	assert!(pen_window_size.x >= base_window_size.x);
+	assert!(pen_window_size.y > base_window_size.y);
 
 	toolbar_state.selected_tool = FrozenToolbarTool::Text;
 
-	let expanded_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
+	let text_primary_size = WindowRenderer::frozen_toolbar_primary_size(&toolbar_state);
+	let text_window_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
 
-	assert!(expanded_size.y > base_size.y);
-	assert_eq!(expanded_size, pen_size);
+	assert_eq!(text_primary_size, base_primary_size);
+	assert_eq!(text_window_size.x, base_window_size.x);
+	assert!(text_window_size.y > base_window_size.y);
+	assert!(pen_window_size.y >= text_window_size.y);
 }
 
 #[test]
@@ -1388,7 +1394,10 @@ fn frozen_annotation_toolbar_hud_pill_keeps_standard_corner_radius() {
 	);
 	let hud_pill = hud_pill.expect("annotation toolbar should render after readiness stabilizes");
 
-	assert_eq!(hud_pill.radius_points, 18.0);
+	assert_eq!(
+		hud_pill.radius_points,
+		f32::from(overlay::frozen_toolbar_corner_radius_u8(hud_pill.rect.height())),
+	);
 }
 
 #[test]
@@ -1735,9 +1744,10 @@ fn frozen_toolbar_default_position_fits_below_capture_rect() {
 	let monitor = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
 	let capture_rect = Rect::from_min_size(Pos2::new(50.0, 100.0), Vec2::new(300.0, 200.0));
 	let toolbar_size = Vec2::new(460.0, 54.0);
-	let pos = WindowRenderer::frozen_toolbar_default_pos(
+	let pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		monitor,
 		capture_rect,
+		toolbar_size,
 		toolbar_size,
 		ToolbarPlacement::Bottom,
 	);
@@ -1755,9 +1765,10 @@ fn frozen_toolbar_default_position_falls_inside_when_no_space_below_capture_rect
 	let monitor = Rect::from_min_size(Pos2::ZERO, Vec2::new(500.0, 600.0));
 	let toolbar_size = Vec2::new(460.0, 54.0);
 	let capture_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(500.0, 560.0));
-	let pos = WindowRenderer::frozen_toolbar_default_pos(
+	let pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		monitor,
 		capture_rect,
+		toolbar_size,
 		toolbar_size,
 		ToolbarPlacement::Bottom,
 	);
@@ -1773,13 +1784,36 @@ fn frozen_toolbar_default_position_falls_inside_when_no_space_below_capture_rect
 }
 
 #[test]
+fn frozen_toolbar_default_window_position_clamps_using_secondary_capsule_width() {
+	let monitor = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
+	let capture_rect = Rect::from_min_size(Pos2::new(640.0, 120.0), Vec2::new(120.0, 220.0));
+	let toolbar_primary_size = Vec2::new(268.0, 54.0);
+	let toolbar_window_size = Vec2::new(340.0, 82.0);
+	let pos = WindowRenderer::frozen_toolbar_default_window_pos(
+		monitor,
+		capture_rect,
+		toolbar_primary_size,
+		toolbar_window_size,
+		ToolbarPlacement::Bottom,
+	);
+	let ideal_x = capture_rect.center().x - toolbar_primary_size.x / 2.0;
+	let max_x = (monitor.max.x - toolbar_window_size.x - TOOLBAR_SCREEN_MARGIN_PX)
+		.max(TOOLBAR_SCREEN_MARGIN_PX);
+
+	assert!(ideal_x > max_x);
+	assert_eq!(pos.x, max_x);
+	assert_eq!(pos.y, capture_rect.max.y + TOOLBAR_CAPTURE_GAP_PX);
+}
+
+#[test]
 fn frozen_toolbar_top_default_position_fits_above_capture_rect() {
 	let monitor = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
 	let capture_rect = Rect::from_min_size(Pos2::new(50.0, 180.0), Vec2::new(300.0, 200.0));
 	let toolbar_size = Vec2::new(460.0, 54.0);
-	let pos = WindowRenderer::frozen_toolbar_default_pos(
+	let pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		monitor,
 		capture_rect,
+		toolbar_size,
 		toolbar_size,
 		ToolbarPlacement::Top,
 	);
@@ -1797,9 +1831,10 @@ fn frozen_toolbar_top_default_position_falls_inside_when_no_space_above_capture_
 	let monitor = Rect::from_min_size(Pos2::ZERO, Vec2::new(500.0, 600.0));
 	let capture_rect = Rect::from_min_size(Pos2::new(0.0, 20.0), Vec2::new(500.0, 400.0));
 	let toolbar_size = Vec2::new(460.0, 54.0);
-	let pos = WindowRenderer::frozen_toolbar_default_pos(
+	let pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		monitor,
 		capture_rect,
+		toolbar_size,
 		toolbar_size,
 		ToolbarPlacement::Top,
 	);
@@ -1968,9 +2003,10 @@ fn frozen_selection_size_badge_keeps_below_placement_after_toolbar_leaves_defaul
 	state.monitor = Some(monitor);
 	state.frozen_capture_rect = Some(capture_rect_points);
 
-	let default_toolbar_pos = WindowRenderer::frozen_toolbar_default_pos(
+	let default_toolbar_pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		screen_rect,
 		capture_rect,
+		WindowRenderer::frozen_toolbar_size(&FrozenToolbarState::default()),
 		WindowRenderer::frozen_toolbar_size(&FrozenToolbarState::default()),
 		ToolbarPlacement::Bottom,
 	);
@@ -2057,6 +2093,65 @@ fn overlay_session_computes_frozen_toolbar_reserved_rect_without_inline_toolbar_
 }
 
 #[test]
+fn frozen_annotation_capsule_keeps_top_toolbar_default_slot_stable() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(160, 220, 260, 240);
+	let mut session = OverlaySession::new();
+
+	session.config.toolbar_placement = ToolbarPlacement::Top;
+
+	let base_pos = session.frozen_toolbar_default_position_for_capture_rect(monitor, capture_rect);
+
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	let styled_pos =
+		session.frozen_toolbar_default_position_for_capture_rect(monitor, capture_rect);
+
+	assert_eq!(styled_pos, base_pos);
+}
+
+#[test]
+fn frozen_toolbar_reserved_rect_covers_secondary_annotation_capsule() {
+	let monitor = tests::test_monitor();
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let capture_rect_points = RectPoints::new(200, 180, 200, 300);
+	let capture_rect = Rect::from_min_size(
+		Pos2::new(capture_rect_points.x as f32, capture_rect_points.y as f32),
+		Vec2::new(capture_rect_points.width as f32, capture_rect_points.height as f32),
+	);
+	let mut state = OverlayState::new();
+
+	state.mode = OverlayMode::Frozen;
+	state.monitor = Some(monitor);
+	state.frozen_capture_rect = Some(capture_rect_points);
+
+	let toolbar_state = FrozenToolbarState {
+		selected_tool: FrozenToolbarTool::Text,
+		..FrozenToolbarState::default()
+	};
+	let primary_size = WindowRenderer::frozen_toolbar_primary_size(&toolbar_state);
+	let default_pos = WindowRenderer::frozen_toolbar_default_window_pos(
+		screen_rect,
+		capture_rect,
+		primary_size,
+		WindowRenderer::frozen_toolbar_size(&toolbar_state),
+		ToolbarPlacement::Bottom,
+	);
+	let reserved_rect = WindowRenderer::frozen_toolbar_reserved_rect(
+		&state,
+		monitor,
+		screen_rect,
+		ToolbarPlacement::Bottom,
+		&toolbar_state,
+	)
+	.expect("annotation style capsule should be reserved with the default slot");
+
+	assert_eq!(reserved_rect.min, default_pos);
+	assert_eq!(reserved_rect.size(), WindowRenderer::frozen_toolbar_size(&toolbar_state));
+}
+
+#[test]
 fn frozen_toolbar_reserved_rect_uses_overlay_viewport_size() {
 	let monitor = MonitorRect {
 		id: 1,
@@ -2080,15 +2175,17 @@ fn frozen_toolbar_reserved_rect_uses_overlay_viewport_size() {
 	session.toolbar_state.layout_last_screen_size_points = Some(toolbar_window_rect.size());
 
 	let toolbar_size = WindowRenderer::frozen_toolbar_size(&session.toolbar_state);
-	let overlay_default_pos = WindowRenderer::frozen_toolbar_default_pos(
+	let overlay_default_pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		overlay_screen_rect,
 		capture_rect.intersect(overlay_screen_rect),
 		toolbar_size,
+		toolbar_size,
 		session.config.toolbar_placement,
 	);
-	let toolbar_window_default_pos = WindowRenderer::frozen_toolbar_default_pos(
+	let toolbar_window_default_pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		toolbar_window_rect,
 		capture_rect.intersect(toolbar_window_rect),
+		toolbar_size,
 		toolbar_size,
 		session.config.toolbar_placement,
 	);
@@ -2281,9 +2378,10 @@ fn frozen_toolbar_reserved_rect_restores_near_default_slot() {
 	let mut state = OverlayState::new();
 	let mut toolbar_state = FrozenToolbarState::default();
 	let toolbar_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
-	let default_pos = WindowRenderer::frozen_toolbar_default_pos(
+	let default_pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		screen_rect,
 		capture_rect,
+		toolbar_size,
 		toolbar_size,
 		ToolbarPlacement::Bottom,
 	);

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -681,16 +681,11 @@ fn toolbar_position_update_near_edge_clamps_with_runtime_positioning_geometry() 
 	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
 	let rendered_toolbar_size = WindowRenderer::frozen_toolbar_size(&session.toolbar_state);
 
-	session.toolbar_inner_size_points = Some((
-		startup_size.x.ceil().max(1.0) as u32,
-		startup_size.y.ceil().max(1.0) as u32,
-	));
+	session.toolbar_inner_size_points =
+		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
 
-	let expected_toolbar_size = if cfg!(target_os = "macos") {
-		startup_window_size
-	} else {
-		rendered_toolbar_size
-	};
+	let expected_toolbar_size =
+		if cfg!(target_os = "macos") { startup_window_size } else { rendered_toolbar_size };
 	let expected = WindowRenderer::clamp_toolbar_position(
 		screen_rect,
 		expected_toolbar_size,
@@ -730,16 +725,11 @@ fn toolbar_window_position_sync_near_edge_clamps_with_runtime_positioning_geomet
 	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
 	let rendered_toolbar_size = WindowRenderer::frozen_toolbar_size(&session.toolbar_state);
 
-	session.toolbar_inner_size_points = Some((
-		startup_size.x.ceil().max(1.0) as u32,
-		startup_size.y.ceil().max(1.0) as u32,
-	));
+	session.toolbar_inner_size_points =
+		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
 
-	let expected_toolbar_size = if cfg!(target_os = "macos") {
-		startup_window_size
-	} else {
-		rendered_toolbar_size
-	};
+	let expected_toolbar_size =
+		if cfg!(target_os = "macos") { startup_window_size } else { rendered_toolbar_size };
 	let expected = WindowRenderer::clamp_toolbar_position(
 		screen_rect,
 		expected_toolbar_size,
@@ -767,9 +757,8 @@ fn toolbar_window_position_sync_near_edge_clamps_with_runtime_positioning_geomet
 	);
 	assert_eq!(
 		session.pending_toolbar_outer_pos,
-		(session.toolbar_outer_pos != Some(desired_outer)).then_some(
-			GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32)
-		)
+		(session.toolbar_outer_pos != Some(desired_outer))
+			.then_some(GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32))
 	);
 }
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -1348,7 +1348,7 @@ fn frozen_toolbar_primary_size_stays_stable_when_annotation_style_capsule_appear
 	let text_window_size = WindowRenderer::frozen_toolbar_size(&toolbar_state);
 
 	assert_eq!(text_primary_size, base_primary_size);
-	assert_eq!(text_window_size.x, base_window_size.x);
+	assert!(text_window_size.x >= base_window_size.x);
 	assert!(text_window_size.y > base_window_size.y);
 	assert!(pen_window_size.y >= text_window_size.y);
 }
@@ -1489,6 +1489,70 @@ fn frozen_annotation_toolbar_hud_pill_keeps_standard_corner_radius() {
 	assert_eq!(
 		hud_pill.radius_points,
 		f32::from(overlay::frozen_toolbar_corner_radius_u8(hud_pill.rect.height())),
+	);
+}
+
+#[test]
+fn frozen_annotation_toolbar_hud_pill_covers_full_toolbar_bounds() {
+	let ctx = tests::test_egui_context();
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(200, 180, 200, 300);
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let mut session = OverlaySession::new();
+
+	session.begin_frozen_capture_with_rect(monitor, Some(capture_rect), None, None);
+
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	assert!(!session.advance_frozen_toolbar_readiness_sample(screen_rect));
+	assert!(!session.advance_frozen_toolbar_readiness_sample(screen_rect));
+
+	let toolbar_placement = session.config.toolbar_placement;
+	let state = &session.state;
+	let toolbar_state = &mut session.toolbar_state;
+	let mut hud_pill = None;
+	let _ = ctx.run_ui(
+		egui::RawInput { screen_rect: Some(screen_rect), ..Default::default() },
+		|ui: &mut Ui| {
+			WindowRenderer::render_frozen_toolbar_ui(
+				ui.ctx(),
+				state,
+				monitor,
+				HudTheme::Dark,
+				toolbar_placement,
+				false,
+				false,
+				1.0,
+				0.0,
+				0.0,
+				Some(toolbar_state),
+				None,
+				&mut hud_pill,
+			);
+		},
+	);
+	let hud_pill = hud_pill.expect("annotation toolbar should render after readiness stabilizes");
+
+	assert_eq!(hud_pill.rect.size(), WindowRenderer::frozen_toolbar_size(&session.toolbar_state));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn seeded_frozen_toolbar_default_slot_uses_positioning_window_size() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(760, 160, 160, 240);
+	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let mut session = OverlaySession::new();
+
+	session.toolbar_inner_size_points =
+		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
+
+	session.seed_frozen_toolbar_default_position(monitor, capture_rect);
+
+	assert_eq!(
+		session.toolbar_state.default_slot_position,
+		session.toolbar_state.floating_position
 	);
 }
 

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -2,6 +2,7 @@ use crate::overlay::{
 	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
 	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
 	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
+	WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS};
@@ -36,6 +37,9 @@ impl OverlaySession {
 		);
 		let changed = self.sync_toolbar_outer_position_from_window(monitor, outer_position);
 
+		#[cfg(target_os = "macos")]
+		self.sync_toolbar_window_cursor_hittest(super::macos_mouse_location());
+
 		if self.pending_toolbar_outer_pos.is_some() {
 			self.force_apply_pending_toolbar_window_move();
 		} else {
@@ -63,6 +67,7 @@ impl OverlaySession {
 
 		#[cfg(target_os = "macos")]
 		{
+			self.sync_toolbar_window_cursor_hittest(None);
 			self.request_redraw_toolbar_window();
 		}
 
@@ -435,10 +440,17 @@ impl OverlaySession {
 
 	pub(super) fn set_toolbar_window_hidden(&mut self) {
 		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+			#[cfg(target_os = "macos")]
+			let _ = toolbar_window.window.set_cursor_hittest(false);
+
 			toolbar_window.window.set_visible(false);
 		}
 
 		self.toolbar_window_visible = false;
+		#[cfg(target_os = "macos")]
+		{
+			self.toolbar_window_cursor_hittest_enabled = false;
+		}
 		self.toolbar_window_warmup_redraws_remaining = 0;
 		self.last_present_at = Instant::now();
 	}
@@ -594,6 +606,9 @@ impl OverlaySession {
 
 		let position_update_elapsed = self.update_toolbar_position_after_redraw(monitor);
 
+		#[cfg(target_os = "macos")]
+		self.sync_toolbar_window_cursor_hittest(super::macos_mouse_location());
+
 		if let Some(action) = self.toolbar_state.pending_action.take() {
 			let control = self.handle_toolbar_action(action);
 
@@ -631,6 +646,68 @@ impl OverlaySession {
 		self.force_apply_pending_toolbar_window_move();
 
 		Some(position_update_started_at.elapsed())
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn sync_toolbar_window_cursor_hittest(
+		&mut self,
+		current_cursor: Option<GlobalPoint>,
+	) {
+		let enabled = self.toolbar_window_cursor_hittest_should_be_enabled(current_cursor);
+		let Some(toolbar_window) = self.toolbar_window.as_ref() else {
+			self.toolbar_window_cursor_hittest_enabled = false;
+
+			return;
+		};
+
+		if enabled == self.toolbar_window_cursor_hittest_enabled {
+			return;
+		}
+
+		let _ = toolbar_window.window.set_cursor_hittest(enabled);
+
+		self.toolbar_window_cursor_hittest_enabled = enabled;
+	}
+
+	#[cfg(target_os = "macos")]
+	fn toolbar_window_cursor_hittest_should_be_enabled(
+		&self,
+		current_cursor: Option<GlobalPoint>,
+	) -> bool {
+		if !self.toolbar_window_visible
+			|| !matches!(self.state.mode, OverlayMode::Frozen)
+			|| !self.toolbar_state.visible
+			|| self.state.frozen_image.is_none()
+		{
+			return false;
+		}
+
+		let Some(monitor) = self.state.monitor.or_else(|| self.active_cursor_monitor()) else {
+			return false;
+		};
+		let Some(cursor_global) = current_cursor.or(self.state.cursor) else {
+			return false;
+		};
+		let window_toolbar_outer_pos =
+			self.toolbar_window.as_ref().and_then(Self::toolbar_window_outer_position);
+		let toolbar_outer_pos = window_toolbar_outer_pos
+			.or(self.pending_toolbar_outer_pos)
+			.or(self.toolbar_outer_pos)
+			.or_else(|| {
+				self.toolbar_state.floating_position.map(|floating_position| {
+					GlobalPoint::new(
+						monitor.origin.x.saturating_add(floating_position.x.round() as i32),
+						monitor.origin.y.saturating_add(floating_position.y.round() as i32),
+					)
+				})
+			});
+		let Some(toolbar_outer_pos) = toolbar_outer_pos else {
+			return false;
+		};
+		let cursor_local =
+			Self::toolbar_cursor_local_position_from_outer(toolbar_outer_pos, cursor_global);
+
+		WindowRenderer::frozen_toolbar_visible_capsules_contain(&self.toolbar_state, cursor_local)
 	}
 
 	fn log_toolbar_redraw_phase_timing(

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -2,10 +2,9 @@ use crate::overlay::{
 	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
 	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
 	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
-	WindowRenderer,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS};
+use crate::overlay::{FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS, WindowRenderer};
 
 impl OverlaySession {
 	pub(super) fn handle_toolbar_window_moved(

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -4,7 +4,9 @@ use crate::overlay::{
 	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS, WindowRenderer};
+use crate::overlay::{
+	FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS, WindowRenderer,
+};
 
 impl OverlaySession {
 	pub(super) fn handle_toolbar_window_moved(

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -2,10 +2,9 @@ use crate::overlay::{
 	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
 	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
 	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
-	WindowRenderer,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{FrozenCaptureSource, HudAnchor, LogicalSize, TOOLBAR_WINDOW_WARMUP_REDRAWS};
+use crate::overlay::{FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS};
 
 impl OverlaySession {
 	pub(super) fn handle_toolbar_window_moved(
@@ -58,6 +57,7 @@ impl OverlaySession {
 			self.toolbar_left_button_went_down = false;
 			self.toolbar_left_button_went_up = false;
 			self.toolbar_state.drag_offset = Vec2::ZERO;
+			self.toolbar_state.drag_start_eligible = false;
 			self.toolbar_state.drag_anchor = None;
 		}
 
@@ -155,7 +155,10 @@ impl OverlaySession {
 		#[cfg(not(target_os = "macos"))]
 		let mut mouse_drag = self.toolbar_left_button_down && self.toolbar_state.dragging;
 
-		if self.toolbar_left_button_down && self.toolbar_state.drag_anchor.is_none() {
+		if self.toolbar_left_button_down
+			&& self.toolbar_state.drag_start_eligible
+			&& self.toolbar_state.drag_anchor.is_none()
+		{
 			self.toolbar_state.drag_anchor = Some(cursor_local);
 		}
 		if !mouse_drag
@@ -176,6 +179,7 @@ impl OverlaySession {
 					global_cursor.y as f32 - toolbar_outer_pos.y as f32,
 				);
 				self.toolbar_state.dragging = true;
+				self.toolbar_state.drag_start_eligible = false;
 				self.toolbar_state.drag_anchor = None;
 				mouse_drag = true;
 			}
@@ -232,6 +236,7 @@ impl OverlaySession {
 	#[cfg(target_os = "macos")]
 	fn begin_native_toolbar_drag(&mut self) -> OverlayControl {
 		self.toolbar_state.dragging = true;
+		self.toolbar_state.drag_start_eligible = false;
 		self.toolbar_state.drag_anchor = None;
 
 		let Some(toolbar_window_handle) =
@@ -396,12 +401,14 @@ impl OverlaySession {
 		match toolbar_window.renderer.resize(size) {
 			Ok(()) => {
 				let window = Arc::clone(&toolbar_window.window);
+				let toolbar_height_points = self
+					.toolbar_inner_size_points
+					.map(|(_, height)| height as f32)
+					.unwrap_or_else(|| super::frozen_toolbar_window_startup_size_points().y);
 
 				self.configure_hud_window_common(
 					window.as_ref(),
-					Some(overlay::frozen_toolbar_corner_radius_points(
-						WindowRenderer::frozen_toolbar_size(&self.toolbar_state).y,
-					)),
+					Some(overlay::frozen_toolbar_corner_radius_points(toolbar_height_points)),
 				);
 
 				OverlayControl::Continue
@@ -513,30 +520,6 @@ impl OverlaySession {
 
 			draw_result?;
 
-			let desired_inner_size = toolbar_window.renderer.hud_pill.map(|hud_pill| {
-				(
-					hud_pill.rect.width().ceil().max(1.0) as u32,
-					hud_pill.rect.height().ceil().max(1.0) as u32,
-				)
-			});
-			let toolbar_window = Arc::clone(&toolbar_window.window);
-
-			if let Some(desired) = desired_inner_size
-				&& self.toolbar_inner_size_points != Some(desired)
-			{
-				self.toolbar_inner_size_points = Some(desired);
-
-				self.configure_hud_window_common(
-					toolbar_window.as_ref(),
-					Some(overlay::frozen_toolbar_corner_radius_points(desired.1 as f32)),
-				);
-
-				let _ = toolbar_window.request_inner_size(LogicalSize::new(
-					f64::from(desired.0),
-					f64::from(desired.1),
-				));
-			}
-
 			if toolbar_became_visible {
 				self.note_frozen_transition_toolbar_visible(monitor);
 			}
@@ -571,7 +554,6 @@ impl OverlaySession {
 
 		Some(toolbar_became_visible)
 	}
-
 	pub(super) fn handle_toolbar_window_redraw_requested(&mut self) -> OverlayControl {
 		let redraw_started_at = Instant::now();
 

--- a/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
@@ -4,6 +4,29 @@ use crate::overlay::{
 };
 
 impl OverlaySession {
+	fn toolbar_positioning_size(&self) -> Vec2 {
+		#[cfg(target_os = "macos")]
+		{
+			if let Some((width, height)) = self.toolbar_inner_size_points {
+				Vec2::new(width as f32, height as f32)
+			} else if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+				let toolbar_scale = toolbar_window.window.scale_factor().max(1.0);
+				let size = toolbar_window.window.inner_size();
+				let toolbar_w = ((size.width as f64) / toolbar_scale).ceil().max(1.0) as f32;
+				let toolbar_h = ((size.height as f64) / toolbar_scale).ceil().max(1.0) as f32;
+
+				Vec2::new(toolbar_w, toolbar_h)
+			} else {
+				WindowRenderer::frozen_toolbar_size(&self.toolbar_state)
+			}
+		}
+
+		#[cfg(not(target_os = "macos"))]
+		{
+			WindowRenderer::frozen_toolbar_size(&self.toolbar_state)
+		}
+	}
+
 	pub(super) fn update_hud_window_position(&mut self, monitor: MonitorRect, cursor: GlobalPoint) {
 		if self.live_loupe_uses_hud_window()
 			&& matches!(self.state.mode, OverlayMode::Live)
@@ -194,18 +217,7 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		local_pos: Pos2,
 	) -> bool {
-		let toolbar_size = if let Some((width, height)) = self.toolbar_inner_size_points {
-			Vec2::new(width as f32, height as f32)
-		} else if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			let toolbar_scale = toolbar_window.window.scale_factor().max(1.0);
-			let size = toolbar_window.window.inner_size();
-			let toolbar_w = ((size.width as f64) / toolbar_scale).ceil().max(1.0) as f32;
-			let toolbar_h = ((size.height as f64) / toolbar_scale).ceil().max(1.0) as f32;
-
-			Vec2::new(toolbar_w, toolbar_h)
-		} else {
-			WindowRenderer::frozen_toolbar_size(&self.toolbar_state)
-		};
+		let toolbar_size = self.toolbar_positioning_size();
 		let screen_rect =
 			Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
 		let clamped_local_pos = WindowRenderer::clamp_toolbar_position(
@@ -236,18 +248,7 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		outer_position: GlobalPoint,
 	) -> bool {
-		let toolbar_size = if let Some((width, height)) = self.toolbar_inner_size_points {
-			Vec2::new(width as f32, height as f32)
-		} else if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			let toolbar_scale = toolbar_window.window.scale_factor().max(1.0);
-			let size = toolbar_window.window.inner_size();
-			let toolbar_w = ((size.width as f64) / toolbar_scale).ceil().max(1.0) as f32;
-			let toolbar_h = ((size.height as f64) / toolbar_scale).ceil().max(1.0) as f32;
-
-			Vec2::new(toolbar_w, toolbar_h)
-		} else {
-			WindowRenderer::frozen_toolbar_size(&self.toolbar_state)
-		};
+		let toolbar_size = self.toolbar_positioning_size();
 		let screen_rect =
 			Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
 		let local_pos = Pos2::new(

--- a/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
@@ -4,7 +4,7 @@ use crate::overlay::{
 };
 
 impl OverlaySession {
-	fn toolbar_positioning_size(&self) -> Vec2 {
+	pub(super) fn toolbar_positioning_size(&self) -> Vec2 {
 		#[cfg(target_os = "macos")]
 		{
 			if let Some((width, height)) = self.toolbar_inner_size_points {

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -871,8 +871,15 @@ impl OverlaySession {
 			WindowRenderer::new(gpu, Arc::clone(&window), Arc::clone(&self.egui_repaint_deadline))
 				.map_err(|err| format!("Failed to init toolbar renderer: {err:#}"))?;
 
-		self.toolbar_inner_size_points =
-			Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
+		#[cfg(target_os = "macos")]
+		{
+			self.toolbar_inner_size_points =
+				Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
+		}
+		#[cfg(not(target_os = "macos"))]
+		{
+			self.toolbar_inner_size_points = None;
+		}
 		self.toolbar_window = Some(HudOverlayWindow { window, renderer });
 
 		Ok(())

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -871,6 +871,8 @@ impl OverlaySession {
 			WindowRenderer::new(gpu, Arc::clone(&window), Arc::clone(&self.egui_repaint_deadline))
 				.map_err(|err| format!("Failed to init toolbar renderer: {err:#}"))?;
 
+		self.toolbar_inner_size_points =
+			Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
 		self.toolbar_window = Some(HudOverlayWindow { window, renderer });
 
 		Ok(())

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -853,7 +853,7 @@ impl OverlaySession {
 			.map_err(|err| format!("Unable to create toolbar window: {err}"))?;
 		let window = Arc::new(window);
 		#[cfg(target_os = "macos")]
-		let _ = window.set_cursor_hittest(true);
+		let _ = window.set_cursor_hittest(false);
 		#[cfg(not(target_os = "macos"))]
 		let _ = window.set_cursor_hittest(false);
 
@@ -877,6 +877,7 @@ impl OverlaySession {
 				startup_size.x.ceil().max(1.0) as u32,
 				startup_size.y.ceil().max(1.0) as u32,
 			));
+			self.toolbar_window_cursor_hittest_enabled = false;
 		}
 		#[cfg(not(target_os = "macos"))]
 		{

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -873,8 +873,10 @@ impl OverlaySession {
 
 		#[cfg(target_os = "macos")]
 		{
-			self.toolbar_inner_size_points =
-				Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
+			self.toolbar_inner_size_points = Some((
+				startup_size.x.ceil().max(1.0) as u32,
+				startup_size.y.ceil().max(1.0) as u32,
+			));
 		}
 		#[cfg(not(target_os = "macos"))]
 		{


### PR DESCRIPTION
## Summary
- split pen/text style controls into a separate frozen-toolbar capsule while keeping the primary toolbar slot stable
- keep the frozen toolbar native window geometry fixed, limit drag starts to the primary capsule, and remove leftover detached-toolbar/dead UI paths
- unify default pen and text colors to blue and refresh the related export and geometry tests

## Testing
- cargo make lint-rust
- cargo make test-rust