### PR TITLE
Restore Tab loupe hotkey without reclaiming focus

### DIFF
--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -59,13 +59,13 @@ pub(crate) enum UserEvent {
 
 #[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum OverlayCancelHotkeyRegistrationState {
+enum OverlayHotkeyRegistrationState {
 	Unregistered,
 	Registered,
 	Blocked,
 }
 #[cfg(target_os = "macos")]
-impl OverlayCancelHotkeyRegistrationState {
+impl OverlayHotkeyRegistrationState {
 	fn allows_register_attempt(self) -> bool {
 		matches!(self, Self::Unregistered)
 	}
@@ -89,7 +89,13 @@ struct App {
 	#[cfg(target_os = "macos")]
 	overlay_cancel_hotkey_id: u32,
 	#[cfg(target_os = "macos")]
-	overlay_cancel_hotkey_registration_state: OverlayCancelHotkeyRegistrationState,
+	overlay_cancel_hotkey_registration_state: OverlayHotkeyRegistrationState,
+	#[cfg(target_os = "macos")]
+	overlay_loupe_hotkey: HotKey,
+	#[cfg(target_os = "macos")]
+	overlay_loupe_hotkey_id: u32,
+	#[cfg(target_os = "macos")]
+	overlay_loupe_hotkey_registration_state: OverlayHotkeyRegistrationState,
 	capture_hotkey_recording_suspended: bool,
 	tray_icon: Option<TrayIcon>,
 	#[cfg(target_os = "macos")]
@@ -140,6 +146,11 @@ impl App {
 		HotKey::new(None, Code::Escape)
 	}
 
+	#[cfg(target_os = "macos")]
+	fn overlay_loupe_hotkey() -> HotKey {
+		HotKey::new(None, Code::Tab)
+	}
+
 	#[allow(clippy::too_many_arguments)]
 	fn new(
 		capture_hotkey: HotKey,
@@ -162,8 +173,13 @@ impl App {
 			#[cfg(target_os = "macos")]
 			overlay_cancel_hotkey_id: Self::overlay_cancel_hotkey().id(),
 			#[cfg(target_os = "macos")]
-			overlay_cancel_hotkey_registration_state:
-				OverlayCancelHotkeyRegistrationState::Unregistered,
+			overlay_cancel_hotkey_registration_state: OverlayHotkeyRegistrationState::Unregistered,
+			#[cfg(target_os = "macos")]
+			overlay_loupe_hotkey: Self::overlay_loupe_hotkey(),
+			#[cfg(target_os = "macos")]
+			overlay_loupe_hotkey_id: Self::overlay_loupe_hotkey().id(),
+			#[cfg(target_os = "macos")]
+			overlay_loupe_hotkey_registration_state: OverlayHotkeyRegistrationState::Unregistered,
 			capture_hotkey_recording_suspended: false,
 			_hotkey_manager: hotkey_manager,
 			tray_icon: None,
@@ -294,7 +310,7 @@ mod tests {
 	use global_hotkey::hotkey::{Code, Modifiers};
 
 	#[cfg(target_os = "macos")]
-	use crate::app::OverlayCancelHotkeyRegistrationState;
+	use crate::app::OverlayHotkeyRegistrationState;
 	use crate::app::{self, SettingsWindowEntry};
 
 	#[test]
@@ -329,20 +345,29 @@ mod tests {
 
 	#[cfg(target_os = "macos")]
 	#[test]
-	fn blocked_overlay_cancel_hotkey_registration_skips_retries_until_reset() {
-		assert!(OverlayCancelHotkeyRegistrationState::Unregistered.allows_register_attempt());
-		assert!(!OverlayCancelHotkeyRegistrationState::Registered.allows_register_attempt());
-		assert!(!OverlayCancelHotkeyRegistrationState::Blocked.allows_register_attempt());
+	fn overlay_loupe_hotkey_is_plain_tab() {
+		let hotkey = app::App::overlay_loupe_hotkey();
+
+		assert_eq!(hotkey.key, Code::Tab);
+		assert_eq!(hotkey.mods, Modifiers::empty());
 	}
 
 	#[cfg(target_os = "macos")]
 	#[test]
-	fn already_registered_overlay_cancel_hotkey_error_keeps_registered_state() {
+	fn blocked_overlay_hotkey_registration_skips_retries_until_reset() {
+		assert!(OverlayHotkeyRegistrationState::Unregistered.allows_register_attempt());
+		assert!(!OverlayHotkeyRegistrationState::Registered.allows_register_attempt());
+		assert!(!OverlayHotkeyRegistrationState::Blocked.allows_register_attempt());
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn already_registered_overlay_hotkey_error_keeps_registered_state() {
 		let error = global_hotkey::Error::AlreadyRegistered(app::App::overlay_cancel_hotkey());
 
 		assert_eq!(
-			OverlayCancelHotkeyRegistrationState::next_state_after_register_error(&error),
-			OverlayCancelHotkeyRegistrationState::Registered
+			OverlayHotkeyRegistrationState::next_state_after_register_error(&error),
+			OverlayHotkeyRegistrationState::Registered
 		);
 	}
 }

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -15,6 +15,8 @@ use color_eyre::eyre;
 #[cfg(target_os = "macos")]
 use color_eyre::eyre::Result;
 #[cfg(target_os = "macos")]
+use global_hotkey::hotkey::HotKey;
+#[cfg(target_os = "macos")]
 use objc2::AnyThread;
 #[cfg(target_os = "macos")]
 use objc2::rc::Retained;
@@ -26,7 +28,7 @@ use winit::event_loop::ActiveEventLoop;
 
 use crate::app::App;
 #[cfg(target_os = "macos")]
-use crate::app::OverlayCancelHotkeyRegistrationState;
+use crate::app::OverlayHotkeyRegistrationState;
 #[cfg(target_os = "macos")]
 use crate::app::UserEvent;
 #[cfg(target_os = "macos")]
@@ -48,6 +50,18 @@ const CAPTURE_SUCCESS_SOUND_CANDIDATE_PATHS: [&str; 2] = [
 	"/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/system/Screen Capture.aif",
 	"/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/system/Shutter.aif",
 ];
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy)]
+struct OverlayHotkeySpec {
+	hotkey: HotKey,
+	hotkey_id: u32,
+	hotkey_label: &'static str,
+	missing_manager_message: &'static str,
+	register_failure_message: &'static str,
+	register_success_message: &'static str,
+	unregister_failure_message: &'static str,
+	unregister_success_message: &'static str,
+}
 
 impl App {
 	#[cfg(target_os = "macos")]
@@ -73,101 +87,163 @@ impl App {
 	}
 
 	#[cfg(target_os = "macos")]
-	fn register_overlay_cancel_hotkey(&mut self) {
-		if !self.overlay_cancel_hotkey_registration_state.allows_register_attempt() {
-			return;
+	fn register_overlay_hotkey(
+		&mut self,
+		spec: OverlayHotkeySpec,
+		registration_state: OverlayHotkeyRegistrationState,
+	) -> OverlayHotkeyRegistrationState {
+		if !registration_state.allows_register_attempt() {
+			return registration_state;
 		}
 
 		let Some(manager) = self._hotkey_manager.as_mut() else {
-			self.overlay_cancel_hotkey_registration_state =
-				OverlayCancelHotkeyRegistrationState::Blocked;
+			tracing::warn!(hotkey = spec.hotkey_label, "{}", spec.missing_manager_message);
 
-			tracing::warn!(
-				hotkey = "Esc",
-				"Capture cancel hotkey is unavailable because the global hotkey manager is missing."
-			);
-
-			return;
+			return OverlayHotkeyRegistrationState::Blocked;
 		};
 
-		if let Err(err) = manager.register(self.overlay_cancel_hotkey) {
-			self.overlay_cancel_hotkey_registration_state =
-				OverlayCancelHotkeyRegistrationState::next_state_after_register_error(&err);
+		match manager.register(spec.hotkey) {
+			Ok(()) => {
+				tracing::info!(
+					hotkey = spec.hotkey_label,
+					hotkey_id = %spec.hotkey_id,
+					"{}",
+					spec.register_success_message
+				);
 
-			tracing::warn!(
-				error = ?err,
-				hotkey = "Esc",
-				hotkey_id = %self.overlay_cancel_hotkey_id,
-				"Failed to register the capture cancel hotkey."
-			);
-		} else {
-			self.overlay_cancel_hotkey_registration_state =
-				OverlayCancelHotkeyRegistrationState::Registered;
+				OverlayHotkeyRegistrationState::Registered
+			},
+			Err(err) => {
+				tracing::warn!(
+					error = ?err,
+					hotkey = spec.hotkey_label,
+					hotkey_id = %spec.hotkey_id,
+					"{}",
+					spec.register_failure_message
+				);
 
-			tracing::info!(
-				hotkey = "Esc",
-				hotkey_id = %self.overlay_cancel_hotkey_id,
-				"Registered the capture cancel hotkey."
-			);
+				OverlayHotkeyRegistrationState::next_state_after_register_error(&err)
+			},
 		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn unregister_overlay_hotkey(
+		&mut self,
+		spec: OverlayHotkeySpec,
+		registration_state: OverlayHotkeyRegistrationState,
+	) -> OverlayHotkeyRegistrationState {
+		if matches!(registration_state, OverlayHotkeyRegistrationState::Unregistered) {
+			return registration_state;
+		}
+		if matches!(registration_state, OverlayHotkeyRegistrationState::Blocked) {
+			return OverlayHotkeyRegistrationState::Unregistered;
+		}
+
+		let Some(manager) = self._hotkey_manager.as_mut() else {
+			return OverlayHotkeyRegistrationState::Unregistered;
+		};
+
+		match manager.unregister(spec.hotkey) {
+			Ok(()) => {
+				tracing::info!(
+					hotkey = spec.hotkey_label,
+					hotkey_id = %spec.hotkey_id,
+					"{}",
+					spec.unregister_success_message
+				);
+			},
+			Err(err) => {
+				tracing::warn!(
+					error = ?err,
+					hotkey = spec.hotkey_label,
+					hotkey_id = %spec.hotkey_id,
+					"{}",
+					spec.unregister_failure_message
+				);
+			},
+		}
+
+		OverlayHotkeyRegistrationState::Unregistered
+	}
+
+	#[cfg(target_os = "macos")]
+	fn overlay_cancel_hotkey_spec(&self) -> OverlayHotkeySpec {
+		OverlayHotkeySpec {
+			hotkey: self.overlay_cancel_hotkey,
+			hotkey_id: self.overlay_cancel_hotkey_id,
+			hotkey_label: "Esc",
+			missing_manager_message: "Capture cancel hotkey is unavailable because the global hotkey manager is missing.",
+			register_failure_message: "Failed to register the capture cancel hotkey.",
+			register_success_message: "Registered the capture cancel hotkey.",
+			unregister_failure_message: "Failed to unregister the capture cancel hotkey.",
+			unregister_success_message: "Unregistered the capture cancel hotkey.",
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn overlay_loupe_hotkey_spec(&self) -> OverlayHotkeySpec {
+		OverlayHotkeySpec {
+			hotkey: self.overlay_loupe_hotkey,
+			hotkey_id: self.overlay_loupe_hotkey_id,
+			hotkey_label: "Tab",
+			missing_manager_message: "Capture loupe hotkey is unavailable because the global hotkey manager is missing.",
+			register_failure_message: "Failed to register the capture loupe hotkey.",
+			register_success_message: "Registered the capture loupe hotkey.",
+			unregister_failure_message: "Failed to unregister the capture loupe hotkey.",
+			unregister_success_message: "Unregistered the capture loupe hotkey.",
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn register_overlay_cancel_hotkey(&mut self) {
+		let spec = self.overlay_cancel_hotkey_spec();
+
+		self.overlay_cancel_hotkey_registration_state =
+			self.register_overlay_hotkey(spec, self.overlay_cancel_hotkey_registration_state);
 	}
 
 	#[cfg(target_os = "macos")]
 	fn unregister_overlay_cancel_hotkey(&mut self) {
-		if matches!(
-			self.overlay_cancel_hotkey_registration_state,
-			super::OverlayCancelHotkeyRegistrationState::Unregistered
-		) {
-			return;
-		}
-		if matches!(
-			self.overlay_cancel_hotkey_registration_state,
-			super::OverlayCancelHotkeyRegistrationState::Blocked
-		) {
-			self.overlay_cancel_hotkey_registration_state =
-				OverlayCancelHotkeyRegistrationState::Unregistered;
+		let spec = self.overlay_cancel_hotkey_spec();
 
-			return;
-		}
-
-		let Some(manager) = self._hotkey_manager.as_mut() else {
-			self.overlay_cancel_hotkey_registration_state =
-				OverlayCancelHotkeyRegistrationState::Unregistered;
-
-			return;
-		};
-
-		if let Err(err) = manager.unregister(self.overlay_cancel_hotkey) {
-			self.overlay_cancel_hotkey_registration_state =
-				OverlayCancelHotkeyRegistrationState::Unregistered;
-
-			tracing::warn!(
-				error = ?err,
-				hotkey = "Esc",
-				hotkey_id = %self.overlay_cancel_hotkey_id,
-				"Failed to unregister the capture cancel hotkey."
-			);
-		} else {
-			self.overlay_cancel_hotkey_registration_state =
-				OverlayCancelHotkeyRegistrationState::Unregistered;
-
-			tracing::info!(
-				hotkey = "Esc",
-				hotkey_id = %self.overlay_cancel_hotkey_id,
-				"Unregistered the capture cancel hotkey."
-			);
-		}
+		self.overlay_cancel_hotkey_registration_state =
+			self.unregister_overlay_hotkey(spec, self.overlay_cancel_hotkey_registration_state);
 	}
 
 	#[cfg(target_os = "macos")]
-	fn sync_overlay_cancel_hotkey_registration(&mut self) {
-		let should_register =
-			self.overlay_session.as_ref().is_some_and(OverlaySession::wants_global_cancel_hotkey);
+	fn register_overlay_loupe_hotkey(&mut self) {
+		let spec = self.overlay_loupe_hotkey_spec();
 
-		if should_register {
+		self.overlay_loupe_hotkey_registration_state =
+			self.register_overlay_hotkey(spec, self.overlay_loupe_hotkey_registration_state);
+	}
+
+	#[cfg(target_os = "macos")]
+	fn unregister_overlay_loupe_hotkey(&mut self) {
+		let spec = self.overlay_loupe_hotkey_spec();
+
+		self.overlay_loupe_hotkey_registration_state =
+			self.unregister_overlay_hotkey(spec, self.overlay_loupe_hotkey_registration_state);
+	}
+
+	#[cfg(target_os = "macos")]
+	fn sync_overlay_hotkey_registrations(&mut self) {
+		let should_register_cancel =
+			self.overlay_session.as_ref().is_some_and(OverlaySession::wants_global_cancel_hotkey);
+		let should_register_loupe =
+			self.overlay_session.as_ref().is_some_and(OverlaySession::wants_global_loupe_hotkey);
+
+		if should_register_cancel {
 			self.register_overlay_cancel_hotkey();
 		} else {
 			self.unregister_overlay_cancel_hotkey();
+		}
+
+		if should_register_loupe {
+			self.register_overlay_loupe_hotkey();
+		} else {
+			self.unregister_overlay_loupe_hotkey();
 		}
 	}
 
@@ -337,7 +413,7 @@ impl App {
 				self.overlay_session = Some(overlay_session);
 
 				#[cfg(target_os = "macos")]
-				self.sync_overlay_cancel_hotkey_registration();
+				self.sync_overlay_hotkey_registrations();
 			},
 			Err(err) => {
 				let overlay_start_ms = overlay_start_started_at.elapsed().as_millis();
@@ -576,7 +652,10 @@ impl App {
 		};
 
 		#[cfg(target_os = "macos")]
-		self.unregister_overlay_cancel_hotkey();
+		{
+			self.unregister_overlay_cancel_hotkey();
+			self.unregister_overlay_loupe_hotkey();
+		}
 
 		#[cfg(target_os = "macos")]
 		{
@@ -791,7 +870,7 @@ impl App {
 		}
 
 		#[cfg(target_os = "macos")]
-		self.sync_overlay_cancel_hotkey_registration();
+		self.sync_overlay_hotkey_registrations();
 	}
 }
 

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -239,7 +239,6 @@ impl App {
 		} else {
 			self.unregister_overlay_cancel_hotkey();
 		}
-
 		if should_register_loupe {
 			self.register_overlay_loupe_hotkey();
 		} else {

--- a/apps/rsnap/src/app/shell.rs
+++ b/apps/rsnap/src/app/shell.rs
@@ -230,6 +230,18 @@ impl App {
 		event_loop: &ActiveEventLoop,
 		event: GlobalHotKeyEvent,
 	) {
+		#[cfg(target_os = "macos")]
+		if self.overlay_session.is_some() && event.id() == self.overlay_loupe_hotkey_id {
+			if let Some(session) = self.overlay_session.as_mut() {
+				let control =
+					session.handle_global_loupe_hotkey(event.state() == HotKeyState::Pressed);
+
+				self.handle_overlay_control(control);
+			}
+
+			return;
+		}
+
 		if event.state() != HotKeyState::Pressed {
 			return;
 		}

--- a/apps/rsnap/src/app/shell.rs
+++ b/apps/rsnap/src/app/shell.rs
@@ -231,20 +231,19 @@ impl App {
 		event: GlobalHotKeyEvent,
 	) {
 		#[cfg(target_os = "macos")]
-		if self.overlay_session.is_some() && event.id() == self.overlay_loupe_hotkey_id {
-			if let Some(session) = self.overlay_session.as_mut() {
-				let control =
-					session.handle_global_loupe_hotkey(event.state() == HotKeyState::Pressed);
+			if self.overlay_session.is_some() && event.id() == self.overlay_loupe_hotkey_id {
+				if let Some(session) = self.overlay_session.as_mut() {
+					let control =
+						session.handle_global_loupe_hotkey(event.state() == HotKeyState::Pressed);
 
-				self.handle_overlay_control(control);
+					self.handle_overlay_control(control);
+				}
+
+				return;
 			}
-
-			return;
-		}
-
-		if event.state() != HotKeyState::Pressed {
-			return;
-		}
+			if event.state() != HotKeyState::Pressed {
+				return;
+			}
 		#[cfg(target_os = "macos")]
 		if self.overlay_session.is_some() && event.id() == self.overlay_cancel_hotkey_id {
 			tracing::info!(hotkey = "Esc", "Capture cancel requested from hotkey.");

--- a/apps/rsnap/src/app/shell.rs
+++ b/apps/rsnap/src/app/shell.rs
@@ -231,19 +231,19 @@ impl App {
 		event: GlobalHotKeyEvent,
 	) {
 		#[cfg(target_os = "macos")]
-			if self.overlay_session.is_some() && event.id() == self.overlay_loupe_hotkey_id {
-				if let Some(session) = self.overlay_session.as_mut() {
-					let control =
-						session.handle_global_loupe_hotkey(event.state() == HotKeyState::Pressed);
+		if self.overlay_session.is_some() && event.id() == self.overlay_loupe_hotkey_id {
+			if let Some(session) = self.overlay_session.as_mut() {
+				let control =
+					session.handle_global_loupe_hotkey(event.state() == HotKeyState::Pressed);
 
-					self.handle_overlay_control(control);
-				}
+				self.handle_overlay_control(control);
+			}
 
-				return;
-			}
-			if event.state() != HotKeyState::Pressed {
-				return;
-			}
+			return;
+		}
+		if event.state() != HotKeyState::Pressed {
+			return;
+		}
 		#[cfg(target_os = "macos")]
 		if self.overlay_session.is_some() && event.id() == self.overlay_cancel_hotkey_id {
 			tracing::info!(hotkey = "Esc", "Capture cancel requested from hotkey.");

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -959,6 +959,14 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	/// Returns whether the host should keep the global Tab hotkey registered
+	/// for the current overlay mode.
+	#[must_use]
+	pub fn wants_global_loupe_hotkey(&self) -> bool {
+		matches!(self.state.mode, OverlayMode::Live)
+	}
+
+	#[cfg(target_os = "macos")]
 	/// Registers a wake callback that creates non-critical startup windows after first paint.
 	pub fn set_startup_aux_window_waker(&mut self, waker: Arc<dyn Fn() + Send + Sync>) {
 		self.startup_aux_window_waker = Some(waker);

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -216,6 +216,9 @@ impl OverlaySession {
 	}
 
 	pub(super) fn apply_loupe_activation_key_event(&mut self, pressed: bool, repeat: bool) -> bool {
+		if self.loupe_activation_key_down == pressed && !repeat {
+			return false;
+		}
 		if !matches!(self.state.mode, OverlayMode::Live) {
 			self.loupe_activation_key_down = false;
 
@@ -1169,6 +1172,16 @@ impl OverlaySession {
 		}
 
 		self.cancel_overlay("global_escape_hotkey")
+	}
+
+	#[cfg(target_os = "macos")]
+	/// Handles a host-level Tab hotkey press/release while the live overlay is active.
+	pub fn handle_global_loupe_hotkey(&mut self, pressed: bool) -> OverlayControl {
+		if self.apply_loupe_activation_key_event(pressed, false) {
+			return self.request_redraw_for_alt_state_change();
+		}
+
+		OverlayControl::Continue
 	}
 
 	pub(super) fn handle_key_event(&mut self, event: &KeyEvent) -> OverlayControl {

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -270,15 +270,12 @@ fn duplicate_loupe_activation_key_events_do_not_double_toggle() {
 	assert!(session.apply_loupe_activation_key_event(true, false));
 	assert!(session.state.alt_held);
 	assert!(session.loupe_activation_key_down);
-
 	assert!(!session.apply_loupe_activation_key_event(true, false));
 	assert!(session.state.alt_held);
 	assert!(session.loupe_activation_key_down);
-
 	assert!(!session.apply_loupe_activation_key_event(false, false));
 	assert!(session.state.alt_held);
 	assert!(!session.loupe_activation_key_down);
-
 	assert!(!session.apply_loupe_activation_key_event(false, false));
 	assert!(session.state.alt_held);
 	assert!(!session.loupe_activation_key_down);
@@ -952,7 +949,6 @@ fn global_loupe_hotkey_tracks_live_hold_state() {
 	assert!(matches!(session.handle_global_loupe_hotkey(true), OverlayControl::Continue));
 	assert!(session.state.alt_held);
 	assert!(session.loupe_activation_key_down);
-
 	assert!(matches!(session.handle_global_loupe_hotkey(false), OverlayControl::Continue));
 	assert!(!session.state.alt_held);
 	assert!(!session.loupe_activation_key_down);

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -259,6 +259,31 @@ fn apply_loupe_activation_key_event_ignores_frozen_mode() {
 	assert!(!session.loupe_activation_key_down);
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn duplicate_loupe_activation_key_events_do_not_double_toggle() {
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.config.alt_activation = AltActivationMode::Toggle;
+
+	assert!(session.apply_loupe_activation_key_event(true, false));
+	assert!(session.state.alt_held);
+	assert!(session.loupe_activation_key_down);
+
+	assert!(!session.apply_loupe_activation_key_event(true, false));
+	assert!(session.state.alt_held);
+	assert!(session.loupe_activation_key_down);
+
+	assert!(!session.apply_loupe_activation_key_event(false, false));
+	assert!(session.state.alt_held);
+	assert!(!session.loupe_activation_key_down);
+
+	assert!(!session.apply_loupe_activation_key_event(false, false));
+	assert!(session.state.alt_held);
+	assert!(!session.loupe_activation_key_down);
+}
+
 #[test]
 fn live_drag_alt_activation_does_not_reopen_loupe() {
 	let mut session = OverlaySession::new();
@@ -891,6 +916,20 @@ fn wants_global_cancel_hotkey_only_in_live_mode() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn wants_global_loupe_hotkey_only_in_live_mode() {
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+
+	assert!(session.wants_global_loupe_hotkey());
+
+	session.state.mode = OverlayMode::Frozen;
+
+	assert!(!session.wants_global_loupe_hotkey());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn global_escape_hotkey_cancels_live_capture() {
 	let mut session = OverlaySession::new();
 
@@ -900,6 +939,23 @@ fn global_escape_hotkey_cancels_live_capture() {
 		session.handle_global_escape_hotkey(),
 		OverlayControl::Exit(OverlayExit::Cancelled)
 	));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn global_loupe_hotkey_tracks_live_hold_state() {
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.config.alt_activation = AltActivationMode::Hold;
+
+	assert!(matches!(session.handle_global_loupe_hotkey(true), OverlayControl::Continue));
+	assert!(session.state.alt_held);
+	assert!(session.loupe_activation_key_down);
+
+	assert!(matches!(session.handle_global_loupe_hotkey(false), OverlayControl::Continue));
+	assert!(!session.state.alt_held);
+	assert!(!session.loupe_activation_key_down);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- register a live-only global Tab hotkey so loupe still works while the overlay preserves app focus
- route host-level Tab press and release into overlay loupe activation and ignore duplicate key-state events
- add tests for the new hotkey registration and live loupe behavior

## Testing
- cargo make lint-rust
- cargo make test-rust