### PR TITLE
Ignore startup blur before first live loupe Tab press

### DIFF
--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -21,9 +21,9 @@ impl OverlaySession {
 			return;
 		}
 
-		self.focused_window_ids.remove(&window_id);
+		let was_focused = self.focused_window_ids.remove(&window_id);
 
-		if self.focused_window_ids.is_empty() {
+		if was_focused && self.focused_window_ids.is_empty() {
 			self.pending_focus_loss_cleanup = true;
 		}
 	}

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -387,6 +387,27 @@ fn pending_focus_loss_cleanup_clears_loupe_after_all_overlay_windows_blur() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn initial_unfocused_window_blur_does_not_cancel_first_global_loupe_press() {
+	let overlay_window_id = WindowId::from(1);
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.config.alt_activation = AltActivationMode::Hold;
+
+	session.note_window_focus_change(overlay_window_id, false);
+
+	assert!(matches!(session.handle_global_loupe_hotkey(true), OverlayControl::Continue));
+	assert!(session.state.alt_held);
+	assert!(session.loupe_activation_key_down);
+
+	session.maybe_clear_loupe_activation_after_focus_loss();
+
+	assert!(session.state.alt_held);
+	assert!(session.loupe_activation_key_down);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn live_loupe_keeps_a_dedicated_window_during_live_alt() {
 	let mut session = OverlaySession::new();
 


### PR DESCRIPTION
## Summary
- ignore startup blur events for overlay windows that were never focused
- keep pending focus-loss cleanup for real overlay blur transitions
- add a regression test for the first global Tab press path

## Testing
- cargo make fmt
- cargo make lint-fix
- cargo make checks