### PR TITLE
fix: restore macOS focus preservation through frozen capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Pure-Rust menubar screenshot prototype (macOS-first).
 - Transparent capture-session overlay that blocks desktop interaction.
 - HUD near the cursor showing global `x,y` and `rgb(r,g,b)`.
 - Left click + drag freezes a selected region; a single left click freezes the hovered window or falls back to the active monitor fullscreen.
+- On macOS, entering Frozen mode restores the pre-capture target after selection completes instead of leaving rsnap focused; exiting capture restores the original frontmost app.
 - In Frozen mode, a dragged-region capture can be dragged from inside the bright selection area to reposition it without resizing.
 - In Frozen mode, `Space` copies the current frozen PNG to the clipboard and exits.
 - In Frozen mode, Cmd+S (macOS) / Ctrl+S saves the current PNG to disk and exits.

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -32,6 +32,9 @@ cross-platform architecture.
   if no window is detected, it falls back to freezing that monitor fullscreen.
 - Hovering over a window in live mode shows a glowing border that tracks the target
   window.
+- On macOS, live drag/window-click entry into Frozen mode must restore the pre-capture
+  target after the selection completes instead of leaving rsnap focused, and exiting capture
+  must restore the originally captured frontmost application.
 - `Space` copies the frozen PNG of the selected region/window/fullscreen to clipboard.
 - On macOS, Frozen mode may recognize text from the current frozen capture and copy the recognized text to the clipboard.
 - Cmd+S (macOS) / Ctrl+S saves the frozen PNG to disk.

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1697,6 +1697,7 @@ impl OverlaySession {
 		self.state.hovered_window_rect = None;
 
 		self.reset_frozen_annotation_state();
+
 		self.skip_toolbar_focus_on_next_show = true;
 		#[cfg(target_os = "macos")]
 		{
@@ -2973,6 +2974,7 @@ impl OverlaySession {
 
 		#[cfg(target_os = "macos")]
 		let frontmost_application_before_start = self.frontmost_application_before_start.take();
+
 		self.reset_runtime_for_exit();
 		#[cfg(target_os = "macos")]
 		self.restore_frontmost_application_after_exit(frontmost_application_before_start);
@@ -4343,6 +4345,7 @@ fn macos_configure_overlay_window_mouse_moved_events(window: &Window) {
 		}
 
 		macos_configure_nonactivating_capture_window_with_ns_window(ns_window);
+
 		let _: () = objc::msg_send![ns_window, setOpaque: false];
 		let _: () = objc::msg_send![ns_window, setHasShadow: false];
 		let clear: *mut Object = objc::msg_send![objc::class!(NSColor), clearColor];

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -645,6 +645,8 @@ pub struct OverlaySession {
 	hud_window_visible: bool,
 	toolbar_window_visible: bool,
 	skip_toolbar_focus_on_next_show: bool,
+	#[cfg(target_os = "macos")]
+	preserve_frontmost_on_next_toolbar_show: bool,
 	toolbar_window_warmup_redraws_remaining: u8,
 	loupe_window_visible: bool,
 	loupe_window_warmup_redraws_remaining: u8,
@@ -860,6 +862,8 @@ impl OverlaySession {
 			frozen_spotlight_preview_rect: None, frozen_edit_undo_stack: Vec::new(),
 			frozen_edit_redo_stack: Vec::new(), frozen_mosaic_undo_stack: Vec::new(), frozen_mosaic_redo_stack: Vec::new(),
 			hud_window_visible: false, toolbar_window_visible: false, skip_toolbar_focus_on_next_show: false,
+			#[cfg(target_os = "macos")]
+			preserve_frontmost_on_next_toolbar_show: false,
 			toolbar_window_warmup_redraws_remaining: 0, loupe_window_visible: false, loupe_window_warmup_redraws_remaining: 0,
 			scroll_capture: ScrollCaptureState::default(),
 			#[cfg(target_os = "macos")]
@@ -956,6 +960,22 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn restore_recorded_frontmost_application_for_focus_preservation(&self, reason: &'static str) {
+		let Some(target) = self.frontmost_application_before_start else {
+			return;
+		};
+		let restored = macos_restore_frontmost_application(target);
+
+		tracing::info!(
+			op = "overlay.frontmost_app_focus_preservation_attempted",
+			target_process_id = target.process_id,
+			reason,
+			restored,
+			"Attempted to preserve the pre-capture frontmost application during overlay interaction."
+		);
+	}
+
+	#[cfg(target_os = "macos")]
 	/// Registers a wake callback for macOS live-stream frame notifications.
 	pub fn set_scroll_frame_waker(&mut self, waker: Arc<dyn Fn() + Send + Sync>) {
 		self.scroll_frame_waker = Some(waker);
@@ -966,7 +986,7 @@ impl OverlaySession {
 	/// for the current overlay mode.
 	#[must_use]
 	pub fn wants_global_cancel_hotkey(&self) -> bool {
-		matches!(self.state.mode, OverlayMode::Live)
+		self.session_active
 	}
 
 	#[cfg(target_os = "macos")]
@@ -1677,6 +1697,11 @@ impl OverlaySession {
 		self.state.hovered_window_rect = None;
 
 		self.reset_frozen_annotation_state();
+		self.skip_toolbar_focus_on_next_show = true;
+		#[cfg(target_os = "macos")]
+		{
+			self.preserve_frontmost_on_next_toolbar_show = true;
+		}
 
 		tracing::debug!(
 			monitor_id = monitor.id,
@@ -1706,6 +1731,8 @@ impl OverlaySession {
 		self.left_mouse_button_down_global = None;
 
 		self.refresh_frozen_helper_windows_for_transition(monitor);
+		#[cfg(target_os = "macos")]
+		self.restore_recorded_frontmost_application_for_focus_preservation("begin_frozen_capture");
 
 		#[cfg(target_os = "macos")]
 		{
@@ -2946,7 +2973,6 @@ impl OverlaySession {
 
 		#[cfg(target_os = "macos")]
 		let frontmost_application_before_start = self.frontmost_application_before_start.take();
-
 		self.reset_runtime_for_exit();
 		#[cfg(target_os = "macos")]
 		self.restore_frontmost_application_after_exit(frontmost_application_before_start);
@@ -3030,6 +3056,7 @@ impl OverlaySession {
 		#[cfg(target_os = "macos")]
 		{
 			self.toolbar_window_cursor_hittest_enabled = false;
+			self.preserve_frontmost_on_next_toolbar_show = false;
 		}
 		self.skip_toolbar_focus_on_next_show = false;
 		self.toolbar_window_warmup_redraws_remaining = 0;
@@ -4315,6 +4342,7 @@ fn macos_configure_overlay_window_mouse_moved_events(window: &Window) {
 			return;
 		}
 
+		macos_configure_nonactivating_capture_window_with_ns_window(ns_window);
 		let _: () = objc::msg_send![ns_window, setOpaque: false];
 		let _: () = objc::msg_send![ns_window, setHasShadow: false];
 		let clear: *mut Object = objc::msg_send![objc::class!(NSColor), clearColor];
@@ -4345,6 +4373,8 @@ fn macos_configure_hud_window(
 		if ns_window.is_null() {
 			return;
 		}
+
+		macos_configure_nonactivating_capture_window_with_ns_window(ns_window);
 
 		// winit exposes blur as a boolean. We also set an explicit radius so we can drive it from
 		// settings (this uses the same private CGS API that winit uses internally).
@@ -4400,6 +4430,20 @@ fn macos_configure_hud_window(
 		let radius = corner_radius_points.unwrap_or(height_points * 0.5);
 		let _: () = objc::msg_send![layer, setCornerRadius: radius];
 		let _: () = objc::msg_send![layer, setMasksToBounds: YES];
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn macos_configure_nonactivating_capture_window_with_ns_window(ns_window: *mut Object) {
+	if ns_window.is_null() {
+		return;
+	}
+
+	unsafe {
+		let style_mask: usize = objc::msg_send![ns_window, styleMask];
+		let nonactivating_panel_mask: usize = 1 << 7;
+		let _: () = objc::msg_send![ns_window, setStyleMask: style_mask | nonactivating_panel_mask];
+		let _: () = objc::msg_send![ns_window, setHidesOnDeactivate: false];
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -987,16 +987,19 @@ fn startup_live_rgb_plan_keeps_focus_independent_from_seed_monitor() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn wants_global_cancel_hotkey_only_in_live_mode() {
+fn wants_global_cancel_hotkey_for_any_active_session_mode() {
 	let mut session = OverlaySession::new();
 
+	assert!(!session.wants_global_cancel_hotkey());
+
+	session.session_active = true;
 	session.state.mode = OverlayMode::Live;
 
 	assert!(session.wants_global_cancel_hotkey());
 
 	session.state.mode = OverlayMode::Frozen;
 
-	assert!(!session.wants_global_cancel_hotkey());
+	assert!(session.wants_global_cancel_hotkey());
 }
 
 #[cfg(target_os = "macos")]
@@ -1019,6 +1022,19 @@ fn global_escape_hotkey_cancels_live_capture() {
 	let mut session = OverlaySession::new();
 
 	session.state.mode = OverlayMode::Live;
+
+	assert!(matches!(
+		session.handle_global_escape_hotkey(),
+		OverlayControl::Exit(OverlayExit::Cancelled)
+	));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn global_escape_hotkey_cancels_frozen_capture() {
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Frozen;
 
 	assert!(matches!(
 		session.handle_global_escape_hotkey(),

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -693,6 +693,40 @@ fn frozen_selection_drag_skips_toolbar_focus_even_before_first_show() {
 }
 
 #[test]
+fn entering_frozen_capture_skips_initial_toolbar_focus_restore() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(200, 180, 200, 300);
+	let mut session = OverlaySession::new();
+
+	session.begin_frozen_capture_with_rect(monitor, Some(capture_rect), None, None);
+	session.toolbar_state.visible = true;
+
+	assert!(session.skip_toolbar_focus_on_next_show);
+	assert!(!session.should_focus_frozen_toolbar_window_on_show());
+	#[cfg(target_os = "macos")]
+	assert!(session.preserve_frontmost_on_next_toolbar_show);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn frozen_selection_drag_does_not_rearm_initial_frontmost_restore() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(200, 180, 200, 300);
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+	session.state.finish_freeze(monitor, tests::test_frozen_image());
+	session.state.frozen_capture_rect = Some(capture_rect);
+	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
+	session.preserve_frontmost_on_next_toolbar_show = false;
+
+	assert!(session.begin_frozen_selection_drag(GlobalPoint::new(250, 240)));
+
+	assert!(session.skip_toolbar_focus_on_next_show);
+	assert!(!session.preserve_frontmost_on_next_toolbar_show);
+}
+
+#[test]
 fn frozen_selection_resize_updates_capture_rect_and_toolbar_position() {
 	let monitor = tests::test_monitor();
 	let capture_rect = RectPoints::new(100, 120, 200, 240);

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -699,6 +699,7 @@ fn entering_frozen_capture_skips_initial_toolbar_focus_restore() {
 	let mut session = OverlaySession::new();
 
 	session.begin_frozen_capture_with_rect(monitor, Some(capture_rect), None, None);
+
 	session.toolbar_state.visible = true;
 
 	assert!(session.skip_toolbar_focus_on_next_show);
@@ -716,12 +717,12 @@ fn frozen_selection_drag_does_not_rearm_initial_frontmost_restore() {
 
 	session.state.begin_freeze(monitor);
 	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 	session.preserve_frontmost_on_next_toolbar_show = false;
 
 	assert!(session.begin_frozen_selection_drag(GlobalPoint::new(250, 240)));
-
 	assert!(session.skip_toolbar_focus_on_next_show);
 	assert!(!session.preserve_frontmost_on_next_toolbar_show);
 }

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -583,6 +583,7 @@ impl OverlaySession {
 		#[cfg(target_os = "macos")]
 		if toolbar_became_visible && self.preserve_frontmost_on_next_toolbar_show {
 			self.preserve_frontmost_on_next_toolbar_show = false;
+
 			self.restore_recorded_frontmost_application_for_focus_preservation(
 				"toolbar_first_show",
 			);

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -580,6 +580,13 @@ impl OverlaySession {
 			self.toolbar_window_warmup_redraws_remaining = TOOLBAR_WINDOW_WARMUP_REDRAWS;
 			toolbar_became_visible = true;
 		}
+		#[cfg(target_os = "macos")]
+		if toolbar_became_visible && self.preserve_frontmost_on_next_toolbar_show {
+			self.preserve_frontmost_on_next_toolbar_show = false;
+			self.restore_recorded_frontmost_application_for_focus_preservation(
+				"toolbar_first_show",
+			);
+		}
 		if should_focus_frozen_keyboard {
 			self.focus_frozen_keyboard_window();
 		}


### PR DESCRIPTION
## Summary
- restore macOS focus preservation across live-to-frozen capture transitions and exit cleanup
- keep global `Esc` cancellation active for the full macOS overlay session so frozen mode can always exit
- tighten the initial-toolbar focus-preservation path and document the actual post-selection restore behavior

## Testing
- cargo test -p rsnap-overlay --lib overlay::tests::live_runtime
- cargo test -p rsnap-overlay --lib overlay::tests::rendering_behaviors
- cargo make lint-rust

## Notes
- fixes XY-259
- follow-up residual mouse-down blur is tracked in XY-263
