### PR TITLE
Fix XY-256 frozen toolbar stable anchor

### DIFF
--- a/docs/decisions/frozen-toolbar-anchor.md
+++ b/docs/decisions/frozen-toolbar-anchor.md
@@ -1,0 +1,46 @@
+# Frozen Toolbar Stable Anchor
+
+Status: accepted
+Date: 2026-04-14
+Context:
+
+- The Frozen toolbar has a primary capsule plus a secondary style capsule for Pen/Text controls.
+- Earlier implementations mixed two incompatible meanings for toolbar position:
+  - "primary capsule anchor"
+  - "whole visible toolbar union origin"
+- That ambiguity produced repeated regressions:
+  - default placement reserved space for the secondary capsule too early
+  - opening the secondary capsule visibly moved the primary toolbar
+  - platform-specific native-window bookkeeping leaked through as toolbar motion
+- The governing behavior contract for this decision is `docs/spec/frozen-toolbar-layout.md`.
+
+Decision:
+
+- Treat the primary capsule as the single stable anchor for Frozen toolbar positioning.
+- Derive the style capsule layout from that anchor instead of allowing style-capsule geometry to
+  rewrite toolbar position.
+- Keep default placement based on primary-capsule geometry, then choose style-capsule placement
+  above or below afterward.
+- Accept degraded style-capsule presentation under tight screen constraints before reflowing the
+  primary capsule to make room.
+
+Alternatives considered:
+
+- Keep positioning based on the union bounds of the primary and style capsules.
+  - Rejected because it makes expansion geometry feed back into the primary toolbar position.
+- Reserve worst-case style-capsule space during default placement.
+  - Rejected because it moves the primary toolbar before the user has even asked to open the
+    secondary controls.
+- Use platform-specific native-window offsets as the main geometry authority.
+  - Rejected because it obscures the product contract and creates motion bugs that are artifacts of
+    window bookkeeping rather than intended UI behavior.
+
+Consequences:
+
+- Stored Frozen toolbar positions must keep the meaning "primary capsule anchor".
+- Future work on Pen/Text controls should attach as derived layout around the stable anchor rather
+  than introducing a new source of truth for toolbar position.
+- Native-window sizing, padding, or hit-testing changes are regressions if they cause visible
+  primary-toolbar motion during style-capsule expansion or collapse.
+- Any future redesign that intentionally allows the primary capsule to move when style controls are
+  shown would need to explicitly supersede this decision and update the governing spec.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -45,3 +45,5 @@ Then keep the body decision-oriented:
 
 - `docs/decisions/annotation-pen-style.md` for the pen-tool tradeoff that prioritizes polished
   screenshot annotation over faithful pointer-path reproduction
+- `docs/decisions/frozen-toolbar-anchor.md` for the stable-anchor layout choice that prevents
+  style-capsule expansion from moving the primary Frozen toolbar

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -17,6 +17,7 @@ Defines:
 - hovered-window, region-selection, and fullscreen fallback behavior
 - the current macOS scroll-capture contract
 - the presence of Frozen-mode annotation state in session output
+- the existence of a separate Frozen-toolbar layout contract for primary-toolbar anchoring
 
 This repository contains a pure-Rust screenshot prototype targeting macOS first, with a
 cross-platform architecture.
@@ -71,7 +72,8 @@ cross-platform architecture.
      until authoritative capture completes
    - In Frozen mode, toolbar-driven annotations are part of the frozen capture state. Current
      annotation/edit tools are pointer, pen, arrow, text, mosaic, and spotlight; the pen-tool
-     contract lives in `docs/spec/annotation-pen.md`
+     contract lives in `docs/spec/annotation-pen.md`, and Frozen toolbar placement/expansion
+     invariants live in `docs/spec/frozen-toolbar-layout.md`
    - Arrow annotations are drag-defined overlays that participate in preview, export, and
      undo/redo like other committed Frozen-mode annotations.
    - Spotlight annotations keep the selected rectangle undimmed while darkening the surrounding

--- a/docs/spec/frozen-toolbar-layout.md
+++ b/docs/spec/frozen-toolbar-layout.md
@@ -1,0 +1,101 @@
+# Frozen Toolbar Layout Contract
+
+Purpose: Define the normative placement and expansion invariants for the Frozen-mode toolbar and
+its annotation style capsule.
+
+Status: normative
+
+Read this when: You are implementing, reviewing, or validating Frozen-mode toolbar positioning,
+default placement, dragging, or the Pen/Text style capsule expansion behavior.
+
+Not this document: Current implementation details for overlay windows, or the rationale for why
+the stable-anchor interaction model was chosen. Use `docs/reference/` for current implementation
+context and `docs/decisions/frozen-toolbar-anchor.md` for rationale.
+
+Defines:
+- the stable-anchor contract for the Frozen toolbar primary capsule
+- default placement rules for the Frozen toolbar before the style capsule is expanded
+- allowed above/below placement behavior for the Pen/Text style capsule
+- prohibited geometry feedback from the style capsule back into the primary toolbar anchor
+
+## Terms
+
+- Primary capsule: the always-visible main Frozen toolbar pill containing tool selection and core
+  actions.
+- Style capsule: the secondary pill that exposes Pen/Text color and size controls.
+- Primary anchor: the screen-space top-left origin of the primary capsule.
+
+## Scope
+
+This contract applies to Frozen mode after a capture has been established and the Frozen toolbar is
+visible.
+
+This contract governs:
+
+- default Frozen toolbar placement
+- user-driven drag repositioning of the Frozen toolbar
+- Pen/Text style capsule expansion and collapse
+- platform-specific toolbar-window bookkeeping when native auxiliary windows are used
+
+This contract does not define:
+
+- styling, colors, blur, or material treatment
+- the tool contents inside the primary or style capsules
+- the pen or text editing behavior itself
+
+## Required behavior
+
+### Stable primary anchor
+
+- The primary capsule is the stable toolbar anchor.
+- Expanding or collapsing the style capsule MUST NOT move the primary capsule.
+- Choosing whether the style capsule appears above or below the primary capsule MUST be a derived
+  layout result and MUST NOT rewrite the primary anchor.
+- Platform-specific native window sizing, padding, or bookkeeping MUST NOT produce user-visible
+  motion of the primary capsule during style-capsule expansion or collapse.
+
+### Default placement
+
+- Default Frozen toolbar placement MUST be computed from the primary capsule geometry, not from
+  reserving future space for the style capsule.
+- If the primary capsule fits below the frozen capture with the configured screen margin, the
+  default placement MUST keep it there even when the style capsule would not later fit below.
+- The style capsule MUST NOT cause the default primary placement to be pre-shifted upward, downward,
+  or sideways merely to reserve expansion space.
+
+### Style capsule placement
+
+- The style capsule is attached to the primary capsule and may render either above or below it.
+- When expanded, the style capsule SHOULD render below the primary capsule if there is sufficient
+  space within the current screen constraints.
+- If there is not sufficient space below, the style capsule SHOULD render above the primary
+  capsule instead.
+- The style capsule MAY choose the side with more available room when neither side fully fits, but
+  that fallback MUST NOT move the primary anchor.
+
+### Constrained-space behavior
+
+- When screen constraints are tight, the implementation MAY clamp, crop, or otherwise degrade only
+  the style-capsule presentation before it moves the primary capsule.
+- The primary capsule MAY still be clamped to screen margins or monitor bounds as part of normal
+  toolbar placement and dragging rules, but those clamps are independent of style-capsule
+  expansion.
+
+### Dragging and hit testing
+
+- User drag repositioning MUST operate on the primary capsule anchor.
+- Expanding the style capsule MUST NOT change the meaning of stored toolbar positions from
+  "primary capsule anchor" to "whole visible union origin".
+- The style capsule MUST NOT enlarge the drag-start region for moving the toolbar; interacting with
+  the style capsule is distinct from dragging the primary capsule.
+
+## Practical example
+
+- Valid behavior:
+  - the primary capsule is placed below the frozen capture because it fits there
+  - later, the user opens Text style controls
+  - the style capsule renders above the primary capsule because below is tight
+  - the primary capsule stays exactly where it was
+- Invalid behavior:
+  - the primary capsule is initially shifted upward to reserve possible style-capsule space
+  - or the primary capsule jumps when the style capsule opens or closes

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -57,5 +57,7 @@ Then keep the body explicit:
 - `docs/spec/annotation-pen.md` for the Frozen-mode pen-tool behavior contract and beautification
   invariants
 - `docs/spec/capture-session.md` for the capture-flow and scroll-capture behavior contract
+- `docs/spec/frozen-toolbar-layout.md` for the stable-anchor and above/below expansion contract of
+  the Frozen toolbar style capsule
 - `docs/spec/performance.md` for render cadence, performance scenarios, metrics,
   thresholds, and known performance-contract gaps

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1585,10 +1585,8 @@ impl OverlaySession {
 	}
 
 	fn sync_frozen_annotation_style_capsule_placement(&mut self, monitor: MonitorRect) {
-		let Some(toolbar_pos) = self
-			.toolbar_state
-			.floating_position
-			.or(self.toolbar_state.default_slot_position)
+		let Some(toolbar_pos) =
+			self.toolbar_state.floating_position.or(self.toolbar_state.default_slot_position)
 		else {
 			return;
 		};
@@ -3705,8 +3703,7 @@ fn frozen_toolbar_window_startup_size_points() -> Vec2 {
 	.map(|toolbar_state| WindowRenderer::frozen_toolbar_size(&toolbar_state))
 	.fold(Vec2::new(0.0, TOOLBAR_EXPANDED_HEIGHT_PX), |max_size, size| {
 		Vec2::new(max_size.x.max(size.x), max_size.y.max(size.y))
-	})
-	+ Vec2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
+	}) + Vec2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -3650,6 +3650,7 @@ pub(super) fn frozen_toolbar_corner_radius_points(toolbar_height_points: f32) ->
 	f64::from(frozen_toolbar_corner_radius_u8(toolbar_height_points))
 }
 
+#[cfg(target_os = "macos")]
 pub(in crate::overlay) fn frozen_toolbar_window_primary_origin() -> Pos2 {
 	Pos2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
 }

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1573,15 +1573,33 @@ impl OverlaySession {
 			Vec2::new(capture_rect_points.width as f32, capture_rect_points.height as f32),
 		);
 		let toolbar_primary_size = WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state);
-		let toolbar_window_size = self.toolbar_positioning_size();
+		let toolbar_positioning_size = self.toolbar_positioning_size();
 
 		WindowRenderer::frozen_toolbar_default_window_pos(
 			screen_rect,
 			capture_rect,
 			toolbar_primary_size,
-			toolbar_window_size,
+			toolbar_positioning_size,
 			self.config.toolbar_placement,
 		)
+	}
+
+	fn sync_frozen_annotation_style_capsule_placement(&mut self, monitor: MonitorRect) {
+		let Some(toolbar_pos) = self
+			.toolbar_state
+			.floating_position
+			.or(self.toolbar_state.default_slot_position)
+		else {
+			return;
+		};
+		let screen_rect =
+			Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+
+		WindowRenderer::sync_frozen_annotation_style_capsule_placement(
+			&mut self.toolbar_state,
+			screen_rect,
+			toolbar_pos,
+		);
 	}
 
 	fn initial_session_runtime(config: &OverlayConfig) -> InitialSessionRuntime {
@@ -2579,8 +2597,12 @@ impl OverlaySession {
 		if frozen_toolbar_matches_default_slot(toolbar_pos, previous_default_pos) {
 			self.toolbar_state.floating_position = Some(current_default_pos);
 
+			self.sync_frozen_annotation_style_capsule_placement(monitor);
+
 			return !frozen_toolbar_matches_default_slot(toolbar_pos, current_default_pos);
 		}
+
+		self.sync_frozen_annotation_style_capsule_placement(monitor);
 
 		false
 	}
@@ -3628,6 +3650,10 @@ pub(super) fn frozen_toolbar_corner_radius_points(toolbar_height_points: f32) ->
 	f64::from(frozen_toolbar_corner_radius_u8(toolbar_height_points))
 }
 
+pub(in crate::overlay) fn frozen_toolbar_window_primary_origin() -> Pos2 {
+	Pos2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
+}
+
 fn frozen_toolbar_window_startup_size_points() -> Vec2 {
 	[
 		FrozenToolbarState::default(),
@@ -3679,6 +3705,7 @@ fn frozen_toolbar_window_startup_size_points() -> Vec2 {
 	.fold(Vec2::new(0.0, TOOLBAR_EXPANDED_HEIGHT_PX), |max_size, size| {
 		Vec2::new(max_size.x.max(size.x), max_size.y.max(size.y))
 	})
+	+ Vec2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/config_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/config_runtime.rs
@@ -9,6 +9,7 @@ use crate::overlay;
 use crate::overlay::OverlayWorker;
 use crate::overlay::{
 	Arc, Instant, LOUPE_TILE_CORNER_RADIUS_POINTS, OverlayConfig, OverlayMode, OverlaySession,
+	WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{MacLiveFrameStream, MacOSHudWindowConfigState, SLOW_OP_WARN_HUD_CONFIG};
@@ -175,10 +176,8 @@ impl OverlaySession {
 		}
 		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
 			let window = Arc::clone(&toolbar_window.window);
-			let toolbar_height_points = self
-				.toolbar_inner_size_points
-				.map(|(_, height)| height as f32)
-				.unwrap_or_else(|| overlay::frozen_toolbar_window_startup_size_points().y);
+			let toolbar_height_points =
+				WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state).y;
 
 			self.configure_hud_window_common(
 				window.as_ref(),

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -146,7 +146,12 @@ impl OverlaySession {
 	}
 
 	fn toolbar_primary_rect_contains(&self, cursor_local: Pos2) -> bool {
-		WindowRenderer::frozen_toolbar_primary_rect(&self.toolbar_state, Pos2::ZERO)
+		#[cfg(target_os = "macos")]
+		let toolbar_primary_origin = super::frozen_toolbar_window_primary_origin();
+		#[cfg(not(target_os = "macos"))]
+		let toolbar_primary_origin = Pos2::ZERO;
+
+		WindowRenderer::frozen_toolbar_primary_rect(&self.toolbar_state, toolbar_primary_origin)
 			.contains(cursor_local)
 	}
 

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -1190,10 +1190,7 @@ impl WindowRenderer {
 			toolbar_pos,
 		);
 
-		Some(Self::frozen_toolbar_window_rect(
-			&reserved_toolbar_state,
-			toolbar_pos,
-		))
+		Some(Self::frozen_toolbar_window_rect(&reserved_toolbar_state, toolbar_pos))
 	}
 
 	pub(in crate::overlay) fn selection_size_badge_text(
@@ -2778,11 +2775,7 @@ impl WindowRenderer {
 	) -> Option<Pos2> {
 		if let Some(pos) = toolbar_state.floating_position {
 			#[cfg(any(not(target_os = "macos"), test))]
-			Self::sync_frozen_annotation_style_capsule_placement(
-				toolbar_state,
-				screen_rect,
-				pos,
-			);
+			Self::sync_frozen_annotation_style_capsule_placement(toolbar_state, screen_rect, pos);
 
 			return Some(pos);
 		}
@@ -2922,12 +2915,12 @@ impl WindowRenderer {
 			},
 		};
 		let min_y = screen_rect.min.y + TOOLBAR_SCREEN_MARGIN_PX;
-		let max_y = (screen_rect.max.y - toolbar_positioning_size.y - TOOLBAR_SCREEN_MARGIN_PX)
-			.max(min_y);
+		let max_y =
+			(screen_rect.max.y - toolbar_positioning_size.y - TOOLBAR_SCREEN_MARGIN_PX).max(min_y);
 		let ideal_x = capture_rect.center().x - toolbar_primary_size.x / 2.0;
 		let min_x = screen_rect.min.x + TOOLBAR_SCREEN_MARGIN_PX;
-		let max_x = (screen_rect.max.x - toolbar_positioning_size.x - TOOLBAR_SCREEN_MARGIN_PX)
-			.max(min_x);
+		let max_x =
+			(screen_rect.max.x - toolbar_positioning_size.x - TOOLBAR_SCREEN_MARGIN_PX).max(min_x);
 		let x = ideal_x.clamp(min_x, max_x);
 		let y = y.max(min_y).min(max_y);
 
@@ -2957,11 +2950,9 @@ impl WindowRenderer {
 		let area_id = Id::new(format!("frozen-toolbar-{}", monitor.id));
 		let window_rect = Self::frozen_toolbar_window_rect(toolbar_state, toolbar_pos);
 
-		Area::new(area_id)
-			.order(Order::Foreground)
-			.fixed_pos(window_rect.min)
-			.show(ctx, |ui| {
-			let (_area_rect, _window_response) = ui.allocate_exact_size(toolbar_size, Sense::hover());
+		Area::new(area_id).order(Order::Foreground).fixed_pos(window_rect.min).show(ctx, |ui| {
+			let (_area_rect, _window_response) =
+				ui.allocate_exact_size(toolbar_size, Sense::hover());
 			let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, toolbar_pos);
 			let style_rect =
 				Self::frozen_annotation_style_capsule_rect(toolbar_state, toolbar_rect);

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -14,6 +14,7 @@ use crate::overlay::rendering::{
 	SelectionFlowGeometryCacheKey, SelectionSizeBadgeLayout, SelectionSizeBadgePadding,
 	SelectionSizeBadgeTarget, WindowRenderer,
 };
+use crate::overlay::session_state::FrozenAnnotationStyleCapsulePlacement;
 use crate::overlay::{
 	self, Align, Align2, Area, Color32, CornerRadius, FROZEN_SELECTION_DASHED_BORDER_WIDTH_PX,
 	FROZEN_SELECTION_RESIZE_HANDLE_CENTER_DOT_RADIUS_POINTS,
@@ -1167,12 +1168,12 @@ impl WindowRenderer {
 
 		let capture_rect = Self::frozen_toolbar_capture_rect(state, monitor, screen_rect);
 		let toolbar_primary_size = Self::frozen_toolbar_primary_size(toolbar_state);
-		let toolbar_window_size = Self::frozen_toolbar_size(toolbar_state);
+		let toolbar_positioning_size = Self::frozen_toolbar_positioning_size(toolbar_state);
 		let default_pos = Self::frozen_toolbar_default_window_pos(
 			screen_rect,
 			capture_rect,
 			toolbar_primary_size,
-			toolbar_window_size,
+			toolbar_positioning_size,
 			toolbar_placement,
 		);
 		let toolbar_pos = toolbar_state.floating_position.unwrap_or(default_pos);
@@ -1181,7 +1182,18 @@ impl WindowRenderer {
 			return None;
 		}
 
-		Some(Self::frozen_toolbar_window_rect(toolbar_state, toolbar_pos))
+		let mut reserved_toolbar_state = toolbar_state.clone();
+
+		Self::sync_frozen_annotation_style_capsule_placement(
+			&mut reserved_toolbar_state,
+			screen_rect,
+			toolbar_pos,
+		);
+
+		Some(Self::frozen_toolbar_window_rect(
+			&reserved_toolbar_state,
+			toolbar_pos,
+		))
 	}
 
 	pub(in crate::overlay) fn selection_size_badge_text(
@@ -2529,6 +2541,7 @@ impl WindowRenderer {
 			(Pos2::new(-1.0, -1.0), false)
 		};
 		let toolbar_primary_size = Self::frozen_toolbar_primary_size(toolbar_state);
+		let toolbar_positioning_size = Self::frozen_toolbar_positioning_size(toolbar_state);
 		let toolbar_size = Self::frozen_toolbar_size(toolbar_state);
 		let screen_rect = ctx.input(|i| i.viewport_rect());
 		let capture_rect = Self::frozen_toolbar_capture_rect(state, monitor, screen_rect);
@@ -2540,7 +2553,7 @@ impl WindowRenderer {
 			screen_rect,
 			capture_rect,
 			toolbar_primary_size,
-			toolbar_size,
+			toolbar_positioning_size,
 			toolbar_placement,
 		) else {
 			return;
@@ -2629,6 +2642,78 @@ impl WindowRenderer {
 		Some(Vec2::new(width, height))
 	}
 
+	pub(in crate::overlay) fn frozen_toolbar_positioning_size(
+		toolbar_state: &FrozenToolbarState,
+	) -> Vec2 {
+		Self::frozen_toolbar_primary_size(toolbar_state)
+	}
+
+	pub(in crate::overlay) fn frozen_toolbar_window_top_padding_points() -> f32 {
+		[
+			FrozenToolbarState {
+				selected_tool: FrozenToolbarTool::Pen,
+				..FrozenToolbarState::default()
+			},
+			FrozenToolbarState {
+				selected_tool: FrozenToolbarTool::Text,
+				..FrozenToolbarState::default()
+			},
+		]
+		.into_iter()
+		.map(|toolbar_state| {
+			Self::frozen_annotation_style_capsule_size(&toolbar_state).map_or(0.0, |style_size| {
+				style_size.y + FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS
+			})
+		})
+		.fold(0.0, f32::max)
+	}
+
+	fn frozen_annotation_style_capsule_placement_for_toolbar_pos(
+		toolbar_state: &FrozenToolbarState,
+		screen_rect: Rect,
+		toolbar_pos: Pos2,
+	) -> FrozenAnnotationStyleCapsulePlacement {
+		let Some(style_size) = Self::frozen_annotation_style_capsule_size(toolbar_state) else {
+			return FrozenAnnotationStyleCapsulePlacement::Below;
+		};
+		let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, toolbar_pos);
+		let below_y = toolbar_rect.max.y + FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS;
+		let above_y =
+			toolbar_rect.min.y - FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS - style_size.y;
+		let fits_below = below_y + style_size.y + TOOLBAR_SCREEN_MARGIN_PX <= screen_rect.max.y;
+		let fits_above = above_y >= screen_rect.min.y + TOOLBAR_SCREEN_MARGIN_PX;
+
+		if fits_below {
+			FrozenAnnotationStyleCapsulePlacement::Below
+		} else if fits_above {
+			FrozenAnnotationStyleCapsulePlacement::Above
+		} else {
+			let below_space = screen_rect.max.y - below_y;
+			let above_space = toolbar_rect.min.y
+				- FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS
+				- screen_rect.min.y;
+
+			if above_space > below_space {
+				FrozenAnnotationStyleCapsulePlacement::Above
+			} else {
+				FrozenAnnotationStyleCapsulePlacement::Below
+			}
+		}
+	}
+
+	pub(in crate::overlay) fn sync_frozen_annotation_style_capsule_placement(
+		toolbar_state: &mut FrozenToolbarState,
+		screen_rect: Rect,
+		toolbar_pos: Pos2,
+	) {
+		toolbar_state.annotation_style_capsule_placement =
+			Self::frozen_annotation_style_capsule_placement_for_toolbar_pos(
+				toolbar_state,
+				screen_rect,
+				toolbar_pos,
+			);
+	}
+
 	fn frozen_annotation_style_capsule_rect(
 		toolbar_state: &FrozenToolbarState,
 		toolbar_rect: Rect,
@@ -2637,7 +2722,14 @@ impl WindowRenderer {
 		let min_x = toolbar_rect.left();
 		let max_x = (toolbar_rect.right() - style_size.x).max(min_x);
 		let x = (toolbar_rect.center().x - style_size.x * 0.5).clamp(min_x, max_x);
-		let y = toolbar_rect.max.y + FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS;
+		let y = match toolbar_state.annotation_style_capsule_placement {
+			FrozenAnnotationStyleCapsulePlacement::Above => {
+				toolbar_rect.min.y - FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS - style_size.y
+			},
+			FrozenAnnotationStyleCapsulePlacement::Below => {
+				toolbar_rect.max.y + FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS
+			},
+		};
 
 		Some(Rect::from_min_size(Pos2::new(x, y), style_size))
 	}
@@ -2655,9 +2747,10 @@ impl WindowRenderer {
 	#[cfg(any(target_os = "macos", test))]
 	pub(in crate::overlay) fn frozen_toolbar_visible_capsules_contain(
 		toolbar_state: &FrozenToolbarState,
+		toolbar_pos: Pos2,
 		cursor_local: Pos2,
 	) -> bool {
-		let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, Pos2::ZERO);
+		let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, toolbar_pos);
 
 		if toolbar_rect.contains(cursor_local) {
 			return true;
@@ -2684,6 +2777,13 @@ impl WindowRenderer {
 		toolbar_placement: ToolbarPlacement,
 	) -> Option<Pos2> {
 		if let Some(pos) = toolbar_state.floating_position {
+			#[cfg(any(not(target_os = "macos"), test))]
+			Self::sync_frozen_annotation_style_capsule_placement(
+				toolbar_state,
+				screen_rect,
+				pos,
+			);
+
 			return Some(pos);
 		}
 
@@ -2759,6 +2859,15 @@ impl WindowRenderer {
 		toolbar_state.default_slot_position = Some(default_pos);
 		toolbar_state.floating_position = Some(default_pos);
 
+		#[cfg(any(not(target_os = "macos"), test))]
+		{
+			Self::sync_frozen_annotation_style_capsule_placement(
+				toolbar_state,
+				screen_rect,
+				default_pos,
+			);
+		}
+
 		Some(default_pos)
 	}
 
@@ -2790,7 +2899,7 @@ impl WindowRenderer {
 		screen_rect: Rect,
 		capture_rect: Rect,
 		toolbar_primary_size: Vec2,
-		toolbar_window_size: Vec2,
+		toolbar_positioning_size: Vec2,
 		toolbar_placement: ToolbarPlacement,
 	) -> Pos2 {
 		let y = match toolbar_placement {
@@ -2813,12 +2922,12 @@ impl WindowRenderer {
 			},
 		};
 		let min_y = screen_rect.min.y + TOOLBAR_SCREEN_MARGIN_PX;
-		let max_y =
-			(screen_rect.max.y - toolbar_window_size.y - TOOLBAR_SCREEN_MARGIN_PX).max(min_y);
+		let max_y = (screen_rect.max.y - toolbar_positioning_size.y - TOOLBAR_SCREEN_MARGIN_PX)
+			.max(min_y);
 		let ideal_x = capture_rect.center().x - toolbar_primary_size.x / 2.0;
 		let min_x = screen_rect.min.x + TOOLBAR_SCREEN_MARGIN_PX;
-		let max_x =
-			(screen_rect.max.x - toolbar_window_size.x - TOOLBAR_SCREEN_MARGIN_PX).max(min_x);
+		let max_x = (screen_rect.max.x - toolbar_positioning_size.x - TOOLBAR_SCREEN_MARGIN_PX)
+			.max(min_x);
 		let x = ideal_x.clamp(min_x, max_x);
 		let y = y.max(min_y).min(max_y);
 
@@ -2846,11 +2955,14 @@ impl WindowRenderer {
 		#[cfg(target_os = "macos")]
 		let _ = screen_rect;
 		let area_id = Id::new(format!("frozen-toolbar-{}", monitor.id));
+		let window_rect = Self::frozen_toolbar_window_rect(toolbar_state, toolbar_pos);
 
-		Area::new(area_id).order(Order::Foreground).fixed_pos(toolbar_pos).show(ctx, |ui| {
-			let (window_rect, _window_response) =
-				ui.allocate_exact_size(toolbar_size, Sense::hover());
-			let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, window_rect.min);
+		Area::new(area_id)
+			.order(Order::Foreground)
+			.fixed_pos(window_rect.min)
+			.show(ctx, |ui| {
+			let (_area_rect, _window_response) = ui.allocate_exact_size(toolbar_size, Sense::hover());
+			let toolbar_rect = Self::frozen_toolbar_primary_rect(toolbar_state, toolbar_pos);
 			let style_rect =
 				Self::frozen_annotation_style_capsule_rect(toolbar_state, toolbar_rect);
 			let toolbar_response = ui.interact(
@@ -2869,7 +2981,7 @@ impl WindowRenderer {
 				toolbar_response.drag_started(),
 				toolbar_pos,
 				screen_rect,
-				toolbar_size,
+				Self::frozen_toolbar_positioning_size(toolbar_state),
 				cursor,
 				left_button_down,
 			);

--- a/packages/rsnap-overlay/src/overlay/session_state.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state.rs
@@ -140,13 +140,20 @@ pub(super) struct HudDrawConfig {
 	pub(super) hud_glass_active: bool,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FrozenAnnotationStyleCapsulePlacement {
+	Above,
+	Below,
+}
+
+#[derive(Clone, Debug)]
 pub(super) struct FrozenToolbarState {
 	pub(super) visible: bool,
 	pub(super) dragging: bool,
 	pub(super) drag_start_eligible: bool,
 	pub(super) annotation_size_control_hovered: bool,
 	pub(super) annotation_size_wheel_accumulator: f32,
+	pub(super) annotation_style_capsule_placement: FrozenAnnotationStyleCapsulePlacement,
 	pub(super) selected_tool: FrozenToolbarTool,
 	pub(super) brush_style: FrozenBrushStyle,
 	pub(super) text_style: FrozenTextStyle,
@@ -159,6 +166,7 @@ pub(super) struct FrozenToolbarState {
 	pub(super) pending_action: Option<FrozenToolbarTool>,
 	pub(super) needs_redraw: bool,
 	pub(super) pill_height_points: Option<f32>,
+	// Both positions track the primary capsule anchor, never the full toolbar union origin.
 	pub(super) default_slot_position: Option<Pos2>,
 	pub(super) floating_position: Option<Pos2>,
 	pub(super) layout_last_screen_size_points: Option<Vec2>,
@@ -277,6 +285,7 @@ impl Default for FrozenToolbarState {
 			drag_start_eligible: false,
 			annotation_size_control_hovered: false,
 			annotation_size_wheel_accumulator: 0.0,
+			annotation_style_capsule_placement: FrozenAnnotationStyleCapsulePlacement::Below,
 			selected_tool: FrozenToolbarTool::Pointer,
 			brush_style: FrozenBrushStyle::default(),
 			text_style: FrozenTextStyle::default(),

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -1483,8 +1483,12 @@ fn toolbar_cursor_left_during_drag_keeps_drag_session_alive() {
 #[test]
 fn toolbar_drag_start_eligibility_prefers_live_cursor_over_stale_cache() {
 	let mut session = OverlaySession::new();
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	#[cfg(not(target_os = "macos"))]
+	let primary_origin = Pos2::ZERO;
 	let primary_rect =
-		WindowRenderer::frozen_toolbar_primary_rect(&session.toolbar_state, Pos2::ZERO);
+		WindowRenderer::frozen_toolbar_primary_rect(&session.toolbar_state, primary_origin);
 	let stale_cursor = Pos2::new(primary_rect.right() + 12.0, primary_rect.center().y);
 	let live_cursor = primary_rect.center();
 
@@ -1499,8 +1503,12 @@ fn toolbar_drag_start_eligibility_prefers_live_cursor_over_stale_cache() {
 #[test]
 fn toolbar_drag_start_eligibility_falls_back_to_cached_pointer_when_live_cursor_is_missing() {
 	let mut session = OverlaySession::new();
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	#[cfg(not(target_os = "macos"))]
+	let primary_origin = Pos2::ZERO;
 	let primary_rect =
-		WindowRenderer::frozen_toolbar_primary_rect(&session.toolbar_state, Pos2::ZERO);
+		WindowRenderer::frozen_toolbar_primary_rect(&session.toolbar_state, primary_origin);
 	let cached_cursor = primary_rect.center();
 
 	assert!(primary_rect.contains(cached_cursor));
@@ -1536,15 +1544,18 @@ fn toolbar_visible_capsule_hit_test_excludes_gap_between_capsules() {
 
 	assert!(WindowRenderer::frozen_toolbar_visible_capsules_contain(
 		&session.toolbar_state,
+		Pos2::ZERO,
 		primary_point
 	));
 	assert!(window_rect.contains(gap_point));
 	assert!(!WindowRenderer::frozen_toolbar_visible_capsules_contain(
 		&session.toolbar_state,
+		Pos2::ZERO,
 		gap_point
 	));
 	assert!(WindowRenderer::frozen_toolbar_visible_capsules_contain(
 		&session.toolbar_state,
+		Pos2::ZERO,
 		style_point
 	));
 }

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -16,6 +16,7 @@ use winit::window::CursorIcon;
 use crate::OverlayControl;
 #[cfg(target_os = "macos")]
 use crate::overlay::WindowCaptureAlphaMode;
+use crate::overlay::session_state::FrozenAnnotationStyleCapsulePlacement;
 use crate::overlay::tests::{
 	self, Duration, ElementState, FrozenCaptureSource, FrozenSelectionDragState,
 	FrozenToolbarState, FrozenToolbarTool, GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, HudTheme,
@@ -720,25 +721,41 @@ fn frozen_selection_resize_updates_capture_rect_and_toolbar_position() {
 #[test]
 fn toolbar_position_update_queues_pending_move_without_window() {
 	let monitor = tests::test_monitor();
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
 	let mut session = OverlaySession::new();
 
 	session.toolbar_inner_size_points = Some((460, 54));
 
 	assert!(session.update_toolbar_outer_position(monitor, Pos2::new(120.0, 160.0)));
 	assert_eq!(session.toolbar_state.floating_position, Some(Pos2::new(120.0, 160.0)));
-	assert_eq!(session.toolbar_outer_pos, Some(GlobalPoint::new(120, 160)));
-	assert_eq!(session.pending_toolbar_outer_pos, Some(GlobalPoint::new(120, 160)));
+
+	#[cfg(target_os = "macos")]
+	let expected_outer = GlobalPoint::new(120, (160.0 - primary_origin.y).round() as i32);
+	#[cfg(not(target_os = "macos"))]
+	let expected_outer = GlobalPoint::new(120, 160);
+
+	assert_eq!(session.toolbar_outer_pos, Some(expected_outer));
+	assert_eq!(session.pending_toolbar_outer_pos, Some(expected_outer));
 }
 
 #[test]
 fn toolbar_window_position_sync_updates_runtime_state_without_requeueing_in_bounds_move() {
 	let monitor = tests::test_monitor();
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
 	let mut session = OverlaySession::new();
 
 	session.toolbar_inner_size_points = Some((460, 54));
 
 	assert!(session.sync_toolbar_outer_position_from_window(monitor, GlobalPoint::new(120, 160)));
-	assert_eq!(session.toolbar_state.floating_position, Some(Pos2::new(120.0, 160.0)));
+
+	#[cfg(target_os = "macos")]
+	let expected_anchor = Pos2::new(120.0, 160.0 + primary_origin.y);
+	#[cfg(not(target_os = "macos"))]
+	let expected_anchor = Pos2::new(120.0, 160.0);
+
+	assert_eq!(session.toolbar_state.floating_position, Some(expected_anchor));
 	assert_eq!(session.toolbar_outer_pos, Some(GlobalPoint::new(120, 160)));
 	assert_eq!(session.pending_toolbar_outer_pos, None);
 }
@@ -751,14 +768,16 @@ fn toolbar_position_update_near_edge_clamps_with_runtime_positioning_geometry() 
 	let screen_rect =
 		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
 	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let positioning_size = WindowRenderer::frozen_toolbar_positioning_size(&session.toolbar_state);
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	#[cfg(not(target_os = "macos"))]
 	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
-	let rendered_toolbar_size = WindowRenderer::frozen_toolbar_size(&session.toolbar_state);
 
 	session.toolbar_inner_size_points =
 		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
 
-	let expected_toolbar_size =
-		if cfg!(target_os = "macos") { startup_window_size } else { rendered_toolbar_size };
+	let expected_toolbar_size = positioning_size;
 	let expected = WindowRenderer::clamp_toolbar_position(
 		screen_rect,
 		expected_toolbar_size,
@@ -780,9 +799,18 @@ fn toolbar_position_update_near_edge_clamps_with_runtime_positioning_geometry() 
 	);
 	assert!(session.update_toolbar_outer_position(monitor, desired));
 	assert_eq!(session.toolbar_state.floating_position, Some(expected));
+
+	#[cfg(target_os = "macos")]
+	let expected_outer = GlobalPoint::new(
+		expected.x.round() as i32,
+		(expected.y - primary_origin.y).round() as i32,
+	);
+	#[cfg(not(target_os = "macos"))]
+	let expected_outer = GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32);
+
 	assert_eq!(
 		session.toolbar_outer_pos,
-		Some(GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32))
+		Some(expected_outer)
 	);
 }
 
@@ -795,14 +823,16 @@ fn toolbar_window_position_sync_near_edge_clamps_with_runtime_positioning_geomet
 	let screen_rect =
 		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
 	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let positioning_size = WindowRenderer::frozen_toolbar_positioning_size(&session.toolbar_state);
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	#[cfg(not(target_os = "macos"))]
 	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
-	let rendered_toolbar_size = WindowRenderer::frozen_toolbar_size(&session.toolbar_state);
 
 	session.toolbar_inner_size_points =
 		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
 
-	let expected_toolbar_size =
-		if cfg!(target_os = "macos") { startup_window_size } else { rendered_toolbar_size };
+	let expected_toolbar_size = positioning_size;
 	let expected = WindowRenderer::clamp_toolbar_position(
 		screen_rect,
 		expected_toolbar_size,
@@ -824,15 +854,80 @@ fn toolbar_window_position_sync_near_edge_clamps_with_runtime_positioning_geomet
 	);
 	assert!(session.sync_toolbar_outer_position_from_window(monitor, desired_outer));
 	assert_eq!(session.toolbar_state.floating_position, Some(expected));
+
+	#[cfg(target_os = "macos")]
+	let expected_outer = GlobalPoint::new(
+		expected.x.round() as i32,
+		(expected.y - primary_origin.y).round() as i32,
+	);
+	#[cfg(not(target_os = "macos"))]
+	let expected_outer = GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32);
+
 	assert_eq!(
 		session.toolbar_outer_pos,
-		Some(GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32))
+		Some(expected_outer)
 	);
 	assert_eq!(
 		session.pending_toolbar_outer_pos,
-		(session.toolbar_outer_pos != Some(desired_outer))
-			.then_some(GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32))
+		(session.toolbar_outer_pos != Some(desired_outer)).then_some(expected_outer)
 	);
+}
+
+#[test]
+fn toolbar_position_update_clamps_scroll_mode_pen_from_primary_anchor_width() {
+	let monitor = tests::test_monitor();
+	let desired = Pos2::new(900.0, 160.0);
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let primary_toolbar_state = FrozenToolbarState {
+		selected_tool: FrozenToolbarTool::Pen,
+		scroll_capture_active: true,
+		..FrozenToolbarState::default()
+	};
+	let primary_size = WindowRenderer::frozen_toolbar_primary_size(&primary_toolbar_state);
+	let full_toolbar_size = WindowRenderer::frozen_toolbar_size(&primary_toolbar_state);
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let mut session = OverlaySession::new();
+
+	assert!(
+		full_toolbar_size.x > primary_size.x,
+		"regression setup requires the secondary style capsule to be wider than the primary pill",
+	);
+
+	session.toolbar_state = primary_toolbar_state;
+	session.toolbar_inner_size_points =
+		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
+
+	let expected = WindowRenderer::clamp_toolbar_position(
+		screen_rect,
+		primary_size,
+		desired,
+		TOOLBAR_SCREEN_MARGIN_PX,
+		TOOLBAR_SCREEN_MARGIN_PX,
+	);
+	let union_clamped = WindowRenderer::clamp_toolbar_position(
+		screen_rect,
+		full_toolbar_size,
+		desired,
+		TOOLBAR_SCREEN_MARGIN_PX,
+		TOOLBAR_SCREEN_MARGIN_PX,
+	);
+
+	assert_ne!(expected, union_clamped);
+	assert!(session.update_toolbar_outer_position(monitor, desired));
+	assert_eq!(session.toolbar_state.floating_position, Some(expected));
+
+	#[cfg(target_os = "macos")]
+	let expected_outer = GlobalPoint::new(
+		expected.x.round() as i32,
+		(expected.y - primary_origin.y).round() as i32,
+	);
+	#[cfg(not(target_os = "macos"))]
+	let expected_outer = GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32);
+
+	assert_eq!(session.toolbar_outer_pos, Some(expected_outer));
 }
 
 #[test]
@@ -885,6 +980,12 @@ fn toolbar_event_outer_position_falls_back_to_cached_position() {
 fn toolbar_event_outer_position_falls_back_to_floating_position() {
 	let monitor = tests::test_monitor();
 	let floating_position = Some(Pos2::new(80.4, 90.6));
+	#[cfg(target_os = "macos")]
+	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	#[cfg(target_os = "macos")]
+	let expected = GlobalPoint::new(80, (90.6 - primary_origin.y).round() as i32);
+	#[cfg(not(target_os = "macos"))]
+	let expected = GlobalPoint::new(80, 91);
 
 	assert_eq!(
 		OverlaySession::toolbar_event_outer_position_from_sources(
@@ -893,7 +994,7 @@ fn toolbar_event_outer_position_falls_back_to_floating_position() {
 			None,
 			floating_position,
 		),
-		Some(GlobalPoint::new(80, 91))
+		Some(expected)
 	);
 }
 
@@ -2029,23 +2130,26 @@ fn frozen_toolbar_default_position_falls_inside_when_no_space_below_capture_rect
 }
 
 #[test]
-fn frozen_toolbar_default_window_position_clamps_using_secondary_capsule_width() {
+fn frozen_toolbar_default_window_position_clamps_using_primary_anchor_width() {
 	let monitor = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
 	let capture_rect = Rect::from_min_size(Pos2::new(640.0, 120.0), Vec2::new(120.0, 220.0));
 	let toolbar_primary_size = Vec2::new(268.0, 54.0);
-	let toolbar_window_size = Vec2::new(340.0, 82.0);
+	let secondary_union_size = Vec2::new(340.0, 82.0);
 	let pos = WindowRenderer::frozen_toolbar_default_window_pos(
 		monitor,
 		capture_rect,
 		toolbar_primary_size,
-		toolbar_window_size,
+		toolbar_primary_size,
 		ToolbarPlacement::Bottom,
 	);
 	let ideal_x = capture_rect.center().x - toolbar_primary_size.x / 2.0;
-	let max_x = (monitor.max.x - toolbar_window_size.x - TOOLBAR_SCREEN_MARGIN_PX)
+	let max_x = (monitor.max.x - toolbar_primary_size.x - TOOLBAR_SCREEN_MARGIN_PX)
+		.max(TOOLBAR_SCREEN_MARGIN_PX);
+	let secondary_union_max_x = (monitor.max.x - secondary_union_size.x - TOOLBAR_SCREEN_MARGIN_PX)
 		.max(TOOLBAR_SCREEN_MARGIN_PX);
 
 	assert!(ideal_x > max_x);
+	assert_ne!(max_x, secondary_union_max_x);
 	assert_eq!(pos.x, max_x);
 	assert_eq!(pos.y, capture_rect.max.y + TOOLBAR_CAPTURE_GAP_PX);
 }
@@ -2353,6 +2457,109 @@ fn frozen_annotation_capsule_keeps_top_toolbar_default_slot_stable() {
 		session.frozen_toolbar_default_position_for_capture_rect(monitor, capture_rect);
 
 	assert_eq!(styled_pos, base_pos);
+}
+
+#[test]
+fn frozen_annotation_capsule_flips_above_without_moving_bottom_toolbar_anchor() {
+	let monitor = tests::test_monitor();
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let mut toolbar_state = FrozenToolbarState {
+		selected_tool: FrozenToolbarTool::Text,
+		..FrozenToolbarState::default()
+	};
+	let primary_size = WindowRenderer::frozen_toolbar_primary_size(&toolbar_state);
+	let anchor_y = screen_rect.max.y - TOOLBAR_SCREEN_MARGIN_PX - primary_size.y;
+	let capture_rect = Rect::from_min_size(
+		Pos2::new(160.0, anchor_y - TOOLBAR_CAPTURE_GAP_PX - 200.0),
+		Vec2::new(260.0, 200.0),
+	);
+	let anchor = WindowRenderer::frozen_toolbar_default_window_pos(
+		screen_rect,
+		capture_rect,
+		primary_size,
+		WindowRenderer::frozen_toolbar_positioning_size(&toolbar_state),
+		ToolbarPlacement::Bottom,
+	);
+
+	assert_eq!(anchor.y, anchor_y);
+	assert!(anchor.y + primary_size.y + TOOLBAR_SCREEN_MARGIN_PX <= screen_rect.max.y);
+
+	let mut below_toolbar_state = toolbar_state.clone();
+
+	below_toolbar_state.annotation_style_capsule_placement =
+		FrozenAnnotationStyleCapsulePlacement::Below;
+
+	assert!(
+		WindowRenderer::frozen_toolbar_window_rect(&below_toolbar_state, anchor).max.y
+			> screen_rect.max.y
+	);
+
+	WindowRenderer::sync_frozen_annotation_style_capsule_placement(
+		&mut toolbar_state,
+		screen_rect,
+		anchor,
+	);
+
+	assert_eq!(
+		toolbar_state.annotation_style_capsule_placement,
+		FrozenAnnotationStyleCapsulePlacement::Above
+	);
+	assert_eq!(
+		WindowRenderer::frozen_toolbar_primary_rect(&toolbar_state, anchor).min,
+		anchor
+	);
+	assert!(
+		WindowRenderer::frozen_toolbar_window_rect(&toolbar_state, anchor).min.y < anchor.y,
+		"style capsule should render above the stable primary anchor when bottom space is tight",
+	);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn frozen_annotation_capsule_flip_keeps_native_toolbar_outer_position_stable() {
+	let monitor = tests::test_monitor();
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let mut session = OverlaySession::new();
+
+	session.toolbar_inner_size_points =
+		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
+
+	let primary_size = WindowRenderer::frozen_toolbar_primary_size(&session.toolbar_state);
+	let primary_anchor = Pos2::new(
+		160.0,
+		screen_rect.max.y - TOOLBAR_SCREEN_MARGIN_PX - primary_size.y,
+	);
+	let base_outer = session.toolbar_outer_position_from_primary_anchor(monitor, primary_anchor);
+
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	WindowRenderer::sync_frozen_annotation_style_capsule_placement(
+		&mut session.toolbar_state,
+		screen_rect,
+		primary_anchor,
+	);
+
+	assert_eq!(
+		session.toolbar_state.annotation_style_capsule_placement,
+		FrozenAnnotationStyleCapsulePlacement::Above
+	);
+
+	let mut below_toolbar_state = session.toolbar_state.clone();
+
+	below_toolbar_state.annotation_style_capsule_placement =
+		FrozenAnnotationStyleCapsulePlacement::Below;
+
+	assert!(
+		WindowRenderer::frozen_toolbar_window_rect(&below_toolbar_state, primary_anchor).max.y
+			> screen_rect.max.y
+	);
+	assert_eq!(
+		session.toolbar_outer_position_from_primary_anchor(monitor, primary_anchor),
+		base_outer
+	);
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -801,17 +801,12 @@ fn toolbar_position_update_near_edge_clamps_with_runtime_positioning_geometry() 
 	assert_eq!(session.toolbar_state.floating_position, Some(expected));
 
 	#[cfg(target_os = "macos")]
-	let expected_outer = GlobalPoint::new(
-		expected.x.round() as i32,
-		(expected.y - primary_origin.y).round() as i32,
-	);
+	let expected_outer =
+		GlobalPoint::new(expected.x.round() as i32, (expected.y - primary_origin.y).round() as i32);
 	#[cfg(not(target_os = "macos"))]
 	let expected_outer = GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32);
 
-	assert_eq!(
-		session.toolbar_outer_pos,
-		Some(expected_outer)
-	);
+	assert_eq!(session.toolbar_outer_pos, Some(expected_outer));
 }
 
 #[test]
@@ -856,17 +851,12 @@ fn toolbar_window_position_sync_near_edge_clamps_with_runtime_positioning_geomet
 	assert_eq!(session.toolbar_state.floating_position, Some(expected));
 
 	#[cfg(target_os = "macos")]
-	let expected_outer = GlobalPoint::new(
-		expected.x.round() as i32,
-		(expected.y - primary_origin.y).round() as i32,
-	);
+	let expected_outer =
+		GlobalPoint::new(expected.x.round() as i32, (expected.y - primary_origin.y).round() as i32);
 	#[cfg(not(target_os = "macos"))]
 	let expected_outer = GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32);
 
-	assert_eq!(
-		session.toolbar_outer_pos,
-		Some(expected_outer)
-	);
+	assert_eq!(session.toolbar_outer_pos, Some(expected_outer));
 	assert_eq!(
 		session.pending_toolbar_outer_pos,
 		(session.toolbar_outer_pos != Some(desired_outer)).then_some(expected_outer)
@@ -920,10 +910,8 @@ fn toolbar_position_update_clamps_scroll_mode_pen_from_primary_anchor_width() {
 	assert_eq!(session.toolbar_state.floating_position, Some(expected));
 
 	#[cfg(target_os = "macos")]
-	let expected_outer = GlobalPoint::new(
-		expected.x.round() as i32,
-		(expected.y - primary_origin.y).round() as i32,
-	);
+	let expected_outer =
+		GlobalPoint::new(expected.x.round() as i32, (expected.y - primary_origin.y).round() as i32);
 	#[cfg(not(target_os = "macos"))]
 	let expected_outer = GlobalPoint::new(expected.x.round() as i32, expected.y.round() as i32);
 
@@ -2505,10 +2493,7 @@ fn frozen_annotation_capsule_flips_above_without_moving_bottom_toolbar_anchor() 
 		toolbar_state.annotation_style_capsule_placement,
 		FrozenAnnotationStyleCapsulePlacement::Above
 	);
-	assert_eq!(
-		WindowRenderer::frozen_toolbar_primary_rect(&toolbar_state, anchor).min,
-		anchor
-	);
+	assert_eq!(WindowRenderer::frozen_toolbar_primary_rect(&toolbar_state, anchor).min, anchor);
 	assert!(
 		WindowRenderer::frozen_toolbar_window_rect(&toolbar_state, anchor).min.y < anchor.y,
 		"style capsule should render above the stable primary anchor when bottom space is tight",
@@ -2528,10 +2513,8 @@ fn frozen_annotation_capsule_flip_keeps_native_toolbar_outer_position_stable() {
 		Some((startup_size.x.ceil().max(1.0) as u32, startup_size.y.ceil().max(1.0) as u32));
 
 	let primary_size = WindowRenderer::frozen_toolbar_primary_size(&session.toolbar_state);
-	let primary_anchor = Pos2::new(
-		160.0,
-		screen_rect.max.y - TOOLBAR_SCREEN_MARGIN_PX - primary_size.y,
-	);
+	let primary_anchor =
+		Pos2::new(160.0, screen_rect.max.y - TOOLBAR_SCREEN_MARGIN_PX - primary_size.y);
 	let base_outer = session.toolbar_outer_position_from_primary_anchor(monitor, primary_anchor);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -1,11 +1,12 @@
 use crate::overlay::{
 	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
 	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
-	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
+	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2,
+	WindowId, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
-	FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS, WindowRenderer,
+	FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -1,13 +1,11 @@
 use crate::overlay::{
 	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
 	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
-	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2,
-	WindowId, WindowRenderer,
+	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
+	WindowRenderer,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{
-	FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS,
-};
+use crate::overlay::{FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS};
 
 impl OverlaySession {
 	pub(super) fn handle_toolbar_window_moved(
@@ -511,7 +509,8 @@ impl OverlaySession {
 			let previous_floating_position = self.toolbar_state.floating_position;
 			let frozen_arrow_preview = self.active_frozen_arrow_preview();
 
-			self.toolbar_state.floating_position = Some(super::frozen_toolbar_window_primary_origin());
+			self.toolbar_state.floating_position =
+				Some(super::frozen_toolbar_window_primary_origin());
 
 			let Some(toolbar_window) = self.toolbar_window.as_mut() else {
 				return Ok(());

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -306,6 +306,10 @@ impl OverlaySession {
 	) -> Option<GlobalPoint> {
 		window_toolbar_outer_pos.or(cached_toolbar_outer_pos).or_else(|| {
 			floating_position.map(|floating_position| {
+				#[cfg(target_os = "macos")]
+				let floating_position =
+					floating_position - super::frozen_toolbar_window_primary_origin().to_vec2();
+
 				GlobalPoint::new(
 					monitor.origin.x.saturating_add(floating_position.x.round() as i32),
 					monitor.origin.y.saturating_add(floating_position.y.round() as i32),
@@ -421,10 +425,8 @@ impl OverlaySession {
 		match toolbar_window.renderer.resize(size) {
 			Ok(()) => {
 				let window = Arc::clone(&toolbar_window.window);
-				let toolbar_height_points = self
-					.toolbar_inner_size_points
-					.map(|(_, height)| height as f32)
-					.unwrap_or_else(|| super::frozen_toolbar_window_startup_size_points().y);
+				let toolbar_height_points =
+					WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state).y;
 
 				self.configure_hud_window_common(
 					window.as_ref(),
@@ -499,13 +501,16 @@ impl OverlaySession {
 			let Some(toolbar_became_visible) = self.prepare_toolbar_window_for_draw(monitor) else {
 				return Ok(());
 			};
+
+			self.sync_frozen_annotation_style_capsule_placement(monitor);
+
 			let Some(gpu) = self.gpu.as_ref() else {
 				return Ok(());
 			};
 			let previous_floating_position = self.toolbar_state.floating_position;
 			let frozen_arrow_preview = self.active_frozen_arrow_preview();
 
-			self.toolbar_state.floating_position = Some(Pos2::ZERO);
+			self.toolbar_state.floating_position = Some(super::frozen_toolbar_window_primary_origin());
 
 			let Some(toolbar_window) = self.toolbar_window.as_mut() else {
 				return Ok(());
@@ -714,20 +719,37 @@ impl OverlaySession {
 			.or(self.pending_toolbar_outer_pos)
 			.or(self.toolbar_outer_pos)
 			.or_else(|| {
-				self.toolbar_state.floating_position.map(|floating_position| {
-					GlobalPoint::new(
-						monitor.origin.x.saturating_add(floating_position.x.round() as i32),
-						monitor.origin.y.saturating_add(floating_position.y.round() as i32),
-					)
-				})
+				#[cfg(target_os = "macos")]
+				{
+					self.toolbar_state.floating_position.map(|floating_position| {
+						self.toolbar_outer_position_from_primary_anchor(monitor, floating_position)
+					})
+				}
+				#[cfg(not(target_os = "macos"))]
+				{
+					self.toolbar_state.floating_position.map(|floating_position| {
+						GlobalPoint::new(
+							monitor.origin.x.saturating_add(floating_position.x.round() as i32),
+							monitor.origin.y.saturating_add(floating_position.y.round() as i32),
+						)
+					})
+				}
 			});
 		let Some(toolbar_outer_pos) = toolbar_outer_pos else {
 			return false;
 		};
 		let cursor_local =
 			Self::toolbar_cursor_local_position_from_outer(toolbar_outer_pos, cursor_global);
+		#[cfg(target_os = "macos")]
+		let toolbar_primary_origin = super::frozen_toolbar_window_primary_origin();
+		#[cfg(not(target_os = "macos"))]
+		let toolbar_primary_origin = Pos2::ZERO;
 
-		WindowRenderer::frozen_toolbar_visible_capsules_contain(&self.toolbar_state, cursor_local)
+		WindowRenderer::frozen_toolbar_visible_capsules_contain(
+			&self.toolbar_state,
+			toolbar_primary_origin,
+			cursor_local,
+		)
 	}
 
 	fn log_toolbar_redraw_phase_timing(

--- a/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
@@ -5,26 +5,35 @@ use crate::overlay::{
 
 impl OverlaySession {
 	pub(super) fn toolbar_positioning_size(&self) -> Vec2 {
-		#[cfg(target_os = "macos")]
-		{
-			if let Some((width, height)) = self.toolbar_inner_size_points {
-				Vec2::new(width as f32, height as f32)
-			} else if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-				let toolbar_scale = toolbar_window.window.scale_factor().max(1.0);
-				let size = toolbar_window.window.inner_size();
-				let toolbar_w = ((size.width as f64) / toolbar_scale).ceil().max(1.0) as f32;
-				let toolbar_h = ((size.height as f64) / toolbar_scale).ceil().max(1.0) as f32;
+		WindowRenderer::frozen_toolbar_positioning_size(&self.toolbar_state)
+	}
 
-				Vec2::new(toolbar_w, toolbar_h)
-			} else {
-				WindowRenderer::frozen_toolbar_size(&self.toolbar_state)
-			}
-		}
+	#[cfg(target_os = "macos")]
+	pub(super) fn toolbar_outer_position_from_primary_anchor(
+		&self,
+		monitor: MonitorRect,
+		primary_anchor: Pos2,
+	) -> GlobalPoint {
+		let primary_origin = super::frozen_toolbar_window_primary_origin();
 
-		#[cfg(not(target_os = "macos"))]
-		{
-			WindowRenderer::frozen_toolbar_size(&self.toolbar_state)
-		}
+		GlobalPoint::new(
+			monitor.origin.x.saturating_add((primary_anchor.x - primary_origin.x).round() as i32),
+			monitor.origin.y.saturating_add((primary_anchor.y - primary_origin.y).round() as i32),
+		)
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn toolbar_primary_anchor_from_outer_position(
+		&self,
+		monitor: MonitorRect,
+		outer_position: GlobalPoint,
+	) -> Pos2 {
+		let primary_origin = super::frozen_toolbar_window_primary_origin();
+
+		Pos2::new(
+			outer_position.x as f32 - monitor.origin.x as f32 + primary_origin.x,
+			outer_position.y as f32 - monitor.origin.y as f32 + primary_origin.y,
+		)
 	}
 
 	pub(super) fn update_hud_window_position(&mut self, monitor: MonitorRect, cursor: GlobalPoint) {
@@ -227,6 +236,9 @@ impl OverlaySession {
 			TOOLBAR_SCREEN_MARGIN_PX,
 			TOOLBAR_SCREEN_MARGIN_PX,
 		);
+		#[cfg(target_os = "macos")]
+		let desired = self.toolbar_outer_position_from_primary_anchor(monitor, clamped_local_pos);
+		#[cfg(not(target_os = "macos"))]
 		let desired = GlobalPoint::new(
 			monitor.origin.x.saturating_add(clamped_local_pos.x.round() as i32),
 			monitor.origin.y.saturating_add(clamped_local_pos.y.round() as i32),
@@ -240,6 +252,8 @@ impl OverlaySession {
 		self.pending_toolbar_outer_pos = Some(desired);
 		self.toolbar_state.floating_position = Some(clamped_local_pos);
 
+		self.sync_frozen_annotation_style_capsule_placement(monitor);
+
 		true
 	}
 
@@ -251,6 +265,9 @@ impl OverlaySession {
 		let toolbar_size = self.toolbar_positioning_size();
 		let screen_rect =
 			Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+		#[cfg(target_os = "macos")]
+		let local_pos = self.toolbar_primary_anchor_from_outer_position(monitor, outer_position);
+		#[cfg(not(target_os = "macos"))]
 		let local_pos = Pos2::new(
 			outer_position.x as f32 - monitor.origin.x as f32,
 			outer_position.y as f32 - monitor.origin.y as f32,
@@ -262,6 +279,9 @@ impl OverlaySession {
 			TOOLBAR_SCREEN_MARGIN_PX,
 			TOOLBAR_SCREEN_MARGIN_PX,
 		);
+		#[cfg(target_os = "macos")]
+		let desired = self.toolbar_outer_position_from_primary_anchor(monitor, clamped_local_pos);
+		#[cfg(not(target_os = "macos"))]
 		let desired = GlobalPoint::new(
 			monitor.origin.x.saturating_add(clamped_local_pos.x.round() as i32),
 			monitor.origin.y.saturating_add(clamped_local_pos.y.round() as i32),
@@ -271,6 +291,9 @@ impl OverlaySession {
 
 		self.toolbar_outer_pos = Some(desired);
 		self.toolbar_state.floating_position = Some(clamped_local_pos);
+
+		self.sync_frozen_annotation_style_capsule_placement(monitor);
+
 		self.pending_toolbar_outer_pos = (desired != outer_position).then_some(desired);
 
 		changed

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -861,7 +861,7 @@ impl OverlaySession {
 		self.configure_hud_window_common(
 			window.as_ref(),
 			Some(overlay::frozen_toolbar_corner_radius_points(
-				startup_size.y.max(TOOLBAR_EXPANDED_HEIGHT_PX),
+				WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state).y,
 			)),
 		);
 		window.request_redraw();


### PR DESCRIPTION
## Summary
- keep the frozen toolbar primary pill as the single positioning anchor
- flip the Pen/Text style capsule above the toolbar when needed without moving the primary anchor
- document the stable-anchor contract and rationale to prevent future regressions

## Testing
- cargo make lint
- cargo make test-rust