### PR TITLE
refactor: make macOS frozen capture display-first

### DIFF
--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -875,9 +875,9 @@ impl App {
 
 fn self_capture_exception_window_ids_from_sources(
 	current_window_id: Option<u32>,
-	cached_window_id: Option<u32>,
+	_cached_window_id: Option<u32>,
 ) -> Vec<u32> {
-	current_window_id.or(cached_window_id).into_iter().collect()
+	current_window_id.into_iter().collect()
 }
 
 #[cfg(test)]
@@ -885,10 +885,10 @@ mod tests {
 	use crate::app::capture;
 
 	#[test]
-	fn self_capture_exception_window_ids_fall_back_to_cached_settings_window_id() {
+	fn self_capture_exception_window_ids_ignore_stale_cached_settings_window_id() {
 		assert_eq!(
 			capture::self_capture_exception_window_ids_from_sources(None, Some(41)),
-			vec![41]
+			Vec::<u32>::new()
 		);
 	}
 

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -70,9 +70,21 @@ cross-platform architecture.
    - `Space` -> copy the frozen cropped PNG (region/window/fullscreen) to the system clipboard, then exit
    - On macOS, the frozen toolbar may expose `Recognize Text`, which runs Apple Vision OCR on the current frozen capture, copies the recognized text to the clipboard, and exits
    - Cmd+S (macOS) / Ctrl+S -> save the frozen cropped PNG to disk, then exit
-   - On macOS, freeze may complete directly from a fresh live-stream snapshot only when the
-     live stream has complete self-capture exclusions. Otherwise live snapshots are preview-only
-     until authoritative capture completes
+   - On macOS, Frozen entry is display-first: entering Frozen mode MUST commit a display image in
+     a single visible handoff instead of waiting on a later visible capture swap.
+   - Background region/fullscreen/window-background freezes SHOULD complete directly from a fresh
+     live-stream snapshot when one is available. If no usable live snapshot is available yet, the
+     session may wait briefly for a follow-up live snapshot before escalating to the exceptional
+     hidden authoritative fallback.
+   - Window matte freezes MAY seed display from a live-stream snapshot first and continue preparing
+     export authority in the background. The later export-authority response MUST NOT overwrite an
+     already-visible display image.
+   - Frozen-mode display readiness and export readiness are separate. Pointer drag/reposition,
+     pen, arrow, text, spotlight, and toolbar visibility are display-driven; copy/save/OCR/scroll/
+     mosaic remain gated on export-ready bytes.
+   - On macOS, the normal Frozen-entry path MUST NOT hide overlay/HUD/toolbar windows. Hiding
+     capture windows is reserved for exceptional authoritative fallback when no usable display-first
+     path arrives in time.
    - In Frozen mode, toolbar-driven annotations are part of the frozen capture state. Current
      annotation/edit tools are pointer, pen, arrow, text, mosaic, and spotlight; the pen-tool
      contract lives in `docs/spec/annotation-pen.md`, and Frozen toolbar placement/expansion

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1573,7 +1573,7 @@ impl OverlaySession {
 			.live_sample_stream
 			.as_ref()
 			.and_then(|stream| stream.latest_frame_frontier_for_monitor(monitor))
-			.map_or(0, |(frame_seq, _)| frame_seq);
+			.map_or(0, |(_, stream_generation)| stream_generation);
 
 		self.state.live_bg_monitor = None;
 		self.state.live_bg_image = None;

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -274,6 +274,8 @@ const LIVE_HOVER_HIT_TEST_INTERVAL: Duration = Duration::from_millis(60);
 const LIVE_WINDOW_LIST_REFRESH_INTERVAL: Duration = Duration::from_millis(120);
 const PENDING_CLICK_HIT_TEST_TIMEOUT: Duration = Duration::from_millis(250);
 #[cfg(target_os = "macos")]
+const DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT: Duration = Duration::from_millis(150);
+#[cfg(target_os = "macos")]
 const POST_HIDE_LIVE_SNAPSHOT_GRACE: Duration = Duration::from_millis(12);
 const LIVE_PRESENT_INTERVAL_MIN: Duration = Duration::from_nanos(8_333_333);
 const HUD_LOUPE_MOVE_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
@@ -603,6 +605,8 @@ pub struct OverlaySession {
 	pending_freeze_capture_windows_hidden_at: Option<Instant>,
 	#[cfg(target_os = "macos")]
 	pending_freeze_capture_hidden_after_stream_generation: Option<u64>,
+	frozen_export_ready: bool,
+	#[cfg(test)]
 	authoritative_frozen_capture_ready: bool,
 	frozen_transition_started_at: Option<Instant>,
 	frozen_transition_preview_committed_at: Option<Instant>,
@@ -777,9 +781,10 @@ impl OverlaySession {
 	#[allow(clippy::too_many_lines)]
 	#[rustfmt::skip]
 	fn build_base_session_defaults() -> Self {
+		let now = Instant::now();
+
 		Self {
-			config: OverlayConfig::default(),
-			worker: None,
+			config: OverlayConfig::default(), worker: None,
 			#[cfg(target_os = "macos")]
 			live_sample_worker: None,
 			#[cfg(target_os = "macos")]
@@ -799,16 +804,13 @@ impl OverlaySession {
 			loupe_outer_pos: None, pending_loupe_outer_pos: None, loupe_inner_size_points: None,
 			toolbar_outer_pos: None, pending_toolbar_outer_pos: None, toolbar_inner_size_points: None,
 			gpu: None,
-			last_hud_window_move_at: Instant::now(),
-			last_loupe_window_move_at: Instant::now(),
-			last_toolbar_window_move_at: Instant::now(),
-			last_present_at: Instant::now(),
-			last_live_cursor_poll_at: Instant::now(),
-			last_frozen_cursor_poll_at: Instant::now(),
+			last_hud_window_move_at: now, last_loupe_window_move_at: now,
+			last_toolbar_window_move_at: now, last_present_at: now,
+			last_live_cursor_poll_at: now, last_frozen_cursor_poll_at: now,
 			window_list_snapshot: None,
-			last_window_list_refresh_request_at: Instant::now(),
+			last_window_list_refresh_request_at: now,
 			window_list_refresh_interval: Duration::ZERO,
-			last_live_bg_request_at: Instant::now(),
+			last_live_bg_request_at: now,
 			live_bg_request_interval: Duration::ZERO,
 			freeze_capture_send_full_count: 0,
 			hit_test_send_full_count: 0,
@@ -833,7 +835,7 @@ impl OverlaySession {
 			keyboard_modifiers: ModifiersState::default(),
 			event_loop_phase: OverlayEventLoopPhase::Idle,
 			event_loop_progress_seq: 0,
-			event_loop_last_progress_at: Instant::now(),
+			event_loop_last_progress_at: now,
 			event_loop_last_progress_window_id: None, event_loop_last_progress_monitor_id: None,
 			event_loop_last_progress_detail: None,
 			event_loop_last_stall_warn_at: None,
@@ -842,7 +844,10 @@ impl OverlaySession {
 			egui_repaint_deadline: Arc::new(Mutex::new(None)),
 			pending_freeze_capture: None, inflight_freeze_capture: None, pending_freeze_capture_armed: false,
 			#[cfg(target_os = "macos")] pending_freeze_capture_windows_hidden_at: None, #[cfg(target_os = "macos")] pending_freeze_capture_hidden_after_stream_generation: None,
-			authoritative_frozen_capture_ready: false, frozen_transition_started_at: None, frozen_transition_preview_committed_at: None,
+			frozen_export_ready: false,
+			#[cfg(test)]
+			authoritative_frozen_capture_ready: false,
+			frozen_transition_started_at: None, frozen_transition_preview_committed_at: None,
 			frozen_transition_preview_source: None, frozen_transition_final_ready_at: None,
 			frozen_transition_toolbar_visible_at: None, frozen_transition_target_window_id: None,
 			pending_window_freeze_capture: None, inflight_window_freeze_capture: None, frozen_window_image: None,
@@ -850,8 +855,7 @@ impl OverlaySession {
 			capture_windows_hidden: false,
 			#[cfg(target_os = "macos")]
 			next_ocr_request_id: 0,
-			pending_encode_png: None,
-			pending_png_action: None,
+			pending_encode_png: None, pending_png_action: None,
 			#[cfg(target_os = "macos")]
 			png_encode_inflight: false,
 			#[cfg(target_os = "macos")]
@@ -1108,10 +1112,7 @@ impl OverlaySession {
 	}
 
 	fn maybe_keep_frozen_capture_redraw(&self) {
-		if !matches!(self.state.mode, OverlayMode::Frozen) {
-			return;
-		}
-		if self.state.frozen_image.is_some() {
+		if !matches!(self.state.mode, OverlayMode::Frozen) || self.frozen_display_ready() {
 			return;
 		}
 
@@ -1128,8 +1129,17 @@ impl OverlaySession {
 		self.schedule_egui_repaint_after(self.repaint_interval_for_monitor(self.state.monitor));
 	}
 
+	fn frozen_display_ready(&self) -> bool {
+		matches!(self.state.mode, OverlayMode::Frozen)
+			&& self.state.frozen_surface_image().is_some()
+	}
+
+	fn frozen_display_ready_for_monitor(&self, monitor: MonitorRect) -> bool {
+		self.frozen_display_ready() && self.state.monitor == Some(monitor)
+	}
+
 	fn frozen_preview_visible(&self) -> bool {
-		matches!(self.state.mode, OverlayMode::Frozen) && self.state.frozen_image.is_some()
+		self.frozen_display_ready()
 	}
 
 	fn maybe_tick_toolbar_window_warmup_redraw(&mut self) {
@@ -1145,7 +1155,7 @@ impl OverlaySession {
 		{
 			if !matches!(self.state.mode, OverlayMode::Frozen)
 				|| !self.toolbar_state.visible
-				|| self.state.frozen_image.is_none()
+				|| !self.frozen_display_ready()
 				|| self.state.monitor.is_none()
 			{
 				self.toolbar_window_warmup_redraws_remaining = 0;
@@ -1174,13 +1184,21 @@ impl OverlaySession {
 
 	#[cfg(not(target_os = "macos"))]
 	fn should_dispatch_pending_freeze_capture(&self, monitor: MonitorRect) -> bool {
-		self.pending_freeze_capture_matches(monitor) && self.state.frozen_image.is_none()
+		self.pending_freeze_capture_matches(monitor) && !self.frozen_preview_visible()
 	}
 
 	fn frozen_final_capture_ready(&self) -> bool {
 		matches!(self.state.mode, OverlayMode::Frozen)
-			&& self.authoritative_frozen_capture_ready
-			&& self.state.frozen_image.is_some()
+			&& {
+				#[cfg(test)]
+				{
+					self.frozen_export_ready || self.authoritative_frozen_capture_ready
+				}
+				#[cfg(not(test))]
+				{
+					self.frozen_export_ready
+				}
+			} && self.state.frozen_export_image.is_some()
 			&& self.pending_freeze_capture.is_none()
 			&& self.inflight_freeze_capture.is_none()
 	}
@@ -1517,7 +1535,7 @@ impl OverlaySession {
 		image: RgbaImage,
 		cursor: Option<GlobalPoint>,
 	) {
-		self.state.finish_freeze(monitor, image);
+		self.state.commit_frozen_display_image(monitor, image);
 
 		if let Some(cursor) = cursor {
 			self.update_cursor_state(monitor, cursor);
@@ -1550,6 +1568,29 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn begin_hidden_authoritative_freeze_capture_fallback(&mut self, monitor: MonitorRect) {
+		let after_stream_generation = self
+			.live_sample_stream
+			.as_ref()
+			.and_then(|stream| stream.latest_frame_frontier_for_monitor(monitor))
+			.map_or(0, |(frame_seq, _)| frame_seq);
+
+		self.state.live_bg_monitor = None;
+		self.state.live_bg_image = None;
+		self.capture_windows_hidden = true;
+
+		self.hide_capture_windows();
+
+		self.pending_freeze_capture_windows_hidden_at = Some(Instant::now());
+		self.pending_freeze_capture_hidden_after_stream_generation = Some(after_stream_generation);
+		self.pending_freeze_capture_armed = true;
+		self.freeze_capture_send_full_count = 0;
+
+		self.note_frozen_transition_authoritative_handoff_armed(monitor);
+		self.request_redraw_for_monitor(monitor);
+	}
+
+	#[cfg(target_os = "macos")]
 	fn maybe_finish_frozen_capture_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1568,6 +1609,7 @@ impl OverlaySession {
 			return false;
 		};
 		let snapshot_image = snapshot.image.as_ref().clone();
+		let export_image = snapshot_image.clone();
 		let restore_hidden_capture_windows = self.capture_windows_hidden;
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);
@@ -1580,8 +1622,13 @@ impl OverlaySession {
 		self.pending_freeze_capture_hidden_after_stream_generation = None;
 		self.pending_window_freeze_capture = None;
 		self.inflight_window_freeze_capture = None;
-		self.authoritative_frozen_capture_ready = true;
+		self.frozen_export_ready = true;
+		#[cfg(test)]
+		{
+			self.authoritative_frozen_capture_ready = true;
+		}
 
+		self.state.commit_frozen_export_image(export_image);
 		self.note_frozen_transition_final_ready(
 			monitor,
 			source,
@@ -1610,7 +1657,7 @@ impl OverlaySession {
 		true
 	}
 
-	#[cfg(all(test, target_os = "macos"))]
+	#[cfg(target_os = "macos")]
 	fn maybe_seed_frozen_capture_preview_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1639,6 +1686,46 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn maybe_update_pending_frozen_capture_from_live_stream_snapshot(
+		&mut self,
+		monitor: MonitorRect,
+	) -> bool {
+		if !self.pending_freeze_capture_matches(monitor)
+			|| self.frozen_export_ready
+			|| self.inflight_freeze_capture.is_some()
+			|| self.capture_windows_hidden
+		{
+			return false;
+		}
+
+		let window_target = self.pending_window_freeze_capture_for_monitor(monitor);
+		let snapshot = self
+			.live_sample_stream
+			.as_ref()
+			.and_then(|stream| stream.peek_latest_rgba_snapshot(monitor));
+
+		if self.snapshot_can_finish_frozen_capture(window_target) {
+			return self.maybe_finish_frozen_capture_from_snapshot(
+				monitor,
+				window_target,
+				self.state.cursor,
+				snapshot,
+				"live_stream_snapshot_followup",
+			);
+		}
+		if self.frozen_preview_visible() {
+			return false;
+		}
+
+		self.maybe_seed_frozen_capture_preview_from_snapshot(
+			monitor,
+			self.state.cursor,
+			snapshot,
+			"live_stream_snapshot_preview_followup",
+		)
+	}
+
+	#[cfg(target_os = "macos")]
 	fn maybe_finish_pending_frozen_capture_from_hidden_live_stream_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1653,7 +1740,7 @@ impl OverlaySession {
 		};
 
 		if !self.pending_freeze_capture_matches(monitor)
-			|| self.authoritative_frozen_capture_ready
+			|| self.frozen_export_ready
 			|| self.inflight_freeze_capture.is_some()
 			|| !self.capture_windows_hidden
 		{
@@ -1861,7 +1948,11 @@ impl OverlaySession {
 			self.pending_freeze_capture_hidden_after_stream_generation = None;
 		}
 		self.inflight_freeze_capture = None;
-		self.authoritative_frozen_capture_ready = false;
+		self.frozen_export_ready = false;
+		#[cfg(test)]
+		{
+			self.authoritative_frozen_capture_ready = false;
+		}
 		self.freeze_capture_send_full_count = 0;
 		self.pending_window_freeze_capture = window_target;
 		self.inflight_window_freeze_capture = None;
@@ -1952,7 +2043,7 @@ impl OverlaySession {
 	fn begin_frozen_capture_with_rect_macos(
 		&mut self,
 		monitor: MonitorRect,
-		_window_target: Option<WindowFreezeCaptureTarget>,
+		window_target: Option<WindowFreezeCaptureTarget>,
 		cursor: Option<GlobalPoint>,
 	) -> bool {
 		if let Some(cursor) = cursor {
@@ -1961,31 +2052,55 @@ impl OverlaySession {
 
 		self.state.live_bg_monitor = None;
 		self.state.live_bg_image = None;
-		self.capture_windows_hidden = true;
-		self.pending_freeze_capture_armed = true;
+		self.capture_windows_hidden = false;
+		self.pending_freeze_capture_windows_hidden_at = None;
+		self.pending_freeze_capture_hidden_after_stream_generation = None;
+
+		let snapshot = self
+			.live_sample_stream
+			.as_ref()
+			.and_then(|stream| stream.peek_latest_rgba_snapshot(monitor));
+
+		if self.maybe_finish_frozen_capture_from_snapshot(
+			monitor,
+			window_target,
+			cursor,
+			snapshot.clone(),
+			"live_stream_snapshot_at_freeze_begin",
+		) {
+			return true;
+		}
+
+		let seeded_preview = self.maybe_seed_frozen_capture_preview_from_snapshot(
+			monitor,
+			cursor,
+			snapshot.clone(),
+			"live_stream_snapshot_preview_at_freeze_begin",
+		);
+
+		self.pending_freeze_capture_armed = window_target.is_some()
+			&& self.config.window_capture_alpha_mode != WindowCaptureAlphaMode::Background;
+
+		if let Some(stream) = self.live_sample_stream.as_ref() {
+			let after_frame_seq = stream
+				.latest_frame_frontier_for_monitor(monitor)
+				.map_or(0, |(frame_seq, _)| frame_seq);
+			let _ = stream.refresh_monitor_nonblocking_if_stale(monitor, after_frame_seq, true);
+		}
 
 		self.note_frozen_transition_preview_deferred(
 			monitor,
-			"waiting_for_hidden_live_snapshot_or_authoritative_capture",
+			if seeded_preview {
+				"waiting_for_export_authority"
+			} else {
+				"waiting_for_live_stream_snapshot"
+			},
 			None,
 		);
-		self.hide_capture_windows();
 
-		self.pending_freeze_capture_hidden_after_stream_generation =
-			self.live_sample_stream.as_ref().and_then(|stream| {
-				let (after_frame_seq, hidden_after_stream_generation) = stream
-					.latest_frame_frontier_for_monitor(monitor)
-					.map_or((0, 0), |(frame_seq, stream_generation)| {
-						(frame_seq, stream_generation)
-					});
-
-				stream
-					.refresh_monitor_nonblocking_if_stale(monitor, after_frame_seq, true)
-					.then_some(hidden_after_stream_generation)
-			});
-		self.pending_freeze_capture_windows_hidden_at = Some(Instant::now());
-
-		self.note_frozen_transition_authoritative_handoff_armed(monitor);
+		if self.pending_freeze_capture_armed {
+			self.note_frozen_transition_authoritative_handoff_armed(monitor);
+		}
 
 		false
 	}
@@ -2009,7 +2124,11 @@ impl OverlaySession {
 
 			self.pending_freeze_capture = None;
 			self.pending_freeze_capture_armed = false;
-			self.authoritative_frozen_capture_ready = true;
+			self.frozen_export_ready = true;
+			#[cfg(test)]
+			{
+				self.authoritative_frozen_capture_ready = true;
+			}
 
 			self.note_frozen_transition_final_ready(monitor, "cached_live_background", None);
 
@@ -2035,7 +2154,7 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		capture_rect_pixels: RectPoints,
 	) -> Option<RgbaImage> {
-		let frozen_image = self.state.frozen_image.as_ref()?;
+		let frozen_image = self.state.frozen_export_image.as_ref()?;
 		let x = capture_rect_pixels.x.min(frozen_image.width());
 		let y = capture_rect_pixels.y.min(frozen_image.height());
 		let max_width = frozen_image.width().saturating_sub(x);
@@ -2179,9 +2298,14 @@ impl OverlaySession {
 	) {
 		if matches!(self.state.mode, OverlayMode::Frozen) && self.state.monitor == Some(monitor) {
 			self.inflight_freeze_capture = None;
-			self.authoritative_frozen_capture_ready = true;
+			self.frozen_export_ready = true;
+			#[cfg(test)]
+			{
+				self.authoritative_frozen_capture_ready = true;
+			}
 
 			let window_capture_target = self.inflight_window_freeze_capture.take();
+			let had_display_image = self.frozen_display_ready();
 			let mut frozen_preview_image = image;
 
 			self.pending_window_freeze_capture = None;
@@ -2212,8 +2336,16 @@ impl OverlaySession {
 				}
 			}
 
-			self.state.finish_freeze(monitor, frozen_preview_image);
-			self.note_frozen_transition_preview_committed(monitor, "authoritative_capture", None);
+			if !had_display_image {
+				self.state.commit_frozen_display_image(monitor, frozen_preview_image.clone());
+				self.note_frozen_transition_preview_committed(
+					monitor,
+					"authoritative_capture",
+					None,
+				);
+			}
+
+			self.state.commit_frozen_export_image(frozen_preview_image.clone());
 			self.note_frozen_transition_final_ready(
 				monitor,
 				"authoritative_capture",
@@ -2629,7 +2761,7 @@ impl OverlaySession {
 		}
 
 		let crop_rect = self.deferred_text_recognition_crop_rect_pixels()?;
-		let frozen_image = self.state.frozen_image.take()?;
+		let frozen_image = self.state.frozen_export_image.take()?;
 
 		Some(DeferredTextRecognitionRequest::frozen_crop(
 			request_id,
@@ -2641,7 +2773,7 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	fn deferred_text_recognition_crop_rect_pixels(&self) -> Option<Option<RectPoints>> {
-		let frozen_image = self.state.frozen_image.as_ref()?;
+		let frozen_image = self.state.frozen_export_image.as_ref()?;
 		let Some(monitor) = self.state.monitor else {
 			return Some(None);
 		};
@@ -3017,8 +3149,8 @@ impl OverlaySession {
 			window_id = ?window_id,
 			monitor_id = overlay_monitor.id,
 			frozen_generation = self.state.frozen_generation,
-			final_capture_ready = self.authoritative_frozen_capture_ready,
-			frozen_image_ready = self.state.frozen_image.is_some(),
+			final_capture_ready = self.frozen_export_ready,
+			frozen_image_ready = self.frozen_display_ready(),
 			pending_freeze_capture = self.pending_freeze_capture.map(|m| m.id),
 			draw_toolbar,
 			toolbar_visible = self.toolbar_state.visible,
@@ -3453,6 +3585,7 @@ struct FrozenImagePatch {
 #[derive(Clone, Debug)]
 struct FrozenMosaicEdit {
 	preview_patch: FrozenImagePatch,
+	export_patch: FrozenImagePatch,
 	window_patch: Option<FrozenImagePatch>,
 }
 

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -2298,13 +2298,25 @@ impl OverlaySession {
 	) {
 		if matches!(self.state.mode, OverlayMode::Frozen) && self.state.monitor == Some(monitor) {
 			self.inflight_freeze_capture = None;
+
+			let window_capture_target = self.inflight_window_freeze_capture.take();
+
+			#[cfg(target_os = "macos")]
+			if self.maybe_retry_unhidden_matte_capture_after_window_miss(
+				monitor,
+				window_capture_target,
+				window_image.is_some(),
+				captured_window_id,
+			) {
+				return;
+			}
+
 			self.frozen_export_ready = true;
 			#[cfg(test)]
 			{
 				self.authoritative_frozen_capture_ready = true;
 			}
 
-			let window_capture_target = self.inflight_window_freeze_capture.take();
 			let had_display_image = self.frozen_display_ready();
 			let mut frozen_preview_image = image;
 
@@ -2393,6 +2405,42 @@ impl OverlaySession {
 
 			self.request_redraw_for_monitor(monitor);
 		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn maybe_retry_unhidden_matte_capture_after_window_miss(
+		&mut self,
+		monitor: MonitorRect,
+		window_capture_target: Option<WindowFreezeCaptureTarget>,
+		window_image_present: bool,
+		captured_window_id: Option<u32>,
+	) -> bool {
+		let Some(target) = window_capture_target else {
+			return false;
+		};
+
+		if target.monitor != monitor
+			|| !matches!(
+				self.config.window_capture_alpha_mode,
+				WindowCaptureAlphaMode::MatteLight | WindowCaptureAlphaMode::MatteDark
+			) || self.capture_windows_hidden
+			|| (captured_window_id == Some(target.window_id) && window_image_present)
+		{
+			return false;
+		}
+
+		self.pending_freeze_capture = Some(monitor);
+		self.pending_window_freeze_capture = Some(target);
+		self.frozen_export_ready = false;
+		#[cfg(test)]
+		{
+			self.authoritative_frozen_capture_ready = false;
+		}
+		self.frozen_window_image = None;
+
+		self.begin_hidden_authoritative_freeze_capture_fallback(monitor);
+
+		true
 	}
 
 	fn handle_encoded_png_response(&mut self, png_bytes: Vec<u8>) -> OverlayControl {

--- a/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
@@ -21,7 +21,7 @@ impl OverlaySession {
 		}
 		if !matches!(self.state.mode, OverlayMode::Frozen)
 			|| !self.loupe_window_visible
-			|| self.state.frozen_image.is_none()
+			|| !self.frozen_display_ready()
 			|| self.state.monitor.is_none()
 		{
 			self.loupe_window_warmup_redraws_remaining = 0;
@@ -43,7 +43,7 @@ impl OverlaySession {
 		if !matches!(self.state.mode, OverlayMode::Frozen)
 			|| !self.state.alt_held
 			|| !self.loupe_window_visible
-			|| self.state.frozen_image.is_none()
+			|| !self.frozen_display_ready()
 			|| self.state.monitor.is_none()
 		{
 			return;
@@ -68,6 +68,8 @@ impl OverlaySession {
 		#[cfg(target_os = "macos")]
 		{
 			if let Some(monitor) = self.pending_freeze_capture {
+				let _ = self.maybe_update_pending_frozen_capture_from_live_stream_snapshot(monitor);
+				let _ = self.maybe_escalate_pending_display_first_freeze_to_hidden_fallback(now);
 				let _ = self
 					.maybe_finish_pending_frozen_capture_from_hidden_live_stream_snapshot(monitor);
 			}

--- a/packages/rsnap-overlay/src/overlay/frozen_brush_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_brush_runtime.rs
@@ -32,7 +32,7 @@ impl OverlaySession {
 	pub(super) fn frozen_brush_capture_target(&self) -> Option<(MonitorRect, RectPoints)> {
 		if !matches!(self.state.mode, OverlayMode::Frozen)
 			|| self.scroll_capture.active
-			|| self.state.frozen_image.is_none()
+			|| !self.frozen_display_ready()
 		{
 			return None;
 		}

--- a/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
@@ -24,7 +24,7 @@ impl OverlaySession {
 			}
 		}
 
-		let frozen_image = self.state.frozen_image.as_ref()?;
+		let frozen_image = self.state.frozen_export_image.as_ref()?;
 		let Some(monitor) = self.state.monitor else {
 			return Some(frozen_image.clone());
 		};
@@ -629,8 +629,9 @@ impl OverlaySession {
 				.map(|session| session.export_image().clone());
 		}
 
-		let mut export_image =
-			self.cropped_frozen_capture_image().or_else(|| self.state.frozen_image.clone())?;
+		let mut export_image = self
+			.cropped_frozen_capture_image()
+			.or_else(|| self.state.frozen_export_image.clone())?;
 
 		self.render_frozen_committed_overlays_into_image(&mut export_image);
 

--- a/packages/rsnap-overlay/src/overlay/frozen_mosaic_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_mosaic_runtime.rs
@@ -148,6 +148,14 @@ impl OverlaySession {
 		else {
 			return false;
 		};
+		let Some(export_patch) = self
+			.state
+			.frozen_export_image
+			.as_ref()
+			.and_then(|image| Self::build_frozen_image_patch(image, preview_rect_px))
+		else {
+			return false;
+		};
 		let window_patch = match (self.frozen_window_image.as_ref(), self.state.frozen_capture_rect)
 		{
 			(Some(window_image), Some(capture_rect_points)) => Self::map_rect_into_window_image(
@@ -163,13 +171,20 @@ impl OverlaySession {
 		if let Some(image) = self.state.frozen_image.as_mut() {
 			Self::apply_frozen_image_patch(image, &preview_patch, true);
 		}
+		if let Some(image) = self.state.frozen_export_image.as_mut() {
+			Self::apply_frozen_image_patch(image, &export_patch, true);
+		}
 		if let (Some(window_image), Some(window_patch)) =
 			(self.frozen_window_image.as_mut(), window_patch.as_ref())
 		{
 			Self::apply_frozen_image_patch(window_image, window_patch, true);
 		}
 
-		self.push_frozen_mosaic_edit(FrozenMosaicEdit { preview_patch, window_patch });
+		self.push_frozen_mosaic_edit(FrozenMosaicEdit {
+			preview_patch,
+			export_patch,
+			window_patch,
+		});
 		self.push_frozen_edit_to_undo_history(FrozenEditKind::MosaicEdit);
 		self.note_frozen_image_mutated(monitor);
 
@@ -183,6 +198,9 @@ impl OverlaySession {
 
 		if let Some(image) = self.state.frozen_image.as_mut() {
 			Self::apply_frozen_image_patch(image, &edit.preview_patch, use_after);
+		}
+		if let Some(image) = self.state.frozen_export_image.as_mut() {
+			Self::apply_frozen_image_patch(image, &edit.export_patch, use_after);
 		}
 		if let (Some(window_image), Some(window_patch)) =
 			(self.frozen_window_image.as_mut(), edit.window_patch.as_ref())

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -225,7 +225,7 @@ impl OverlaySession {
 		if !matches!(self.state.mode, OverlayMode::Frozen)
 			|| self.frozen_capture_source != FrozenCaptureSource::DragRegion
 			|| self.scroll_capture.active
-			|| self.state.frozen_image.is_none()
+			|| !self.frozen_display_ready()
 		{
 			return None;
 		}
@@ -253,7 +253,7 @@ impl OverlaySession {
 	fn frozen_mosaic_drag_target(&self) -> Option<(MonitorRect, RectPoints)> {
 		if !matches!(self.state.mode, OverlayMode::Frozen)
 			|| self.scroll_capture.active
-			|| self.state.frozen_image.is_none()
+			|| !self.frozen_display_ready()
 			|| !self.frozen_final_capture_ready()
 			|| self.toolbar_state.selected_tool != FrozenToolbarTool::Mosaic
 		{

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -946,6 +946,23 @@ fn begin_ocr_action_drag_region_still_uses_frozen_image_under_matte_mode() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn authoritative_freeze_response_updates_export_authority_without_overwriting_display_preview() {
+	let monitor = test_monitor();
+	let preview_image = image::RgbaImage::from_pixel(8, 8, Rgba([18, 24, 32, 255]));
+	let authoritative_image = image::RgbaImage::from_pixel(8, 8, Rgba([92, 108, 124, 255]));
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+	session.state.commit_frozen_display_image(monitor, preview_image.clone());
+	session.handle_captured_freeze_response(monitor, authoritative_image.clone(), None, None);
+
+	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
+	assert_eq!(session.state.frozen_export_image.as_ref(), Some(&authoritative_image));
+	assert!(session.authoritative_frozen_capture_ready);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn window_matte_mosaic_export_and_ocr_match_preview_pixels() {
 	let monitor = test_monitor_with_scale(8, 8, 1_000);
 	let capture_rect = RectPoints::new(2, 1, 4, 4);
@@ -1336,7 +1353,11 @@ fn test_frozen_mosaic_edit() -> FrozenMosaicEdit {
 		after: image::RgbaImage::from_pixel(1, 1, Rgba([255, 255, 255, 255])),
 	};
 
-	FrozenMosaicEdit { preview_patch: patch.clone(), window_patch: Some(patch) }
+	FrozenMosaicEdit {
+		preview_patch: patch.clone(),
+		export_patch: patch.clone(),
+		window_patch: Some(patch),
+	}
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -267,7 +267,7 @@ fn hidden_live_snapshot_can_finish_frozen_capture_before_authoritative_dispatch(
 	session.live_sample_stream.as_ref().unwrap().debug_set_active_stream_generation(monitor.id, 1);
 	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
 		monitor,
-		1,
+		50,
 		1,
 		Instant::now(),
 	);
@@ -280,7 +280,7 @@ fn hidden_live_snapshot_can_finish_frozen_capture_before_authoritative_dispatch(
 	session.live_sample_stream.as_ref().unwrap().debug_set_active_stream_generation(monitor.id, 2);
 	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
 		monitor,
-		2,
+		51,
 		2,
 		Instant::now() + Duration::from_millis(1),
 	);

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -2,8 +2,6 @@
 use std::ptr;
 
 #[cfg(target_os = "macos")]
-use crate::overlay::POST_HIDE_LIVE_SNAPSHOT_GRACE;
-#[cfg(target_os = "macos")]
 use crate::overlay::RectPoints;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::WorkerRequestSendError;
@@ -19,6 +17,10 @@ use crate::overlay::tests::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::worker_runtime::FREEZE_CAPTURE_SEND_FULL_RETRY_LIMIT;
+#[cfg(target_os = "macos")]
+use crate::overlay::{
+	POST_HIDE_LIVE_SNAPSHOT_GRACE, WindowCaptureAlphaMode, WindowFreezeCaptureTarget,
+};
 
 #[cfg(target_os = "macos")]
 #[test]
@@ -228,11 +230,17 @@ fn armed_freeze_capture_without_worker_restores_visibility_and_surfaces_error() 
 
 #[cfg(target_os = "macos")]
 #[test]
-fn begin_frozen_capture_hides_overlay_windows_immediately_on_macos() {
+fn begin_frozen_capture_background_snapshot_finishes_without_hiding_overlay_windows_on_macos() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);
 	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
 
+	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
+		monitor,
+		1,
+		1,
+		Instant::now(),
+	);
 	session.begin_frozen_capture_with_rect(
 		monitor,
 		Some(RectPoints::new(100, 140, 320, 240)),
@@ -240,15 +248,13 @@ fn begin_frozen_capture_hides_overlay_windows_immediately_on_macos() {
 		Some(cursor),
 	);
 
-	assert!(session.pending_freeze_capture_armed);
-	assert!(session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_none());
-	assert!(session.pending_freeze_capture_windows_hidden_at.is_some());
-	assert!(
-		session
-			.pending_freeze_capture_windows_hidden_at
-			.is_some_and(|hidden_at| hidden_at >= session.last_present_at)
-	);
+	assert!(session.pending_freeze_capture.is_none());
+	assert!(!session.pending_freeze_capture_armed);
+	assert!(!session.capture_windows_hidden);
+	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_export_image.is_some());
+	assert!(session.frozen_final_capture_ready());
+	assert!(session.pending_freeze_capture_windows_hidden_at.is_none());
 }
 
 #[cfg(target_os = "macos")]
@@ -292,57 +298,13 @@ fn hidden_live_snapshot_can_finish_frozen_capture_before_authoritative_dispatch(
 
 #[cfg(target_os = "macos")]
 #[test]
-fn authoritative_dispatch_waits_briefly_for_hidden_live_snapshot() {
+fn window_matte_capture_seeds_preview_and_arms_worker_without_hiding_overlay_windows() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);
 	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
 
-	session.begin_frozen_capture_with_rect(
-		monitor,
-		Some(RectPoints::new(100, 140, 320, 240)),
-		None,
-		Some(cursor),
-	);
-	session.maybe_dispatch_armed_freeze_capture();
+	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
 
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
-	assert!(session.capture_windows_hidden);
-}
-
-#[cfg(target_os = "macos")]
-#[test]
-fn authoritative_dispatch_falls_back_after_hidden_live_snapshot_grace_expires() {
-	let monitor = tests::test_monitor();
-	let cursor = GlobalPoint::new(120, 180);
-	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
-
-	session.begin_frozen_capture_with_rect(
-		monitor,
-		Some(RectPoints::new(100, 140, 320, 240)),
-		None,
-		Some(cursor),
-	);
-
-	session.pending_freeze_capture_windows_hidden_at =
-		Some(Instant::now() - POST_HIDE_LIVE_SNAPSHOT_GRACE - Duration::from_millis(1));
-
-	session.maybe_dispatch_armed_freeze_capture();
-
-	assert!(session.pending_freeze_capture.is_none());
-	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, Some(monitor));
-}
-
-#[cfg(target_os = "macos")]
-#[test]
-fn pre_hide_live_snapshot_does_not_finish_frozen_capture_before_authoritative_dispatch() {
-	let monitor = tests::test_monitor();
-	let cursor = GlobalPoint::new(120, 180);
-	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
-
-	session.live_sample_stream.as_ref().unwrap().debug_set_active_stream_generation(monitor.id, 1);
 	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
 		monitor,
 		1,
@@ -352,23 +314,176 @@ fn pre_hide_live_snapshot_does_not_finish_frozen_capture_before_authoritative_di
 	session.begin_frozen_capture_with_rect(
 		monitor,
 		Some(RectPoints::new(100, 140, 320, 240)),
+		Some(WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 41,
+			rect: RectPoints::new(100, 140, 320, 240),
+		}),
+		Some(cursor),
+	);
+
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(session.pending_freeze_capture_armed);
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(!session.capture_windows_hidden);
+	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_export_image.is_none());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn window_matte_capture_dispatches_worker_without_hiding_overlay_windows() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+
+	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
+		monitor,
+		1,
+		1,
+		Instant::now(),
+	);
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
+		Some(WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 41,
+			rect: RectPoints::new(100, 140, 320, 240),
+		}),
+		Some(cursor),
+	);
+	session.maybe_dispatch_armed_freeze_capture();
+
+	assert!(session.pending_freeze_capture.is_none());
+	assert!(!session.pending_freeze_capture_armed);
+	assert_eq!(session.inflight_freeze_capture, Some(monitor));
+	assert!(!session.capture_windows_hidden);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn window_matte_capture_without_live_preview_waits_for_hidden_fallback_before_dispatch() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
+		Some(WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 41,
+			rect: RectPoints::new(100, 140, 320, 240),
+		}),
+		Some(cursor),
+	);
+	session.maybe_dispatch_armed_freeze_capture();
+
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(session.pending_freeze_capture_armed);
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(!session.capture_windows_hidden);
+	assert!(session.state.frozen_image.is_none());
+
+	session.frozen_transition_started_at = Some(
+		Instant::now()
+			- crate::overlay::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT
+			- Duration::from_millis(1),
+	);
+
+	let _ = session.about_to_wait();
+
+	assert_eq!(session.pending_freeze_capture, None);
+	assert!(!session.pending_freeze_capture_armed);
+	assert_eq!(session.inflight_freeze_capture, Some(monitor));
+	assert!(session.capture_windows_hidden);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn background_capture_without_initial_snapshot_waits_for_live_stream_followup_without_hiding() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
 		None,
 		Some(cursor),
 	);
-	session.live_sample_stream.as_ref().unwrap().debug_set_active_stream_generation(monitor.id, 1);
+
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(!session.pending_freeze_capture_armed);
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(!session.capture_windows_hidden);
+	assert!(session.state.frozen_image.is_none());
+
 	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
 		monitor,
 		2,
 		1,
-		Instant::now() + Duration::from_millis(1),
+		Instant::now(),
+	);
+
+	let _ = session.about_to_wait();
+
+	assert_eq!(session.pending_freeze_capture, None);
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(!session.capture_windows_hidden);
+	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_export_image.is_some());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn background_capture_without_live_snapshot_escalates_to_hidden_fallback_after_timeout() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
+		None,
+		Some(cursor),
+	);
+
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(!session.pending_freeze_capture_armed);
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(!session.capture_windows_hidden);
+	assert!(session.state.frozen_image.is_none());
+
+	session.frozen_transition_started_at = Some(
+		Instant::now()
+			- crate::overlay::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT
+			- Duration::from_millis(1),
 	);
 
 	let _ = session.about_to_wait();
 
 	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(session.pending_freeze_capture_armed);
 	assert_eq!(session.inflight_freeze_capture, None);
 	assert!(session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_none());
+	assert!(session.pending_freeze_capture_windows_hidden_at.is_some());
+
+	session.pending_freeze_capture_windows_hidden_at =
+		Some(Instant::now() - POST_HIDE_LIVE_SNAPSHOT_GRACE - Duration::from_millis(1));
+	session.pending_freeze_capture_hidden_after_stream_generation = Some(0);
+
+	session.maybe_dispatch_armed_freeze_capture();
+
+	assert_eq!(session.pending_freeze_capture, None);
+	assert!(!session.pending_freeze_capture_armed);
+	assert_eq!(session.inflight_freeze_capture, Some(monitor));
+	assert!(session.capture_windows_hidden);
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -365,6 +365,55 @@ fn window_matte_capture_dispatches_worker_without_hiding_overlay_windows() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn window_matte_capture_miss_rearms_hidden_retry_before_accepting_monitor_fallback() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+
+	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
+		monitor,
+		1,
+		1,
+		Instant::now(),
+	);
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
+		Some(WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 41,
+			rect: RectPoints::new(100, 140, 320, 240),
+		}),
+		Some(cursor),
+	);
+
+	let preview_image = session.state.frozen_image.clone();
+
+	session.maybe_dispatch_armed_freeze_capture();
+
+	let control = session.maybe_tick_worker_response_limiter(WorkerResponse::CapturedFreeze {
+		monitor,
+		image: tests::test_frozen_image(),
+		window_image: None,
+		captured_window_id: None,
+	});
+
+	assert!(matches!(control, super::OverlayControl::Continue));
+	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(session.pending_freeze_capture_armed);
+	assert_eq!(session.pending_window_freeze_capture.map(|target| target.window_id), Some(41));
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(session.capture_windows_hidden);
+	assert!(session.pending_freeze_capture_windows_hidden_at.is_some());
+	assert!(session.state.frozen_export_image.is_none());
+	assert!(!session.frozen_export_ready);
+	assert_eq!(session.state.frozen_image, preview_image);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn window_matte_capture_without_live_preview_waits_for_hidden_fallback_before_dispatch() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -440,10 +440,8 @@ impl OverlaySession {
 
 	pub(super) fn should_hide_toolbar_window(&self, monitor: MonitorRect) -> bool {
 		self.frozen_selection_drag_hides_auxiliary_windows()
-			|| !matches!(self.state.mode, OverlayMode::Frozen)
+			|| !self.frozen_display_ready_for_monitor(monitor)
 			|| !self.toolbar_state.visible
-			|| self.state.frozen_image.is_none()
-			|| self.state.monitor != Some(monitor)
 	}
 
 	#[cfg(any(target_os = "macos", test))]
@@ -708,9 +706,8 @@ impl OverlaySession {
 		current_cursor: Option<GlobalPoint>,
 	) -> bool {
 		if !self.toolbar_window_visible
-			|| !matches!(self.state.mode, OverlayMode::Frozen)
+			|| !self.frozen_display_ready()
 			|| !self.toolbar_state.visible
-			|| self.state.frozen_image.is_none()
 		{
 			return false;
 		}

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -932,10 +932,8 @@ impl OverlaySession {
 			&& self.loupe_window.is_some();
 		let request_toolbar_window = !hide_auxiliary_windows
 			&& cfg!(target_os = "macos")
-			&& matches!(self.state.mode, OverlayMode::Frozen)
-			&& self.toolbar_state.visible
-			&& self.state.monitor == Some(monitor)
-			&& self.state.frozen_image.is_some();
+			&& self.frozen_display_ready_for_monitor(monitor)
+			&& self.toolbar_state.visible;
 		let request_scroll_preview_window =
 			!hide_auxiliary_windows && self.scroll_preview_window.is_some();
 

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -87,6 +87,40 @@ impl OverlaySession {
 		self.request_redraw_all();
 	}
 
+	#[cfg(target_os = "macos")]
+	pub(super) fn maybe_escalate_pending_display_first_freeze_to_hidden_fallback(
+		&mut self,
+		now: Instant,
+	) -> bool {
+		let Some(overlay_monitor) = self.pending_freeze_capture else {
+			return false;
+		};
+		let Some(started_at) = self.frozen_transition_started_at else {
+			return false;
+		};
+
+		if !self.pending_freeze_capture_matches(overlay_monitor)
+			|| self.capture_windows_hidden
+			|| self.frozen_export_ready
+			|| self.inflight_freeze_capture.is_some()
+			|| self.frozen_preview_visible()
+		{
+			return false;
+		}
+
+		let Some(elapsed) = now.checked_duration_since(started_at) else {
+			return false;
+		};
+
+		if elapsed < crate::overlay::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT {
+			return false;
+		}
+
+		self.begin_hidden_authoritative_freeze_capture_fallback(overlay_monitor);
+
+		true
+	}
+
 	pub(super) fn note_freeze_capture_request_started(
 		&mut self,
 		overlay_monitor: MonitorRect,
@@ -171,7 +205,9 @@ impl OverlaySession {
 
 			return;
 		}
-		if self.should_wait_for_hidden_live_snapshot_before_authoritative_dispatch(overlay_monitor)
+		if self.capture_windows_hidden
+			&& self
+				.should_wait_for_hidden_live_snapshot_before_authoritative_dispatch(overlay_monitor)
 		{
 			self.schedule_egui_repaint_after(POST_HIDE_LIVE_SNAPSHOT_GRACE);
 
@@ -180,6 +216,23 @@ impl OverlaySession {
 
 		let pending_window_target =
 			self.pending_window_freeze_capture.filter(|target| target.monitor == overlay_monitor);
+
+		if !self.capture_windows_hidden
+			&& self.snapshot_can_finish_frozen_capture(pending_window_target)
+		{
+			self.pending_freeze_capture_armed = false;
+			self.freeze_capture_send_full_count = 0;
+
+			return;
+		}
+		if !self.capture_windows_hidden
+			&& pending_window_target.is_some()
+			&& !self.snapshot_can_finish_frozen_capture(pending_window_target)
+			&& !self.frozen_preview_visible()
+		{
+			return;
+		}
+
 		let freeze_target = pending_window_target.map_or(FreezeCaptureTarget::Monitor, |target| {
 			FreezeCaptureTarget::Window { window_id: target.window_id }
 		});

--- a/packages/rsnap-overlay/src/state.rs
+++ b/packages/rsnap-overlay/src/state.rs
@@ -312,7 +312,7 @@ pub struct OverlayState {
 	pub live_bg_image: Option<RgbaImage>,
 	pub live_bg_generation: u64,
 	pub frozen_image: Option<RgbaImage>,
-	pub frozen_transition_image: Option<RgbaImage>,
+	pub frozen_export_image: Option<RgbaImage>,
 	pub frozen_generation: u64,
 	pub error_message: Option<String>,
 	pub alt_held: bool,
@@ -334,7 +334,7 @@ impl OverlayState {
 			live_bg_image: None,
 			live_bg_generation: 0,
 			frozen_image: None,
-			frozen_transition_image: None,
+			frozen_export_image: None,
 			frozen_generation: 0,
 			error_message: None,
 			alt_held: false,
@@ -359,29 +359,35 @@ impl OverlayState {
 	pub fn begin_freeze(&mut self, monitor: MonitorRect) {
 		self.monitor = Some(monitor);
 		self.frozen_image = None;
-		self.frozen_transition_image = None;
+		self.frozen_export_image = None;
 		self.frozen_mosaic_preview_rect = None;
 		self.loupe = None;
 		self.mode = OverlayMode::Frozen;
 		self.frozen_generation = self.frozen_generation.wrapping_add(1);
 	}
 
+	#[cfg(any(test, not(target_os = "macos")))]
 	pub fn finish_freeze(&mut self, monitor: MonitorRect, image: RgbaImage) {
 		// Keep the existing generation set by `begin_freeze` so renderers can key off a single
 		// freeze request/response cycle.
 		self.monitor = Some(monitor);
+		self.frozen_export_image = Some(image.clone());
 		self.frozen_image = Some(image);
-		self.frozen_transition_image = None;
 		self.mode = OverlayMode::Frozen;
 	}
 
-	#[cfg(test)]
-	pub fn seed_frozen_transition_image(&mut self, image: RgbaImage) {
-		self.frozen_transition_image = Some(image);
+	pub fn commit_frozen_display_image(&mut self, monitor: MonitorRect, image: RgbaImage) {
+		self.monitor = Some(monitor);
+		self.frozen_image = Some(image);
+		self.mode = OverlayMode::Frozen;
+	}
+
+	pub fn commit_frozen_export_image(&mut self, image: RgbaImage) {
+		self.frozen_export_image = Some(image);
 	}
 
 	pub fn frozen_surface_image(&self) -> Option<&RgbaImage> {
-		self.frozen_image.as_ref().or(self.frozen_transition_image.as_ref())
+		self.frozen_image.as_ref()
 	}
 }
 
@@ -430,7 +436,7 @@ mod tests {
 	}
 
 	#[test]
-	fn begin_freeze_clears_frozen_transition_image() {
+	fn begin_freeze_clears_frozen_images() {
 		let monitor = MonitorRect {
 			id: 7,
 			origin: GlobalPoint::new(0, 0),
@@ -440,15 +446,16 @@ mod tests {
 		};
 		let mut state = crate::state::OverlayState::new();
 
-		state.seed_frozen_transition_image(RgbaImage::new(2, 2));
+		state.commit_frozen_display_image(monitor, RgbaImage::new(2, 2));
+		state.commit_frozen_export_image(RgbaImage::new(2, 2));
 		state.begin_freeze(monitor);
 
-		assert!(state.frozen_transition_image.is_none());
 		assert!(state.frozen_image.is_none());
+		assert!(state.frozen_export_image.is_none());
 	}
 
 	#[test]
-	fn frozen_surface_image_prefers_final_frozen_image() {
+	fn finish_freeze_populates_display_and_export_images() {
 		let monitor = MonitorRect {
 			id: 7,
 			origin: GlobalPoint::new(0, 0),
@@ -456,19 +463,14 @@ mod tests {
 			height: 100,
 			scale_factor_x1000: 1_000,
 		};
-		let transition = RgbaImage::from_pixel(2, 2, Rgba([10, 20, 30, 255]));
 		let final_image = RgbaImage::from_pixel(2, 2, Rgba([40, 50, 60, 255]));
 		let mut state = crate::state::OverlayState::new();
 
 		state.begin_freeze(monitor);
-		state.seed_frozen_transition_image(transition);
-
-		assert_eq!(state.frozen_surface_image(), state.frozen_transition_image.as_ref());
-
 		state.finish_freeze(monitor, final_image.clone());
 
 		assert_eq!(state.frozen_image.as_ref(), Some(&final_image));
-		assert!(state.frozen_transition_image.is_none());
+		assert_eq!(state.frozen_export_image.as_ref(), Some(&final_image));
 		assert_eq!(state.frozen_surface_image(), Some(&final_image));
 	}
 }


### PR DESCRIPTION
## Summary
- split frozen state into display authority and export authority so preview bytes and final/export bytes stop sharing one mutable buffer
- switch macOS frozen entry to a display-first live-snapshot path, with exceptional hidden authoritative fallback only when a usable preview never arrives in time
- rebind helper-window visibility and display-only interactions to display readiness while keeping copy/save/OCR/scroll/mosaic gated on export-ready bytes
- stop feeding stale cached settings-window IDs into self-capture exception filters
- update the capture-session spec to match the new display-first contract

## Issues
- XY-264
- XY-265
- XY-266
- XY-267

## Verification
- `cargo make fmt-rust-check`
- `cargo make lint`
- `cargo test -p rsnap-overlay --lib`
