### PR TITLE
fix: remove hidden fallback from display-first frozen entry

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -274,9 +274,7 @@ const LIVE_HOVER_HIT_TEST_INTERVAL: Duration = Duration::from_millis(60);
 const LIVE_WINDOW_LIST_REFRESH_INTERVAL: Duration = Duration::from_millis(120);
 const PENDING_CLICK_HIT_TEST_TIMEOUT: Duration = Duration::from_millis(250);
 #[cfg(target_os = "macos")]
-const DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT: Duration = Duration::from_millis(150);
-#[cfg(target_os = "macos")]
-const POST_HIDE_LIVE_SNAPSHOT_GRACE: Duration = Duration::from_millis(12);
+const DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT: Duration = Duration::from_millis(600);
 const LIVE_PRESENT_INTERVAL_MIN: Duration = Duration::from_nanos(8_333_333);
 const HUD_LOUPE_MOVE_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
 const CURSOR_POLL_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
@@ -601,10 +599,6 @@ pub struct OverlaySession {
 	pending_freeze_capture: Option<MonitorRect>,
 	inflight_freeze_capture: Option<MonitorRect>,
 	pending_freeze_capture_armed: bool,
-	#[cfg(target_os = "macos")]
-	pending_freeze_capture_windows_hidden_at: Option<Instant>,
-	#[cfg(target_os = "macos")]
-	pending_freeze_capture_hidden_after_stream_generation: Option<u64>,
 	frozen_export_ready: bool,
 	#[cfg(test)]
 	authoritative_frozen_capture_ready: bool,
@@ -843,7 +837,6 @@ impl OverlaySession {
 			loupe_patch_height_px: 0,
 			egui_repaint_deadline: Arc::new(Mutex::new(None)),
 			pending_freeze_capture: None, inflight_freeze_capture: None, pending_freeze_capture_armed: false,
-			#[cfg(target_os = "macos")] pending_freeze_capture_windows_hidden_at: None, #[cfg(target_os = "macos")] pending_freeze_capture_hidden_after_stream_generation: None,
 			frozen_export_ready: false,
 			#[cfg(test)]
 			authoritative_frozen_capture_ready: false,
@@ -1568,29 +1561,6 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
-	fn begin_hidden_authoritative_freeze_capture_fallback(&mut self, monitor: MonitorRect) {
-		let after_stream_generation = self
-			.live_sample_stream
-			.as_ref()
-			.and_then(|stream| stream.latest_frame_frontier_for_monitor(monitor))
-			.map_or(0, |(_, stream_generation)| stream_generation);
-
-		self.state.live_bg_monitor = None;
-		self.state.live_bg_image = None;
-		self.capture_windows_hidden = true;
-
-		self.hide_capture_windows();
-
-		self.pending_freeze_capture_windows_hidden_at = Some(Instant::now());
-		self.pending_freeze_capture_hidden_after_stream_generation = Some(after_stream_generation);
-		self.pending_freeze_capture_armed = true;
-		self.freeze_capture_send_full_count = 0;
-
-		self.note_frozen_transition_authoritative_handoff_armed(monitor);
-		self.request_redraw_for_monitor(monitor);
-	}
-
-	#[cfg(target_os = "macos")]
 	fn maybe_finish_frozen_capture_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1618,8 +1588,6 @@ impl OverlaySession {
 		self.pending_freeze_capture = None;
 		self.inflight_freeze_capture = None;
 		self.pending_freeze_capture_armed = false;
-		self.pending_freeze_capture_windows_hidden_at = None;
-		self.pending_freeze_capture_hidden_after_stream_generation = None;
 		self.pending_window_freeze_capture = None;
 		self.inflight_window_freeze_capture = None;
 		self.frozen_export_ready = true;
@@ -1658,6 +1626,16 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn request_pending_frozen_capture_live_stream_refresh(&self, monitor: MonitorRect) {
+		let Some(stream) = self.live_sample_stream.as_ref() else {
+			return;
+		};
+		let after_frame_seq =
+			stream.latest_frame_frontier_for_monitor(monitor).map_or(0, |(frame_seq, _)| frame_seq);
+		let _ = stream.refresh_monitor_nonblocking_if_stale(monitor, after_frame_seq, true);
+	}
+
+	#[cfg(target_os = "macos")]
 	fn maybe_seed_frozen_capture_preview_from_snapshot(
 		&mut self,
 		monitor: MonitorRect,
@@ -1693,7 +1671,6 @@ impl OverlaySession {
 		if !self.pending_freeze_capture_matches(monitor)
 			|| self.frozen_export_ready
 			|| self.inflight_freeze_capture.is_some()
-			|| self.capture_windows_hidden
 		{
 			return false;
 		}
@@ -1723,90 +1700,6 @@ impl OverlaySession {
 			snapshot,
 			"live_stream_snapshot_preview_followup",
 		)
-	}
-
-	#[cfg(target_os = "macos")]
-	fn maybe_finish_pending_frozen_capture_from_hidden_live_stream_snapshot(
-		&mut self,
-		monitor: MonitorRect,
-	) -> bool {
-		let Some(hidden_at) = self.pending_freeze_capture_windows_hidden_at else {
-			return false;
-		};
-		let Some(hidden_after_stream_generation) =
-			self.pending_freeze_capture_hidden_after_stream_generation
-		else {
-			return false;
-		};
-
-		if !self.pending_freeze_capture_matches(monitor)
-			|| self.frozen_export_ready
-			|| self.inflight_freeze_capture.is_some()
-			|| !self.capture_windows_hidden
-		{
-			return false;
-		}
-
-		let window_target = self.pending_window_freeze_capture_for_monitor(monitor);
-
-		if !self.snapshot_can_finish_frozen_capture(window_target) {
-			return false;
-		}
-
-		let Some(stream) = self.live_sample_stream.as_ref() else {
-			return false;
-		};
-		let Some(snapshot) = stream.peek_latest_rgba_snapshot(monitor) else {
-			return false;
-		};
-
-		if snapshot.captured_at < hidden_at
-			|| snapshot.stream_generation <= hidden_after_stream_generation
-		{
-			return false;
-		}
-
-		self.maybe_finish_frozen_capture_from_snapshot(
-			monitor,
-			window_target,
-			self.state.cursor,
-			Some(snapshot),
-			"live_stream_snapshot_after_hide",
-		)
-	}
-
-	#[cfg(target_os = "macos")]
-	fn should_wait_for_hidden_live_snapshot_before_authoritative_dispatch(
-		&self,
-		monitor: MonitorRect,
-	) -> bool {
-		let Some(hidden_at) = self.pending_freeze_capture_windows_hidden_at else {
-			return false;
-		};
-		let Some(hidden_after_stream_generation) =
-			self.pending_freeze_capture_hidden_after_stream_generation
-		else {
-			return false;
-		};
-
-		if hidden_at.elapsed() >= POST_HIDE_LIVE_SNAPSHOT_GRACE {
-			return false;
-		}
-
-		let window_target = self.pending_window_freeze_capture_for_monitor(monitor);
-
-		if !self.snapshot_can_finish_frozen_capture(window_target) {
-			return false;
-		}
-
-		let Some(stream) = self.live_sample_stream.as_ref() else {
-			return false;
-		};
-
-		stream.peek_latest_rgba_snapshot(monitor).is_none_or(|snapshot| {
-			snapshot.captured_at < hidden_at
-				|| snapshot.stream_generation <= hidden_after_stream_generation
-		})
 	}
 
 	fn seed_frozen_toolbar_default_position(
@@ -1942,11 +1835,6 @@ impl OverlaySession {
 	) {
 		self.pending_freeze_capture = Some(monitor);
 		self.pending_freeze_capture_armed = false;
-		#[cfg(target_os = "macos")]
-		{
-			self.pending_freeze_capture_windows_hidden_at = None;
-			self.pending_freeze_capture_hidden_after_stream_generation = None;
-		}
 		self.inflight_freeze_capture = None;
 		self.frozen_export_ready = false;
 		#[cfg(test)]
@@ -2033,9 +1921,9 @@ impl OverlaySession {
 
 		#[cfg(not(target_os = "macos"))]
 		self.begin_frozen_capture_with_rect_non_macos(monitor, window_target, cursor);
-		// Do not request the first frozen redraw until the session either has a preview image or has
-		// committed to hiding capture windows for the authoritative handoff. Otherwise the overlay can
-		// briefly present an empty black frozen frame before the real preview arrives.
+		// Do not request the first frozen redraw until the session has either committed a preview or
+		// started the asynchronous export-authority path. Otherwise the overlay can briefly present
+		// an empty black frozen frame before the real preview arrives.
 		self.refresh_frozen_helper_windows_for_transition(monitor);
 	}
 
@@ -2053,8 +1941,6 @@ impl OverlaySession {
 		self.state.live_bg_monitor = None;
 		self.state.live_bg_image = None;
 		self.capture_windows_hidden = false;
-		self.pending_freeze_capture_windows_hidden_at = None;
-		self.pending_freeze_capture_hidden_after_stream_generation = None;
 
 		let snapshot = self
 			.live_sample_stream
@@ -2081,13 +1967,7 @@ impl OverlaySession {
 		self.pending_freeze_capture_armed = window_target.is_some()
 			&& self.config.window_capture_alpha_mode != WindowCaptureAlphaMode::Background;
 
-		if let Some(stream) = self.live_sample_stream.as_ref() {
-			let after_frame_seq = stream
-				.latest_frame_frontier_for_monitor(monitor)
-				.map_or(0, |(frame_seq, _)| frame_seq);
-			let _ = stream.refresh_monitor_nonblocking_if_stale(monitor, after_frame_seq, true);
-		}
-
+		self.request_pending_frozen_capture_live_stream_refresh(monitor);
 		self.note_frozen_transition_preview_deferred(
 			monitor,
 			if seeded_preview {
@@ -2300,9 +2180,13 @@ impl OverlaySession {
 			self.inflight_freeze_capture = None;
 
 			let window_capture_target = self.inflight_window_freeze_capture.take();
+			let had_display_image = self.frozen_display_ready();
+			let frozen_preview_image = image;
 
-			#[cfg(target_os = "macos")]
-			if self.maybe_retry_unhidden_matte_capture_after_window_miss(
+			self.pending_window_freeze_capture = None;
+			self.frozen_window_image = None;
+
+			if self.reject_dirty_window_export_authority(
 				monitor,
 				window_capture_target,
 				window_image.is_some(),
@@ -2317,36 +2201,14 @@ impl OverlaySession {
 				self.authoritative_frozen_capture_ready = true;
 			}
 
-			let had_display_image = self.frozen_display_ready();
-			let mut frozen_preview_image = image;
-
-			self.pending_window_freeze_capture = None;
-			self.frozen_window_image = None;
-
-			if let (Some(target), Some(window_capture_image), Some(window_id)) =
-				(window_capture_target, window_image, captured_window_id)
-				&& target.monitor == monitor
-				&& target.window_id == window_id
-			{
-				match self.config.window_capture_alpha_mode {
-					WindowCaptureAlphaMode::Background => {},
-					WindowCaptureAlphaMode::MatteLight | WindowCaptureAlphaMode::MatteDark => {
-						let window_capture_image = Self::compose_window_preview_layer(
-							&window_capture_image,
-							self.config.window_capture_alpha_mode,
-						);
-
-						frozen_preview_image = Self::composite_window_capture_preview(
-							frozen_preview_image,
-							&window_capture_image,
-							monitor,
-							target.rect,
-							WindowCaptureAlphaMode::Background,
-						);
-						self.frozen_window_image = Some(window_capture_image);
-					},
-				}
-			}
+			let frozen_preview_image = self.apply_window_capture_export_authority(
+				monitor,
+				had_display_image,
+				frozen_preview_image,
+				window_capture_target,
+				window_image,
+				captured_window_id,
+			);
 
 			if !had_display_image {
 				self.state.commit_frozen_display_image(monitor, frozen_preview_image.clone());
@@ -2408,7 +2270,7 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
-	fn maybe_retry_unhidden_matte_capture_after_window_miss(
+	fn reject_dirty_window_export_authority(
 		&mut self,
 		monitor: MonitorRect,
 		window_capture_target: Option<WindowFreezeCaptureTarget>,
@@ -2423,24 +2285,79 @@ impl OverlaySession {
 			|| !matches!(
 				self.config.window_capture_alpha_mode,
 				WindowCaptureAlphaMode::MatteLight | WindowCaptureAlphaMode::MatteDark
-			) || self.capture_windows_hidden
-			|| (captured_window_id == Some(target.window_id) && window_image_present)
+			) || (captured_window_id == Some(target.window_id) && window_image_present)
 		{
 			return false;
 		}
 
-		self.pending_freeze_capture = Some(monitor);
-		self.pending_window_freeze_capture = Some(target);
 		self.frozen_export_ready = false;
 		#[cfg(test)]
 		{
 			self.authoritative_frozen_capture_ready = false;
 		}
-		self.frozen_window_image = None;
 
-		self.begin_hidden_authoritative_freeze_capture_fallback(monitor);
+		self.note_frozen_transition_aborted(
+			"Window export authority did not resolve to a clean target window.",
+		);
+		self.state.set_error("Window capture is unavailable. Please try again.");
+
+		self.toolbar_state.needs_redraw = true;
+
+		self.request_redraw_toolbar_window();
+		self.request_redraw_for_monitor(monitor);
 
 		true
+	}
+
+	#[cfg(target_os = "macos")]
+	fn apply_window_capture_export_authority(
+		&mut self,
+		monitor: MonitorRect,
+		had_display_image: bool,
+		base_image: RgbaImage,
+		window_capture_target: Option<WindowFreezeCaptureTarget>,
+		window_image: Option<RgbaImage>,
+		captured_window_id: Option<u32>,
+	) -> RgbaImage {
+		let Some((target, window_capture_image, window_id)) = window_capture_target
+			.zip(window_image)
+			.zip(captured_window_id)
+			.map(|((target, window_capture_image), window_id)| {
+				(target, window_capture_image, window_id)
+			})
+		else {
+			return base_image;
+		};
+
+		if target.monitor != monitor || target.window_id != window_id {
+			return base_image;
+		}
+
+		match self.config.window_capture_alpha_mode {
+			WindowCaptureAlphaMode::Background => base_image,
+			WindowCaptureAlphaMode::MatteLight | WindowCaptureAlphaMode::MatteDark => {
+				let base_image = if had_display_image {
+					self.state.frozen_image.clone().unwrap_or(base_image)
+				} else {
+					base_image
+				};
+				let window_capture_image = Self::compose_window_preview_layer(
+					&window_capture_image,
+					self.config.window_capture_alpha_mode,
+				);
+				let preview_image = Self::composite_window_capture_preview(
+					base_image,
+					&window_capture_image,
+					monitor,
+					target.rect,
+					WindowCaptureAlphaMode::Background,
+				);
+
+				self.frozen_window_image = Some(window_capture_image);
+
+				preview_image
+			},
+		}
 	}
 
 	fn handle_encoded_png_response(&mut self, png_bytes: Vec<u8>) -> OverlayControl {

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -2269,7 +2269,6 @@ impl OverlaySession {
 		}
 	}
 
-	#[cfg(target_os = "macos")]
 	fn reject_dirty_window_export_authority(
 		&mut self,
 		monitor: MonitorRect,
@@ -2309,7 +2308,6 @@ impl OverlaySession {
 		true
 	}
 
-	#[cfg(target_os = "macos")]
 	fn apply_window_capture_export_authority(
 		&mut self,
 		monitor: MonitorRect,

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -2192,6 +2192,8 @@ impl OverlaySession {
 				window_image.is_some(),
 				captured_window_id,
 			) {
+				self.restore_capture_windows_visibility();
+
 				return;
 			}
 

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1105,7 +1105,7 @@ impl OverlaySession {
 	}
 
 	fn maybe_keep_frozen_capture_redraw(&self) {
-		if !matches!(self.state.mode, OverlayMode::Frozen) || self.frozen_display_ready() {
+		if !self.frozen_capture_redraw_pending() {
 			return;
 		}
 
@@ -1120,6 +1120,12 @@ impl OverlaySession {
 		}
 
 		self.schedule_egui_repaint_after(self.repaint_interval_for_monitor(self.state.monitor));
+	}
+
+	fn frozen_capture_redraw_pending(&self) -> bool {
+		matches!(self.state.mode, OverlayMode::Frozen)
+			&& !self.frozen_display_ready()
+			&& (self.pending_freeze_capture.is_some() || self.inflight_freeze_capture.is_some())
 	}
 
 	fn frozen_display_ready(&self) -> bool {

--- a/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
@@ -69,9 +69,7 @@ impl OverlaySession {
 		{
 			if let Some(monitor) = self.pending_freeze_capture {
 				let _ = self.maybe_update_pending_frozen_capture_from_live_stream_snapshot(monitor);
-				let _ = self.maybe_escalate_pending_display_first_freeze_to_hidden_fallback(now);
-				let _ = self
-					.maybe_finish_pending_frozen_capture_from_hidden_live_stream_snapshot(monitor);
+				let _ = self.maybe_drive_pending_display_first_freeze_preview(now);
 			}
 
 			self.maybe_dispatch_armed_freeze_capture();

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -5,8 +5,9 @@ use crate::overlay::{GlobalPoint, MonitorRect, OverlayMode, OverlaySession};
 impl OverlaySession {
 	#[cfg(target_os = "macos")]
 	pub(super) const fn should_hide_overlay_windows_during_capture(&self) -> bool {
-		// Authoritative freeze capture still falls back to CoreGraphics monitor capture.
-		// Keep overlays hidden until XY-74/XY-75 replace that path with a verified exclusion contract.
+		// Display-first frozen entry no longer depends on hiding overlays. Keep the legacy hide policy
+		// available only for explicit last-resort macOS capture paths until the backend contract is
+		// fully retired.
 		true
 	}
 
@@ -19,6 +20,7 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	#[allow(dead_code)]
 	pub(super) fn hide_capture_windows(&mut self) {
 		self.capture_windows_hidden = true;
 

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -62,7 +62,7 @@ use crate::overlay::{
 	SELECTION_SIZE_BADGE_INSIDE_MARGIN_PX, SELECTION_SIZE_BADGE_SCREEN_MARGIN_PX,
 	SelectionDashedBorderCache, SelectionFlowGeometryCache, SelectionSizeBadgeTarget,
 	SurfaceFrameSkipReason, TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement,
-	Vec2, WindowRenderer, hud_helpers,
+	Vec2, WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
@@ -72,7 +72,6 @@ use crate::overlay::{
 	OverlayExit, SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
 	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES,
 	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE, ScrollCaptureFrameSource, StartupLiveRgbPlan,
-	WindowCaptureAlphaMode,
 };
 use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
 #[cfg(target_os = "macos")]
@@ -959,6 +958,34 @@ fn authoritative_freeze_response_updates_export_authority_without_overwriting_di
 	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
 	assert_eq!(session.state.frozen_export_image.as_ref(), Some(&authoritative_image));
 	assert!(session.authoritative_frozen_capture_ready);
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn window_matte_capture_miss_restores_hidden_windows_before_returning() {
+	let monitor = test_monitor();
+	let preview_image = test_frozen_image();
+	let capture_rect = RectPoints::new(2, 1, 4, 4);
+	let mut session = OverlaySession::new();
+
+	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+
+	session.state.begin_freeze(monitor);
+	session.state.commit_frozen_display_image(monitor, preview_image.clone());
+
+	session.capture_windows_hidden = true;
+	session.inflight_window_freeze_capture =
+		Some(crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 41, rect: capture_rect });
+
+	session.handle_captured_freeze_response(monitor, test_frozen_image(), None, None);
+
+	assert!(!session.capture_windows_hidden);
+	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
+	assert!(session.state.frozen_export_image.is_none());
+	assert_eq!(
+		session.state.error_message.as_deref(),
+		Some("Window capture is unavailable. Please try again.")
+	);
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -974,8 +974,11 @@ fn window_matte_capture_miss_restores_hidden_windows_before_returning() {
 	session.state.commit_frozen_display_image(monitor, preview_image.clone());
 
 	session.capture_windows_hidden = true;
-	session.inflight_window_freeze_capture =
-		Some(crate::overlay::WindowFreezeCaptureTarget { monitor, window_id: 41, rect: capture_rect });
+	session.inflight_window_freeze_capture = Some(crate::overlay::WindowFreezeCaptureTarget {
+		monitor,
+		window_id: 41,
+		rect: capture_rect,
+	});
 
 	session.handle_captured_freeze_response(monitor, test_frozen_image(), None, None);
 

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -18,9 +18,7 @@ use crate::overlay::tests::{
 #[cfg(target_os = "macos")]
 use crate::overlay::worker_runtime::FREEZE_CAPTURE_SEND_FULL_RETRY_LIMIT;
 #[cfg(target_os = "macos")]
-use crate::overlay::{
-	POST_HIDE_LIVE_SNAPSHOT_GRACE, WindowCaptureAlphaMode, WindowFreezeCaptureTarget,
-};
+use crate::overlay::{WindowCaptureAlphaMode, WindowFreezeCaptureTarget};
 
 #[cfg(target_os = "macos")]
 #[test]
@@ -254,23 +252,15 @@ fn begin_frozen_capture_background_snapshot_finishes_without_hiding_overlay_wind
 	assert!(session.state.frozen_image.is_some());
 	assert!(session.state.frozen_export_image.is_some());
 	assert!(session.frozen_final_capture_ready());
-	assert!(session.pending_freeze_capture_windows_hidden_at.is_none());
 }
 
 #[cfg(target_os = "macos")]
 #[test]
-fn hidden_live_snapshot_can_finish_frozen_capture_before_authoritative_dispatch() {
+fn live_snapshot_followup_can_finish_background_capture_before_timeout() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);
 	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
 
-	session.live_sample_stream.as_ref().unwrap().debug_set_active_stream_generation(monitor.id, 1);
-	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
-		monitor,
-		50,
-		1,
-		Instant::now(),
-	);
 	session.begin_frozen_capture_with_rect(
 		monitor,
 		Some(RectPoints::new(100, 140, 320, 240)),
@@ -292,7 +282,6 @@ fn hidden_live_snapshot_can_finish_frozen_capture_before_authoritative_dispatch(
 	assert!(session.inflight_freeze_capture.is_none());
 	assert!(!session.pending_freeze_capture_armed);
 	assert!(!session.capture_windows_hidden);
-	assert!(session.pending_freeze_capture_windows_hidden_at.is_none());
 	assert!(session.state.frozen_image.is_some());
 }
 
@@ -365,7 +354,7 @@ fn window_matte_capture_dispatches_worker_without_hiding_overlay_windows() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn window_matte_capture_miss_rearms_hidden_retry_before_accepting_monitor_fallback() {
+fn window_matte_capture_miss_keeps_preview_and_surfaces_export_error() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);
 	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
@@ -401,25 +390,29 @@ fn window_matte_capture_miss_rearms_hidden_retry_before_accepting_monitor_fallba
 	});
 
 	assert!(matches!(control, super::OverlayControl::Continue));
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(session.pending_freeze_capture_armed);
-	assert_eq!(session.pending_window_freeze_capture.map(|target| target.window_id), Some(41));
+	assert_eq!(session.pending_freeze_capture, None);
+	assert!(!session.pending_freeze_capture_armed);
+	assert_eq!(session.pending_window_freeze_capture, None);
 	assert_eq!(session.inflight_freeze_capture, None);
-	assert!(session.capture_windows_hidden);
-	assert!(session.pending_freeze_capture_windows_hidden_at.is_some());
+	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_export_image.is_none());
 	assert!(!session.frozen_export_ready);
 	assert_eq!(session.state.frozen_image, preview_image);
+	assert_eq!(
+		session.state.error_message.as_deref(),
+		Some("Window capture is unavailable. Please try again.")
+	);
 }
 
 #[cfg(target_os = "macos")]
 #[test]
-fn window_matte_capture_without_live_preview_waits_for_hidden_fallback_before_dispatch() {
+fn window_matte_capture_without_live_preview_aborts_after_timeout_without_hiding() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);
 	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
 
 	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+	session.scroll_capture.active = false;
 
 	session.begin_frozen_capture_with_rect(
 		monitor,
@@ -449,8 +442,12 @@ fn window_matte_capture_without_live_preview_waits_for_hidden_fallback_before_di
 
 	assert_eq!(session.pending_freeze_capture, None);
 	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, Some(monitor));
-	assert!(session.capture_windows_hidden);
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(!session.capture_windows_hidden);
+	assert_eq!(
+		session.state.error_message.as_deref(),
+		Some("Unable to capture a clean preview. Please try again.")
+	);
 }
 
 #[cfg(target_os = "macos")]
@@ -491,10 +488,12 @@ fn background_capture_without_initial_snapshot_waits_for_live_stream_followup_wi
 
 #[cfg(target_os = "macos")]
 #[test]
-fn background_capture_without_live_snapshot_escalates_to_hidden_fallback_after_timeout() {
+fn background_capture_without_live_snapshot_aborts_after_timeout_without_hiding() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);
 	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.scroll_capture.active = false;
 
 	session.begin_frozen_capture_with_rect(
 		monitor,
@@ -517,22 +516,14 @@ fn background_capture_without_live_snapshot_escalates_to_hidden_fallback_after_t
 
 	let _ = session.about_to_wait();
 
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
-	assert!(session.capture_windows_hidden);
-	assert!(session.pending_freeze_capture_windows_hidden_at.is_some());
-
-	session.pending_freeze_capture_windows_hidden_at =
-		Some(Instant::now() - POST_HIDE_LIVE_SNAPSHOT_GRACE - Duration::from_millis(1));
-	session.pending_freeze_capture_hidden_after_stream_generation = Some(0);
-
-	session.maybe_dispatch_armed_freeze_capture();
-
 	assert_eq!(session.pending_freeze_capture, None);
 	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, Some(monitor));
-	assert!(session.capture_windows_hidden);
+	assert_eq!(session.inflight_freeze_capture, None);
+	assert!(!session.capture_windows_hidden);
+	assert_eq!(
+		session.state.error_message.as_deref(),
+		Some("Unable to capture a clean preview. Please try again.")
+	);
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -444,6 +444,7 @@ fn window_matte_capture_without_live_preview_aborts_after_timeout_without_hiding
 	assert!(!session.pending_freeze_capture_armed);
 	assert_eq!(session.inflight_freeze_capture, None);
 	assert!(!session.capture_windows_hidden);
+	assert!(!session.frozen_capture_redraw_pending());
 	assert_eq!(
 		session.state.error_message.as_deref(),
 		Some("Unable to capture a clean preview. Please try again.")

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -5,9 +5,7 @@ use crate::overlay::{
 	WindowListSnapshot, WorkerErrorSource, WorkerRequestSendError, WorkerResponse,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{
-	CursorSampleRequest, FreezeCaptureTarget, POST_HIDE_LIVE_SNAPSHOT_GRACE, mem,
-};
+use crate::overlay::{CursorSampleRequest, FreezeCaptureTarget, mem};
 
 pub(super) const FREEZE_CAPTURE_SEND_FULL_RETRY_LIMIT: u64 = 8;
 
@@ -67,11 +65,6 @@ impl OverlaySession {
 		self.pending_freeze_capture = None;
 		self.inflight_freeze_capture = None;
 		self.pending_freeze_capture_armed = false;
-		#[cfg(target_os = "macos")]
-		{
-			self.pending_freeze_capture_windows_hidden_at = None;
-			self.pending_freeze_capture_hidden_after_stream_generation = None;
-		}
 		self.pending_window_freeze_capture = None;
 		self.inflight_window_freeze_capture = None;
 		self.freeze_capture_send_full_count = 0;
@@ -88,26 +81,29 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
-	pub(super) fn maybe_escalate_pending_display_first_freeze_to_hidden_fallback(
+	pub(super) fn maybe_drive_pending_display_first_freeze_preview(
 		&mut self,
 		now: Instant,
 	) -> bool {
 		let Some(overlay_monitor) = self.pending_freeze_capture else {
 			return false;
 		};
-		let Some(started_at) = self.frozen_transition_started_at else {
-			return false;
-		};
 
 		if !self.pending_freeze_capture_matches(overlay_monitor)
-			|| self.capture_windows_hidden
 			|| self.frozen_export_ready
 			|| self.inflight_freeze_capture.is_some()
-			|| self.frozen_preview_visible()
 		{
 			return false;
 		}
+		if self.frozen_preview_visible() {
+			return false;
+		}
 
+		self.request_pending_frozen_capture_live_stream_refresh(overlay_monitor);
+
+		let Some(started_at) = self.frozen_transition_started_at else {
+			return false;
+		};
 		let Some(elapsed) = now.checked_duration_since(started_at) else {
 			return false;
 		};
@@ -116,7 +112,7 @@ impl OverlaySession {
 			return false;
 		}
 
-		self.begin_hidden_authoritative_freeze_capture_fallback(overlay_monitor);
+		self.abort_pending_freeze_capture("Unable to capture a clean preview. Please try again.");
 
 		true
 	}
@@ -128,11 +124,6 @@ impl OverlaySession {
 	) {
 		self.pending_freeze_capture = None;
 		self.pending_freeze_capture_armed = false;
-		#[cfg(target_os = "macos")]
-		{
-			self.pending_freeze_capture_windows_hidden_at = None;
-			self.pending_freeze_capture_hidden_after_stream_generation = None;
-		}
 		self.inflight_freeze_capture = Some(overlay_monitor);
 		self.inflight_window_freeze_capture = pending_window_target;
 		self.pending_window_freeze_capture = None;
@@ -185,11 +176,6 @@ impl OverlaySession {
 		let Some(overlay_monitor) = self.pending_freeze_capture else {
 			self.pending_freeze_capture_armed = false;
 			self.freeze_capture_send_full_count = 0;
-			#[cfg(target_os = "macos")]
-			{
-				self.pending_freeze_capture_windows_hidden_at = None;
-				self.pending_freeze_capture_hidden_after_stream_generation = None;
-			}
 
 			return;
 		};
@@ -197,19 +183,6 @@ impl OverlaySession {
 		if !self.pending_freeze_capture_matches(overlay_monitor) {
 			self.pending_freeze_capture_armed = false;
 			self.freeze_capture_send_full_count = 0;
-			#[cfg(target_os = "macos")]
-			{
-				self.pending_freeze_capture_windows_hidden_at = None;
-				self.pending_freeze_capture_hidden_after_stream_generation = None;
-			}
-
-			return;
-		}
-		if self.capture_windows_hidden
-			&& self
-				.should_wait_for_hidden_live_snapshot_before_authoritative_dispatch(overlay_monitor)
-		{
-			self.schedule_egui_repaint_after(POST_HIDE_LIVE_SNAPSHOT_GRACE);
 
 			return;
 		}


### PR DESCRIPTION
## Summary
- remove the hidden macOS fallback state and timeout escalation from display-first frozen entry
- keep frozen display authority on clean live snapshots and fail closed when no preview converges
- keep matte preview stable while rejecting dirty export authority instead of re-arming hidden retry

## Testing
- cargo make fmt-rust-check
- cargo test -p rsnap-overlay --lib overlay::tests::self_capture_runtime
- cargo test -p rsnap-overlay --lib
- cargo make lint

Closes XY-268.