### PR TITLE
refactor: replace frozen readiness flags with explicit session state

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -166,6 +166,7 @@ use self::session_state::InflightScrollCaptureObservation;
 use self::session_state::{
 	ActiveFrozenBrushStroke, CursorMoveTrace, FrozenAnnotationColor, FrozenArrowAnnotation,
 	FrozenArrowDragState, FrozenBrushModelState, FrozenBrushState, FrozenBrushStroke,
+	FrozenCaptureSessionState, FrozenCaptureWorkerState, FrozenExportSessionState,
 	FrozenMosaicDragState, FrozenSelectionDragCursorMoveTiming, FrozenSelectionDragState,
 	FrozenSpotlightAnnotation, FrozenSpotlightDragState, FrozenTextAnnotation, FrozenTextEditState,
 	FrozenTextStyle, FrozenToolbarPointerState, FrozenToolbarState, HudDrawConfig,
@@ -596,20 +597,13 @@ pub struct OverlaySession {
 	event_loop_last_stall_warn_at: Option<Instant>,
 	loupe_patch_width_px: u32,
 	loupe_patch_height_px: u32,
-	pending_freeze_capture: Option<MonitorRect>,
-	inflight_freeze_capture: Option<MonitorRect>,
-	pending_freeze_capture_armed: bool,
-	frozen_export_ready: bool,
-	#[cfg(test)]
-	authoritative_frozen_capture_ready: bool,
+	frozen_capture_session_state: FrozenCaptureSessionState,
 	frozen_transition_started_at: Option<Instant>,
 	frozen_transition_preview_committed_at: Option<Instant>,
 	frozen_transition_preview_source: Option<&'static str>,
 	frozen_transition_final_ready_at: Option<Instant>,
 	frozen_transition_toolbar_visible_at: Option<Instant>,
 	frozen_transition_target_window_id: Option<u32>,
-	pending_window_freeze_capture: Option<WindowFreezeCaptureTarget>,
-	inflight_window_freeze_capture: Option<WindowFreezeCaptureTarget>,
 	frozen_window_image: Option<RgbaImage>,
 	frozen_capture_source: FrozenCaptureSource,
 	capture_windows_hidden: bool,
@@ -836,14 +830,11 @@ impl OverlaySession {
 			loupe_patch_width_px: 0,
 			loupe_patch_height_px: 0,
 			egui_repaint_deadline: Arc::new(Mutex::new(None)),
-			pending_freeze_capture: None, inflight_freeze_capture: None, pending_freeze_capture_armed: false,
-			frozen_export_ready: false,
-			#[cfg(test)]
-			authoritative_frozen_capture_ready: false,
+			frozen_capture_session_state: FrozenCaptureSessionState::Inactive,
 			frozen_transition_started_at: None, frozen_transition_preview_committed_at: None,
 			frozen_transition_preview_source: None, frozen_transition_final_ready_at: None,
 			frozen_transition_toolbar_visible_at: None, frozen_transition_target_window_id: None,
-			pending_window_freeze_capture: None, inflight_window_freeze_capture: None, frozen_window_image: None,
+			frozen_window_image: None,
 			frozen_capture_source: FrozenCaptureSource::None,
 			capture_windows_hidden: false,
 			#[cfg(target_os = "macos")]
@@ -1125,12 +1116,144 @@ impl OverlaySession {
 	fn frozen_capture_redraw_pending(&self) -> bool {
 		matches!(self.state.mode, OverlayMode::Frozen)
 			&& !self.frozen_display_ready()
-			&& (self.pending_freeze_capture.is_some() || self.inflight_freeze_capture.is_some())
+			&& self.frozen_capture_export_pending()
+	}
+
+	fn frozen_capture_monitor(&self) -> Option<MonitorRect> {
+		match self.frozen_capture_session_state {
+			FrozenCaptureSessionState::Inactive => None,
+			FrozenCaptureSessionState::DisplayPending { monitor, .. }
+			| FrozenCaptureSessionState::DisplayFailed { monitor }
+			| FrozenCaptureSessionState::DisplayReady { monitor, .. } => Some(monitor),
+		}
+	}
+
+	fn frozen_capture_window_target(&self) -> Option<WindowFreezeCaptureTarget> {
+		match self.frozen_capture_session_state {
+			FrozenCaptureSessionState::DisplayPending { window_target, .. } => window_target,
+			FrozenCaptureSessionState::DisplayReady {
+				export: FrozenExportSessionState::Pending { window_target, .. },
+				..
+			} => window_target,
+			FrozenCaptureSessionState::Inactive
+			| FrozenCaptureSessionState::DisplayFailed { .. }
+			| FrozenCaptureSessionState::DisplayReady { .. } => None,
+		}
+	}
+
+	fn frozen_capture_worker_state(&self) -> Option<FrozenCaptureWorkerState> {
+		match self.frozen_capture_session_state {
+			FrozenCaptureSessionState::DisplayPending { worker_state, .. } => Some(worker_state),
+			FrozenCaptureSessionState::DisplayReady {
+				export: FrozenExportSessionState::Pending { worker_state, .. },
+				..
+			} => Some(worker_state),
+			FrozenCaptureSessionState::Inactive
+			| FrozenCaptureSessionState::DisplayFailed { .. }
+			| FrozenCaptureSessionState::DisplayReady { .. } => None,
+		}
+	}
+
+	fn frozen_capture_export_pending(&self) -> bool {
+		matches!(
+			self.frozen_capture_session_state,
+			FrozenCaptureSessionState::DisplayPending { .. }
+				| FrozenCaptureSessionState::DisplayReady {
+					export: FrozenExportSessionState::Pending { .. },
+					..
+				}
+		)
+	}
+
+	fn frozen_capture_export_ready(&self) -> bool {
+		matches!(
+			self.frozen_capture_session_state,
+			FrozenCaptureSessionState::DisplayReady { export: FrozenExportSessionState::Ready, .. }
+		)
+	}
+
+	fn frozen_capture_worker_armed(&self) -> bool {
+		self.frozen_capture_worker_state() == Some(FrozenCaptureWorkerState::Armed)
+	}
+
+	fn frozen_capture_worker_inflight(&self) -> bool {
+		self.frozen_capture_worker_state() == Some(FrozenCaptureWorkerState::Inflight)
+	}
+
+	fn set_frozen_capture_display_pending(
+		&mut self,
+		monitor: MonitorRect,
+		worker_state: FrozenCaptureWorkerState,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	) {
+		self.frozen_capture_session_state =
+			FrozenCaptureSessionState::DisplayPending { monitor, worker_state, window_target };
+	}
+
+	fn promote_frozen_capture_display_ready(&mut self, monitor: MonitorRect) {
+		let export = match self.frozen_capture_session_state {
+			FrozenCaptureSessionState::DisplayPending { worker_state, window_target, .. } => {
+				FrozenExportSessionState::Pending { worker_state, window_target }
+			},
+			FrozenCaptureSessionState::DisplayReady { export, .. } => export,
+			FrozenCaptureSessionState::DisplayFailed { .. }
+			| FrozenCaptureSessionState::Inactive => FrozenExportSessionState::Pending {
+				worker_state: FrozenCaptureWorkerState::Idle,
+				window_target: None,
+			},
+		};
+
+		self.frozen_capture_session_state =
+			FrozenCaptureSessionState::DisplayReady { monitor, export };
+	}
+
+	fn set_frozen_capture_worker_state(&mut self, worker_state: FrozenCaptureWorkerState) {
+		self.frozen_capture_session_state = match self.frozen_capture_session_state {
+			FrozenCaptureSessionState::DisplayPending { monitor, window_target, .. } => {
+				FrozenCaptureSessionState::DisplayPending { monitor, worker_state, window_target }
+			},
+			FrozenCaptureSessionState::DisplayReady {
+				monitor,
+				export: FrozenExportSessionState::Pending { window_target, .. },
+			} => FrozenCaptureSessionState::DisplayReady {
+				monitor,
+				export: FrozenExportSessionState::Pending { worker_state, window_target },
+			},
+			other => other,
+		};
+	}
+
+	fn set_frozen_capture_export_ready(&mut self, monitor: MonitorRect) {
+		self.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
+			monitor,
+			export: FrozenExportSessionState::Ready,
+		};
+	}
+
+	fn set_frozen_capture_export_failed(&mut self, monitor: MonitorRect) {
+		self.frozen_capture_session_state = match self.frozen_capture_session_state {
+			FrozenCaptureSessionState::DisplayReady { .. } => {
+				FrozenCaptureSessionState::DisplayReady {
+					monitor,
+					export: FrozenExportSessionState::Failed,
+				}
+			},
+			FrozenCaptureSessionState::DisplayPending { .. }
+			| FrozenCaptureSessionState::DisplayFailed { .. }
+			| FrozenCaptureSessionState::Inactive => FrozenCaptureSessionState::DisplayFailed { monitor },
+		};
+	}
+
+	fn clear_frozen_capture_session_state(&mut self) {
+		self.frozen_capture_session_state = FrozenCaptureSessionState::Inactive;
 	}
 
 	fn frozen_display_ready(&self) -> bool {
 		matches!(self.state.mode, OverlayMode::Frozen)
-			&& self.state.frozen_surface_image().is_some()
+			&& matches!(
+				self.frozen_capture_session_state,
+				FrozenCaptureSessionState::DisplayReady { .. }
+			) && self.state.frozen_surface_image().is_some()
 	}
 
 	fn frozen_display_ready_for_monitor(&self, monitor: MonitorRect) -> bool {
@@ -1171,9 +1294,10 @@ impl OverlaySession {
 	}
 
 	fn pending_freeze_capture_matches(&self, monitor: MonitorRect) -> bool {
-		self.pending_freeze_capture == Some(monitor)
+		self.frozen_capture_monitor() == Some(monitor)
 			&& matches!(self.state.mode, OverlayMode::Frozen)
 			&& self.state.monitor == Some(monitor)
+			&& self.frozen_capture_export_pending()
 	}
 
 	#[cfg(target_os = "macos")]
@@ -1188,18 +1312,8 @@ impl OverlaySession {
 
 	fn frozen_final_capture_ready(&self) -> bool {
 		matches!(self.state.mode, OverlayMode::Frozen)
-			&& {
-				#[cfg(test)]
-				{
-					self.frozen_export_ready || self.authoritative_frozen_capture_ready
-				}
-				#[cfg(not(test))]
-				{
-					self.frozen_export_ready
-				}
-			} && self.state.frozen_export_image.is_some()
-			&& self.pending_freeze_capture.is_none()
-			&& self.inflight_freeze_capture.is_none()
+			&& self.frozen_capture_export_ready()
+			&& self.state.frozen_export_image.is_some()
 	}
 
 	#[cfg(target_os = "macos")]
@@ -1207,7 +1321,7 @@ impl OverlaySession {
 		&self,
 		monitor: MonitorRect,
 	) -> Option<WindowFreezeCaptureTarget> {
-		self.pending_window_freeze_capture.filter(|target| target.monitor == monitor)
+		self.frozen_capture_window_target().filter(|target| target.monitor == monitor)
 	}
 
 	fn frozen_transition_elapsed_ms_since(
@@ -1535,6 +1649,7 @@ impl OverlaySession {
 		cursor: Option<GlobalPoint>,
 	) {
 		self.state.commit_frozen_display_image(monitor, image);
+		self.promote_frozen_capture_display_ready(monitor);
 
 		if let Some(cursor) = cursor {
 			self.update_cursor_state(monitor, cursor);
@@ -1590,18 +1705,8 @@ impl OverlaySession {
 
 		self.commit_frozen_preview(monitor, snapshot_image, cursor);
 		self.note_frozen_transition_preview_committed(monitor, source, Some(snapshot_age_ms));
-
-		self.pending_freeze_capture = None;
-		self.inflight_freeze_capture = None;
-		self.pending_freeze_capture_armed = false;
-		self.pending_window_freeze_capture = None;
-		self.inflight_window_freeze_capture = None;
-		self.frozen_export_ready = true;
-		#[cfg(test)]
-		{
-			self.authoritative_frozen_capture_ready = true;
-		}
-
+		self.promote_frozen_capture_display_ready(monitor);
+		self.set_frozen_capture_export_ready(monitor);
 		self.state.commit_frozen_export_image(export_image);
 		self.note_frozen_transition_final_ready(
 			monitor,
@@ -1675,8 +1780,8 @@ impl OverlaySession {
 		monitor: MonitorRect,
 	) -> bool {
 		if !self.pending_freeze_capture_matches(monitor)
-			|| self.frozen_export_ready
-			|| self.inflight_freeze_capture.is_some()
+			|| self.frozen_capture_export_ready()
+			|| self.frozen_capture_worker_inflight()
 		{
 			return false;
 		}
@@ -1839,17 +1944,13 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		window_target: Option<WindowFreezeCaptureTarget>,
 	) {
-		self.pending_freeze_capture = Some(monitor);
-		self.pending_freeze_capture_armed = false;
-		self.inflight_freeze_capture = None;
-		self.frozen_export_ready = false;
-		#[cfg(test)]
-		{
-			self.authoritative_frozen_capture_ready = false;
-		}
+		self.set_frozen_capture_display_pending(
+			monitor,
+			FrozenCaptureWorkerState::Idle,
+			window_target,
+		);
+
 		self.freeze_capture_send_full_count = 0;
-		self.pending_window_freeze_capture = window_target;
-		self.inflight_window_freeze_capture = None;
 		self.frozen_window_image = None;
 		self.capture_windows_hidden = false;
 		self.pending_click_hit_test_request_id = None;
@@ -1969,10 +2070,14 @@ impl OverlaySession {
 			snapshot.clone(),
 			"live_stream_snapshot_preview_at_freeze_begin",
 		);
-
-		self.pending_freeze_capture_armed = window_target.is_some()
+		let arm_worker = window_target.is_some()
 			&& self.config.window_capture_alpha_mode != WindowCaptureAlphaMode::Background;
 
+		self.set_frozen_capture_worker_state(if arm_worker {
+			FrozenCaptureWorkerState::Armed
+		} else {
+			FrozenCaptureWorkerState::Idle
+		});
 		self.request_pending_frozen_capture_live_stream_refresh(monitor);
 		self.note_frozen_transition_preview_deferred(
 			monitor,
@@ -1984,7 +2089,7 @@ impl OverlaySession {
 			None,
 		);
 
-		if self.pending_freeze_capture_armed {
+		if arm_worker {
 			self.note_frozen_transition_authoritative_handoff_armed(monitor);
 		}
 
@@ -2007,15 +2112,8 @@ impl OverlaySession {
 
 			self.state.finish_freeze(monitor, image);
 			self.note_frozen_transition_preview_committed(monitor, "cached_live_background", None);
-
-			self.pending_freeze_capture = None;
-			self.pending_freeze_capture_armed = false;
-			self.frozen_export_ready = true;
-			#[cfg(test)]
-			{
-				self.authoritative_frozen_capture_ready = true;
-			}
-
+			self.promote_frozen_capture_display_ready(monitor);
+			self.set_frozen_capture_export_ready(monitor);
 			self.note_frozen_transition_final_ready(monitor, "cached_live_background", None);
 
 			if let Some(cursor) = cursor {
@@ -2182,14 +2280,14 @@ impl OverlaySession {
 		window_image: Option<RgbaImage>,
 		captured_window_id: Option<u32>,
 	) {
-		if matches!(self.state.mode, OverlayMode::Frozen) && self.state.monitor == Some(monitor) {
-			self.inflight_freeze_capture = None;
-
-			let window_capture_target = self.inflight_window_freeze_capture.take();
+		if matches!(self.state.mode, OverlayMode::Frozen)
+			&& self.state.monitor == Some(monitor)
+			&& self.frozen_capture_export_pending()
+		{
+			let window_capture_target = self.frozen_capture_window_target();
 			let had_display_image = self.frozen_display_ready();
 			let frozen_preview_image = image;
 
-			self.pending_window_freeze_capture = None;
 			self.frozen_window_image = None;
 
 			if self.reject_dirty_window_export_authority(
@@ -2203,12 +2301,6 @@ impl OverlaySession {
 				return;
 			}
 
-			self.frozen_export_ready = true;
-			#[cfg(test)]
-			{
-				self.authoritative_frozen_capture_ready = true;
-			}
-
 			let frozen_preview_image = self.apply_window_capture_export_authority(
 				monitor,
 				had_display_image,
@@ -2220,6 +2312,7 @@ impl OverlaySession {
 
 			if !had_display_image {
 				self.state.commit_frozen_display_image(monitor, frozen_preview_image.clone());
+				self.promote_frozen_capture_display_ready(monitor);
 				self.note_frozen_transition_preview_committed(
 					monitor,
 					"authoritative_capture",
@@ -2228,6 +2321,7 @@ impl OverlaySession {
 			}
 
 			self.state.commit_frozen_export_image(frozen_preview_image.clone());
+			self.set_frozen_capture_export_ready(monitor);
 			self.note_frozen_transition_final_ready(
 				monitor,
 				"authoritative_capture",
@@ -2258,12 +2352,8 @@ impl OverlaySession {
 
 			return;
 		}
-		if self.inflight_freeze_capture == Some(monitor) {
-			self.inflight_freeze_capture = None;
-		}
-		if self.inflight_window_freeze_capture.is_some_and(|inflight| inflight.monitor == monitor) {
-			self.inflight_window_freeze_capture = None;
-			self.pending_window_freeze_capture = None;
+		if self.frozen_capture_worker_inflight() && self.frozen_capture_monitor() == Some(monitor) {
+			self.clear_frozen_capture_session_state();
 		}
 		if matches!(self.state.mode, OverlayMode::Live)
 			&& self.use_fake_hud_blur()
@@ -2297,12 +2387,7 @@ impl OverlaySession {
 			return false;
 		}
 
-		self.frozen_export_ready = false;
-		#[cfg(test)]
-		{
-			self.authoritative_frozen_capture_ready = false;
-		}
-
+		self.set_frozen_capture_export_failed(monitor);
 		self.note_frozen_transition_aborted(
 			"Window export authority did not resolve to a clean target window.",
 		);
@@ -3120,9 +3205,13 @@ impl OverlaySession {
 			window_id = ?window_id,
 			monitor_id = overlay_monitor.id,
 			frozen_generation = self.state.frozen_generation,
-			final_capture_ready = self.frozen_export_ready,
+			final_capture_ready = self.frozen_final_capture_ready(),
 			frozen_image_ready = self.frozen_display_ready(),
-			pending_freeze_capture = self.pending_freeze_capture.map(|m| m.id),
+			frozen_capture_session_state = ?self.frozen_capture_session_state,
+			pending_freeze_capture = self
+				.frozen_capture_monitor()
+				.filter(|_| self.frozen_capture_export_pending())
+				.map(|m| m.id),
 			draw_toolbar,
 			toolbar_visible = self.toolbar_state.visible,
 			toolbar_floating_position = ?self.toolbar_state.floating_position,
@@ -3198,9 +3287,8 @@ impl OverlaySession {
 		draw_toolbar: bool,
 	) -> OverlayControl {
 		if self.should_dispatch_pending_freeze_capture(overlay_monitor) {
-			let pending_window_target = self
-				.pending_window_freeze_capture
-				.filter(|target| target.monitor == overlay_monitor);
+			let pending_window_target =
+				self.pending_window_freeze_capture_for_monitor(overlay_monitor);
 			let freeze_target = pending_window_target
 				.map_or(FreezeCaptureTarget::Monitor, |target| FreezeCaptureTarget::Window {
 					window_id: target.window_id,
@@ -3211,7 +3299,7 @@ impl OverlaySession {
 			#[cfg(not(target_os = "macos"))]
 			{
 				// Capture must happen on a post-hide redraw so the HUD/loupe are not included.
-				if self.pending_freeze_capture_armed {
+				if self.frozen_capture_worker_armed() {
 					let Some(worker) = &self.worker else {
 						self.abort_pending_freeze_capture("Capture worker is unavailable.");
 
@@ -3231,8 +3319,8 @@ impl OverlaySession {
 					}
 				} else {
 					self.freeze_capture_send_full_count = 0;
-					self.pending_freeze_capture_armed = true;
 
+					self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Armed);
 					#[cfg(not(target_os = "macos"))]
 					self.hide_capture_windows();
 					self.request_redraw_for_monitor(overlay_monitor);

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1172,6 +1172,24 @@ impl OverlaySession {
 		)
 	}
 
+	fn frozen_capture_dispatch_pending(&self) -> bool {
+		matches!(
+			self.frozen_capture_session_state,
+			FrozenCaptureSessionState::DisplayPending {
+				worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
+				..
+			}
+				| FrozenCaptureSessionState::DisplayReady {
+					export:
+						FrozenExportSessionState::Pending {
+							worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
+							..
+						},
+					..
+				}
+		)
+	}
+
 	fn frozen_capture_worker_armed(&self) -> bool {
 		self.frozen_capture_worker_state() == Some(FrozenCaptureWorkerState::Armed)
 	}
@@ -1297,7 +1315,7 @@ impl OverlaySession {
 		self.frozen_capture_monitor() == Some(monitor)
 			&& matches!(self.state.mode, OverlayMode::Frozen)
 			&& self.state.monitor == Some(monitor)
-			&& self.frozen_capture_export_pending()
+			&& self.frozen_capture_dispatch_pending()
 	}
 
 	#[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
@@ -67,7 +67,9 @@ impl OverlaySession {
 
 		#[cfg(target_os = "macos")]
 		{
-			if let Some(monitor) = self.pending_freeze_capture {
+			if let Some(monitor) =
+				self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
+			{
 				let _ = self.maybe_update_pending_frozen_capture_from_live_stream_snapshot(monitor);
 				let _ = self.maybe_drive_pending_display_first_freeze_preview(now);
 			}

--- a/packages/rsnap-overlay/src/overlay/config_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/config_runtime.rs
@@ -12,7 +12,10 @@ use crate::overlay::{
 	WindowRenderer,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{MacLiveFrameStream, MacOSHudWindowConfigState, SLOW_OP_WARN_HUD_CONFIG};
+use crate::overlay::{
+	FrozenCaptureWorkerState, MacLiveFrameStream, MacOSHudWindowConfigState,
+	SLOW_OP_WARN_HUD_CONFIG,
+};
 
 impl OverlaySession {
 	/// Applies updated runtime configuration to an existing session.
@@ -154,7 +157,7 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	pub(super) fn has_inflight_worker_response_state(&self) -> bool {
-		self.inflight_freeze_capture.is_some()
+		self.frozen_capture_worker_state() == Some(FrozenCaptureWorkerState::Inflight)
 			|| self.pending_click_hit_test_request_id.is_some()
 			|| self.window_list_refresh_inflight
 			|| self.png_encode_inflight

--- a/packages/rsnap-overlay/src/overlay/session_state.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state.rs
@@ -26,6 +26,42 @@ pub(super) struct WindowFreezeCaptureTarget {
 	pub(super) rect: RectPoints,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum FrozenCaptureWorkerState {
+	#[default]
+	Idle,
+	Armed,
+	Inflight,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FrozenExportSessionState {
+	Pending {
+		worker_state: FrozenCaptureWorkerState,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	},
+	Ready,
+	Failed,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum FrozenCaptureSessionState {
+	#[default]
+	Inactive,
+	DisplayPending {
+		monitor: MonitorRect,
+		worker_state: FrozenCaptureWorkerState,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	},
+	DisplayFailed {
+		monitor: MonitorRect,
+	},
+	DisplayReady {
+		monitor: MonitorRect,
+		export: FrozenExportSessionState,
+	},
+}
+
 #[derive(Default)]
 pub(super) struct SlowOperationLogger {
 	last_warn_at: HashMap<&'static str, Instant>,

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -48,9 +48,11 @@ use crate::live_frame_stream_macos::MacLiveFrameStream;
 use crate::overlay::FrozenCaptureSource;
 use crate::overlay::PngAction;
 use crate::overlay::rendering;
-use crate::overlay::session_state::FrozenBrushStyle;
 #[cfg(target_os = "macos")]
 use crate::overlay::session_state::ScrollCaptureLiveFrame;
+use crate::overlay::session_state::{
+	FrozenBrushStyle, FrozenCaptureSessionState, FrozenCaptureWorkerState, FrozenExportSessionState,
+};
 use crate::overlay::{
 	self, ActiveFrozenBrushStroke, FROZEN_EDIT_HISTORY_LIMIT, FROZEN_TEXT_CARET_REPAINT_INTERVAL,
 	FrozenAnnotationColor, FrozenArrowAnnotation, FrozenBrushModelState, FrozenBrushStroke,
@@ -133,6 +135,291 @@ impl CaptureBackend for SequenceScrollCaptureBackend {
 	fn refresh_window_cache(&mut self) -> Result<Arc<WindowListSnapshot>> {
 		Err(eyre::eyre!("unused in this test"))
 	}
+}
+
+fn session_pending_freeze_capture(session: &OverlaySession) -> Option<MonitorRect> {
+	match session.frozen_capture_session_state {
+		FrozenCaptureSessionState::DisplayPending {
+			monitor,
+			worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
+			..
+		} => Some(monitor),
+		FrozenCaptureSessionState::DisplayReady { monitor, export } => match export {
+			FrozenExportSessionState::Pending {
+				worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
+				..
+			} => Some(monitor),
+			FrozenExportSessionState::Pending {
+				worker_state: FrozenCaptureWorkerState::Inflight,
+				..
+			}
+			| FrozenExportSessionState::Ready
+			| FrozenExportSessionState::Failed => None,
+		},
+		FrozenCaptureSessionState::Inactive
+		| FrozenCaptureSessionState::DisplayFailed { .. }
+		| FrozenCaptureSessionState::DisplayPending {
+			worker_state: FrozenCaptureWorkerState::Inflight,
+			..
+		} => None,
+	}
+}
+
+fn session_inflight_freeze_capture(session: &OverlaySession) -> Option<MonitorRect> {
+	match session.frozen_capture_session_state {
+		FrozenCaptureSessionState::DisplayPending {
+			monitor,
+			worker_state: FrozenCaptureWorkerState::Inflight,
+			..
+		}
+		| FrozenCaptureSessionState::DisplayReady {
+			monitor,
+			export:
+				FrozenExportSessionState::Pending {
+					worker_state: FrozenCaptureWorkerState::Inflight,
+					..
+				},
+		} => Some(monitor),
+		FrozenCaptureSessionState::Inactive
+		| FrozenCaptureSessionState::DisplayFailed { .. }
+		| FrozenCaptureSessionState::DisplayPending { .. }
+		| FrozenCaptureSessionState::DisplayReady { .. } => None,
+	}
+}
+
+fn session_pending_window_freeze_capture(
+	session: &OverlaySession,
+) -> Option<crate::overlay::session_state::WindowFreezeCaptureTarget> {
+	match session.frozen_capture_session_state {
+		FrozenCaptureSessionState::DisplayPending {
+			worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
+			window_target,
+			..
+		} => window_target,
+		FrozenCaptureSessionState::DisplayReady { export, .. } => match export {
+			FrozenExportSessionState::Pending {
+				worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
+				window_target,
+			} => window_target,
+			FrozenExportSessionState::Pending {
+				worker_state: FrozenCaptureWorkerState::Inflight,
+				..
+			}
+			| FrozenExportSessionState::Ready
+			| FrozenExportSessionState::Failed => None,
+		},
+		FrozenCaptureSessionState::Inactive
+		| FrozenCaptureSessionState::DisplayFailed { .. }
+		| FrozenCaptureSessionState::DisplayPending {
+			worker_state: FrozenCaptureWorkerState::Inflight,
+			..
+		} => None,
+	}
+}
+
+fn session_inflight_window_freeze_capture(
+	session: &OverlaySession,
+) -> Option<crate::overlay::session_state::WindowFreezeCaptureTarget> {
+	match session.frozen_capture_session_state {
+		FrozenCaptureSessionState::DisplayPending {
+			worker_state: FrozenCaptureWorkerState::Inflight,
+			window_target,
+			..
+		}
+		| FrozenCaptureSessionState::DisplayReady {
+			export:
+				FrozenExportSessionState::Pending {
+					worker_state: FrozenCaptureWorkerState::Inflight,
+					window_target,
+				},
+			..
+		} => window_target,
+		FrozenCaptureSessionState::Inactive
+		| FrozenCaptureSessionState::DisplayFailed { .. }
+		| FrozenCaptureSessionState::DisplayPending { .. }
+		| FrozenCaptureSessionState::DisplayReady { .. } => None,
+	}
+}
+
+fn session_frozen_capture_armed(session: &OverlaySession) -> bool {
+	matches!(
+		session.frozen_capture_session_state,
+		FrozenCaptureSessionState::DisplayPending {
+			worker_state: FrozenCaptureWorkerState::Armed,
+			..
+		} | FrozenCaptureSessionState::DisplayReady {
+			export: FrozenExportSessionState::Pending {
+				worker_state: FrozenCaptureWorkerState::Armed,
+				..
+			},
+			..
+		}
+	)
+}
+
+fn session_frozen_export_ready_state(session: &OverlaySession) -> bool {
+	matches!(
+		session.frozen_capture_session_state,
+		FrozenCaptureSessionState::DisplayReady { export: FrozenExportSessionState::Ready, .. }
+	)
+}
+
+fn set_session_frozen_capture_state(
+	session: &mut OverlaySession,
+	monitor: Option<MonitorRect>,
+	worker_state: FrozenCaptureWorkerState,
+	window_target: Option<crate::overlay::session_state::WindowFreezeCaptureTarget>,
+) {
+	let Some(monitor) = monitor else {
+		session.frozen_capture_session_state = FrozenCaptureSessionState::Inactive;
+
+		return;
+	};
+	let display_ready = matches!(session.state.mode, OverlayMode::Frozen)
+		&& session.state.monitor == Some(monitor)
+		&& session.state.frozen_surface_image().is_some();
+
+	session.frozen_capture_session_state = if display_ready {
+		FrozenCaptureSessionState::DisplayReady {
+			monitor,
+			export: FrozenExportSessionState::Pending { worker_state, window_target },
+		}
+	} else {
+		FrozenCaptureSessionState::DisplayPending { monitor, worker_state, window_target }
+	};
+}
+
+fn set_session_pending_freeze_capture(session: &mut OverlaySession, monitor: Option<MonitorRect>) {
+	let worker_state = if session_frozen_capture_armed(session) {
+		FrozenCaptureWorkerState::Armed
+	} else {
+		FrozenCaptureWorkerState::Idle
+	};
+	let window_target = session_pending_window_freeze_capture(session)
+		.or_else(|| session_inflight_window_freeze_capture(session));
+
+	set_session_frozen_capture_state(session, monitor, worker_state, window_target);
+}
+
+fn set_session_pending_window_freeze_capture(
+	session: &mut OverlaySession,
+	window_target: Option<crate::overlay::session_state::WindowFreezeCaptureTarget>,
+) {
+	let monitor = session_pending_freeze_capture(session)
+		.or_else(|| session_inflight_freeze_capture(session))
+		.or_else(|| window_target.map(|target| target.monitor));
+	let worker_state = match session_inflight_freeze_capture(session) {
+		Some(_) => FrozenCaptureWorkerState::Inflight,
+		None if session_frozen_capture_armed(session) => FrozenCaptureWorkerState::Armed,
+		None => FrozenCaptureWorkerState::Idle,
+	};
+
+	set_session_frozen_capture_state(session, monitor, worker_state, window_target);
+}
+
+fn set_session_inflight_freeze_capture(session: &mut OverlaySession, monitor: Option<MonitorRect>) {
+	let window_target = session_pending_window_freeze_capture(session)
+		.or_else(|| session_inflight_window_freeze_capture(session));
+
+	set_session_frozen_capture_state(
+		session,
+		monitor,
+		FrozenCaptureWorkerState::Inflight,
+		window_target,
+	);
+}
+
+fn set_session_inflight_window_freeze_capture(
+	session: &mut OverlaySession,
+	window_target: Option<crate::overlay::session_state::WindowFreezeCaptureTarget>,
+) {
+	let monitor = session_inflight_freeze_capture(session)
+		.or_else(|| session_pending_freeze_capture(session))
+		.or_else(|| window_target.map(|target| target.monitor));
+
+	set_session_frozen_capture_state(
+		session,
+		monitor,
+		FrozenCaptureWorkerState::Inflight,
+		window_target,
+	);
+}
+
+fn set_session_pending_freeze_capture_armed(session: &mut OverlaySession, armed: bool) {
+	let monitor = session_pending_freeze_capture(session)
+		.or_else(|| session_inflight_freeze_capture(session));
+	let window_target = session_pending_window_freeze_capture(session)
+		.or_else(|| session_inflight_window_freeze_capture(session));
+	let worker_state = if session_inflight_freeze_capture(session).is_some() {
+		FrozenCaptureWorkerState::Inflight
+	} else if armed {
+		FrozenCaptureWorkerState::Armed
+	} else {
+		FrozenCaptureWorkerState::Idle
+	};
+
+	set_session_frozen_capture_state(session, monitor, worker_state, window_target);
+}
+
+fn set_session_frozen_export_ready_state(session: &mut OverlaySession, ready: bool) {
+	if ready {
+		let monitor = session
+			.state
+			.monitor
+			.or_else(|| session_pending_freeze_capture(session))
+			.or_else(|| session_inflight_freeze_capture(session))
+			.unwrap_or_else(test_monitor);
+
+		session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
+			monitor,
+			export: FrozenExportSessionState::Ready,
+		};
+	} else if let Some(monitor) = session
+		.state
+		.monitor
+		.or_else(|| session_pending_freeze_capture(session))
+		.or_else(|| session_inflight_freeze_capture(session))
+	{
+		session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
+			monitor,
+			export: FrozenExportSessionState::Failed,
+		};
+	} else {
+		session.frozen_capture_session_state = FrozenCaptureSessionState::Inactive;
+	}
+}
+
+fn finish_frozen_display_state(
+	session: &mut OverlaySession,
+	monitor: MonitorRect,
+	image: image::RgbaImage,
+) {
+	session.state.finish_freeze(monitor, image);
+
+	session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
+		monitor,
+		export: FrozenExportSessionState::Pending {
+			worker_state: FrozenCaptureWorkerState::Idle,
+			window_target: None,
+		},
+	};
+}
+
+fn commit_frozen_display_preview_state(
+	session: &mut OverlaySession,
+	monitor: MonitorRect,
+	image: image::RgbaImage,
+) {
+	session.state.commit_frozen_display_image(monitor, image);
+
+	session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
+		monitor,
+		export: FrozenExportSessionState::Pending {
+			worker_state: FrozenCaptureWorkerState::Idle,
+			window_target: session_pending_window_freeze_capture(session)
+				.or_else(|| session_inflight_window_freeze_capture(session)),
+		},
+	};
 }
 
 fn make_scroll_capture_test_image(width: u32, rows: &[[u8; 4]]) -> image::RgbaImage {
@@ -331,11 +618,13 @@ fn seed_ready_scroll_capture_selection(session: &mut OverlaySession) {
 	let monitor = test_monitor_with_scale(8, 8, 1_000);
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(1, 1, 4, 4));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(session, true);
 }
 
 #[test]
@@ -349,11 +638,14 @@ fn begin_png_action_copies_preview_render_image_during_active_scroll_capture() {
 	let monitor = test_monitor();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.scroll_capture.active = true;
 	session.scroll_capture.session = Some(scroll_session);
 	session.scroll_capture.preview_display_image =
@@ -377,7 +669,9 @@ fn current_export_image_includes_frozen_brush_strokes() {
 		.finish_freeze(monitor, image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])));
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
 	assert!(session.begin_frozen_brush_stroke(GlobalPoint::new(2, 2)));
@@ -404,7 +698,9 @@ fn current_export_image_uses_selected_brush_color() {
 		.finish_freeze(monitor, image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])));
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 	session.toolbar_state.brush_style.color = FrozenAnnotationColor::Green;
 
@@ -430,7 +726,9 @@ fn frozen_brush_undo_and_redo_update_export_image() {
 		.finish_freeze(monitor, image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])));
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
 	assert!(session.begin_frozen_brush_stroke(GlobalPoint::new(3, 3)));
@@ -457,10 +755,17 @@ fn current_export_image_antialiases_frozen_brush_edges() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, image::RgbaImage::from_pixel(16, 16, background));
+
+	finish_frozen_display_state(
+		&mut session,
+		monitor,
+		image::RgbaImage::from_pixel(16, 16, background),
+	);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 16, 16));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
 	assert!(session.begin_frozen_brush_stroke(GlobalPoint::new(3, 3)));
@@ -892,12 +1197,14 @@ fn begin_ocr_action_exits_with_deferred_request_and_clears_stale_png_output_inte
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, expected_export.clone());
+
+	finish_frozen_display_state(&mut session, monitor, expected_export.clone());
 
 	session.state.frozen_capture_rect =
 		Some(RectPoints::new(0, 0, expected_export.width(), expected_export.height()));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
 
 	session.begin_png_action(PngAction::Copy);
 
@@ -926,12 +1233,14 @@ fn begin_ocr_action_drag_region_still_uses_frozen_image_under_matte_mode() {
 	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteLight;
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, expected_export.clone());
+
+	finish_frozen_display_state(&mut session, monitor, expected_export.clone());
 
 	session.state.frozen_capture_rect =
 		Some(RectPoints::new(0, 0, expected_export.width(), expected_export.height()));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
 
 	let control = session.begin_ocr_action();
 	let OverlayControl::Exit(OverlayExit::DeferredTextRecognition(request)) = control else {
@@ -952,12 +1261,14 @@ fn authoritative_freeze_response_updates_export_authority_without_overwriting_di
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.commit_frozen_display_image(monitor, preview_image.clone());
+
+	commit_frozen_display_preview_state(&mut session, monitor, preview_image.clone());
+
 	session.handle_captured_freeze_response(monitor, authoritative_image.clone(), None, None);
 
 	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
 	assert_eq!(session.state.frozen_export_image.as_ref(), Some(&authoritative_image));
-	assert!(session.authoritative_frozen_capture_ready);
+	assert!(session_frozen_export_ready_state(&session));
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -1021,8 +1332,11 @@ fn window_matte_mosaic_export_and_ocr_match_preview_pixels() {
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::Window;
-	session.inflight_window_freeze_capture =
-		Some(crate::overlay::WindowFreezeCaptureTarget { monitor, window_id, rect: capture_rect });
+
+	set_session_inflight_window_freeze_capture(
+		&mut session,
+		Some(crate::overlay::WindowFreezeCaptureTarget { monitor, window_id, rect: capture_rect }),
+	);
 
 	session.handle_captured_freeze_response(
 		monitor,
@@ -1031,7 +1345,7 @@ fn window_matte_mosaic_export_and_ocr_match_preview_pixels() {
 		Some(window_id),
 	);
 
-	assert!(session.authoritative_frozen_capture_ready);
+	assert!(session_frozen_export_ready_state(&session));
 	assert!(session.apply_frozen_mosaic_edit(capture_rect));
 
 	let expected_export = imageops::crop_imm(
@@ -1066,11 +1380,13 @@ fn begin_ocr_action_skips_deferred_request_when_drag_region_crop_is_out_of_bound
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, frozen_image.clone());
+
+	finish_frozen_display_state(&mut session, monitor, frozen_image.clone());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(monitor.width + 10, 20, 100, 80));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
 
 	let control = session.begin_ocr_action();
 
@@ -1091,11 +1407,14 @@ fn begin_ocr_action_uses_scroll_capture_export_image_in_deferred_request() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.scroll_capture.active = true;
 	session.scroll_capture.session = Some(scroll_session);
 	session.scroll_capture.preview_display_image =
@@ -1116,7 +1435,8 @@ fn begin_frozen_text_edit_at_starts_text_input_inside_capture_rect() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1142,7 +1462,8 @@ fn begin_frozen_text_edit_at_ignores_non_authoritative_monitor() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1360,7 +1681,8 @@ fn overlay_window_mouse_wheel_routes_inline_toolbar_size_adjustments() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
 	session.toolbar_state.visible = true;
@@ -1396,7 +1718,8 @@ fn frozen_text_edit_drag_repositions_anchor_within_capture_rect() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1418,7 +1741,8 @@ fn toolbar_mouse_release_stops_active_frozen_text_edit_drag() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1440,7 +1764,8 @@ fn toolbar_mouse_release_commits_active_frozen_arrow_drag() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Arrow;
@@ -1464,7 +1789,8 @@ fn toolbar_mouse_release_commits_active_frozen_spotlight_drag() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Spotlight;
@@ -1489,7 +1815,8 @@ fn toolbar_mouse_release_finishes_active_frozen_brush_stroke() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
@@ -1641,7 +1968,8 @@ fn adjacent_text_events_from_key_and_ime_are_deduplicated() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1693,7 +2021,8 @@ fn non_adjacent_identical_text_events_from_different_sources_are_not_deduplicate
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1725,7 +2054,8 @@ fn backspace_clears_recent_input_dedupe_marker_before_cross_source_retype() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1758,7 +2088,8 @@ fn text_input_resets_frozen_text_caret_blink_phase() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1789,7 +2120,8 @@ fn ime_preedit_updates_reset_frozen_text_caret_blink_phase() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1813,7 +2145,8 @@ fn ime_disabled_clears_frozen_text_preedit_state() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1835,7 +2168,8 @@ fn frozen_text_preedit_cursor_range_updates_caret_position() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1864,7 +2198,8 @@ fn frozen_text_style_change_refresh_check_requires_active_ime_preedit() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1888,7 +2223,8 @@ fn frozen_text_style_change_refresh_check_ignores_other_monitor() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1906,7 +2242,8 @@ fn frozen_text_enter_does_not_finish_while_ime_preedit_is_active() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1929,7 +2266,8 @@ fn frozen_text_caret_repaint_schedules_delayed_repaint_while_editing() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.frozen_text_edit = Some(FrozenTextEditState::new(Pos2::new(120.0, 140.0)));
 	*session.egui_repaint_deadline.lock().unwrap_or_else(|err| err.into_inner()) = None;
@@ -1968,7 +2306,8 @@ fn finish_frozen_text_editing_commits_current_toolbar_text_style() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -1991,10 +2330,13 @@ fn finish_frozen_brush_stroke_commits_current_toolbar_brush_style() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 	session.toolbar_state.brush_style.stroke_width_points = 4.25;
 	session.toolbar_state.brush_style.color = FrozenAnnotationColor::Green;
@@ -2014,7 +2356,8 @@ fn finish_frozen_text_editing_commits_active_ime_preedit_text() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -2033,10 +2376,13 @@ fn inline_toolbar_mode_switch_finishes_active_frozen_text_edit() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
 
 	assert!(session.begin_frozen_text_edit_at(monitor, GlobalPoint::new(140, 160)));
@@ -2058,10 +2404,13 @@ fn inline_toolbar_mode_switch_commits_active_ime_preedit_text() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
 
 	assert!(session.begin_frozen_text_edit_at(monitor, GlobalPoint::new(140, 160)));
@@ -2083,7 +2432,8 @@ fn frozen_text_undo_and_redo_round_trip_annotations() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
@@ -2112,7 +2462,8 @@ fn current_export_image_renders_frozen_text_annotations() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, base);
+
+	finish_frozen_display_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(10, 12, 120, 80));
 
@@ -2136,7 +2487,8 @@ fn current_export_image_applies_frozen_spotlight_outside_selection() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, base);
+
+	finish_frozen_display_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
@@ -2179,7 +2531,8 @@ fn current_export_image_applies_multiple_frozen_spotlights_without_extra_darkeni
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, base);
+
+	finish_frozen_display_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
@@ -2211,7 +2564,8 @@ fn current_export_image_renders_frozen_arrow_after_spotlight_scrim() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, base);
+
+	finish_frozen_display_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
@@ -2241,7 +2595,8 @@ fn current_export_image_renders_frozen_arrow_outline_without_tinting() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, base);
+
+	finish_frozen_display_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 32, 32));
 
@@ -2313,7 +2668,9 @@ fn frozen_committed_overlay_iteration_preserves_cross_tool_order() {
 		.finish_freeze(monitor, image::RgbaImage::from_pixel(16, 16, Rgba([0, 0, 0, 255])));
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 16, 16));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
 	assert!(session.begin_frozen_brush_stroke(GlobalPoint::new(2, 2)));
@@ -2362,10 +2719,13 @@ fn frozen_annotation_history_undoes_across_tools_in_reverse_commit_order() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, original.clone());
+
+	finish_frozen_display_state(&mut session, monitor, original.clone());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
 	assert!(session.begin_frozen_brush_stroke(GlobalPoint::new(2, 2)));
@@ -2419,10 +2779,13 @@ fn committing_new_frozen_edit_clears_redo_across_tools() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, base);
+
+	finish_frozen_display_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
-	session.authoritative_frozen_capture_ready = true;
+
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
 
 	assert!(session.begin_frozen_text_edit_at(monitor, GlobalPoint::new(2, 2)));
@@ -2797,7 +3160,6 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 		png_encode_inflight: true,
 		pending_self_capture_exception_window_ids_worker_refresh: true,
 		pending_startup_aux_live_stream_filter_upgrade: true,
-		authoritative_frozen_capture_ready: true,
 		capture_windows_hidden: true,
 		loupe_activation_key_down: true,
 		keyboard_modifiers: ModifiersState::SHIFT,
@@ -2814,6 +3176,8 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 		..OverlaySession::default()
 	};
 
+	set_session_frozen_export_ready_state(&mut session, true);
+
 	session.reset_for_start();
 
 	assert!(!session.is_active());
@@ -2822,7 +3186,7 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 	assert!(!session.png_encode_inflight);
 	assert!(!session.pending_self_capture_exception_window_ids_worker_refresh);
 	assert!(!session.pending_startup_aux_live_stream_filter_upgrade);
-	assert!(!session.authoritative_frozen_capture_ready);
+	assert!(!session_frozen_export_ready_state(&session));
 	assert!(!session.capture_windows_hidden);
 	assert!(!session.loupe_activation_key_down);
 	assert_eq!(session.keyboard_modifiers, ModifiersState::default());
@@ -3304,12 +3668,12 @@ fn toolbar_window_hides_until_frozen_pixels_exist() {
 
 	assert!(session.should_hide_toolbar_window(monitor));
 
-	session.pending_freeze_capture = Some(monitor);
+	set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(session.should_hide_toolbar_window(monitor));
 
-	session.pending_freeze_capture = None;
-	session.inflight_freeze_capture = Some(monitor);
+	set_session_pending_freeze_capture(&mut session, None);
+	set_session_inflight_freeze_capture(&mut session, Some(monitor));
 
 	assert!(session.should_hide_toolbar_window(monitor));
 }
@@ -3321,14 +3685,15 @@ fn toolbar_window_is_needed_for_seeded_preview_before_final_capture_ready() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	session.toolbar_state.visible = true;
 
 	session.request_aux_window_creation_if_needed();
 
 	assert!(session.startup_aux_window_creation_pending);
-	assert!(!session.authoritative_frozen_capture_ready);
+	assert!(!session_frozen_export_ready_state(&session));
 }
 
 #[test]
@@ -3337,16 +3702,17 @@ fn toolbar_window_stays_visible_while_final_capture_is_pending() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_frozen_image());
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
 	assert!(!session.should_hide_toolbar_window(monitor));
 
-	session.pending_freeze_capture = Some(monitor);
+	set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.should_hide_toolbar_window(monitor));
 
-	session.pending_freeze_capture = None;
-	session.inflight_freeze_capture = Some(monitor);
+	set_session_pending_freeze_capture(&mut session, None);
+	set_session_inflight_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.should_hide_toolbar_window(monitor));
 }

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -3717,6 +3717,26 @@ fn toolbar_window_stays_visible_while_final_capture_is_pending() {
 	assert!(!session.should_hide_toolbar_window(monitor));
 }
 
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn handle_capture_redraw_does_not_rearm_inflight_freeze_capture() {
+	let monitor = test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	set_session_inflight_freeze_capture(&mut session, Some(monitor));
+
+	session.capture_windows_hidden = true;
+
+	let _ = session.handle_capture_and_toolbar_redraw_post(monitor, false);
+
+	assert_eq!(session_inflight_freeze_capture(&session), Some(monitor));
+	assert!(session_pending_freeze_capture(&session).is_none());
+	assert!(!session_frozen_capture_armed(&session));
+	assert!(session.capture_windows_hidden);
+}
+
 #[test]
 fn tinted_hud_body_fill_amount_zero_keeps_base_fill() {
 	for theme in [HudTheme::Dark, HudTheme::Light] {

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -1089,7 +1089,8 @@ fn frozen_selection_drag_uses_non_rounding_cursor_move_updates_without_shifting_
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.monitor = Some(monitor);
 	session.state.frozen_capture_rect = Some(capture_rect);
@@ -1134,7 +1135,8 @@ fn frozen_arrow_drag_updates_from_overlay_cursor_moved_events() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.monitor = Some(monitor);
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 600, 400));
@@ -1168,7 +1170,8 @@ fn frozen_spotlight_drag_updates_from_overlay_cursor_moved_events() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.monitor = Some(monitor);
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 600, 400));

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -73,9 +73,9 @@ fn pending_freeze_capture_dispatches_even_with_seeded_preview() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
 
-	session.pending_freeze_capture = Some(monitor);
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(session.should_dispatch_pending_freeze_capture(monitor));
 }
@@ -97,23 +97,27 @@ fn snapshot_background_capture_finishes_frozen_transition_immediately() {
 	session.state.begin_freeze(monitor);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
-	session.pending_freeze_capture = Some(monitor);
-	session.pending_window_freeze_capture = Some(crate::overlay::WindowFreezeCaptureTarget {
-		monitor,
-		window_id: 11,
-		rect: capture_rect,
-	});
+
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
+	tests::set_session_pending_window_freeze_capture(
+		&mut session,
+		Some(crate::overlay::WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 11,
+			rect: capture_rect,
+		}),
+	);
 
 	assert!(session.maybe_finish_frozen_capture_from_snapshot(
 		monitor,
-		session.pending_window_freeze_capture,
+		tests::session_pending_window_freeze_capture(&session),
 		None,
 		Some(snapshot),
 		"live_stream_snapshot",
 	));
-	assert!(session.authoritative_frozen_capture_ready);
-	assert!(session.pending_freeze_capture.is_none());
-	assert!(session.pending_window_freeze_capture.is_none());
+	assert!(tests::session_frozen_export_ready_state(&session));
+	assert!(tests::session_pending_freeze_capture(&session).is_none());
+	assert!(tests::session_pending_window_freeze_capture(&session).is_none());
 	assert_eq!(session.state.frozen_image.as_ref(), Some(&frozen_image));
 	assert!(session.toolbar_state.final_capture_ready);
 }
@@ -138,8 +142,9 @@ fn snapshot_matte_window_capture_keeps_authoritative_handoff_pending() {
 	session.state.begin_freeze(monitor);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
-	session.pending_freeze_capture = Some(monitor);
-	session.pending_window_freeze_capture = Some(window_target);
+
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
+	tests::set_session_pending_window_freeze_capture(&mut session, Some(window_target));
 
 	assert!(!session.maybe_finish_frozen_capture_from_snapshot(
 		monitor,
@@ -148,9 +153,9 @@ fn snapshot_matte_window_capture_keeps_authoritative_handoff_pending() {
 		Some(snapshot),
 		"live_stream_snapshot",
 	));
-	assert!(!session.authoritative_frozen_capture_ready);
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert_eq!(session.pending_window_freeze_capture, Some(window_target));
+	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert_eq!(tests::session_pending_window_freeze_capture(&session), Some(window_target));
 	assert!(session.state.frozen_image.is_none());
 }
 
@@ -174,8 +179,9 @@ fn stale_snapshot_does_not_finish_frozen_transition_immediately() {
 	session.state.begin_freeze(monitor);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
-	session.pending_freeze_capture = Some(monitor);
-	session.pending_window_freeze_capture = Some(window_target);
+
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
+	tests::set_session_pending_window_freeze_capture(&mut session, Some(window_target));
 
 	assert!(!session.maybe_finish_frozen_capture_from_snapshot(
 		monitor,
@@ -184,9 +190,9 @@ fn stale_snapshot_does_not_finish_frozen_transition_immediately() {
 		Some(snapshot),
 		"live_stream_snapshot",
 	));
-	assert!(!session.authoritative_frozen_capture_ready);
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert_eq!(session.pending_window_freeze_capture, Some(window_target));
+	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert_eq!(tests::session_pending_window_freeze_capture(&session), Some(window_target));
 	assert!(session.state.frozen_image.is_none());
 }
 
@@ -207,7 +213,8 @@ fn snapshot_seeded_preview_keeps_authoritative_handoff_pending() {
 	session.state.begin_freeze(monitor);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
-	session.pending_freeze_capture = Some(monitor);
+
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(session.maybe_seed_frozen_capture_preview_from_snapshot(
 		monitor,
@@ -215,8 +222,8 @@ fn snapshot_seeded_preview_keeps_authoritative_handoff_pending() {
 		Some(snapshot),
 		"live_stream_snapshot_seeded_unverified",
 	));
-	assert!(!session.authoritative_frozen_capture_ready);
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
+	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
 	assert_eq!(session.state.frozen_image.as_ref(), Some(&frozen_image));
 	assert!(!session.toolbar_state.final_capture_ready);
 }
@@ -239,7 +246,8 @@ fn snapshot_seeded_preview_makes_toolbar_eligible_before_final_capture_ready() {
 	session.state.begin_freeze(monitor);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
-	session.pending_freeze_capture = Some(monitor);
+
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(session.maybe_seed_frozen_capture_preview_from_snapshot(
 		monitor,
@@ -248,7 +256,7 @@ fn snapshot_seeded_preview_makes_toolbar_eligible_before_final_capture_ready() {
 		"live_stream_snapshot_seeded_unverified",
 	));
 	assert!(session.frozen_preview_visible());
-	assert!(!session.authoritative_frozen_capture_ready);
+	assert!(!tests::session_frozen_export_ready_state(&session));
 	assert!(session.startup_aux_window_creation_pending);
 }
 
@@ -270,7 +278,8 @@ fn stale_snapshot_does_not_seed_frozen_preview() {
 	session.state.begin_freeze(monitor);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
-	session.pending_freeze_capture = Some(monitor);
+
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.maybe_seed_frozen_capture_preview_from_snapshot(
 		monitor,
@@ -278,8 +287,8 @@ fn stale_snapshot_does_not_seed_frozen_preview() {
 		Some(snapshot),
 		"live_stream_snapshot_seeded_unverified",
 	));
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(!session.authoritative_frozen_capture_ready);
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert!(!tests::session_frozen_export_ready_state(&session));
 	assert!(session.state.frozen_image.is_none());
 	assert!(!session.toolbar_state.final_capture_ready);
 }
@@ -291,9 +300,9 @@ fn pending_freeze_capture_waits_for_empty_frozen_image_off_macos() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
 
-	session.pending_freeze_capture = Some(monitor);
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.should_dispatch_pending_freeze_capture(monitor));
 }
@@ -307,18 +316,17 @@ fn frozen_final_capture_ready_requires_no_pending_or_inflight_capture() {
 
 	assert!(!session.frozen_final_capture_ready());
 
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
-
-	session.authoritative_frozen_capture_ready = true;
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+	tests::set_session_frozen_export_ready_state(&mut session, true);
 
 	assert!(session.frozen_final_capture_ready());
 
-	session.pending_freeze_capture = Some(monitor);
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.frozen_final_capture_ready());
 
-	session.pending_freeze_capture = None;
-	session.inflight_freeze_capture = Some(monitor);
+	tests::set_session_pending_freeze_capture(&mut session, None);
+	tests::set_session_inflight_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.frozen_final_capture_ready());
 }
@@ -330,17 +338,19 @@ fn frozen_preview_does_not_become_final_ready_when_capture_tracking_clears_witho
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
-	session.inflight_freeze_capture = Some(monitor);
+
+	tests::set_session_inflight_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.frozen_final_capture_ready());
 	assert!(!session.scroll_capture_selection_is_ready());
 
 	// Emulate a preview-first failure where the authoritative capture tracking clears.
-	session.inflight_freeze_capture = None;
+	tests::set_session_inflight_freeze_capture(&mut session, None);
 
 	assert!(!session.frozen_final_capture_ready());
 	assert!(!session.scroll_capture_selection_is_ready());
@@ -359,13 +369,16 @@ fn unrelated_worker_errors_do_not_clear_pending_freeze_capture_state() {
 
 	session.state.begin_freeze(monitor);
 
-	session.pending_freeze_capture = Some(monitor);
-	session.pending_freeze_capture_armed = true;
-	session.pending_window_freeze_capture = Some(crate::overlay::WindowFreezeCaptureTarget {
-		monitor,
-		window_id: 42,
-		rect: RectPoints::new(10, 20, 30, 40),
-	});
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
+	tests::set_session_pending_freeze_capture_armed(&mut session, true);
+	tests::set_session_pending_window_freeze_capture(
+		&mut session,
+		Some(crate::overlay::WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 42,
+			rect: RectPoints::new(10, 20, 30, 40),
+		}),
+	);
 
 	let control = session.maybe_tick_worker_response_limiter(WorkerResponse::Error {
 		source: WorkerErrorSource::RefreshWindowList,
@@ -373,10 +386,10 @@ fn unrelated_worker_errors_do_not_clear_pending_freeze_capture_state() {
 	});
 
 	assert!(matches!(control, OverlayControl::Continue));
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(session.pending_freeze_capture_armed);
-	assert!(session.inflight_freeze_capture.is_none());
-	assert!(session.pending_window_freeze_capture.is_some());
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert!(tests::session_frozen_capture_armed(&session));
+	assert!(tests::session_inflight_freeze_capture(&session).is_none());
+	assert!(tests::session_pending_window_freeze_capture(&session).is_some());
 	assert_eq!(session.state.error_message.as_deref(), Some("window refresh failed"));
 }
 
@@ -387,7 +400,8 @@ fn frozen_selection_drag_starts_only_for_drag_region_inside_capture_rect() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 
@@ -424,7 +438,8 @@ fn frozen_selection_drag_starts_corner_resize_from_handle_hit_zone() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -451,7 +466,8 @@ fn frozen_mosaic_drag_waits_for_final_capture_ready() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, original.clone());
+
+	tests::finish_frozen_display_state(&mut session, monitor, original.clone());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Mosaic;
@@ -464,7 +480,7 @@ fn frozen_mosaic_drag_waits_for_final_capture_ready() {
 	assert_eq!(session.state.frozen_mosaic_preview_rect, None);
 	assert_eq!(session.state.frozen_image.as_ref(), Some(&original));
 
-	session.authoritative_frozen_capture_ready = true;
+	tests::set_session_frozen_export_ready_state(&mut session, true);
 
 	assert!(session.begin_frozen_mosaic_drag(GlobalPoint::new(1, 1)));
 }
@@ -475,11 +491,13 @@ fn frozen_mosaic_drag_updates_preview_rect_inside_capture_bounds() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_mosaic_source_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, test_mosaic_source_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(2, 2, 4, 4));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Mosaic;
-	session.authoritative_frozen_capture_ready = true;
+
+	tests::set_session_frozen_export_ready_state(&mut session, true);
 
 	assert!(session.begin_frozen_mosaic_drag(GlobalPoint::new(3, 3)));
 	assert!(session.update_frozen_mosaic_drag_rect(GlobalPoint::new(30, 30)));
@@ -494,11 +512,13 @@ fn frozen_mosaic_commit_round_trips_through_undo_and_redo() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, original.clone());
+
+	tests::finish_frozen_display_state(&mut session, monitor, original.clone());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Mosaic;
-	session.authoritative_frozen_capture_ready = true;
+
+	tests::set_session_frozen_export_ready_state(&mut session, true);
 
 	assert!(session.begin_frozen_mosaic_drag(GlobalPoint::new(1, 1)));
 	assert!(session.update_frozen_mosaic_drag_rect(GlobalPoint::new(4, 4)));
@@ -529,7 +549,8 @@ fn frozen_arrow_drag_commits_without_final_capture_and_round_trips_undo_redo() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_mosaic_source_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, test_mosaic_source_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Arrow;
@@ -569,7 +590,8 @@ fn frozen_spotlight_drag_clamps_preview_and_round_trips_undo_redo() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, test_mosaic_source_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, test_mosaic_source_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(2, 2, 4, 4));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Spotlight;
@@ -603,7 +625,8 @@ fn frozen_selection_drag_updates_capture_rect_and_toolbar_position() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -628,7 +651,8 @@ fn frozen_selection_drag_hides_auxiliary_windows_while_active() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -663,7 +687,8 @@ fn frozen_selection_drag_releases_scroll_preview_hide_after_drag_stops() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -686,7 +711,8 @@ fn frozen_selection_drag_defers_pending_toolbar_window_move() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -710,7 +736,8 @@ fn frozen_selection_drag_skips_toolbar_focus_even_before_first_show() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -753,7 +780,8 @@ fn frozen_selection_drag_does_not_rearm_initial_frontmost_restore() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -771,7 +799,8 @@ fn frozen_selection_resize_updates_capture_rect_and_toolbar_position() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1064,7 +1093,8 @@ fn frozen_selection_resize_preserves_handle_press_offset() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1081,7 +1111,8 @@ fn frozen_selection_drag_clamps_capture_rect_to_monitor_bounds() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1100,7 +1131,8 @@ fn frozen_selection_resize_clamps_to_minimum_size_and_monitor_bounds() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1119,7 +1151,8 @@ fn frozen_selection_rect_update_preserves_manual_toolbar_move() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1157,7 +1190,8 @@ fn cropped_frozen_capture_image_uses_moved_capture_rect() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, image);
+
+	tests::finish_frozen_display_state(&mut session, monitor, image);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(8, 6, 40, 32));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1187,7 +1221,8 @@ fn auto_center_frozen_capture_rect_recenters_detected_content() {
 	}
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, image);
+
+	tests::finish_frozen_display_state(&mut session, monitor, image);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1218,7 +1253,8 @@ fn auto_center_frozen_capture_rect_works_outside_pointer_mode() {
 	}
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, image);
+
+	tests::finish_frozen_display_state(&mut session, monitor, image);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1264,7 +1300,8 @@ fn frozen_selection_cursor_icon_uses_corner_resize_hover() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1812,7 +1849,8 @@ fn frozen_selection_cursor_icon_tracks_active_resize_drag() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1837,7 +1875,8 @@ fn frozen_selection_cursor_rects_use_native_handle_hover_and_full_window_resize_
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1883,7 +1922,8 @@ fn frozen_selection_cursor_rects_preserve_grabbing_cursor_during_move_drag() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1913,9 +1953,10 @@ fn frozen_mosaic_cursor_rects_preserve_crosshair_hover_and_drag() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
 
-	session.authoritative_frozen_capture_ready = true;
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+	tests::set_session_frozen_export_ready_state(&mut session, true);
+
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Mosaic;
@@ -1997,7 +2038,8 @@ fn frozen_selection_cursor_rects_match_resize_hit_test_for_tiny_overlapping_hand
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -2037,7 +2079,8 @@ fn frozen_selection_cursor_icon_tracks_active_move_drag() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -2075,7 +2118,12 @@ fn auto_center_frozen_capture_rect_noops_for_uniform_crop() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, RgbaImage::from_pixel(80, 60, Rgba([24, 24, 28, 255])));
+
+	tests::finish_frozen_display_state(
+		&mut session,
+		monitor,
+		RgbaImage::from_pixel(80, 60, Rgba([24, 24, 28, 255])),
+	);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -2125,15 +2173,16 @@ fn scroll_capture_and_export_wait_for_authoritative_frozen_capture() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
 
-	session.authoritative_frozen_capture_ready = true;
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+	tests::set_session_frozen_export_ready_state(&mut session, true);
+
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 
 	assert!(session.scroll_capture_selection_is_ready());
 
-	session.inflight_freeze_capture = Some(monitor);
+	tests::set_session_inflight_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.scroll_capture_selection_is_ready());
 
@@ -3413,7 +3462,8 @@ fn drag_region_toolbar_size_stays_stable_while_final_capture_readiness_changes()
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session.state.finish_freeze(monitor, tests::test_frozen_image());
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(120, 160, 320, 240));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -3427,7 +3477,7 @@ fn drag_region_toolbar_size_stays_stable_while_final_capture_readiness_changes()
 	assert!(pending_tools.contains(&FrozenToolbarTool::AutoCenter));
 	assert!(pending_tools.contains(&FrozenToolbarTool::Scroll));
 
-	session.authoritative_frozen_capture_ready = true;
+	tests::set_session_frozen_export_ready_state(&mut session, true);
 
 	session.sync_frozen_toolbar_state();
 

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -2,6 +2,9 @@
 use std::ptr;
 
 #[cfg(target_os = "macos")]
+use image::{Rgba, RgbaImage};
+
+#[cfg(target_os = "macos")]
 use crate::overlay::RectPoints;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::WorkerRequestSendError;
@@ -213,15 +216,16 @@ fn armed_freeze_capture_without_worker_restores_visibility_and_surfaces_error() 
 
 	session.state.begin_freeze(monitor);
 
-	session.pending_freeze_capture = Some(monitor);
-	session.pending_freeze_capture_armed = true;
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
+	tests::set_session_pending_freeze_capture_armed(&mut session, true);
+
 	session.capture_windows_hidden = true;
 
 	session.maybe_dispatch_armed_freeze_capture();
 
-	assert!(session.pending_freeze_capture.is_none());
-	assert!(session.inflight_freeze_capture.is_none());
-	assert!(!session.pending_freeze_capture_armed);
+	assert!(tests::session_pending_freeze_capture(&session).is_none());
+	assert!(tests::session_inflight_freeze_capture(&session).is_none());
+	assert!(!tests::session_frozen_capture_armed(&session));
 	assert!(!session.capture_windows_hidden);
 	assert_eq!(session.state.error_message.as_deref(), Some("Capture worker is unavailable."));
 }
@@ -246,8 +250,8 @@ fn begin_frozen_capture_background_snapshot_finishes_without_hiding_overlay_wind
 		Some(cursor),
 	);
 
-	assert!(session.pending_freeze_capture.is_none());
-	assert!(!session.pending_freeze_capture_armed);
+	assert!(tests::session_pending_freeze_capture(&session).is_none());
+	assert!(!tests::session_frozen_capture_armed(&session));
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_image.is_some());
 	assert!(session.state.frozen_export_image.is_some());
@@ -277,10 +281,10 @@ fn live_snapshot_followup_can_finish_background_capture_before_timeout() {
 
 	let _ = session.about_to_wait();
 
-	assert!(session.authoritative_frozen_capture_ready);
-	assert!(session.pending_freeze_capture.is_none());
-	assert!(session.inflight_freeze_capture.is_none());
-	assert!(!session.pending_freeze_capture_armed);
+	assert!(tests::session_frozen_export_ready_state(&session));
+	assert!(tests::session_pending_freeze_capture(&session).is_none());
+	assert!(tests::session_inflight_freeze_capture(&session).is_none());
+	assert!(!tests::session_frozen_capture_armed(&session));
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_image.is_some());
 }
@@ -311,9 +315,9 @@ fn window_matte_capture_seeds_preview_and_arms_worker_without_hiding_overlay_win
 		Some(cursor),
 	);
 
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert!(tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_image.is_some());
 	assert!(session.state.frozen_export_image.is_none());
@@ -346,9 +350,9 @@ fn window_matte_capture_dispatches_worker_without_hiding_overlay_windows() {
 	);
 	session.maybe_dispatch_armed_freeze_capture();
 
-	assert!(session.pending_freeze_capture.is_none());
-	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, Some(monitor));
+	assert!(tests::session_pending_freeze_capture(&session).is_none());
+	assert!(!tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_inflight_freeze_capture(&session), Some(monitor));
 	assert!(!session.capture_windows_hidden);
 }
 
@@ -390,14 +394,76 @@ fn window_matte_capture_miss_keeps_preview_and_surfaces_export_error() {
 	});
 
 	assert!(matches!(control, super::OverlayControl::Continue));
-	assert_eq!(session.pending_freeze_capture, None);
-	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.pending_window_freeze_capture, None);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), None);
+	assert!(!tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_pending_window_freeze_capture(&session), None);
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_export_image.is_none());
-	assert!(!session.frozen_export_ready);
+	assert!(!tests::session_frozen_export_ready_state(&session));
 	assert_eq!(session.state.frozen_image, preview_image);
+	assert_eq!(
+		session.state.error_message.as_deref(),
+		Some("Window capture is unavailable. Please try again.")
+	);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn stale_window_matte_response_after_export_failure_is_ignored() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+	let late_image = RgbaImage::from_pixel(8, 8, Rgba([77, 91, 103, 255]));
+
+	session.config.window_capture_alpha_mode = WindowCaptureAlphaMode::MatteDark;
+
+	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
+		monitor,
+		1,
+		1,
+		Instant::now(),
+	);
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
+		Some(WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 41,
+			rect: RectPoints::new(100, 140, 320, 240),
+		}),
+		Some(cursor),
+	);
+
+	let preview_image = session
+		.state
+		.frozen_image
+		.clone()
+		.expect("preview should be seeded before the matte export worker runs");
+
+	session.maybe_dispatch_armed_freeze_capture();
+
+	let _ = session.maybe_tick_worker_response_limiter(WorkerResponse::CapturedFreeze {
+		monitor,
+		image: tests::test_frozen_image(),
+		window_image: None,
+		captured_window_id: None,
+	});
+
+	assert!(session.state.frozen_export_image.is_none());
+	assert!(!tests::session_frozen_export_ready_state(&session));
+
+	let control = session.maybe_tick_worker_response_limiter(WorkerResponse::CapturedFreeze {
+		monitor,
+		image: late_image,
+		window_image: None,
+		captured_window_id: None,
+	});
+
+	assert!(matches!(control, super::OverlayControl::Continue));
+	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
+	assert!(session.state.frozen_export_image.is_none());
+	assert!(!tests::session_frozen_export_ready_state(&session));
 	assert_eq!(
 		session.state.error_message.as_deref(),
 		Some("Window capture is unavailable. Please try again.")
@@ -426,9 +492,9 @@ fn window_matte_capture_without_live_preview_aborts_after_timeout_without_hiding
 	);
 	session.maybe_dispatch_armed_freeze_capture();
 
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert!(tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_image.is_none());
 
@@ -440,9 +506,9 @@ fn window_matte_capture_without_live_preview_aborts_after_timeout_without_hiding
 
 	let _ = session.about_to_wait();
 
-	assert_eq!(session.pending_freeze_capture, None);
-	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), None);
+	assert!(!tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(!session.frozen_capture_redraw_pending());
 	assert_eq!(
@@ -465,9 +531,9 @@ fn background_capture_without_initial_snapshot_waits_for_live_stream_followup_wi
 		Some(cursor),
 	);
 
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert!(!tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_image.is_none());
 
@@ -480,8 +546,8 @@ fn background_capture_without_initial_snapshot_waits_for_live_stream_followup_wi
 
 	let _ = session.about_to_wait();
 
-	assert_eq!(session.pending_freeze_capture, None);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), None);
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_image.is_some());
 	assert!(session.state.frozen_export_image.is_some());
@@ -503,9 +569,9 @@ fn background_capture_without_live_snapshot_aborts_after_timeout_without_hiding(
 		Some(cursor),
 	);
 
-	assert_eq!(session.pending_freeze_capture, Some(monitor));
-	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+	assert!(!tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_image.is_none());
 
@@ -517,9 +583,9 @@ fn background_capture_without_live_snapshot_aborts_after_timeout_without_hiding(
 
 	let _ = session.about_to_wait();
 
-	assert_eq!(session.pending_freeze_capture, None);
-	assert!(!session.pending_freeze_capture_armed);
-	assert_eq!(session.inflight_freeze_capture, None);
+	assert_eq!(tests::session_pending_freeze_capture(&session), None);
+	assert!(!tests::session_frozen_capture_armed(&session));
+	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert_eq!(
 		session.state.error_message.as_deref(),
@@ -550,24 +616,25 @@ fn repeated_freeze_capture_send_full_aborts_and_restores_hidden_windows() {
 
 	session.state.begin_freeze(monitor);
 
-	session.pending_freeze_capture = Some(monitor);
-	session.pending_freeze_capture_armed = true;
+	tests::set_session_pending_freeze_capture(&mut session, Some(monitor));
+	tests::set_session_pending_freeze_capture_armed(&mut session, true);
+
 	session.capture_windows_hidden = true;
 
 	for _ in 0..FREEZE_CAPTURE_SEND_FULL_RETRY_LIMIT.saturating_sub(1) {
 		session.handle_freeze_capture_request_send_error(monitor, WorkerRequestSendError::Full);
 
-		assert_eq!(session.pending_freeze_capture, Some(monitor));
-		assert!(session.pending_freeze_capture_armed);
+		assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
+		assert!(tests::session_frozen_capture_armed(&session));
 		assert!(session.capture_windows_hidden);
 		assert!(session.state.error_message.is_none());
 	}
 
 	session.handle_freeze_capture_request_send_error(monitor, WorkerRequestSendError::Full);
 
-	assert!(session.pending_freeze_capture.is_none());
-	assert!(session.inflight_freeze_capture.is_none());
-	assert!(!session.pending_freeze_capture_armed);
+	assert!(tests::session_pending_freeze_capture(&session).is_none());
+	assert!(tests::session_inflight_freeze_capture(&session).is_none());
+	assert!(!tests::session_frozen_capture_armed(&session));
 	assert!(!session.capture_windows_hidden);
 	assert_eq!(session.freeze_capture_send_full_count, 0);
 	assert_eq!(
@@ -641,7 +708,7 @@ fn apply_self_capture_exception_window_ids_to_active_streams_defers_worker_refre
 	let monitor = tests::test_monitor();
 	let (mut session, original_worker_debug_id) = tests::configured_session_with_macos_worker();
 
-	session.inflight_freeze_capture = Some(monitor);
+	tests::set_session_inflight_freeze_capture(&mut session, Some(monitor));
 
 	session.apply_self_capture_exception_window_ids_to_active_streams();
 
@@ -701,7 +768,8 @@ fn captured_freeze_response_applies_deferred_worker_refresh() {
 	let monitor = tests::test_monitor();
 	let (mut session, original_worker_debug_id) = tests::configured_session_with_macos_worker();
 
-	session.inflight_freeze_capture = Some(monitor);
+	tests::set_session_inflight_freeze_capture(&mut session, Some(monitor));
+
 	session.pending_self_capture_exception_window_ids_worker_refresh = true;
 
 	let control = session.maybe_tick_worker_response_limiter(WorkerResponse::CapturedFreeze {
@@ -722,7 +790,8 @@ fn freeze_error_response_applies_deferred_worker_refresh() {
 	let monitor = tests::test_monitor();
 	let (mut session, original_worker_debug_id) = tests::configured_session_with_macos_worker();
 
-	session.inflight_freeze_capture = Some(monitor);
+	tests::set_session_inflight_freeze_capture(&mut session, Some(monitor));
+
 	session.pending_self_capture_exception_window_ids_worker_refresh = true;
 
 	let control = session.maybe_tick_worker_response_limiter(WorkerResponse::Error {

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -1,8 +1,9 @@
 use crate::overlay::{
-	Arc, CURSOR_POLL_INTERVAL_MIN, CapturedMonitorRegionResult, Duration, GlobalPoint, Instant,
-	LiveCaptureInteraction, LiveClickCaptureTarget, LiveCursorSample, LiveSampleApplyResult,
-	MonitorRect, OverlayControl, OverlayMode, OverlaySession, WindowFreezeCaptureTarget, WindowHit,
-	WindowListSnapshot, WorkerErrorSource, WorkerRequestSendError, WorkerResponse,
+	Arc, CURSOR_POLL_INTERVAL_MIN, CapturedMonitorRegionResult, Duration, FrozenCaptureWorkerState,
+	GlobalPoint, Instant, LiveCaptureInteraction, LiveClickCaptureTarget, LiveCursorSample,
+	LiveSampleApplyResult, MonitorRect, OverlayControl, OverlayMode, OverlaySession,
+	WindowFreezeCaptureTarget, WindowHit, WindowListSnapshot, WorkerErrorSource,
+	WorkerRequestSendError, WorkerResponse,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{CursorSampleRequest, FreezeCaptureTarget, mem};
@@ -62,11 +63,8 @@ impl OverlaySession {
 	}
 
 	fn clear_freeze_capture_tracking(&mut self) {
-		self.pending_freeze_capture = None;
-		self.inflight_freeze_capture = None;
-		self.pending_freeze_capture_armed = false;
-		self.pending_window_freeze_capture = None;
-		self.inflight_window_freeze_capture = None;
+		self.clear_frozen_capture_session_state();
+
 		self.freeze_capture_send_full_count = 0;
 	}
 
@@ -74,9 +72,25 @@ impl OverlaySession {
 		let message = message.into();
 
 		self.note_frozen_transition_aborted(message.as_str());
-		self.clear_freeze_capture_tracking();
+
+		if matches!(self.state.mode, OverlayMode::Frozen)
+			&& let Some(monitor) = self.frozen_capture_monitor()
+			&& self.state.monitor == Some(monitor)
+		{
+			self.set_frozen_capture_export_failed(monitor);
+		} else {
+			self.clear_freeze_capture_tracking();
+		}
+
+		self.freeze_capture_send_full_count = 0;
+
 		self.restore_capture_windows_visibility();
 		self.state.set_error(message);
+
+		self.toolbar_state.needs_redraw = true;
+
+		self.sync_frozen_toolbar_state();
+		self.request_redraw_toolbar_window();
 		self.request_redraw_all();
 	}
 
@@ -85,13 +99,15 @@ impl OverlaySession {
 		&mut self,
 		now: Instant,
 	) -> bool {
-		let Some(overlay_monitor) = self.pending_freeze_capture else {
+		let Some(overlay_monitor) =
+			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
+		else {
 			return false;
 		};
 
 		if !self.pending_freeze_capture_matches(overlay_monitor)
-			|| self.frozen_export_ready
-			|| self.inflight_freeze_capture.is_some()
+			|| self.frozen_capture_export_ready()
+			|| self.frozen_capture_worker_inflight()
 		{
 			return false;
 		}
@@ -122,11 +138,8 @@ impl OverlaySession {
 		overlay_monitor: MonitorRect,
 		pending_window_target: Option<WindowFreezeCaptureTarget>,
 	) {
-		self.pending_freeze_capture = None;
-		self.pending_freeze_capture_armed = false;
-		self.inflight_freeze_capture = Some(overlay_monitor);
-		self.inflight_window_freeze_capture = pending_window_target;
-		self.pending_window_freeze_capture = None;
+		self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Inflight);
+
 		self.freeze_capture_send_full_count = 0;
 
 		self.note_frozen_transition_worker_requested(overlay_monitor, pending_window_target);
@@ -169,31 +182,35 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	pub(super) fn maybe_dispatch_armed_freeze_capture(&mut self) {
-		if !self.pending_freeze_capture_armed {
+		if !self.frozen_capture_worker_armed() {
 			return;
 		}
 
-		let Some(overlay_monitor) = self.pending_freeze_capture else {
-			self.pending_freeze_capture_armed = false;
+		let Some(overlay_monitor) =
+			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
+		else {
+			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+
 			self.freeze_capture_send_full_count = 0;
 
 			return;
 		};
 
 		if !self.pending_freeze_capture_matches(overlay_monitor) {
-			self.pending_freeze_capture_armed = false;
+			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+
 			self.freeze_capture_send_full_count = 0;
 
 			return;
 		}
 
-		let pending_window_target =
-			self.pending_window_freeze_capture.filter(|target| target.monitor == overlay_monitor);
+		let pending_window_target = self.pending_window_freeze_capture_for_monitor(overlay_monitor);
 
 		if !self.capture_windows_hidden
 			&& self.snapshot_can_finish_frozen_capture(pending_window_target)
 		{
-			self.pending_freeze_capture_armed = false;
+			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+
 			self.freeze_capture_send_full_count = 0;
 
 			return;


### PR DESCRIPTION
## Summary
- replace pending/inflight/export-ready frozen capture flags with an explicit session state model
- migrate overlay and worker runtime transitions plus test helpers to the new display/export state flow
- ignore stale captured-freeze responses once export authority has already failed and cover it with regression tests

## Testing
- cargo make fmt-rust-check
- cargo make lint
- cargo test -p rsnap-overlay --lib