### PR TITLE
refactor: move macos frozen capture policy behind adapter boundary

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -8,6 +8,7 @@ mod cursor_context_runtime;
 mod cursor_runtime;
 mod frozen_arrow_runtime;
 mod frozen_brush_runtime;
+mod frozen_capture_backend_adapter;
 mod frozen_export_runtime;
 mod frozen_mosaic_runtime;
 mod frozen_selection_runtime;
@@ -185,13 +186,9 @@ use self::trace_recording::{
 #[cfg(target_os = "macos")]
 use crate::deferred_text_recognition::DeferredTextRecognitionRequest;
 #[cfg(target_os = "macos")]
-use crate::live_frame_stream_macos::{
-	CursorSampleRequest, MacLiveFrameStream, STREAM_REGION_FRAME_MAX_AGE,
-};
+use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
 use crate::scroll_capture::{self, ScrollDirection, ScrollObserveOutcome, ScrollSession};
 use crate::state::LiveCursorSample;
-#[cfg(target_os = "macos")]
-use crate::state::MonitorImageSnapshot;
 use crate::worker::CapturedMonitorRegionResult;
 use crate::{
 	state::{
@@ -1674,163 +1671,6 @@ impl OverlaySession {
 		}
 	}
 
-	#[cfg(target_os = "macos")]
-	fn snapshot_can_finish_frozen_capture(
-		&self,
-		window_target: Option<WindowFreezeCaptureTarget>,
-	) -> bool {
-		window_target.is_none()
-			|| self.config.window_capture_alpha_mode == WindowCaptureAlphaMode::Background
-	}
-
-	#[cfg(target_os = "macos")]
-	fn usable_frozen_capture_snapshot(
-		&self,
-		monitor: MonitorRect,
-		snapshot: Option<Arc<MonitorImageSnapshot>>,
-	) -> Option<(Arc<MonitorImageSnapshot>, u128)> {
-		let snapshot = snapshot.filter(|snapshot| snapshot.monitor == monitor)?;
-		let snapshot_age = snapshot.captured_at.elapsed();
-
-		if snapshot_age > STREAM_REGION_FRAME_MAX_AGE {
-			return None;
-		}
-
-		Some((snapshot, snapshot_age.as_millis()))
-	}
-
-	#[cfg(target_os = "macos")]
-	fn maybe_finish_frozen_capture_from_snapshot(
-		&mut self,
-		monitor: MonitorRect,
-		window_target: Option<WindowFreezeCaptureTarget>,
-		cursor: Option<GlobalPoint>,
-		snapshot: Option<Arc<MonitorImageSnapshot>>,
-		source: &'static str,
-	) -> bool {
-		if !self.snapshot_can_finish_frozen_capture(window_target) {
-			return false;
-		}
-
-		let Some((snapshot, snapshot_age_ms)) =
-			self.usable_frozen_capture_snapshot(monitor, snapshot)
-		else {
-			return false;
-		};
-		let snapshot_image = snapshot.image.as_ref().clone();
-		let export_image = snapshot_image.clone();
-		let restore_hidden_capture_windows = self.capture_windows_hidden;
-
-		self.commit_frozen_preview(monitor, snapshot_image, cursor);
-		self.note_frozen_transition_preview_committed(monitor, source, Some(snapshot_age_ms));
-		self.promote_frozen_capture_display_ready(monitor);
-		self.set_frozen_capture_export_ready(monitor);
-		self.state.commit_frozen_export_image(export_image);
-		self.note_frozen_transition_final_ready(
-			monitor,
-			source,
-			window_target.map(|target| target.window_id),
-		);
-
-		self.freeze_capture_send_full_count = 0;
-		self.frozen_window_image = None;
-		self.toolbar_state.needs_redraw = true;
-
-		if restore_hidden_capture_windows {
-			self.destroy_live_only_aux_windows();
-			self.restore_capture_windows_visibility();
-		} else {
-			self.capture_windows_hidden = false;
-		}
-
-		self.sync_frozen_toolbar_state();
-		self.request_redraw_for_monitor(monitor);
-		#[cfg(target_os = "macos")]
-		{
-			self.request_aux_window_creation_if_needed();
-			self.request_redraw_toolbar_window();
-		}
-
-		true
-	}
-
-	#[cfg(target_os = "macos")]
-	fn request_pending_frozen_capture_live_stream_refresh(&self, monitor: MonitorRect) {
-		let Some(stream) = self.live_sample_stream.as_ref() else {
-			return;
-		};
-		let after_frame_seq =
-			stream.latest_frame_frontier_for_monitor(monitor).map_or(0, |(frame_seq, _)| frame_seq);
-		let _ = stream.refresh_monitor_nonblocking_if_stale(monitor, after_frame_seq, true);
-	}
-
-	#[cfg(target_os = "macos")]
-	fn maybe_seed_frozen_capture_preview_from_snapshot(
-		&mut self,
-		monitor: MonitorRect,
-		cursor: Option<GlobalPoint>,
-		snapshot: Option<Arc<MonitorImageSnapshot>>,
-		source: &'static str,
-	) -> bool {
-		let Some((snapshot, snapshot_age_ms)) =
-			self.usable_frozen_capture_snapshot(monitor, snapshot)
-		else {
-			return false;
-		};
-		let snapshot_image = snapshot.image.as_ref().clone();
-
-		self.commit_frozen_preview(monitor, snapshot_image, cursor);
-		self.note_frozen_transition_preview_committed(monitor, source, Some(snapshot_age_ms));
-
-		self.toolbar_state.needs_redraw = true;
-
-		self.sync_frozen_toolbar_state();
-		self.request_redraw_for_monitor(monitor);
-		self.request_aux_window_creation_if_needed();
-		self.request_redraw_toolbar_window();
-
-		true
-	}
-
-	#[cfg(target_os = "macos")]
-	fn maybe_update_pending_frozen_capture_from_live_stream_snapshot(
-		&mut self,
-		monitor: MonitorRect,
-	) -> bool {
-		if !self.pending_freeze_capture_matches(monitor)
-			|| self.frozen_capture_export_ready()
-			|| self.frozen_capture_worker_inflight()
-		{
-			return false;
-		}
-
-		let window_target = self.pending_window_freeze_capture_for_monitor(monitor);
-		let snapshot = self
-			.live_sample_stream
-			.as_ref()
-			.and_then(|stream| stream.peek_latest_rgba_snapshot(monitor));
-
-		if self.snapshot_can_finish_frozen_capture(window_target) {
-			return self.maybe_finish_frozen_capture_from_snapshot(
-				monitor,
-				window_target,
-				self.state.cursor,
-				snapshot,
-				"live_stream_snapshot_followup",
-			);
-		}
-		if self.frozen_preview_visible() {
-			return false;
-		}
-
-		self.maybe_seed_frozen_capture_preview_from_snapshot(
-			monitor,
-			self.state.cursor,
-			snapshot,
-			"live_stream_snapshot_preview_followup",
-		)
-	}
-
 	fn seed_frozen_toolbar_default_position(
 		&mut self,
 		monitor: MonitorRect,
@@ -2050,68 +1890,6 @@ impl OverlaySession {
 		// started the asynchronous export-authority path. Otherwise the overlay can briefly present
 		// an empty black frozen frame before the real preview arrives.
 		self.refresh_frozen_helper_windows_for_transition(monitor);
-	}
-
-	#[cfg(target_os = "macos")]
-	fn begin_frozen_capture_with_rect_macos(
-		&mut self,
-		monitor: MonitorRect,
-		window_target: Option<WindowFreezeCaptureTarget>,
-		cursor: Option<GlobalPoint>,
-	) -> bool {
-		if let Some(cursor) = cursor {
-			self.update_cursor_state(monitor, cursor);
-		}
-
-		self.state.live_bg_monitor = None;
-		self.state.live_bg_image = None;
-		self.capture_windows_hidden = false;
-
-		let snapshot = self
-			.live_sample_stream
-			.as_ref()
-			.and_then(|stream| stream.peek_latest_rgba_snapshot(monitor));
-
-		if self.maybe_finish_frozen_capture_from_snapshot(
-			monitor,
-			window_target,
-			cursor,
-			snapshot.clone(),
-			"live_stream_snapshot_at_freeze_begin",
-		) {
-			return true;
-		}
-
-		let seeded_preview = self.maybe_seed_frozen_capture_preview_from_snapshot(
-			monitor,
-			cursor,
-			snapshot.clone(),
-			"live_stream_snapshot_preview_at_freeze_begin",
-		);
-		let arm_worker = window_target.is_some()
-			&& self.config.window_capture_alpha_mode != WindowCaptureAlphaMode::Background;
-
-		self.set_frozen_capture_worker_state(if arm_worker {
-			FrozenCaptureWorkerState::Armed
-		} else {
-			FrozenCaptureWorkerState::Idle
-		});
-		self.request_pending_frozen_capture_live_stream_refresh(monitor);
-		self.note_frozen_transition_preview_deferred(
-			monitor,
-			if seeded_preview {
-				"waiting_for_export_authority"
-			} else {
-				"waiting_for_live_stream_snapshot"
-			},
-			None,
-		);
-
-		if arm_worker {
-			self.note_frozen_transition_authoritative_handoff_armed(monitor);
-		}
-
-		false
 	}
 
 	#[cfg(not(target_os = "macos"))]

--- a/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
@@ -64,19 +64,10 @@ impl OverlaySession {
 		self.mark_progress(OverlayEventLoopPhase::AboutToWait);
 		self.maybe_clear_loupe_activation_after_focus_loss();
 		self.maybe_timeout_pending_click_hit_test(now);
-
 		#[cfg(target_os = "macos")]
 		{
-			if let Some(monitor) =
-				self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
-			{
-				let _ = self.maybe_update_pending_frozen_capture_from_live_stream_snapshot(monitor);
-				let _ = self.maybe_drive_pending_display_first_freeze_preview(now);
-			}
-
-			self.maybe_dispatch_armed_freeze_capture();
+			self.maybe_drive_macos_display_first_frozen_capture_backend(now);
 		}
-
 		self.maybe_request_keepalive_redraw();
 		self.maybe_keep_selection_flow_repaint();
 		self.maybe_keep_frozen_text_caret_repaint();

--- a/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
@@ -41,7 +41,6 @@ struct FrozenCaptureBackendUpdate {
 	display_candidate: Option<FrozenCaptureDisplayCandidate>,
 	signal: FrozenCaptureBackendSignal,
 }
-
 #[cfg(target_os = "macos")]
 impl FrozenCaptureBackendUpdate {
 	fn none() -> Self {
@@ -144,6 +143,7 @@ impl OverlaySession {
 		}
 
 		self.toolbar_state.needs_redraw = true;
+
 		self.sync_frozen_toolbar_state();
 		self.request_redraw_for_monitor(monitor);
 		self.request_aux_window_creation_if_needed();
@@ -287,6 +287,7 @@ impl OverlaySession {
 		if self.frozen_preview_visible() {
 			return FrozenCaptureBackendUpdate::none();
 		}
+
 		if let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
 			monitor,
 			window_target,
@@ -331,6 +332,7 @@ impl OverlaySession {
 			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
 		else {
 			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+
 			self.freeze_capture_send_full_count = 0;
 
 			return None;
@@ -338,6 +340,7 @@ impl OverlaySession {
 
 		if !self.pending_freeze_capture_matches(monitor) {
 			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+
 			self.freeze_capture_send_full_count = 0;
 
 			return None;
@@ -347,6 +350,7 @@ impl OverlaySession {
 
 		if !self.capture_windows_hidden && self.snapshot_can_finish_frozen_capture(window_target) {
 			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+
 			self.freeze_capture_send_full_count = 0;
 
 			return None;
@@ -373,8 +377,8 @@ impl OverlaySession {
 		else {
 			return;
 		};
-
 		let update = self.maybe_macos_pending_frozen_capture_backend_update(monitor, now);
+
 		self.apply_frozen_capture_backend_update(monitor, update);
 
 		let Some(monitor) =
@@ -404,6 +408,7 @@ impl OverlaySession {
 		if !self.snapshot_can_finish_frozen_capture(window_target) {
 			return false;
 		}
+
 		let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
 			monitor,
 			window_target,

--- a/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
@@ -1,0 +1,496 @@
+#[cfg(target_os = "macos")]
+use image::RgbaImage;
+
+#[cfg(target_os = "macos")]
+use crate::live_frame_stream_macos::STREAM_REGION_FRAME_MAX_AGE;
+#[cfg(target_os = "macos")]
+use crate::overlay::{
+	Arc, DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT, FreezeCaptureTarget, FrozenCaptureWorkerState,
+	GlobalPoint, Instant, MonitorRect, OverlaySession, WindowCaptureAlphaMode,
+	WindowFreezeCaptureTarget,
+};
+#[cfg(target_os = "macos")]
+use crate::state::MonitorImageSnapshot;
+
+#[cfg(target_os = "macos")]
+struct FrozenCaptureDisplayCandidate {
+	display_image: RgbaImage,
+	export_image: Option<RgbaImage>,
+	cursor: Option<GlobalPoint>,
+	source: &'static str,
+	snapshot_age_ms: u128,
+	captured_window_id: Option<u32>,
+}
+
+#[cfg(target_os = "macos")]
+struct FrozenCaptureBackendDispatch {
+	freeze_target: FreezeCaptureTarget,
+	window_target: Option<WindowFreezeCaptureTarget>,
+}
+
+#[cfg(target_os = "macos")]
+enum FrozenCaptureBackendSignal {
+	None,
+	Wait { reason: &'static str, arm_worker: bool },
+	Dispatch(FrozenCaptureBackendDispatch),
+	Abort { message: &'static str },
+}
+
+#[cfg(target_os = "macos")]
+struct FrozenCaptureBackendUpdate {
+	display_candidate: Option<FrozenCaptureDisplayCandidate>,
+	signal: FrozenCaptureBackendSignal,
+}
+
+#[cfg(target_os = "macos")]
+impl FrozenCaptureBackendUpdate {
+	fn none() -> Self {
+		Self { display_candidate: None, signal: FrozenCaptureBackendSignal::None }
+	}
+}
+
+#[cfg(target_os = "macos")]
+impl OverlaySession {
+	fn snapshot_can_finish_frozen_capture(
+		&self,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	) -> bool {
+		window_target.is_none()
+			|| self.config.window_capture_alpha_mode == WindowCaptureAlphaMode::Background
+	}
+
+	fn usable_frozen_capture_snapshot(
+		&self,
+		monitor: MonitorRect,
+		snapshot: Option<Arc<MonitorImageSnapshot>>,
+	) -> Option<(Arc<MonitorImageSnapshot>, u128)> {
+		let snapshot = snapshot.filter(|snapshot| snapshot.monitor == monitor)?;
+		let snapshot_age = snapshot.captured_at.elapsed();
+
+		if snapshot_age > STREAM_REGION_FRAME_MAX_AGE {
+			return None;
+		}
+
+		Some((snapshot, snapshot_age.as_millis()))
+	}
+
+	fn request_pending_frozen_capture_live_stream_refresh(&self, monitor: MonitorRect) {
+		let Some(stream) = self.live_sample_stream.as_ref() else {
+			return;
+		};
+		let after_frame_seq =
+			stream.latest_frame_frontier_for_monitor(monitor).map_or(0, |(frame_seq, _)| frame_seq);
+		let _ = stream.refresh_monitor_nonblocking_if_stale(monitor, after_frame_seq, true);
+	}
+
+	fn frozen_capture_display_candidate_from_snapshot(
+		&self,
+		monitor: MonitorRect,
+		window_target: Option<WindowFreezeCaptureTarget>,
+		cursor: Option<GlobalPoint>,
+		snapshot: Option<Arc<MonitorImageSnapshot>>,
+		source: &'static str,
+		export_ready: bool,
+	) -> Option<FrozenCaptureDisplayCandidate> {
+		let (snapshot, snapshot_age_ms) = self.usable_frozen_capture_snapshot(monitor, snapshot)?;
+		let display_image = snapshot.image.as_ref().clone();
+		let export_image = export_ready.then(|| display_image.clone());
+
+		Some(FrozenCaptureDisplayCandidate {
+			display_image,
+			export_image,
+			cursor,
+			source,
+			snapshot_age_ms,
+			captured_window_id: export_ready
+				.then(|| window_target.map(|target| target.window_id))
+				.flatten(),
+		})
+	}
+
+	fn apply_frozen_capture_display_candidate(
+		&mut self,
+		monitor: MonitorRect,
+		candidate: FrozenCaptureDisplayCandidate,
+	) {
+		let restore_hidden_capture_windows =
+			self.capture_windows_hidden && candidate.export_image.is_some();
+
+		self.commit_frozen_preview(monitor, candidate.display_image, candidate.cursor);
+		self.note_frozen_transition_preview_committed(
+			monitor,
+			candidate.source,
+			Some(candidate.snapshot_age_ms),
+		);
+
+		if let Some(export_image) = candidate.export_image {
+			self.set_frozen_capture_export_ready(monitor);
+			self.state.commit_frozen_export_image(export_image);
+			self.note_frozen_transition_final_ready(
+				monitor,
+				candidate.source,
+				candidate.captured_window_id,
+			);
+
+			self.freeze_capture_send_full_count = 0;
+			self.frozen_window_image = None;
+
+			if restore_hidden_capture_windows {
+				self.destroy_live_only_aux_windows();
+				self.restore_capture_windows_visibility();
+			} else {
+				self.capture_windows_hidden = false;
+			}
+		}
+
+		self.toolbar_state.needs_redraw = true;
+		self.sync_frozen_toolbar_state();
+		self.request_redraw_for_monitor(monitor);
+		self.request_aux_window_creation_if_needed();
+		self.request_redraw_toolbar_window();
+	}
+
+	fn apply_frozen_capture_backend_signal(
+		&mut self,
+		monitor: MonitorRect,
+		signal: FrozenCaptureBackendSignal,
+	) {
+		match signal {
+			FrozenCaptureBackendSignal::None => {},
+			FrozenCaptureBackendSignal::Wait { reason, arm_worker } => {
+				self.set_frozen_capture_worker_state(if arm_worker {
+					FrozenCaptureWorkerState::Armed
+				} else {
+					FrozenCaptureWorkerState::Idle
+				});
+				self.request_pending_frozen_capture_live_stream_refresh(monitor);
+				self.note_frozen_transition_preview_deferred(monitor, reason, None);
+
+				if arm_worker {
+					self.note_frozen_transition_authoritative_handoff_armed(monitor);
+				}
+			},
+			FrozenCaptureBackendSignal::Dispatch(dispatch) => {
+				let Some(worker) = &self.worker else {
+					self.abort_pending_freeze_capture("Capture worker is unavailable.");
+
+					return;
+				};
+
+				match worker.request_freeze_capture(monitor, dispatch.freeze_target) {
+					Ok(()) => {
+						self.note_freeze_capture_request_started(monitor, dispatch.window_target);
+					},
+					Err(err) => self.handle_freeze_capture_request_send_error(monitor, err),
+				}
+			},
+			FrozenCaptureBackendSignal::Abort { message } => {
+				self.abort_pending_freeze_capture(message);
+			},
+		}
+	}
+
+	fn apply_frozen_capture_backend_update(
+		&mut self,
+		monitor: MonitorRect,
+		update: FrozenCaptureBackendUpdate,
+	) {
+		if let Some(candidate) = update.display_candidate {
+			self.apply_frozen_capture_display_candidate(monitor, candidate);
+		}
+
+		self.apply_frozen_capture_backend_signal(monitor, update.signal);
+	}
+
+	fn macos_begin_frozen_capture_backend_update(
+		&self,
+		monitor: MonitorRect,
+		window_target: Option<WindowFreezeCaptureTarget>,
+		cursor: Option<GlobalPoint>,
+	) -> FrozenCaptureBackendUpdate {
+		let snapshot = self
+			.live_sample_stream
+			.as_ref()
+			.and_then(|stream| stream.peek_latest_rgba_snapshot(monitor));
+
+		if self.snapshot_can_finish_frozen_capture(window_target)
+			&& let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
+				monitor,
+				window_target,
+				cursor,
+				snapshot.clone(),
+				"live_stream_snapshot_at_freeze_begin",
+				true,
+			) {
+			return FrozenCaptureBackendUpdate {
+				display_candidate: Some(display_candidate),
+				signal: FrozenCaptureBackendSignal::None,
+			};
+		}
+
+		let display_candidate = self.frozen_capture_display_candidate_from_snapshot(
+			monitor,
+			window_target,
+			cursor,
+			snapshot,
+			"live_stream_snapshot_preview_at_freeze_begin",
+			false,
+		);
+		let arm_worker = window_target.is_some()
+			&& self.config.window_capture_alpha_mode != WindowCaptureAlphaMode::Background;
+		let reason = if display_candidate.is_some() {
+			"waiting_for_export_authority"
+		} else {
+			"waiting_for_live_stream_snapshot"
+		};
+
+		FrozenCaptureBackendUpdate {
+			display_candidate,
+			signal: FrozenCaptureBackendSignal::Wait { reason, arm_worker },
+		}
+	}
+
+	fn maybe_macos_pending_frozen_capture_backend_update(
+		&mut self,
+		monitor: MonitorRect,
+		now: Instant,
+	) -> FrozenCaptureBackendUpdate {
+		if !self.pending_freeze_capture_matches(monitor)
+			|| self.frozen_capture_export_ready()
+			|| self.frozen_capture_worker_inflight()
+		{
+			return FrozenCaptureBackendUpdate::none();
+		}
+
+		self.request_pending_frozen_capture_live_stream_refresh(monitor);
+
+		let window_target = self.pending_window_freeze_capture_for_monitor(monitor);
+		let snapshot = self
+			.live_sample_stream
+			.as_ref()
+			.and_then(|stream| stream.peek_latest_rgba_snapshot(monitor));
+
+		if self.snapshot_can_finish_frozen_capture(window_target)
+			&& let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
+				monitor,
+				window_target,
+				self.state.cursor,
+				snapshot.clone(),
+				"live_stream_snapshot_followup",
+				true,
+			) {
+			return FrozenCaptureBackendUpdate {
+				display_candidate: Some(display_candidate),
+				signal: FrozenCaptureBackendSignal::None,
+			};
+		}
+		if self.frozen_preview_visible() {
+			return FrozenCaptureBackendUpdate::none();
+		}
+		if let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
+			monitor,
+			window_target,
+			self.state.cursor,
+			snapshot,
+			"live_stream_snapshot_preview_followup",
+			false,
+		) {
+			return FrozenCaptureBackendUpdate {
+				display_candidate: Some(display_candidate),
+				signal: FrozenCaptureBackendSignal::None,
+			};
+		}
+
+		let Some(started_at) = self.frozen_transition_started_at else {
+			return FrozenCaptureBackendUpdate::none();
+		};
+		let Some(elapsed) = now.checked_duration_since(started_at) else {
+			return FrozenCaptureBackendUpdate::none();
+		};
+
+		if elapsed < DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT {
+			return FrozenCaptureBackendUpdate::none();
+		}
+
+		FrozenCaptureBackendUpdate {
+			display_candidate: None,
+			signal: FrozenCaptureBackendSignal::Abort {
+				message: "Unable to capture a clean preview. Please try again.",
+			},
+		}
+	}
+
+	fn maybe_macos_armed_frozen_capture_backend_dispatch(
+		&mut self,
+	) -> Option<FrozenCaptureBackendDispatch> {
+		if !self.frozen_capture_worker_armed() {
+			return None;
+		}
+
+		let Some(monitor) =
+			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
+		else {
+			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+			self.freeze_capture_send_full_count = 0;
+
+			return None;
+		};
+
+		if !self.pending_freeze_capture_matches(monitor) {
+			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+			self.freeze_capture_send_full_count = 0;
+
+			return None;
+		}
+
+		let window_target = self.pending_window_freeze_capture_for_monitor(monitor);
+
+		if !self.capture_windows_hidden && self.snapshot_can_finish_frozen_capture(window_target) {
+			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
+			self.freeze_capture_send_full_count = 0;
+
+			return None;
+		}
+		if !self.capture_windows_hidden
+			&& window_target.is_some()
+			&& !self.snapshot_can_finish_frozen_capture(window_target)
+			&& !self.frozen_preview_visible()
+		{
+			return None;
+		}
+
+		Some(FrozenCaptureBackendDispatch {
+			freeze_target: window_target.map_or(FreezeCaptureTarget::Monitor, |target| {
+				FreezeCaptureTarget::Window { window_id: target.window_id }
+			}),
+			window_target,
+		})
+	}
+
+	pub(super) fn maybe_drive_macos_display_first_frozen_capture_backend(&mut self, now: Instant) {
+		let Some(monitor) =
+			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
+		else {
+			return;
+		};
+
+		let update = self.maybe_macos_pending_frozen_capture_backend_update(monitor, now);
+		self.apply_frozen_capture_backend_update(monitor, update);
+
+		let Some(monitor) =
+			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
+		else {
+			return;
+		};
+		let Some(dispatch) = self.maybe_macos_armed_frozen_capture_backend_dispatch() else {
+			return;
+		};
+
+		self.apply_frozen_capture_backend_signal(
+			monitor,
+			FrozenCaptureBackendSignal::Dispatch(dispatch),
+		);
+	}
+
+	#[cfg(test)]
+	pub(super) fn maybe_finish_frozen_capture_from_snapshot(
+		&mut self,
+		monitor: MonitorRect,
+		window_target: Option<WindowFreezeCaptureTarget>,
+		cursor: Option<GlobalPoint>,
+		snapshot: Option<Arc<MonitorImageSnapshot>>,
+		source: &'static str,
+	) -> bool {
+		if !self.snapshot_can_finish_frozen_capture(window_target) {
+			return false;
+		}
+		let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
+			monitor,
+			window_target,
+			cursor,
+			snapshot,
+			source,
+			true,
+		) else {
+			return false;
+		};
+
+		self.apply_frozen_capture_backend_update(
+			monitor,
+			FrozenCaptureBackendUpdate {
+				display_candidate: Some(display_candidate),
+				signal: FrozenCaptureBackendSignal::None,
+			},
+		);
+
+		true
+	}
+
+	#[cfg(test)]
+	pub(super) fn maybe_seed_frozen_capture_preview_from_snapshot(
+		&mut self,
+		monitor: MonitorRect,
+		cursor: Option<GlobalPoint>,
+		snapshot: Option<Arc<MonitorImageSnapshot>>,
+		source: &'static str,
+	) -> bool {
+		let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
+			monitor, None, cursor, snapshot, source, false,
+		) else {
+			return false;
+		};
+
+		self.apply_frozen_capture_backend_update(
+			monitor,
+			FrozenCaptureBackendUpdate {
+				display_candidate: Some(display_candidate),
+				signal: FrozenCaptureBackendSignal::None,
+			},
+		);
+
+		true
+	}
+
+	#[cfg(test)]
+	pub(super) fn maybe_dispatch_armed_freeze_capture(&mut self) {
+		let Some(dispatch) = self.maybe_macos_armed_frozen_capture_backend_dispatch() else {
+			return;
+		};
+		let Some(monitor) =
+			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
+		else {
+			return;
+		};
+
+		self.apply_frozen_capture_backend_signal(
+			monitor,
+			FrozenCaptureBackendSignal::Dispatch(dispatch),
+		);
+	}
+
+	pub(super) fn begin_frozen_capture_with_rect_macos(
+		&mut self,
+		monitor: MonitorRect,
+		window_target: Option<WindowFreezeCaptureTarget>,
+		cursor: Option<GlobalPoint>,
+	) -> bool {
+		if let Some(cursor) = cursor {
+			self.update_cursor_state(monitor, cursor);
+		}
+
+		self.state.live_bg_monitor = None;
+		self.state.live_bg_image = None;
+		self.capture_windows_hidden = false;
+
+		let update = self.macos_begin_frozen_capture_backend_update(monitor, window_target, cursor);
+		let finished = update
+			.display_candidate
+			.as_ref()
+			.and_then(|candidate| candidate.export_image.as_ref())
+			.is_some();
+
+		self.apply_frozen_capture_backend_update(monitor, update);
+
+		finished
+	}
+}

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -6,7 +6,7 @@ use crate::overlay::{
 	WorkerRequestSendError, WorkerResponse,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{CursorSampleRequest, FreezeCaptureTarget, mem};
+use crate::overlay::{CursorSampleRequest, mem};
 
 pub(super) const FREEZE_CAPTURE_SEND_FULL_RETRY_LIMIT: u64 = 8;
 
@@ -94,45 +94,6 @@ impl OverlaySession {
 		self.request_redraw_all();
 	}
 
-	#[cfg(target_os = "macos")]
-	pub(super) fn maybe_drive_pending_display_first_freeze_preview(
-		&mut self,
-		now: Instant,
-	) -> bool {
-		let Some(overlay_monitor) =
-			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
-		else {
-			return false;
-		};
-
-		if !self.pending_freeze_capture_matches(overlay_monitor)
-			|| self.frozen_capture_export_ready()
-			|| self.frozen_capture_worker_inflight()
-		{
-			return false;
-		}
-		if self.frozen_preview_visible() {
-			return false;
-		}
-
-		self.request_pending_frozen_capture_live_stream_refresh(overlay_monitor);
-
-		let Some(started_at) = self.frozen_transition_started_at else {
-			return false;
-		};
-		let Some(elapsed) = now.checked_duration_since(started_at) else {
-			return false;
-		};
-
-		if elapsed < crate::overlay::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT {
-			return false;
-		}
-
-		self.abort_pending_freeze_capture("Unable to capture a clean preview. Please try again.");
-
-		true
-	}
-
 	pub(super) fn note_freeze_capture_request_started(
 		&mut self,
 		overlay_monitor: MonitorRect,
@@ -177,66 +138,6 @@ impl OverlaySession {
 
 				self.abort_pending_freeze_capture("Capture worker is unavailable.");
 			},
-		}
-	}
-
-	#[cfg(target_os = "macos")]
-	pub(super) fn maybe_dispatch_armed_freeze_capture(&mut self) {
-		if !self.frozen_capture_worker_armed() {
-			return;
-		}
-
-		let Some(overlay_monitor) =
-			self.frozen_capture_monitor().filter(|_| self.frozen_capture_export_pending())
-		else {
-			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
-
-			self.freeze_capture_send_full_count = 0;
-
-			return;
-		};
-
-		if !self.pending_freeze_capture_matches(overlay_monitor) {
-			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
-
-			self.freeze_capture_send_full_count = 0;
-
-			return;
-		}
-
-		let pending_window_target = self.pending_window_freeze_capture_for_monitor(overlay_monitor);
-
-		if !self.capture_windows_hidden
-			&& self.snapshot_can_finish_frozen_capture(pending_window_target)
-		{
-			self.set_frozen_capture_worker_state(FrozenCaptureWorkerState::Idle);
-
-			self.freeze_capture_send_full_count = 0;
-
-			return;
-		}
-		if !self.capture_windows_hidden
-			&& pending_window_target.is_some()
-			&& !self.snapshot_can_finish_frozen_capture(pending_window_target)
-			&& !self.frozen_preview_visible()
-		{
-			return;
-		}
-
-		let freeze_target = pending_window_target.map_or(FreezeCaptureTarget::Monitor, |target| {
-			FreezeCaptureTarget::Window { window_id: target.window_id }
-		});
-		let Some(worker) = &self.worker else {
-			self.abort_pending_freeze_capture("Capture worker is unavailable.");
-
-			return;
-		};
-
-		match worker.request_freeze_capture(overlay_monitor, freeze_target) {
-			Ok(()) => {
-				self.note_freeze_capture_request_started(overlay_monitor, pending_window_target);
-			},
-			Err(err) => self.handle_freeze_capture_request_send_error(overlay_monitor, err),
 		}
 	}
 


### PR DESCRIPTION
## Summary
- move macOS display-first frozen capture policy into a dedicated backend adapter module
- keep overlay event-loop orchestration and worker runtime on generic session concerns
- preserve existing frozen preview/export behavior behind adapter-owned update and dispatch signals

## Testing
- cargo make fmt-rust-check
- cargo make lint
- cargo test -p rsnap-overlay --lib

Refs XY-270