### PR TITLE
refactor: retire legacy frozen image semantics

### DIFF
--- a/packages/rsnap-overlay/src/deferred_text_recognition.rs
+++ b/packages/rsnap-overlay/src/deferred_text_recognition.rs
@@ -27,16 +27,16 @@ const PUBLISH_GATE_PENDING_POLL_INTERVAL: Duration = Duration::from_millis(5);
 #[derive(Debug)]
 pub(crate) enum DeferredTextRecognitionImageSource {
 	Prepared { image: RgbaImage },
-	FrozenCrop { frozen_image: RgbaImage, crop_rect: Option<RectPoints> },
+	FrozenCrop { export_image: RgbaImage, crop_rect: Option<RectPoints> },
 }
 #[cfg(target_os = "macos")]
 impl DeferredTextRecognitionImageSource {
 	fn image_dimensions(&self) -> (u32, u32) {
 		match self {
 			Self::Prepared { image } => image.dimensions(),
-			Self::FrozenCrop { frozen_image, crop_rect } => crop_rect
+			Self::FrozenCrop { export_image, crop_rect } => crop_rect
 				.map(|crop_rect| (crop_rect.width, crop_rect.height))
-				.unwrap_or_else(|| frozen_image.dimensions()),
+				.unwrap_or_else(|| export_image.dimensions()),
 		}
 	}
 
@@ -44,8 +44,8 @@ impl DeferredTextRecognitionImageSource {
 	fn export_image(&self) -> Option<RgbaImage> {
 		match self {
 			Self::Prepared { image } => Some(image.clone()),
-			Self::FrozenCrop { frozen_image, crop_rect } => {
-				export_image_from_frozen_crop(frozen_image, *crop_rect)
+			Self::FrozenCrop { export_image, crop_rect } => {
+				export_image_from_frozen_crop(export_image, *crop_rect)
 			},
 		}
 	}
@@ -53,8 +53,8 @@ impl DeferredTextRecognitionImageSource {
 	fn into_export_image(self) -> Option<RgbaImage> {
 		match self {
 			Self::Prepared { image } => Some(image),
-			Self::FrozenCrop { frozen_image, crop_rect } => {
-				export_image_from_frozen_crop(&frozen_image, crop_rect)
+			Self::FrozenCrop { export_image, crop_rect } => {
+				export_image_from_frozen_crop(&export_image, crop_rect)
 			},
 		}
 	}
@@ -99,14 +99,14 @@ impl DeferredTextRecognitionRequest {
 	pub(crate) fn frozen_crop(
 		request_id: u64,
 		requested_at: Instant,
-		frozen_image: RgbaImage,
+		export_image: RgbaImage,
 		crop_rect: Option<RectPoints>,
 	) -> Self {
 		Self {
 			request_id,
 			requested_at,
 			image_source: DeferredTextRecognitionImageSource::FrozenCrop {
-				frozen_image,
+				export_image,
 				crop_rect,
 			},
 		}
@@ -499,7 +499,7 @@ fn outcome(
 
 #[cfg(target_os = "macos")]
 fn export_image_from_frozen_crop(
-	frozen_image: &RgbaImage,
+	export_image: &RgbaImage,
 	crop_rect: Option<RectPoints>,
 ) -> Option<RgbaImage> {
 	match crop_rect {
@@ -510,7 +510,7 @@ fn export_image_from_frozen_crop(
 
 			Some(
 				imageops::crop_imm(
-					frozen_image,
+					export_image,
 					crop_rect.x,
 					crop_rect.y,
 					crop_rect.width,
@@ -519,7 +519,7 @@ fn export_image_from_frozen_crop(
 				.to_image(),
 			)
 		},
-		None => Some(frozen_image.clone()),
+		None => Some(export_image.clone()),
 	}
 }
 
@@ -578,7 +578,7 @@ mod tests {
 			request_id: 7,
 			requested_at: Instant::now(),
 			image_source: DeferredTextRecognitionImageSource::FrozenCrop {
-				frozen_image: image,
+				export_image: image,
 				crop_rect: Some(RectPoints::new(2, 1, 2, 2)),
 			},
 		};

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1268,7 +1268,7 @@ impl OverlaySession {
 			&& matches!(
 				self.frozen_capture_session_state,
 				FrozenCaptureSessionState::DisplayReady { .. }
-			) && self.state.frozen_surface_image().is_some()
+			) && self.state.frozen_display_surface_image().is_some()
 	}
 
 	fn frozen_display_ready_for_monitor(&self, monitor: MonitorRect) -> bool {
@@ -1906,7 +1906,7 @@ impl OverlaySession {
 		{
 			self.state.live_bg_monitor = None;
 
-			self.state.finish_freeze(monitor, image);
+			self.state.commit_frozen_final_image(monitor, image);
 			self.note_frozen_transition_preview_committed(monitor, "cached_live_background", None);
 			self.promote_frozen_capture_display_ready(monitor);
 			self.set_frozen_capture_export_ready(monitor);
@@ -1934,11 +1934,11 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		capture_rect_pixels: RectPoints,
 	) -> Option<RgbaImage> {
-		let frozen_image = self.state.frozen_export_image.as_ref()?;
-		let x = capture_rect_pixels.x.min(frozen_image.width());
-		let y = capture_rect_pixels.y.min(frozen_image.height());
-		let max_width = frozen_image.width().saturating_sub(x);
-		let max_height = frozen_image.height().saturating_sub(y);
+		let export_image = self.state.frozen_export_image.as_ref()?;
+		let x = capture_rect_pixels.x.min(export_image.width());
+		let y = capture_rect_pixels.y.min(export_image.height());
+		let max_width = export_image.width().saturating_sub(x);
+		let max_height = export_image.height().saturating_sub(y);
 		let width = capture_rect_pixels.width.min(max_width);
 		let height = capture_rect_pixels.height.min(max_height);
 
@@ -1946,13 +1946,13 @@ impl OverlaySession {
 			tracing::debug!(
 				monitor_id = monitor.id,
 				capture_rect_pixels = ?capture_rect_pixels,
-				frozen_image_size = ?(frozen_image.width(), frozen_image.height()),
+				export_image_size = ?(export_image.width(), export_image.height()),
 				"Scroll capture base-frame crop resolved to an empty region."
 			);
 
 			None
 		} else {
-			Some(imageops::crop_imm(frozen_image, x, y, width, height).to_image())
+			Some(imageops::crop_imm(export_image, x, y, width, height).to_image())
 		}
 	}
 
@@ -2224,7 +2224,7 @@ impl OverlaySession {
 			WindowCaptureAlphaMode::Background => base_image,
 			WindowCaptureAlphaMode::MatteLight | WindowCaptureAlphaMode::MatteDark => {
 				let base_image = if had_display_image {
-					self.state.frozen_image.clone().unwrap_or(base_image)
+					self.state.frozen_display_image.clone().unwrap_or(base_image)
 				} else {
 					base_image
 				};
@@ -2613,19 +2613,19 @@ impl OverlaySession {
 		}
 
 		let crop_rect = self.deferred_text_recognition_crop_rect_pixels()?;
-		let frozen_image = self.state.frozen_export_image.take()?;
+		let export_image = self.state.frozen_export_image.take()?;
 
 		Some(DeferredTextRecognitionRequest::frozen_crop(
 			request_id,
 			requested_at,
-			frozen_image,
+			export_image,
 			crop_rect,
 		))
 	}
 
 	#[cfg(target_os = "macos")]
 	fn deferred_text_recognition_crop_rect_pixels(&self) -> Option<Option<RectPoints>> {
-		let frozen_image = self.state.frozen_export_image.as_ref()?;
+		let export_image = self.state.frozen_export_image.as_ref()?;
 		let Some(monitor) = self.state.monitor else {
 			return Some(None);
 		};
@@ -2634,17 +2634,17 @@ impl OverlaySession {
 			.frozen_capture_rect
 			.unwrap_or_else(|| RectPoints::new(0, 0, monitor.width, monitor.height));
 		let capture_rect = monitor.local_rect_to_pixels(capture_rect);
-		let x = capture_rect.x.min(frozen_image.width());
-		let y = capture_rect.y.min(frozen_image.height());
-		let max_width = frozen_image.width().saturating_sub(x);
-		let max_height = frozen_image.height().saturating_sub(y);
+		let x = capture_rect.x.min(export_image.width());
+		let y = capture_rect.y.min(export_image.height());
+		let max_width = export_image.width().saturating_sub(x);
+		let max_height = export_image.height().saturating_sub(y);
 		let width = capture_rect.width.min(max_width);
 		let height = capture_rect.height.min(max_height);
 
 		if width == 0 || height == 0 {
 			return None;
 		}
-		if x == 0 && y == 0 && width == frozen_image.width() && height == frozen_image.height() {
+		if x == 0 && y == 0 && width == export_image.width() && height == export_image.height() {
 			return Some(None);
 		}
 

--- a/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
@@ -24,26 +24,26 @@ impl OverlaySession {
 			}
 		}
 
-		let frozen_image = self.state.frozen_export_image.as_ref()?;
+		let export_image = self.state.frozen_export_image.as_ref()?;
 		let Some(monitor) = self.state.monitor else {
-			return Some(frozen_image.clone());
+			return Some(export_image.clone());
 		};
 		let capture_rect = self
 			.state
 			.frozen_capture_rect
 			.unwrap_or_else(|| RectPoints::new(0, 0, monitor.width, monitor.height));
 		let capture_rect = monitor.local_rect_to_pixels(capture_rect);
-		let x = capture_rect.x.min(frozen_image.width());
-		let y = capture_rect.y.min(frozen_image.height());
-		let max_width = frozen_image.width().saturating_sub(x);
-		let max_height = frozen_image.height().saturating_sub(y);
+		let x = capture_rect.x.min(export_image.width());
+		let y = capture_rect.y.min(export_image.height());
+		let max_width = export_image.width().saturating_sub(x);
+		let max_height = export_image.height().saturating_sub(y);
 		let width = capture_rect.width.min(max_width);
 		let height = capture_rect.height.min(max_height);
 
 		if width == 0 || height == 0 {
 			None
 		} else {
-			Some(imageops::crop_imm(frozen_image, x, y, width, height).to_image())
+			Some(imageops::crop_imm(export_image, x, y, width, height).to_image())
 		}
 	}
 

--- a/packages/rsnap-overlay/src/overlay/frozen_mosaic_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_mosaic_runtime.rs
@@ -142,7 +142,7 @@ impl OverlaySession {
 		let preview_rect_px = monitor.local_rect_to_pixels(rect_points);
 		let Some(preview_patch) = self
 			.state
-			.frozen_image
+			.frozen_display_image
 			.as_ref()
 			.and_then(|image| Self::build_frozen_image_patch(image, preview_rect_px))
 		else {
@@ -168,7 +168,7 @@ impl OverlaySession {
 			_ => None,
 		};
 
-		if let Some(image) = self.state.frozen_image.as_mut() {
+		if let Some(image) = self.state.frozen_display_image.as_mut() {
 			Self::apply_frozen_image_patch(image, &preview_patch, true);
 		}
 		if let Some(image) = self.state.frozen_export_image.as_mut() {
@@ -196,7 +196,7 @@ impl OverlaySession {
 			return false;
 		};
 
-		if let Some(image) = self.state.frozen_image.as_mut() {
+		if let Some(image) = self.state.frozen_display_image.as_mut() {
 			Self::apply_frozen_image_patch(image, &edit.preview_patch, use_after);
 		}
 		if let Some(image) = self.state.frozen_export_image.as_mut() {

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -1482,7 +1482,7 @@ impl WindowRenderer {
 
 		let draw_frozen_bg = hud_cfg.needs_frozen_surface_bg
 			&& state.monitor == Some(monitor)
-			&& state.frozen_surface_image().is_some();
+			&& state.frozen_display_surface_image().is_some();
 
 		self.finish_window_renderer_draw(
 			gpu,

--- a/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
@@ -36,7 +36,7 @@ impl WindowRenderer {
 					screen_size_points = ?screen_size_points,
 					flip_y = false,
 					frozen_generation = state.frozen_generation,
-					frozen_image_ready = state.frozen_image.is_some(),
+					display_image_ready = state.frozen_display_image.is_some(),
 					toolbar_active,
 					"Frozen frame metrics."
 				);
@@ -396,7 +396,7 @@ impl WindowRenderer {
 				(state.live_bg_generation, state.live_bg_image.as_ref())
 			},
 			OverlayMode::Frozen if state.monitor == Some(monitor) => {
-				(state.frozen_generation, state.frozen_surface_image())
+				(state.frozen_generation, state.frozen_display_surface_image())
 			},
 			OverlayMode::Live => {
 				self.hud_bg = None;

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -257,7 +257,7 @@ fn session_frozen_capture_armed(session: &OverlaySession) -> bool {
 	)
 }
 
-fn session_frozen_export_ready_state(session: &OverlaySession) -> bool {
+fn session_export_authority_ready(session: &OverlaySession) -> bool {
 	matches!(
 		session.frozen_capture_session_state,
 		FrozenCaptureSessionState::DisplayReady { export: FrozenExportSessionState::Ready, .. }
@@ -277,7 +277,7 @@ fn set_session_frozen_capture_state(
 	};
 	let display_ready = matches!(session.state.mode, OverlayMode::Frozen)
 		&& session.state.monitor == Some(monitor)
-		&& session.state.frozen_surface_image().is_some();
+		&& session.state.frozen_display_surface_image().is_some();
 
 	session.frozen_capture_session_state = if display_ready {
 		FrozenCaptureSessionState::DisplayReady {
@@ -361,32 +361,24 @@ fn set_session_pending_freeze_capture_armed(session: &mut OverlaySession, armed:
 	set_session_frozen_capture_state(session, monitor, worker_state, window_target);
 }
 
-fn set_session_frozen_export_ready_state(session: &mut OverlaySession, ready: bool) {
-	if ready {
-		let monitor = session
-			.state
-			.monitor
-			.or_else(|| session_pending_freeze_capture(session))
-			.or_else(|| session_inflight_freeze_capture(session))
-			.unwrap_or_else(test_monitor);
-
-		session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
-			monitor,
-			export: FrozenExportSessionState::Ready,
-		};
-	} else if let Some(monitor) = session
+fn promote_session_export_authority_ready(session: &mut OverlaySession) {
+	let monitor = session
 		.state
 		.monitor
 		.or_else(|| session_pending_freeze_capture(session))
 		.or_else(|| session_inflight_freeze_capture(session))
+		.unwrap_or_else(test_monitor);
+
+	if session.state.frozen_export_image.is_none()
+		&& let Some(display_image) = session.state.frozen_display_image.clone()
 	{
-		session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
-			monitor,
-			export: FrozenExportSessionState::Failed,
-		};
-	} else {
-		session.frozen_capture_session_state = FrozenCaptureSessionState::Inactive;
+		session.state.commit_frozen_export_image(display_image);
 	}
+
+	session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
+		monitor,
+		export: FrozenExportSessionState::Ready,
+	};
 }
 
 fn finish_frozen_display_state(
@@ -394,7 +386,7 @@ fn finish_frozen_display_state(
 	monitor: MonitorRect,
 	image: image::RgbaImage,
 ) {
-	session.state.finish_freeze(monitor, image);
+	session.state.commit_frozen_display_image(monitor, image);
 
 	session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
 		monitor,
@@ -402,6 +394,19 @@ fn finish_frozen_display_state(
 			worker_state: FrozenCaptureWorkerState::Idle,
 			window_target: None,
 		},
+	};
+}
+
+fn finish_frozen_ready_state(
+	session: &mut OverlaySession,
+	monitor: MonitorRect,
+	image: image::RgbaImage,
+) {
+	session.state.commit_frozen_final_image(monitor, image);
+
+	session.frozen_capture_session_state = FrozenCaptureSessionState::DisplayReady {
+		monitor,
+		export: FrozenExportSessionState::Ready,
 	};
 }
 
@@ -624,7 +629,7 @@ fn seed_ready_scroll_capture_selection(session: &mut OverlaySession) {
 	session.state.frozen_capture_rect = Some(RectPoints::new(1, 1, 4, 4));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 
-	set_session_frozen_export_ready_state(session, true);
+	promote_session_export_authority_ready(session);
 }
 
 #[test]
@@ -644,7 +649,7 @@ fn begin_png_action_copies_preview_render_image_during_active_scroll_capture() {
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.scroll_capture.active = true;
 	session.scroll_capture.session = Some(scroll_session);
@@ -664,13 +669,14 @@ fn current_export_image_includes_frozen_brush_strokes() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session
-		.state
-		.finish_freeze(monitor, image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])));
+	session.state.commit_frozen_final_image(
+		monitor,
+		image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])),
+	);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
@@ -693,13 +699,14 @@ fn current_export_image_uses_selected_brush_color() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session
-		.state
-		.finish_freeze(monitor, image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])));
+	session.state.commit_frozen_final_image(
+		monitor,
+		image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])),
+	);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 	session.toolbar_state.brush_style.color = FrozenAnnotationColor::Green;
@@ -721,13 +728,14 @@ fn frozen_brush_undo_and_redo_update_export_image() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session
-		.state
-		.finish_freeze(monitor, image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])));
+	session.state.commit_frozen_final_image(
+		monitor,
+		image::RgbaImage::from_pixel(8, 8, Rgba([12, 34, 56, 255])),
+	);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
@@ -764,7 +772,7 @@ fn current_export_image_antialiases_frozen_brush_edges() {
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 16, 16));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
@@ -1204,7 +1212,7 @@ fn begin_ocr_action_exits_with_deferred_request_and_clears_stale_png_output_inte
 		Some(RectPoints::new(0, 0, expected_export.width(), expected_export.height()));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.begin_png_action(PngAction::Copy);
 
@@ -1240,7 +1248,7 @@ fn begin_ocr_action_drag_region_still_uses_frozen_image_under_matte_mode() {
 		Some(RectPoints::new(0, 0, expected_export.width(), expected_export.height()));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	let control = session.begin_ocr_action();
 	let OverlayControl::Exit(OverlayExit::DeferredTextRecognition(request)) = control else {
@@ -1266,9 +1274,9 @@ fn authoritative_freeze_response_updates_export_authority_without_overwriting_di
 
 	session.handle_captured_freeze_response(monitor, authoritative_image.clone(), None, None);
 
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&preview_image));
 	assert_eq!(session.state.frozen_export_image.as_ref(), Some(&authoritative_image));
-	assert!(session_frozen_export_ready_state(&session));
+	assert!(session_export_authority_ready(&session));
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -1345,15 +1353,15 @@ fn window_matte_mosaic_export_and_ocr_match_preview_pixels() {
 		Some(window_id),
 	);
 
-	assert!(session_frozen_export_ready_state(&session));
+	assert!(session_export_authority_ready(&session));
 	assert!(session.apply_frozen_mosaic_edit(capture_rect));
 
 	let expected_export = imageops::crop_imm(
 		session
 			.state
-			.frozen_image
+			.frozen_display_image
 			.as_ref()
-			.expect("window matte preview should populate the frozen image"),
+			.expect("window matte preview should populate the frozen display image"),
 		capture_rect.x,
 		capture_rect.y,
 		capture_rect.width,
@@ -1386,12 +1394,12 @@ fn begin_ocr_action_skips_deferred_request_when_drag_region_crop_is_out_of_bound
 	session.state.frozen_capture_rect = Some(RectPoints::new(monitor.width + 10, 20, 100, 80));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	let control = session.begin_ocr_action();
 
 	assert!(matches!(control, OverlayControl::Continue));
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&frozen_image));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&frozen_image));
 	assert!(session.state.error_message.is_none());
 }
 
@@ -1413,7 +1421,7 @@ fn begin_ocr_action_uses_scroll_capture_export_image_in_deferred_request() {
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.scroll_capture.active = true;
 	session.scroll_capture.session = Some(scroll_session);
@@ -2335,7 +2343,7 @@ fn finish_frozen_brush_stroke_commits_current_toolbar_brush_style() {
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 	session.toolbar_state.brush_style.stroke_width_points = 4.25;
@@ -2381,7 +2389,7 @@ fn inline_toolbar_mode_switch_finishes_active_frozen_text_edit() {
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
 
@@ -2409,7 +2417,7 @@ fn inline_toolbar_mode_switch_commits_active_ime_preedit_text() {
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
 
@@ -2463,7 +2471,7 @@ fn current_export_image_renders_frozen_text_annotations() {
 
 	session.state.begin_freeze(monitor);
 
-	finish_frozen_display_state(&mut session, monitor, base);
+	finish_frozen_ready_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(10, 12, 120, 80));
 
@@ -2488,7 +2496,7 @@ fn current_export_image_applies_frozen_spotlight_outside_selection() {
 
 	session.state.begin_freeze(monitor);
 
-	finish_frozen_display_state(&mut session, monitor, base);
+	finish_frozen_ready_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
@@ -2532,7 +2540,7 @@ fn current_export_image_applies_multiple_frozen_spotlights_without_extra_darkeni
 
 	session.state.begin_freeze(monitor);
 
-	finish_frozen_display_state(&mut session, monitor, base);
+	finish_frozen_ready_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
@@ -2565,7 +2573,7 @@ fn current_export_image_renders_frozen_arrow_after_spotlight_scrim() {
 
 	session.state.begin_freeze(monitor);
 
-	finish_frozen_display_state(&mut session, monitor, base);
+	finish_frozen_ready_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
@@ -2596,7 +2604,7 @@ fn current_export_image_renders_frozen_arrow_outline_without_tinting() {
 
 	session.state.begin_freeze(monitor);
 
-	finish_frozen_display_state(&mut session, monitor, base);
+	finish_frozen_ready_state(&mut session, monitor, base);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 32, 32));
 
@@ -2663,13 +2671,14 @@ fn frozen_committed_overlay_iteration_preserves_cross_tool_order() {
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
-	session
-		.state
-		.finish_freeze(monitor, image::RgbaImage::from_pixel(16, 16, Rgba([0, 0, 0, 255])));
+	session.state.commit_frozen_final_image(
+		monitor,
+		image::RgbaImage::from_pixel(16, 16, Rgba([0, 0, 0, 255])),
+	);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 16, 16));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
@@ -2724,7 +2733,7 @@ fn frozen_annotation_history_undoes_across_tools_in_reverse_commit_order() {
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Pen;
 
@@ -2743,11 +2752,14 @@ fn frozen_annotation_history_undoes_across_tools_in_reverse_commit_order() {
 	assert!(session.update_frozen_mosaic_drag_rect(GlobalPoint::new(4, 4)));
 	assert!(session.commit_frozen_mosaic_drag());
 
-	let mosaiced =
-		session.state.frozen_image.clone().expect("mosaic commit should retain the frozen image");
+	let mosaiced = session
+		.state
+		.frozen_display_image
+		.clone()
+		.expect("mosaic commit should retain the frozen display image");
 
 	assert!(session.perform_frozen_undo());
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&original));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&original));
 	assert_eq!(session.frozen_text_annotations.len(), 1);
 	assert_eq!(session.frozen_brush.committed_strokes.len(), 1);
 	assert!(session.perform_frozen_undo());
@@ -2760,12 +2772,12 @@ fn frozen_annotation_history_undoes_across_tools_in_reverse_commit_order() {
 	assert!(session.perform_frozen_redo());
 	assert_eq!(session.frozen_brush.committed_strokes.len(), 1);
 	assert!(session.frozen_text_annotations.is_empty());
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&original));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&original));
 	assert!(session.perform_frozen_redo());
 	assert_eq!(session.frozen_text_annotations.len(), 1);
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&original));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&original));
 	assert!(session.perform_frozen_redo());
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&mosaiced));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&mosaiced));
 	assert!(session.toolbar_state.undo_available);
 	assert!(!session.toolbar_state.redo_available);
 }
@@ -2784,7 +2796,7 @@ fn committing_new_frozen_edit_clears_redo_across_tools() {
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
 
@@ -2962,7 +2974,7 @@ fn scroll_capture_guard_error_keeps_frozen_capture_available() {
 	let control = session.start_scroll_capture();
 
 	assert!(matches!(control, OverlayControl::Continue));
-	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_display_image.is_some());
 	assert!(
 		session
 			.state
@@ -2984,7 +2996,7 @@ fn scroll_capture_guard_silent_reject_keeps_frozen_capture_available_without_err
 	let control = session.start_scroll_capture();
 
 	assert!(matches!(control, OverlayControl::Continue));
-	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_display_image.is_some());
 	assert!(session.state.error_message.is_none());
 }
 
@@ -3002,7 +3014,7 @@ fn scroll_capture_starting_hook_error_keeps_frozen_capture_available() {
 	let control = session.start_scroll_capture();
 
 	assert!(matches!(control, OverlayControl::Continue));
-	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_display_image.is_some());
 	assert!(
 		session
 			.state
@@ -3176,7 +3188,7 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 		..OverlaySession::default()
 	};
 
-	set_session_frozen_export_ready_state(&mut session, true);
+	promote_session_export_authority_ready(&mut session);
 
 	session.reset_for_start();
 
@@ -3186,7 +3198,7 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 	assert!(!session.png_encode_inflight);
 	assert!(!session.pending_self_capture_exception_window_ids_worker_refresh);
 	assert!(!session.pending_startup_aux_live_stream_filter_upgrade);
-	assert!(!session_frozen_export_ready_state(&session));
+	assert!(!session_export_authority_ready(&session));
 	assert!(!session.capture_windows_hidden);
 	assert!(!session.loupe_activation_key_down);
 	assert_eq!(session.keyboard_modifiers, ModifiersState::default());
@@ -3693,7 +3705,7 @@ fn toolbar_window_is_needed_for_seeded_preview_before_final_capture_ready() {
 	session.request_aux_window_creation_if_needed();
 
 	assert!(session.startup_aux_window_creation_pending);
-	assert!(!session_frozen_export_ready_state(&session));
+	assert!(!session_export_authority_ready(&session));
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -82,9 +82,8 @@ fn frozen_toolbar_cursor_event_updates_frozen_cursor_context() {
 	let patch = RgbaImage::from_pixel(400, 300, crate::overlay::tests::Rgba([10, 20, 30, 255]));
 	let mut session = OverlaySession::new();
 
-	session.state.mode = OverlayMode::Frozen;
-	session.state.monitor = Some(monitor);
-	session.state.frozen_image = Some(patch.clone());
+	session.state.commit_frozen_display_image(monitor, patch.clone());
+
 	session.state.alt_held = true;
 
 	session.note_frozen_toolbar_cursor_event(monitor, cursor);

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -115,10 +115,10 @@ fn snapshot_background_capture_finishes_frozen_transition_immediately() {
 		Some(snapshot),
 		"live_stream_snapshot",
 	));
-	assert!(tests::session_frozen_export_ready_state(&session));
+	assert!(tests::session_export_authority_ready(&session));
 	assert!(tests::session_pending_freeze_capture(&session).is_none());
 	assert!(tests::session_pending_window_freeze_capture(&session).is_none());
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&frozen_image));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&frozen_image));
 	assert!(session.toolbar_state.final_capture_ready);
 }
 
@@ -153,10 +153,10 @@ fn snapshot_matte_window_capture_keeps_authoritative_handoff_pending() {
 		Some(snapshot),
 		"live_stream_snapshot",
 	));
-	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert!(!tests::session_export_authority_ready(&session));
 	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
 	assert_eq!(tests::session_pending_window_freeze_capture(&session), Some(window_target));
-	assert!(session.state.frozen_image.is_none());
+	assert!(session.state.frozen_display_image.is_none());
 }
 
 #[cfg(target_os = "macos")]
@@ -190,10 +190,10 @@ fn stale_snapshot_does_not_finish_frozen_transition_immediately() {
 		Some(snapshot),
 		"live_stream_snapshot",
 	));
-	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert!(!tests::session_export_authority_ready(&session));
 	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
 	assert_eq!(tests::session_pending_window_freeze_capture(&session), Some(window_target));
-	assert!(session.state.frozen_image.is_none());
+	assert!(session.state.frozen_display_image.is_none());
 }
 
 #[cfg(target_os = "macos")]
@@ -222,9 +222,9 @@ fn snapshot_seeded_preview_keeps_authoritative_handoff_pending() {
 		Some(snapshot),
 		"live_stream_snapshot_seeded_unverified",
 	));
-	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert!(!tests::session_export_authority_ready(&session));
 	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&frozen_image));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&frozen_image));
 	assert!(!session.toolbar_state.final_capture_ready);
 }
 
@@ -256,7 +256,7 @@ fn snapshot_seeded_preview_makes_toolbar_eligible_before_final_capture_ready() {
 		"live_stream_snapshot_seeded_unverified",
 	));
 	assert!(session.frozen_preview_visible());
-	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert!(!tests::session_export_authority_ready(&session));
 	assert!(session.startup_aux_window_creation_pending);
 }
 
@@ -288,8 +288,8 @@ fn stale_snapshot_does_not_seed_frozen_preview() {
 		"live_stream_snapshot_seeded_unverified",
 	));
 	assert_eq!(tests::session_pending_freeze_capture(&session), Some(monitor));
-	assert!(!tests::session_frozen_export_ready_state(&session));
-	assert!(session.state.frozen_image.is_none());
+	assert!(!tests::session_export_authority_ready(&session));
+	assert!(session.state.frozen_display_image.is_none());
 	assert!(!session.toolbar_state.final_capture_ready);
 }
 
@@ -317,7 +317,7 @@ fn frozen_final_capture_ready_requires_no_pending_or_inflight_capture() {
 	assert!(!session.frozen_final_capture_ready());
 
 	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
-	tests::set_session_frozen_export_ready_state(&mut session, true);
+	tests::promote_session_export_authority_ready(&mut session);
 
 	assert!(session.frozen_final_capture_ready());
 
@@ -478,9 +478,9 @@ fn frozen_mosaic_drag_waits_for_final_capture_ready() {
 	assert!(!session.perform_frozen_undo());
 	assert!(!session.perform_frozen_redo());
 	assert_eq!(session.state.frozen_mosaic_preview_rect, None);
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&original));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&original));
 
-	tests::set_session_frozen_export_ready_state(&mut session, true);
+	tests::promote_session_export_authority_ready(&mut session);
 
 	assert!(session.begin_frozen_mosaic_drag(GlobalPoint::new(1, 1)));
 }
@@ -497,7 +497,7 @@ fn frozen_mosaic_drag_updates_preview_rect_inside_capture_bounds() {
 	session.state.frozen_capture_rect = Some(RectPoints::new(2, 2, 4, 4));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Mosaic;
 
-	tests::set_session_frozen_export_ready_state(&mut session, true);
+	tests::promote_session_export_authority_ready(&mut session);
 
 	assert!(session.begin_frozen_mosaic_drag(GlobalPoint::new(3, 3)));
 	assert!(session.update_frozen_mosaic_drag_rect(GlobalPoint::new(30, 30)));
@@ -518,14 +518,17 @@ fn frozen_mosaic_commit_round_trips_through_undo_and_redo() {
 	session.state.frozen_capture_rect = Some(RectPoints::new(0, 0, 8, 8));
 	session.toolbar_state.selected_tool = FrozenToolbarTool::Mosaic;
 
-	tests::set_session_frozen_export_ready_state(&mut session, true);
+	tests::promote_session_export_authority_ready(&mut session);
 
 	assert!(session.begin_frozen_mosaic_drag(GlobalPoint::new(1, 1)));
 	assert!(session.update_frozen_mosaic_drag_rect(GlobalPoint::new(4, 4)));
 	assert!(session.commit_frozen_mosaic_drag());
 
-	let edited =
-		session.state.frozen_image.clone().expect("mosaic commit should retain the frozen image");
+	let edited = session
+		.state
+		.frozen_display_image
+		.clone()
+		.expect("mosaic commit should retain the frozen display image");
 
 	assert_eq!(edited.get_pixel(2, 2), &expected_fill);
 	assert_eq!(edited.get_pixel(4, 4), &expected_fill);
@@ -534,11 +537,11 @@ fn frozen_mosaic_commit_round_trips_through_undo_and_redo() {
 	assert!(session.toolbar_state.undo_available);
 	assert!(!session.toolbar_state.redo_available);
 	assert!(session.perform_frozen_undo());
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&original));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&original));
 	assert!(!session.toolbar_state.undo_available);
 	assert!(session.toolbar_state.redo_available);
 	assert!(session.perform_frozen_redo());
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&edited));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&edited));
 	assert!(session.toolbar_state.undo_available);
 	assert!(!session.toolbar_state.redo_available);
 }
@@ -1191,7 +1194,7 @@ fn cropped_frozen_capture_image_uses_moved_capture_rect() {
 
 	session.state.begin_freeze(monitor);
 
-	tests::finish_frozen_display_state(&mut session, monitor, image);
+	tests::finish_frozen_ready_state(&mut session, monitor, image);
 
 	session.state.frozen_capture_rect = Some(RectPoints::new(8, 6, 40, 32));
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1222,7 +1225,7 @@ fn auto_center_frozen_capture_rect_recenters_detected_content() {
 
 	session.state.begin_freeze(monitor);
 
-	tests::finish_frozen_display_state(&mut session, monitor, image);
+	tests::finish_frozen_ready_state(&mut session, monitor, image);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1254,7 +1257,7 @@ fn auto_center_frozen_capture_rect_works_outside_pointer_mode() {
 
 	session.state.begin_freeze(monitor);
 
-	tests::finish_frozen_display_state(&mut session, monitor, image);
+	tests::finish_frozen_ready_state(&mut session, monitor, image);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -1955,7 +1958,7 @@ fn frozen_mosaic_cursor_rects_preserve_crosshair_hover_and_drag() {
 	session.state.begin_freeze(monitor);
 
 	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
-	tests::set_session_frozen_export_ready_state(&mut session, true);
+	tests::promote_session_export_authority_ready(&mut session);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -2175,7 +2178,7 @@ fn scroll_capture_and_export_wait_for_authoritative_frozen_capture() {
 	session.state.begin_freeze(monitor);
 
 	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
-	tests::set_session_frozen_export_ready_state(&mut session, true);
+	tests::promote_session_export_authority_ready(&mut session);
 
 	session.state.frozen_capture_rect = Some(capture_rect);
 	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
@@ -3477,7 +3480,7 @@ fn drag_region_toolbar_size_stays_stable_while_final_capture_readiness_changes()
 	assert!(pending_tools.contains(&FrozenToolbarTool::AutoCenter));
 	assert!(pending_tools.contains(&FrozenToolbarTool::Scroll));
 
-	tests::set_session_frozen_export_ready_state(&mut session, true);
+	tests::promote_session_export_authority_ready(&mut session);
 
 	session.sync_frozen_toolbar_state();
 

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -253,7 +253,7 @@ fn begin_frozen_capture_background_snapshot_finishes_without_hiding_overlay_wind
 	assert!(tests::session_pending_freeze_capture(&session).is_none());
 	assert!(!tests::session_frozen_capture_armed(&session));
 	assert!(!session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_display_image.is_some());
 	assert!(session.state.frozen_export_image.is_some());
 	assert!(session.frozen_final_capture_ready());
 }
@@ -281,12 +281,12 @@ fn live_snapshot_followup_can_finish_background_capture_before_timeout() {
 
 	let _ = session.about_to_wait();
 
-	assert!(tests::session_frozen_export_ready_state(&session));
+	assert!(tests::session_export_authority_ready(&session));
 	assert!(tests::session_pending_freeze_capture(&session).is_none());
 	assert!(tests::session_inflight_freeze_capture(&session).is_none());
 	assert!(!tests::session_frozen_capture_armed(&session));
 	assert!(!session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_display_image.is_some());
 }
 
 #[cfg(target_os = "macos")]
@@ -319,7 +319,7 @@ fn window_matte_capture_seeds_preview_and_arms_worker_without_hiding_overlay_win
 	assert!(tests::session_frozen_capture_armed(&session));
 	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_display_image.is_some());
 	assert!(session.state.frozen_export_image.is_none());
 }
 
@@ -382,7 +382,7 @@ fn window_matte_capture_miss_keeps_preview_and_surfaces_export_error() {
 		Some(cursor),
 	);
 
-	let preview_image = session.state.frozen_image.clone();
+	let preview_image = session.state.frozen_display_image.clone();
 
 	session.maybe_dispatch_armed_freeze_capture();
 
@@ -400,8 +400,8 @@ fn window_matte_capture_miss_keeps_preview_and_surfaces_export_error() {
 	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
 	assert!(session.state.frozen_export_image.is_none());
-	assert!(!tests::session_frozen_export_ready_state(&session));
-	assert_eq!(session.state.frozen_image, preview_image);
+	assert!(!tests::session_export_authority_ready(&session));
+	assert_eq!(session.state.frozen_display_image, preview_image);
 	assert_eq!(
 		session.state.error_message.as_deref(),
 		Some("Window capture is unavailable. Please try again.")
@@ -437,7 +437,7 @@ fn stale_window_matte_response_after_export_failure_is_ignored() {
 
 	let preview_image = session
 		.state
-		.frozen_image
+		.frozen_display_image
 		.clone()
 		.expect("preview should be seeded before the matte export worker runs");
 
@@ -451,7 +451,7 @@ fn stale_window_matte_response_after_export_failure_is_ignored() {
 	});
 
 	assert!(session.state.frozen_export_image.is_none());
-	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert!(!tests::session_export_authority_ready(&session));
 
 	let control = session.maybe_tick_worker_response_limiter(WorkerResponse::CapturedFreeze {
 		monitor,
@@ -461,9 +461,9 @@ fn stale_window_matte_response_after_export_failure_is_ignored() {
 	});
 
 	assert!(matches!(control, super::OverlayControl::Continue));
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&preview_image));
 	assert!(session.state.frozen_export_image.is_none());
-	assert!(!tests::session_frozen_export_ready_state(&session));
+	assert!(!tests::session_export_authority_ready(&session));
 	assert_eq!(
 		session.state.error_message.as_deref(),
 		Some("Window capture is unavailable. Please try again.")
@@ -496,7 +496,7 @@ fn window_matte_capture_without_live_preview_aborts_after_timeout_without_hiding
 	assert!(tests::session_frozen_capture_armed(&session));
 	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_none());
+	assert!(session.state.frozen_display_image.is_none());
 
 	session.frozen_transition_started_at = Some(
 		Instant::now()
@@ -535,7 +535,7 @@ fn background_capture_without_initial_snapshot_waits_for_live_stream_followup_wi
 	assert!(!tests::session_frozen_capture_armed(&session));
 	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_none());
+	assert!(session.state.frozen_display_image.is_none());
 
 	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
 		monitor,
@@ -549,7 +549,7 @@ fn background_capture_without_initial_snapshot_waits_for_live_stream_followup_wi
 	assert_eq!(tests::session_pending_freeze_capture(&session), None);
 	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_some());
+	assert!(session.state.frozen_display_image.is_some());
 	assert!(session.state.frozen_export_image.is_some());
 }
 
@@ -573,7 +573,7 @@ fn background_capture_without_live_snapshot_aborts_after_timeout_without_hiding(
 	assert!(!tests::session_frozen_capture_armed(&session));
 	assert_eq!(tests::session_inflight_freeze_capture(&session), None);
 	assert!(!session.capture_windows_hidden);
-	assert!(session.state.frozen_image.is_none());
+	assert!(session.state.frozen_display_image.is_none());
 
 	session.frozen_transition_started_at = Some(
 		Instant::now()

--- a/packages/rsnap-overlay/src/state.rs
+++ b/packages/rsnap-overlay/src/state.rs
@@ -311,7 +311,7 @@ pub struct OverlayState {
 	pub live_bg_monitor: Option<MonitorRect>,
 	pub live_bg_image: Option<RgbaImage>,
 	pub live_bg_generation: u64,
-	pub frozen_image: Option<RgbaImage>,
+	pub frozen_display_image: Option<RgbaImage>,
 	pub frozen_export_image: Option<RgbaImage>,
 	pub frozen_generation: u64,
 	pub error_message: Option<String>,
@@ -333,7 +333,7 @@ impl OverlayState {
 			live_bg_monitor: None,
 			live_bg_image: None,
 			live_bg_generation: 0,
-			frozen_image: None,
+			frozen_display_image: None,
 			frozen_export_image: None,
 			frozen_generation: 0,
 			error_message: None,
@@ -358,7 +358,7 @@ impl OverlayState {
 
 	pub fn begin_freeze(&mut self, monitor: MonitorRect) {
 		self.monitor = Some(monitor);
-		self.frozen_image = None;
+		self.frozen_display_image = None;
 		self.frozen_export_image = None;
 		self.frozen_mosaic_preview_rect = None;
 		self.loupe = None;
@@ -367,18 +367,18 @@ impl OverlayState {
 	}
 
 	#[cfg(any(test, not(target_os = "macos")))]
-	pub fn finish_freeze(&mut self, monitor: MonitorRect, image: RgbaImage) {
+	pub fn commit_frozen_final_image(&mut self, monitor: MonitorRect, image: RgbaImage) {
 		// Keep the existing generation set by `begin_freeze` so renderers can key off a single
 		// freeze request/response cycle.
 		self.monitor = Some(monitor);
 		self.frozen_export_image = Some(image.clone());
-		self.frozen_image = Some(image);
+		self.frozen_display_image = Some(image);
 		self.mode = OverlayMode::Frozen;
 	}
 
 	pub fn commit_frozen_display_image(&mut self, monitor: MonitorRect, image: RgbaImage) {
 		self.monitor = Some(monitor);
-		self.frozen_image = Some(image);
+		self.frozen_display_image = Some(image);
 		self.mode = OverlayMode::Frozen;
 	}
 
@@ -386,8 +386,8 @@ impl OverlayState {
 		self.frozen_export_image = Some(image);
 	}
 
-	pub fn frozen_surface_image(&self) -> Option<&RgbaImage> {
-		self.frozen_image.as_ref()
+	pub fn frozen_display_surface_image(&self) -> Option<&RgbaImage> {
+		self.frozen_display_image.as_ref()
 	}
 }
 
@@ -450,12 +450,32 @@ mod tests {
 		state.commit_frozen_export_image(RgbaImage::new(2, 2));
 		state.begin_freeze(monitor);
 
-		assert!(state.frozen_image.is_none());
+		assert!(state.frozen_display_image.is_none());
 		assert!(state.frozen_export_image.is_none());
 	}
 
 	#[test]
-	fn finish_freeze_populates_display_and_export_images() {
+	fn commit_frozen_display_image_leaves_export_authority_unset() {
+		let monitor = MonitorRect {
+			id: 3,
+			origin: GlobalPoint::new(0, 0),
+			width: 100,
+			height: 100,
+			scale_factor_x1000: 1_000,
+		};
+		let display_image = RgbaImage::from_pixel(2, 2, Rgba([10, 20, 30, 255]));
+		let mut state = crate::state::OverlayState::new();
+
+		state.begin_freeze(monitor);
+		state.commit_frozen_display_image(monitor, display_image.clone());
+
+		assert_eq!(state.frozen_display_image.as_ref(), Some(&display_image));
+		assert!(state.frozen_export_image.is_none());
+		assert_eq!(state.frozen_display_surface_image(), Some(&display_image));
+	}
+
+	#[test]
+	fn commit_frozen_final_image_populates_display_and_export_images() {
 		let monitor = MonitorRect {
 			id: 7,
 			origin: GlobalPoint::new(0, 0),
@@ -467,10 +487,10 @@ mod tests {
 		let mut state = crate::state::OverlayState::new();
 
 		state.begin_freeze(monitor);
-		state.finish_freeze(monitor, final_image.clone());
+		state.commit_frozen_final_image(monitor, final_image.clone());
 
-		assert_eq!(state.frozen_image.as_ref(), Some(&final_image));
+		assert_eq!(state.frozen_display_image.as_ref(), Some(&final_image));
 		assert_eq!(state.frozen_export_image.as_ref(), Some(&final_image));
-		assert_eq!(state.frozen_surface_image(), Some(&final_image));
+		assert_eq!(state.frozen_display_surface_image(), Some(&final_image));
 	}
 }


### PR DESCRIPTION
## Summary
- rename remaining session/runtime surfaces to explicit display/export image terminology
- replace legacy test compatibility toggles with display-only and export-ready fixtures
- add direct coverage that display-only freeze state leaves export authority unset

## Testing
- cargo make fmt-rust-check
- cargo make lint
- cargo test -p rsnap-overlay --lib

Refs XY-271