### PR TITLE
Repair frozen capture state references after session-state migration

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1175,15 +1175,13 @@ impl OverlaySession {
 			FrozenCaptureSessionState::DisplayPending {
 				worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
 				..
-			}
-				| FrozenCaptureSessionState::DisplayReady {
-					export:
-						FrozenExportSessionState::Pending {
-							worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
-							..
-						},
+			} | FrozenCaptureSessionState::DisplayReady {
+				export: FrozenExportSessionState::Pending {
+					worker_state: FrozenCaptureWorkerState::Idle | FrozenCaptureWorkerState::Armed,
 					..
-				}
+				},
+				..
+			}
 		)
 	}
 
@@ -1331,7 +1329,6 @@ impl OverlaySession {
 			&& self.state.frozen_export_image.is_some()
 	}
 
-	#[cfg(target_os = "macos")]
 	fn pending_window_freeze_capture_for_monitor(
 		&self,
 		monitor: MonitorRect,

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -1293,16 +1293,20 @@ fn window_matte_capture_miss_restores_hidden_windows_before_returning() {
 	session.state.commit_frozen_display_image(monitor, preview_image.clone());
 
 	session.capture_windows_hidden = true;
-	session.inflight_window_freeze_capture = Some(crate::overlay::WindowFreezeCaptureTarget {
-		monitor,
-		window_id: 41,
-		rect: capture_rect,
-	});
+
+	set_session_inflight_window_freeze_capture(
+		&mut session,
+		Some(crate::overlay::WindowFreezeCaptureTarget {
+			monitor,
+			window_id: 41,
+			rect: capture_rect,
+		}),
+	);
 
 	session.handle_captured_freeze_response(monitor, test_frozen_image(), None, None);
 
 	assert!(!session.capture_windows_hidden);
-	assert_eq!(session.state.frozen_image.as_ref(), Some(&preview_image));
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&preview_image));
 	assert!(session.state.frozen_export_image.is_none());
 	assert_eq!(
 		session.state.error_message.as_deref(),

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -257,6 +257,7 @@ fn session_frozen_capture_armed(session: &OverlaySession) -> bool {
 	)
 }
 
+#[cfg(target_os = "macos")]
 fn session_export_authority_ready(session: &OverlaySession) -> bool {
 	matches!(
 		session.frozen_capture_session_state,
@@ -410,6 +411,7 @@ fn finish_frozen_ready_state(
 	};
 }
 
+#[cfg(target_os = "macos")]
 fn commit_frozen_display_preview_state(
 	session: &mut OverlaySession,
 	monitor: MonitorRect,


### PR DESCRIPTION
## Summary
- make `pending_window_freeze_capture_for_monitor` available on all platforms so Linux lint builds see the same frozen capture session helper as macOS
- update the stale non-macOS window-matte regression test to use the unified frozen capture session-state helpers
- keep the preview assertion on `frozen_display_image`, which is the post-migration display authority field

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make checks

## CI root cause
- fixes `Language Checks` failure on `main` run 24440051029 (`2026-04-15T06:33:11Z`), which failed in `Rust checks / Run lint` with stale frozen-capture references
