### PR TITLE
Keep drag-capture handoff widget from jumping before the frozen toolbar appears

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -641,6 +641,7 @@ pub struct OverlaySession {
 	frozen_mosaic_redo_stack: Vec<FrozenMosaicEdit>,
 	hud_window_visible: bool,
 	toolbar_window_visible: bool,
+	toolbar_window_drawn_once: bool,
 	skip_toolbar_focus_on_next_show: bool,
 	#[cfg(target_os = "macos")]
 	preserve_frontmost_on_next_toolbar_show: bool,
@@ -855,7 +856,7 @@ impl OverlaySession {
 			frozen_mosaic_drag: FrozenMosaicDragState::default(), frozen_spotlight_drag: FrozenSpotlightDragState::default(),
 			frozen_spotlight_preview_rect: None, frozen_edit_undo_stack: Vec::new(),
 			frozen_edit_redo_stack: Vec::new(), frozen_mosaic_undo_stack: Vec::new(), frozen_mosaic_redo_stack: Vec::new(),
-			hud_window_visible: false, toolbar_window_visible: false, skip_toolbar_focus_on_next_show: false,
+			hud_window_visible: false, toolbar_window_visible: false, toolbar_window_drawn_once: false, skip_toolbar_focus_on_next_show: false,
 			#[cfg(target_os = "macos")]
 			preserve_frontmost_on_next_toolbar_show: false,
 			toolbar_window_warmup_redraws_remaining: 0, loupe_window_visible: false, loupe_window_warmup_redraws_remaining: 0,
@@ -2860,7 +2861,7 @@ impl OverlaySession {
 				self.request_redraw_for_monitor(overlay_monitor);
 			}
 
-			ready
+			ready && self.toolbar_window_drawn_once
 		}
 
 		#[cfg(not(target_os = "macos"))]
@@ -3283,6 +3284,7 @@ impl OverlaySession {
 		self.pending_toolbar_outer_pos = None;
 		self.hud_window_visible = false;
 		self.toolbar_window_visible = false;
+		self.toolbar_window_drawn_once = false;
 		#[cfg(target_os = "macos")]
 		{
 			self.toolbar_window_cursor_hittest_enabled = false;

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -128,8 +128,13 @@ impl OverlaySession {
 				}
 
 				self.toolbar_window_visible = show_toolbar;
+
+				if !show_toolbar {
+					self.toolbar_window_drawn_once = false;
+				}
 			} else {
 				self.toolbar_window_visible = false;
+				self.toolbar_window_drawn_once = false;
 			}
 			if let Some(preview_window) = &self.scroll_preview_window {
 				preview_window.window.set_visible(self.scroll_capture.active);

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -714,6 +714,7 @@ impl OverlaySession {
 
 		self.skip_toolbar_focus_on_next_show = true;
 		self.toolbar_window_visible = false;
+		self.toolbar_window_drawn_once = false;
 		self.toolbar_window_warmup_redraws_remaining = 0;
 
 		if let Some(preview_window) = self.scroll_preview_window.as_ref() {

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -3190,6 +3190,7 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 		},
 		hud_window_visible: true,
 		toolbar_window_visible: true,
+		toolbar_window_drawn_once: true,
 		toolbar_window_warmup_redraws_remaining: 3,
 		..OverlaySession::default()
 	};
@@ -3211,6 +3212,7 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 	assert_eq!(session.live_capture_interaction, LiveCaptureInteraction::Idle);
 	assert!(!session.hud_window_visible);
 	assert!(!session.toolbar_window_visible);
+	assert!(!session.toolbar_window_drawn_once);
 	assert_eq!(session.toolbar_window_warmup_redraws_remaining, 0);
 }
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -2853,6 +2853,40 @@ fn frozen_toolbar_ready_for_draw_recovers_after_preseeded_position_is_sampled() 
 	assert!(session.frozen_toolbar_ready_for_draw(screen_rect));
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn frozen_toolbar_badge_visibility_waits_for_first_toolbar_draw() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(200, 180, 200, 300);
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let mut session = OverlaySession::new();
+
+	session.begin_frozen_capture_with_rect(monitor, Some(capture_rect), None, None);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.sync_frozen_toolbar_state();
+
+	assert!(session.maybe_recenter_frozen_toolbar_default_slot(monitor));
+	assert!(!session.toolbar_window_visible);
+	assert!(!session.should_hide_toolbar_window(monitor));
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+	assert_eq!(session.toolbar_state.layout_last_screen_size_points, Some(screen_rect.size()));
+	assert_eq!(session.toolbar_state.layout_stable_frames, 0);
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+	assert_eq!(session.toolbar_state.layout_stable_frames, 1);
+
+	session.toolbar_window_visible = true;
+
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+
+	session.toolbar_window_drawn_once = true;
+
+	assert!(session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+	assert!(session.frozen_size_badge_toolbar_reserved_rect(monitor, screen_rect, true).is_some());
+}
+
 #[test]
 fn render_frozen_toolbar_ui_waits_for_readiness_before_first_visible_frame() {
 	let ctx = tests::test_egui_context();

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -461,6 +461,7 @@ impl OverlaySession {
 		}
 
 		self.toolbar_window_visible = false;
+		self.toolbar_window_drawn_once = false;
 		#[cfg(target_os = "macos")]
 		{
 			self.toolbar_window_cursor_hittest_enabled = false;
@@ -554,6 +555,8 @@ impl OverlaySession {
 			self.toolbar_state.floating_position = previous_floating_position;
 
 			draw_result?;
+
+			self.toolbar_window_drawn_once = true;
 
 			if toolbar_became_visible {
 				self.note_frozen_transition_toolbar_visible(monitor);


### PR DESCRIPTION
## Summary
- gate frozen overlay badge slot reservation on the toolbar's first successful macOS draw, not just preseeded visibility
- reset the new toolbar-drawn state whenever the auxiliary toolbar hides so re-shows stay visually aligned
- add regression coverage for the first-draw boundary and the reused-session reset path

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make checks