### PR TITLE
Improve macOS frozen entry responsiveness and handoff stability

### DIFF
--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -1845,13 +1845,16 @@ fn refresh_stream_nonblocking(
 	shared_latest_frame: Arc<SharedLatestFrame>,
 ) -> StreamRequestProgress {
 	let now = Instant::now();
+	let current_monitor_id = state.as_ref().map(|current| current.monitor_id);
 
-	if let Some(last) = *last_setup_attempt_at
+	if refresh_stream_requires_setup_backoff(current_monitor_id, monitor.id)
+		&& let Some(last) = *last_setup_attempt_at
 		&& now.duration_since(last) < STREAM_SETUP_BACKOFF
 	{
 		tracing::info!(
 			op = "live_frame_stream.refresh_monitor_backoff",
 			monitor_id = monitor.id,
+			current_monitor_id,
 			elapsed_since_last_setup_ms = now.duration_since(last).as_millis(),
 			backoff_ms = STREAM_SETUP_BACKOFF.as_millis(),
 			"Skipped ScreenCaptureKit refresh because setup backoff is still active."
@@ -1859,12 +1862,11 @@ fn refresh_stream_nonblocking(
 
 		return StreamRequestProgress::Settled;
 	}
-
-	if state.as_ref().is_none_or(|current| current.monitor_id != monitor.id) {
+	if current_monitor_id != Some(monitor.id) {
 		tracing::info!(
 			op = "live_frame_stream.refresh_monitor_recover_via_ensure",
 			monitor_id = monitor.id,
-			current_monitor_id = state.as_ref().map(|current| current.monitor_id),
+			current_monitor_id,
 			"Refresh request found no matching live stream and is falling back to ensure."
 		);
 
@@ -1892,6 +1894,13 @@ fn refresh_stream_nonblocking(
 		frame_seq_counter,
 		shared_latest_frame,
 	})
+}
+
+fn refresh_stream_requires_setup_backoff(
+	current_monitor_id: Option<u32>,
+	requested_monitor_id: u32,
+) -> bool {
+	current_monitor_id != Some(requested_monitor_id)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3245,6 +3254,13 @@ mod tests {
 			),
 			Duration::ZERO
 		);
+	}
+
+	#[test]
+	fn refresh_stream_requires_setup_backoff_only_for_recovery_paths() {
+		assert!(live_frame_stream_macos::refresh_stream_requires_setup_backoff(None, 7));
+		assert!(live_frame_stream_macos::refresh_stream_requires_setup_backoff(Some(9), 7));
+		assert!(!live_frame_stream_macos::refresh_stream_requires_setup_backoff(Some(7), 7));
 	}
 
 	#[test]

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1294,6 +1294,7 @@ impl OverlaySession {
 		self.frozen_display_ready() && self.state.monitor == Some(monitor)
 	}
 
+	#[cfg(target_os = "macos")]
 	fn preserve_live_frozen_entry_affordance(&self) -> bool {
 		!self.scroll_capture.active
 			&& !self.frozen_selection_drag.active

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -76,9 +76,7 @@ use image::imageops;
 #[cfg(target_os = "macos")]
 use objc::declare::ClassDecl;
 #[cfg(target_os = "macos")]
-use objc::runtime::Sel;
-#[cfg(target_os = "macos")]
-use objc::runtime::{BOOL, Class, Object, YES};
+use objc::runtime::{self, BOOL, Class, Imp, NO, Object, Sel, YES};
 #[cfg(target_os = "macos")]
 use objc::{Encode, Encoding};
 #[cfg(target_os = "macos")]
@@ -595,11 +593,14 @@ pub struct OverlaySession {
 	loupe_patch_width_px: u32,
 	loupe_patch_height_px: u32,
 	frozen_capture_session_state: FrozenCaptureSessionState,
+	frozen_transition_press_pending_at: Option<Instant>,
 	frozen_transition_started_at: Option<Instant>,
 	frozen_transition_preview_committed_at: Option<Instant>,
 	frozen_transition_preview_source: Option<&'static str>,
 	frozen_transition_final_ready_at: Option<Instant>,
 	frozen_transition_toolbar_visible_at: Option<Instant>,
+	frozen_transition_toolbar_first_draw_at: Option<Instant>,
+	frozen_transition_badge_slot_armed_at: Option<Instant>,
 	frozen_transition_target_window_id: Option<u32>,
 	frozen_window_image: Option<RgbaImage>,
 	frozen_capture_source: FrozenCaptureSource,
@@ -642,6 +643,7 @@ pub struct OverlaySession {
 	hud_window_visible: bool,
 	toolbar_window_visible: bool,
 	toolbar_window_drawn_once: bool,
+	toolbar_badge_slot_ready: bool,
 	skip_toolbar_focus_on_next_show: bool,
 	#[cfg(target_os = "macos")]
 	preserve_frontmost_on_next_toolbar_show: bool,
@@ -829,9 +831,11 @@ impl OverlaySession {
 			loupe_patch_height_px: 0,
 			egui_repaint_deadline: Arc::new(Mutex::new(None)),
 			frozen_capture_session_state: FrozenCaptureSessionState::Inactive,
+			frozen_transition_press_pending_at: None,
 			frozen_transition_started_at: None, frozen_transition_preview_committed_at: None,
 			frozen_transition_preview_source: None, frozen_transition_final_ready_at: None,
-			frozen_transition_toolbar_visible_at: None, frozen_transition_target_window_id: None,
+			frozen_transition_toolbar_visible_at: None, frozen_transition_toolbar_first_draw_at: None,
+			frozen_transition_badge_slot_armed_at: None, frozen_transition_target_window_id: None,
 			frozen_window_image: None,
 			frozen_capture_source: FrozenCaptureSource::None,
 			capture_windows_hidden: false,
@@ -856,7 +860,7 @@ impl OverlaySession {
 			frozen_mosaic_drag: FrozenMosaicDragState::default(), frozen_spotlight_drag: FrozenSpotlightDragState::default(),
 			frozen_spotlight_preview_rect: None, frozen_edit_undo_stack: Vec::new(),
 			frozen_edit_redo_stack: Vec::new(), frozen_mosaic_undo_stack: Vec::new(), frozen_mosaic_redo_stack: Vec::new(),
-			hud_window_visible: false, toolbar_window_visible: false, toolbar_window_drawn_once: false, skip_toolbar_focus_on_next_show: false,
+			hud_window_visible: false, toolbar_window_visible: false, toolbar_window_drawn_once: false, toolbar_badge_slot_ready: false, skip_toolbar_focus_on_next_show: false,
 			#[cfg(target_os = "macos")]
 			preserve_frontmost_on_next_toolbar_show: false,
 			toolbar_window_warmup_redraws_remaining: 0, loupe_window_visible: false, loupe_window_warmup_redraws_remaining: 0,
@@ -1290,6 +1294,32 @@ impl OverlaySession {
 		self.frozen_display_ready() && self.state.monitor == Some(monitor)
 	}
 
+	fn preserve_live_frozen_entry_affordance(&self) -> bool {
+		!self.scroll_capture.active
+			&& !self.frozen_selection_drag.active
+			&& !self.toolbar_state.dragging
+			&& self.frozen_edit_undo_stack.is_empty()
+			&& self.state.frozen_mosaic_preview_rect.is_none()
+			&& self.frozen_text_edit.is_none()
+			&& self.active_frozen_arrow_preview().is_none()
+			&& self.frozen_spotlight_preview_rect.is_none()
+	}
+
+	fn frozen_visual_handoff_pending_for_monitor(&self, monitor: MonitorRect) -> bool {
+		#[cfg(target_os = "macos")]
+		{
+			self.frozen_display_ready_for_monitor(monitor)
+				&& self.preserve_live_frozen_entry_affordance()
+		}
+
+		#[cfg(not(target_os = "macos"))]
+		{
+			let _ = monitor;
+
+			false
+		}
+	}
+
 	fn frozen_preview_visible(&self) -> bool {
 		self.frozen_display_ready()
 	}
@@ -1366,35 +1396,78 @@ impl OverlaySession {
 		self.frozen_transition_preview_source = None;
 		self.frozen_transition_final_ready_at = None;
 		self.frozen_transition_toolbar_visible_at = None;
+		self.frozen_transition_toolbar_first_draw_at = None;
+		self.frozen_transition_badge_slot_armed_at = None;
 		self.frozen_transition_target_window_id = None;
 	}
 
 	fn log_frozen_transition_timing_info(&self, event: FrozenTransitionTimingInfo) {
 		let now = Instant::now();
+		let since_press_ms =
+			self.frozen_transition_elapsed_ms_since(self.frozen_transition_press_pending_at, now);
+		let since_begin_ms =
+			self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now);
+		let since_preview_ms = self
+			.frozen_transition_elapsed_ms_since(self.frozen_transition_preview_committed_at, now);
+		let since_final_ready_ms =
+			self.frozen_transition_elapsed_ms_since(self.frozen_transition_final_ready_at, now);
+		let since_toolbar_first_draw_ms = self
+			.frozen_transition_elapsed_ms_since(self.frozen_transition_toolbar_first_draw_at, now);
+		let slow_transition = matches!(
+			event.op,
+			"overlay.freeze_transition_preview_committed"
+				| "overlay.freeze_transition_toolbar_visible"
+				| "overlay.freeze_transition_toolbar_first_draw"
+				| "overlay.freeze_transition_badge_slot_armed"
+		) && since_press_ms.is_some_and(|elapsed_ms| elapsed_ms >= 400);
 
-		tracing::info!(
-			target: "rsnap",
-			op = event.op,
-			monitor_id = event.monitor.map(|monitor| monitor.id),
-			frozen_capture_source = ?self.frozen_capture_source,
-			alpha_mode = ?self.config.window_capture_alpha_mode,
-			target_window_id = self.frozen_transition_target_window_id,
-			captured_window_id = event.captured_window_id,
+		if slow_transition {
+			tracing::warn!(
+				target: "rsnap",
+				op = event.op,
+				monitor_id = event.monitor.map(|monitor| monitor.id),
+				frozen_capture_source = ?self.frozen_capture_source,
+				alpha_mode = ?self.config.window_capture_alpha_mode,
+				target_window_id = self.frozen_transition_target_window_id,
+				captured_window_id = event.captured_window_id,
 				source = event.source,
 				preview_source = self.frozen_transition_preview_source,
 				reason = event.reason,
 				snapshot_age_ms = event.snapshot_age_ms,
 				grace_ms = event.grace_ms,
 				capture_windows_hidden = self.capture_windows_hidden,
-			since_begin_ms =
-				self.frozen_transition_elapsed_ms_since(self.frozen_transition_started_at, now),
-			since_preview_ms =
-				self.frozen_transition_elapsed_ms_since(self.frozen_transition_preview_committed_at, now),
-			since_final_ready_ms =
-				self.frozen_transition_elapsed_ms_since(self.frozen_transition_final_ready_at, now),
-			"{}",
-			event.message
-		);
+				since_press_ms,
+				since_begin_ms,
+				since_preview_ms,
+				since_final_ready_ms,
+				since_toolbar_first_draw_ms,
+				"{}",
+				event.message
+			);
+		} else {
+			tracing::info!(
+				target: "rsnap",
+				op = event.op,
+				monitor_id = event.monitor.map(|monitor| monitor.id),
+				frozen_capture_source = ?self.frozen_capture_source,
+				alpha_mode = ?self.config.window_capture_alpha_mode,
+				target_window_id = self.frozen_transition_target_window_id,
+				captured_window_id = event.captured_window_id,
+				source = event.source,
+				preview_source = self.frozen_transition_preview_source,
+				reason = event.reason,
+				snapshot_age_ms = event.snapshot_age_ms,
+				grace_ms = event.grace_ms,
+				capture_windows_hidden = self.capture_windows_hidden,
+				since_press_ms,
+				since_begin_ms,
+				since_preview_ms,
+				since_final_ready_ms,
+				since_toolbar_first_draw_ms,
+				"{}",
+				event.message
+			);
+		}
 	}
 
 	fn begin_frozen_transition_timing(
@@ -1429,6 +1502,41 @@ impl OverlaySession {
 			grace_ms: None,
 			captured_window_id: None,
 			message: "Frozen transition started.",
+		});
+	}
+
+	fn note_frozen_transition_press_pending(
+		&mut self,
+		monitor: MonitorRect,
+		click_target: Option<LiveClickCaptureTarget>,
+	) {
+		let now = Instant::now();
+		let reason = click_target.map(|target| {
+			if target.window_target.is_some() {
+				"window_target"
+			} else if target.capture_rect.is_none() {
+				"fullscreen_fallback"
+			} else {
+				"rect_target"
+			}
+		});
+
+		self.frozen_transition_press_pending_at = Some(now);
+
+		if self.frozen_transition_target_window_id.is_none() {
+			self.frozen_transition_target_window_id =
+				click_target.and_then(|target| target.window_target).map(|target| target.window_id);
+		}
+
+		self.log_frozen_transition_timing_info(FrozenTransitionTimingInfo {
+			op: "overlay.freeze_transition_press_pending",
+			monitor: Some(monitor),
+			reason,
+			source: None,
+			snapshot_age_ms: None,
+			grace_ms: None,
+			captured_window_id: None,
+			message: "Frozen transition intent was armed on mouse-down.",
 		});
 	}
 
@@ -1625,6 +1733,46 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn note_frozen_transition_toolbar_first_draw(&mut self, monitor: MonitorRect) {
+		if self.frozen_transition_toolbar_first_draw_at.is_some() {
+			return;
+		}
+
+		self.frozen_transition_toolbar_first_draw_at = Some(Instant::now());
+
+		self.log_frozen_transition_timing_info(FrozenTransitionTimingInfo {
+			op: "overlay.freeze_transition_toolbar_first_draw",
+			monitor: Some(monitor),
+			reason: None,
+			source: None,
+			snapshot_age_ms: None,
+			grace_ms: None,
+			captured_window_id: None,
+			message: "Frozen transition rendered the first visible toolbar frame.",
+		});
+	}
+
+	#[cfg(target_os = "macos")]
+	fn note_frozen_transition_badge_slot_armed(&mut self, monitor: MonitorRect) {
+		if self.frozen_transition_badge_slot_armed_at.is_some() {
+			return;
+		}
+
+		self.frozen_transition_badge_slot_armed_at = Some(Instant::now());
+
+		self.log_frozen_transition_timing_info(FrozenTransitionTimingInfo {
+			op: "overlay.freeze_transition_badge_slot_armed",
+			monitor: Some(monitor),
+			reason: None,
+			source: None,
+			snapshot_age_ms: None,
+			grace_ms: None,
+			captured_window_id: None,
+			message: "Frozen transition armed overlay badge-slot avoidance after toolbar draw.",
+		});
+	}
+
+	#[cfg(target_os = "macos")]
 	fn note_frozen_transition_authoritative_handoff_armed(&self, monitor: MonitorRect) {
 		self.log_frozen_transition_timing_info(FrozenTransitionTimingInfo {
 			op: "overlay.freeze_transition_authoritative_handoff_armed",
@@ -1772,6 +1920,8 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		capture_rect: RectPoints,
 	) {
+		self.toolbar_window_drawn_once = false;
+		self.toolbar_badge_slot_ready = false;
 		self.toolbar_state.floating_position = None;
 		self.toolbar_state.default_slot_position = None;
 		self.toolbar_state.dragging = false;
@@ -2812,6 +2962,33 @@ impl OverlaySession {
 		macos_make_window_key(target_window);
 	}
 
+	#[cfg(target_os = "macos")]
+	fn restore_passive_capture_window_focus_policy_for_pointer_interaction(
+		&self,
+		reason: &'static str,
+	) {
+		for overlay_window in self.windows.values() {
+			macos_update_capture_window_focus_policy(overlay_window.window.as_ref(), false, reason);
+		}
+
+		if let Some(hud_window) = self.hud_window.as_ref() {
+			macos_update_capture_window_focus_policy(hud_window.window.as_ref(), false, reason);
+		}
+		if let Some(loupe_window) = self.loupe_window.as_ref() {
+			macos_update_capture_window_focus_policy(loupe_window.window.as_ref(), false, reason);
+		}
+		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+			macos_update_capture_window_focus_policy(toolbar_window.window.as_ref(), false, reason);
+		}
+		if let Some(scroll_preview_window) = self.scroll_preview_window.as_ref() {
+			macos_update_capture_window_focus_policy(
+				scroll_preview_window.window.as_ref(),
+				false,
+				reason,
+			);
+		}
+	}
+
 	fn maybe_recenter_frozen_toolbar_default_slot(&mut self, monitor: MonitorRect) -> bool {
 		if !matches!(self.state.mode, OverlayMode::Frozen) || self.state.monitor != Some(monitor) {
 			return false;
@@ -2871,7 +3048,7 @@ impl OverlaySession {
 				self.request_redraw_for_monitor(overlay_monitor);
 			}
 
-			ready && self.toolbar_window_drawn_once
+			ready && self.toolbar_window_drawn_once && self.toolbar_badge_slot_ready
 		}
 
 		#[cfg(not(target_os = "macos"))]
@@ -2880,18 +3057,47 @@ impl OverlaySession {
 		}
 	}
 
+	fn pending_frozen_display_handoff_state(
+		&self,
+		overlay_monitor: MonitorRect,
+	) -> (bool, Option<MonitorRect>) {
+		let pending_frozen_display_handoff = self.frozen_display_handoff_pending()
+			|| self.frozen_visual_handoff_pending_for_monitor(overlay_monitor);
+		let pending_frozen_display_handoff_monitor =
+			self.frozen_capture_monitor().filter(|_| pending_frozen_display_handoff);
+
+		(pending_frozen_display_handoff, pending_frozen_display_handoff_monitor)
+	}
+
+	fn allow_frozen_surface_bg_for_overlay_monitor(
+		&self,
+		overlay_monitor: MonitorRect,
+		scroll_capture_active: bool,
+	) -> bool {
+		!scroll_capture_active
+			&& !self.frozen_display_handoff_pending()
+			&& !self.frozen_visual_handoff_pending_for_monitor(overlay_monitor)
+	}
+
+	fn mark_overlay_window_redraw_progress(
+		&mut self,
+		window_id: WindowId,
+		overlay_monitor: MonitorRect,
+	) {
+		self.sync_overlay_cursor_icons();
+		self.sync_frozen_toolbar_state();
+
+		self.event_loop_last_progress_window_id = Some(window_id);
+		self.event_loop_last_progress_monitor_id = Some(overlay_monitor.id);
+	}
+
 	fn handle_overlay_window_redraw(&mut self, window_id: WindowId) -> OverlayControl {
 		let Some(overlay_monitor) = self.windows.get(&window_id).map(|overlay| overlay.monitor)
 		else {
 			return OverlayControl::Continue;
 		};
 
-		self.sync_overlay_cursor_icons();
-		self.sync_frozen_toolbar_state();
-
-		self.event_loop_last_progress_window_id = Some(window_id);
-		self.event_loop_last_progress_monitor_id = Some(overlay_monitor.id);
-
+		self.mark_overlay_window_redraw_progress(window_id, overlay_monitor);
 		self.maybe_log_event_loop_stall(Instant::now());
 		self.mark_progress(OverlayEventLoopPhase::OverlayRedraw);
 
@@ -2939,9 +3145,10 @@ impl OverlaySession {
 			if scroll_capture_active { None } else { self.active_frozen_arrow_preview() };
 		let visible_frozen_spotlight_preview_rect =
 			if scroll_capture_active { None } else { self.frozen_spotlight_preview_rect };
-		let pending_frozen_display_handoff = self.frozen_display_handoff_pending();
-		let pending_frozen_display_handoff_monitor =
-			self.frozen_capture_monitor().filter(|_| pending_frozen_display_handoff);
+		let (pending_frozen_display_handoff, pending_frozen_display_handoff_monitor) =
+			self.pending_frozen_display_handoff_state(overlay_monitor);
+		let allow_frozen_surface_bg = self
+			.allow_frozen_surface_bg_for_overlay_monitor(overlay_monitor, scroll_capture_active);
 		let toolbar_state = if draw_toolbar { Some(&mut self.toolbar_state) } else { None };
 
 		{
@@ -2968,7 +3175,7 @@ impl OverlaySession {
 				self.config.theme_mode,
 				self.config.selection_flow_enabled,
 				self.config.selection_flow_stroke_width_px,
-				!scroll_capture_active,
+				allow_frozen_surface_bg,
 				pending_frozen_display_handoff,
 				pending_frozen_display_handoff_monitor,
 				scroll_capture_active,
@@ -2991,11 +3198,41 @@ impl OverlaySession {
 				return self.exit(OverlayExit::Error(format!("{err:#}")));
 			}
 		}
+
+		self.maybe_arm_frozen_toolbar_badge_slot_after_overlay_draw(overlay_monitor);
+
 		self.last_present_at = Instant::now();
 
 		self.note_startup_overlay_frame_presented();
 
 		self.handle_capture_and_toolbar_redraw_post(overlay_monitor, draw_toolbar)
+	}
+
+	#[cfg(target_os = "macos")]
+	fn maybe_arm_frozen_toolbar_badge_slot_after_overlay_draw(
+		&mut self,
+		overlay_monitor: MonitorRect,
+	) {
+		if self.toolbar_badge_slot_ready
+			|| !matches!(self.state.mode, OverlayMode::Frozen)
+			|| self.state.monitor != Some(overlay_monitor)
+			|| !self.toolbar_window_visible
+			|| !self.toolbar_window_drawn_once
+		{
+			return;
+		}
+
+		self.toolbar_badge_slot_ready = true;
+
+		self.note_frozen_transition_badge_slot_armed(overlay_monitor);
+		self.request_redraw_for_monitor(overlay_monitor);
+	}
+
+	#[cfg(not(target_os = "macos"))]
+	fn maybe_arm_frozen_toolbar_badge_slot_after_overlay_draw(
+		&mut self,
+		_overlay_monitor: MonitorRect,
+	) {
 	}
 
 	fn log_frozen_overlay_redraw_trace(
@@ -3281,6 +3518,25 @@ impl OverlaySession {
 		self.set_scroll_overlay_mouse_passthrough(false);
 
 		self.session_active = false;
+		#[cfg(target_os = "macos")]
+		{
+			for overlay_window in self.windows.values() {
+				macos_clear_capture_window_focus_policy(overlay_window.window.as_ref());
+			}
+
+			if let Some(hud_window) = self.hud_window.as_ref() {
+				macos_clear_capture_window_focus_policy(hud_window.window.as_ref());
+			}
+			if let Some(loupe_window) = self.loupe_window.as_ref() {
+				macos_clear_capture_window_focus_policy(loupe_window.window.as_ref());
+			}
+			if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+				macos_clear_capture_window_focus_policy(toolbar_window.window.as_ref());
+			}
+			if let Some(scroll_preview_window) = self.scroll_preview_window.as_ref() {
+				macos_clear_capture_window_focus_policy(scroll_preview_window.window.as_ref());
+			}
+		}
 
 		self.windows.clear();
 
@@ -3300,6 +3556,10 @@ impl OverlaySession {
 		self.hud_window_visible = false;
 		self.toolbar_window_visible = false;
 		self.toolbar_window_drawn_once = false;
+		self.toolbar_badge_slot_ready = false;
+		self.frozen_transition_press_pending_at = None;
+		self.frozen_transition_toolbar_first_draw_at = None;
+		self.frozen_transition_badge_slot_armed_at = None;
 		#[cfg(target_os = "macos")]
 		{
 			self.toolbar_window_cursor_hittest_enabled = false;
@@ -4376,6 +4636,114 @@ fn macos_overlay_cursor_view_class() -> *const Class {
 }
 
 #[cfg(target_os = "macos")]
+fn macos_passive_capture_window_keys() -> &'static Mutex<HashSet<usize>> {
+	static WINDOW_KEYS: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+
+	WINDOW_KEYS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_capture_window_is_passive(window_key: usize) -> bool {
+	macos_passive_capture_window_keys()
+		.lock()
+		.expect("passive capture window key set poisoned")
+		.contains(&window_key)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_update_capture_window_passive_state(window_key: usize, passive: bool) -> bool {
+	let mut window_keys = macos_passive_capture_window_keys()
+		.lock()
+		.expect("passive capture window key set poisoned");
+
+	if passive { window_keys.insert(window_key) } else { window_keys.remove(&window_key) }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_bool_window_method_imp(imp: extern "C" fn(&Object, Sel) -> BOOL) -> Imp {
+	unsafe { mem::transmute::<extern "C" fn(&Object, Sel) -> BOOL, Imp>(imp) }
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn macos_dynamic_capture_window_can_become_main_window(
+	this: &Object,
+	_cmd: Sel,
+) -> BOOL {
+	if macos_capture_window_is_passive((this as *const Object) as usize) { NO } else { YES }
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn macos_dynamic_capture_window_can_become_key_window(this: &Object, _cmd: Sel) -> BOOL {
+	if macos_capture_window_is_passive((this as *const Object) as usize) { NO } else { YES }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_install_capture_window_focus_hooks() {
+	static INSTALLED: OnceLock<()> = OnceLock::new();
+	INSTALLED.get_or_init(|| {
+		let window_class = Class::get("WinitWindow").expect("WinitWindow class should exist");
+
+		unsafe {
+			let can_become_main_window =
+				runtime::class_getInstanceMethod(window_class, objc::sel!(canBecomeMainWindow));
+			let can_become_key_window =
+				runtime::class_getInstanceMethod(window_class, objc::sel!(canBecomeKeyWindow));
+
+			assert!(
+				!can_become_main_window.is_null(),
+				"WinitWindow::canBecomeMainWindow should exist"
+			);
+			assert!(
+				!can_become_key_window.is_null(),
+				"WinitWindow::canBecomeKeyWindow should exist"
+			);
+
+			let _: Imp = runtime::method_setImplementation(
+				can_become_main_window.cast_mut(),
+				macos_bool_window_method_imp(macos_dynamic_capture_window_can_become_main_window),
+			);
+			let _: Imp = runtime::method_setImplementation(
+				can_become_key_window.cast_mut(),
+				macos_bool_window_method_imp(macos_dynamic_capture_window_can_become_key_window),
+			);
+		}
+
+		tracing::trace!(
+			op = "overlay.macos_capture_window_focus_hooks_installed",
+			"Installed passive capture window focus hooks on WinitWindow."
+		);
+	});
+}
+
+#[cfg(target_os = "macos")]
+fn macos_set_capture_window_focus_policy(
+	ns_window: *mut Object,
+	allow_key_focus: bool,
+	reason: &'static str,
+) {
+	if ns_window.is_null() {
+		return;
+	}
+
+	macos_install_capture_window_focus_hooks();
+
+	let window_key = ns_window as usize;
+	let changed = macos_update_capture_window_passive_state(window_key, !allow_key_focus);
+
+	if !changed {
+		return;
+	}
+
+	tracing::trace!(
+		op = "overlay.macos_capture_window_focus_policy_changed",
+		reason,
+		allow_key_focus,
+		window_key,
+		"Updated macOS capture window focus policy."
+	);
+}
+
+#[cfg(target_os = "macos")]
 fn macos_overlay_window_ns_view(window: &Window) -> Option<*mut Object> {
 	let Ok(handle) = window.window_handle() else {
 		return None;
@@ -4585,6 +4953,8 @@ fn macos_restore_frontmost_application(target: MacOSFrontmostApplication) -> boo
 
 #[cfg(target_os = "macos")]
 fn macos_make_window_key(window: &Window) {
+	macos_update_capture_window_focus_policy(window, true, "explicit_focus_request");
+
 	let Ok(handle) = window.window_handle() else {
 		return;
 	};
@@ -4605,6 +4975,60 @@ fn macos_make_window_key(window: &Window) {
 	}
 
 	window.focus_window();
+}
+
+#[cfg(target_os = "macos")]
+fn macos_update_capture_window_focus_policy(
+	window: &Window,
+	allow_key_focus: bool,
+	reason: &'static str,
+) {
+	let Ok(handle) = window.window_handle() else {
+		return;
+	};
+	let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+		return;
+	};
+	let ns_view = appkit.ns_view.as_ptr().cast::<Object>();
+
+	unsafe {
+		let ns_window: *mut Object = objc::msg_send![ns_view, window];
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		macos_set_capture_window_focus_policy(ns_window, allow_key_focus, reason);
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn macos_clear_capture_window_focus_policy(window: &Window) {
+	let Ok(handle) = window.window_handle() else {
+		return;
+	};
+	let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+		return;
+	};
+	let ns_view = appkit.ns_view.as_ptr().cast::<Object>();
+
+	unsafe {
+		let ns_window: *mut Object = objc::msg_send![ns_view, window];
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		let window_key = ns_window as usize;
+
+		if macos_update_capture_window_passive_state(window_key, false) {
+			tracing::trace!(
+				op = "overlay.macos_capture_window_focus_policy_cleared",
+				window_key,
+				"Cleared macOS capture window passive focus policy."
+			);
+		}
+	}
 }
 
 #[cfg(target_os = "macos")]
@@ -4772,6 +5196,8 @@ fn macos_configure_nonactivating_capture_window_with_ns_window(ns_window: *mut O
 		let _: () = objc::msg_send![ns_window, setStyleMask: style_mask | nonactivating_panel_mask];
 		let _: () = objc::msg_send![ns_window, setHidesOnDeactivate: false];
 	}
+
+	macos_set_capture_window_focus_policy(ns_window, false, "capture_window_configured");
 }
 
 #[cfg(test)]

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -131,10 +131,12 @@ impl OverlaySession {
 
 				if !show_toolbar {
 					self.toolbar_window_drawn_once = false;
+					self.toolbar_badge_slot_ready = false;
 				}
 			} else {
 				self.toolbar_window_visible = false;
 				self.toolbar_window_drawn_once = false;
+				self.toolbar_badge_slot_ready = false;
 			}
 			if let Some(preview_window) = &self.scroll_preview_window {
 				preview_window.window.set_visible(self.scroll_capture.active);
@@ -179,6 +181,8 @@ impl OverlaySession {
 	#[cfg(target_os = "macos")]
 	pub(super) fn destroy_live_only_aux_windows(&mut self) {
 		if let Some(loupe_window) = self.loupe_window.take() {
+			super::macos_clear_capture_window_focus_policy(loupe_window.window.as_ref());
+
 			self.remove_macos_hud_window_config_cache_entry(loupe_window.window.id());
 		}
 

--- a/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
@@ -6,7 +6,7 @@ use crate::live_frame_stream_macos::STREAM_REGION_FRAME_MAX_AGE;
 #[cfg(target_os = "macos")]
 use crate::overlay::{
 	Arc, DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT, FreezeCaptureTarget, FrozenCaptureWorkerState,
-	GlobalPoint, Instant, MonitorRect, OverlaySession, WindowCaptureAlphaMode,
+	GlobalPoint, Instant, MonitorRect, OverlayMode, OverlaySession, WindowCaptureAlphaMode,
 	WindowFreezeCaptureTarget,
 };
 #[cfg(target_os = "macos")]
@@ -88,6 +88,17 @@ impl OverlaySession {
 		let after_frame_seq =
 			stream.latest_frame_frontier_for_monitor(monitor).map_or(0, |(frame_seq, _)| frame_seq);
 		let _ = stream.refresh_monitor_nonblocking_if_stale(monitor, after_frame_seq, true);
+	}
+
+	pub(in crate::overlay) fn prewarm_frozen_capture_live_stream_refresh(
+		&self,
+		monitor: MonitorRect,
+	) {
+		if !matches!(self.state.mode, OverlayMode::Live) || self.frozen_display_handoff_pending() {
+			return;
+		}
+
+		self.request_pending_frozen_capture_live_stream_refresh(monitor);
 	}
 
 	fn frozen_capture_display_candidate_from_snapshot(

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -54,14 +54,20 @@ impl OverlaySession {
 	}
 
 	pub(super) fn set_live_capture_interaction(&mut self, interaction: LiveCaptureInteraction) {
-		let was_dragging = self.live_capture_interaction_is_dragging();
+		let was_hiding_auxiliary_windows = self.live_capture_hides_auxiliary_windows();
 
 		self.live_capture_interaction = interaction;
 
 		self.sync_live_capture_visual_state();
 
-		if !was_dragging && self.live_capture_interaction_is_dragging() {
-			self.hide_auxiliary_windows_for_live_drag();
+		let now_hiding_auxiliary_windows = self.live_capture_hides_auxiliary_windows();
+
+		if now_hiding_auxiliary_windows
+			&& (!was_hiding_auxiliary_windows
+				|| self.hud_window_visible
+				|| self.loupe_window_visible)
+		{
+			self.hide_auxiliary_windows_for_live_capture();
 		}
 	}
 
@@ -71,6 +77,14 @@ impl OverlaySession {
 
 	pub(super) fn live_capture_interaction_is_dragging(&self) -> bool {
 		matches!(self.live_capture_interaction, LiveCaptureInteraction::DraggingSelection { .. })
+	}
+
+	pub(super) fn live_capture_interaction_is_frozen_handoff(&self) -> bool {
+		matches!(
+			self.live_capture_interaction,
+			LiveCaptureInteraction::FrozenFromClick { .. }
+				| LiveCaptureInteraction::FrozenFromDrag { .. }
+		)
 	}
 
 	pub(super) fn live_capture_target_from_snapshot(
@@ -109,6 +123,7 @@ impl OverlaySession {
 		// desktop snapshot.
 		let click_target = self.live_capture_target_from_snapshot(monitor, press_global);
 
+		self.note_frozen_transition_press_pending(monitor, click_target);
 		self.set_live_capture_interaction(LiveCaptureInteraction::PressPending {
 			monitor,
 			press_global,
@@ -116,6 +131,8 @@ impl OverlaySession {
 			release_global: None,
 			released: false,
 		});
+		#[cfg(target_os = "macos")]
+		self.prewarm_frozen_capture_live_stream_refresh(monitor);
 	}
 
 	pub(super) fn resolve_live_capture_click_target(
@@ -699,8 +716,12 @@ impl OverlaySession {
 		matches!(self.state.mode, OverlayMode::Frozen) && self.frozen_selection_drag.active
 	}
 
-	pub(super) fn live_drag_hides_auxiliary_windows(&self) -> bool {
-		matches!(self.state.mode, OverlayMode::Live) && self.live_capture_interaction_is_dragging()
+	pub(super) fn live_capture_hides_auxiliary_windows(&self) -> bool {
+		matches!(self.state.mode, OverlayMode::Live)
+			&& (self.live_capture_interaction_is_press_pending()
+				|| self.live_capture_interaction_is_dragging()
+				|| self.live_capture_interaction_is_frozen_handoff()
+				|| self.frozen_display_handoff_pending())
 	}
 
 	fn hide_auxiliary_windows_for_frozen_selection_drag(&mut self) {
@@ -725,6 +746,7 @@ impl OverlaySession {
 		self.skip_toolbar_focus_on_next_show = true;
 		self.toolbar_window_visible = false;
 		self.toolbar_window_drawn_once = false;
+		self.toolbar_badge_slot_ready = false;
 		self.toolbar_window_warmup_redraws_remaining = 0;
 
 		if let Some(preview_window) = self.scroll_preview_window.as_ref() {
@@ -734,7 +756,7 @@ impl OverlaySession {
 		self.last_present_at = Instant::now();
 	}
 
-	fn hide_auxiliary_windows_for_live_drag(&mut self) {
+	fn hide_auxiliary_windows_for_live_capture(&mut self) {
 		if let Some(hud_window) = self.hud_window.as_ref() {
 			hud_window.window.set_visible(false);
 		}

--- a/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
@@ -117,6 +117,10 @@ impl OverlaySession {
 		self.frozen_text_recent_input = None;
 
 		self.sync_text_input_ime_state();
+		#[cfg(target_os = "macos")]
+		self.restore_passive_capture_window_focus_policy_for_pointer_interaction(
+			"frozen_text_edit_finished",
+		);
 
 		had_visible_text
 	}

--- a/packages/rsnap-overlay/src/overlay/hud_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/hud_runtime.rs
@@ -31,7 +31,7 @@ impl OverlaySession {
 	}
 
 	pub(super) fn maybe_skip_hud_redraw(&mut self) -> Option<OverlayControl> {
-		if self.live_drag_hides_auxiliary_windows() {
+		if self.live_capture_hides_auxiliary_windows() {
 			if let Some(hud_window) = self.hud_window.as_ref()
 				&& self.hud_window_visible
 			{
@@ -375,7 +375,7 @@ impl OverlaySession {
 	}
 
 	pub(super) fn should_skip_loupe_redraw(&self) -> bool {
-		self.live_drag_hides_auxiliary_windows()
+		self.live_capture_hides_auxiliary_windows()
 			|| !matches!(self.state.mode, OverlayMode::Live)
 			|| self.frozen_selection_drag_hides_auxiliary_windows()
 			|| self.scroll_capture.active

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -240,7 +240,7 @@ impl OverlaySession {
 
 			return;
 		}
-		if self.live_drag_hides_auxiliary_windows() {
+		if self.live_capture_hides_auxiliary_windows() {
 			self.state.loupe = None;
 
 			self.set_alt_loupe_window_visible(None, false);

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -790,7 +790,9 @@ impl WindowRenderer {
 				);
 			}
 
-			if matches!(state.mode, OverlayMode::Live) && !can_draw_hud {
+			if (matches!(state.mode, OverlayMode::Live) || pending_frozen_display_handoff)
+				&& !can_draw_hud
+			{
 				_show_selection_affordance |= Self::render_live_or_pending_capture_affordances(
 					ctx,
 					state,
@@ -806,6 +808,7 @@ impl WindowRenderer {
 				);
 			}
 			if matches!(state.mode, OverlayMode::Frozen)
+				&& !pending_frozen_display_handoff
 				&& (needs_frozen_surface_bg || show_frozen_capture_affordance)
 				&& state.monitor == Some(monitor)
 				&& state.frozen_capture_rect.is_some()

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -335,7 +335,7 @@ impl WindowRenderer {
 	) -> bool {
 		let mut has_rect = false;
 
-		if !matches!(state.mode, OverlayMode::Live) {
+		if !matches!(state.mode, OverlayMode::Live | OverlayMode::Frozen) {
 			return false;
 		}
 
@@ -416,7 +416,7 @@ impl WindowRenderer {
 		selection_flow_geometry_cache: &mut SelectionFlowGeometryCache,
 		selection_dashed_border_cache: &mut SelectionDashedBorderCache,
 	) -> bool {
-		if !matches!(state.mode, OverlayMode::Live) {
+		if !matches!(state.mode, OverlayMode::Live | OverlayMode::Frozen) {
 			return false;
 		}
 		if pending_handoff_monitor != Some(monitor) {
@@ -432,7 +432,7 @@ impl WindowRenderer {
 			return false;
 		}
 
-		let mut has_affordance = match frozen_capture_source {
+		match frozen_capture_source {
 			FrozenCaptureSource::None => false,
 			FrozenCaptureSource::DragRegion => Self::render_live_drag_selection_affordance(
 				painter,
@@ -464,25 +464,7 @@ impl WindowRenderer {
 
 				rendered
 			},
-		};
-
-		if let Some(target) = Self::selection_size_badge_target_from_rect(capture_rect, screen_rect)
-		{
-			Self::render_selection_size_badge(
-				ctx,
-				painter,
-				monitor,
-				screen_rect,
-				target,
-				None,
-				false,
-				theme,
-			);
-
-			has_affordance = true;
 		}
-
-		has_affordance
 	}
 
 	#[allow(clippy::too_many_arguments)]

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -189,6 +189,27 @@ fn session_inflight_freeze_capture(session: &OverlaySession) -> Option<MonitorRe
 	}
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn passive_capture_window_policy_tracks_window_membership() {
+	let first_window_key = 0x1001usize;
+	let second_window_key = 0x2002usize;
+
+	assert!(!overlay::macos_capture_window_is_passive(first_window_key));
+	assert!(!overlay::macos_capture_window_is_passive(second_window_key));
+	assert!(overlay::macos_update_capture_window_passive_state(first_window_key, true));
+	assert!(overlay::macos_capture_window_is_passive(first_window_key));
+	assert!(!overlay::macos_capture_window_is_passive(second_window_key));
+	assert!(!overlay::macos_update_capture_window_passive_state(first_window_key, true));
+	assert!(overlay::macos_update_capture_window_passive_state(second_window_key, true));
+	assert!(overlay::macos_capture_window_is_passive(second_window_key));
+	assert!(overlay::macos_update_capture_window_passive_state(first_window_key, false));
+	assert!(!overlay::macos_capture_window_is_passive(first_window_key));
+	assert!(overlay::macos_capture_window_is_passive(second_window_key));
+	assert!(overlay::macos_update_capture_window_passive_state(second_window_key, false));
+	assert!(!overlay::macos_capture_window_is_passive(second_window_key));
+}
+
 fn session_pending_window_freeze_capture(
 	session: &OverlaySession,
 ) -> Option<crate::overlay::session_state::WindowFreezeCaptureTarget> {
@@ -3224,6 +3245,7 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 		hud_window_visible: true,
 		toolbar_window_visible: true,
 		toolbar_window_drawn_once: true,
+		toolbar_badge_slot_ready: true,
 		toolbar_window_warmup_redraws_remaining: 3,
 		..OverlaySession::default()
 	};
@@ -3246,6 +3268,7 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 	assert!(!session.hud_window_visible);
 	assert!(!session.toolbar_window_visible);
 	assert!(!session.toolbar_window_drawn_once);
+	assert!(!session.toolbar_badge_slot_ready);
 	assert_eq!(session.toolbar_window_warmup_redraws_remaining, 0);
 }
 
@@ -3768,6 +3791,44 @@ fn toolbar_window_stays_visible_while_final_capture_is_pending() {
 	set_session_inflight_freeze_capture(&mut session, Some(monitor));
 
 	assert!(!session.should_hide_toolbar_window(monitor));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn frozen_visual_handoff_stays_pending_while_frozen_entry_is_still_idle() {
+	let monitor = test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
+
+	assert!(session.frozen_visual_handoff_pending_for_monitor(monitor));
+
+	session.toolbar_window_drawn_once = true;
+
+	assert!(session.frozen_visual_handoff_pending_for_monitor(monitor));
+
+	session.frozen_edit_undo_stack.push(FrozenEditKind::BrushStroke);
+
+	assert!(!session.frozen_visual_handoff_pending_for_monitor(monitor));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn frozen_surface_bg_stays_locked_during_idle_frozen_entry() {
+	let monitor = test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
+
+	assert!(!session.allow_frozen_surface_bg_for_overlay_monitor(monitor, false));
+
+	session.frozen_edit_undo_stack.push(FrozenEditKind::BrushStroke);
+
+	assert!(session.allow_frozen_surface_bg_for_overlay_monitor(monitor, false));
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -624,6 +624,59 @@ fn live_drag_rect_activation_hides_auxiliary_windows() {
 	assert!(!session.loupe_window_visible);
 }
 
+#[test]
+fn live_press_pending_activation_hides_auxiliary_windows_immediately() {
+	let monitor = MonitorRect {
+		id: 1,
+		origin: GlobalPoint::new(0, 0),
+		width: 1_000,
+		height: 800,
+		scale_factor_x1000: 1_000,
+	};
+	let start = GlobalPoint::new(120, 180);
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.hud_window_visible = true;
+	session.loupe_window_visible = true;
+
+	session.set_live_capture_interaction(LiveCaptureInteraction::PressPending {
+		monitor,
+		press_global: start,
+		click_target: None,
+		release_global: None,
+		released: false,
+	});
+
+	assert!(!session.hud_window_visible);
+	assert!(!session.loupe_window_visible);
+}
+
+#[test]
+fn live_frozen_handoff_activation_hides_auxiliary_windows_immediately() {
+	let monitor = MonitorRect {
+		id: 1,
+		origin: GlobalPoint::new(0, 0),
+		width: 1_000,
+		height: 800,
+		scale_factor_x1000: 1_000,
+	};
+	let capture_rect = RectPoints::new(120, 180, 160, 180);
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.hud_window_visible = true;
+	session.loupe_window_visible = true;
+
+	session.set_live_capture_interaction(LiveCaptureInteraction::FrozenFromDrag {
+		monitor,
+		capture_rect,
+	});
+
+	assert!(!session.hud_window_visible);
+	assert!(!session.loupe_window_visible);
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn live_mouse_press_keeps_hovered_window_affordance_until_drag_or_release() {
@@ -977,6 +1030,48 @@ fn prime_startup_live_stream_nonblocking_primes_stream_for_live_mode() {
 	assert_eq!(
 		session.live_sample_stream.as_ref().and_then(MacLiveFrameStream::debug_last_request_kind),
 		Some("prime_monitor_nonblocking")
+	);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn begin_live_capture_press_prewarms_frozen_entry_stream_when_unprimed() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let mut session = OverlaySession::new();
+
+	session.live_sample_stream = Some(MacLiveFrameStream::new());
+
+	session.begin_live_capture_press(monitor, cursor);
+
+	assert!(matches!(
+		session.live_capture_interaction,
+		LiveCaptureInteraction::PressPending { monitor: interaction_monitor, press_global, .. }
+			if interaction_monitor == monitor && press_global == cursor
+	));
+	assert_eq!(
+		session.live_sample_stream.as_ref().and_then(MacLiveFrameStream::debug_last_request_kind),
+		Some("prime_monitor_nonblocking")
+	);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn begin_live_capture_press_force_refreshes_existing_live_snapshot() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let stream = MacLiveFrameStream::new();
+	let mut session = OverlaySession::new();
+
+	stream.debug_store_test_snapshot(monitor, Instant::now());
+
+	session.live_sample_stream = Some(stream);
+
+	session.begin_live_capture_press(monitor, cursor);
+
+	assert_eq!(
+		session.live_sample_stream.as_ref().and_then(MacLiveFrameStream::debug_last_request_kind),
+		Some("refresh_monitor_nonblocking_if_stale")
 	);
 }
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -2910,8 +2910,66 @@ fn frozen_toolbar_badge_visibility_waits_for_first_toolbar_draw() {
 
 	session.toolbar_window_drawn_once = true;
 
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+
+	session.toolbar_badge_slot_ready = true;
+
 	assert!(session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
 	assert!(session.frozen_size_badge_toolbar_reserved_rect(monitor, screen_rect, true).is_some());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn frozen_toolbar_badge_visibility_resets_for_new_frozen_transition() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(200, 180, 200, 300);
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let mut session = OverlaySession::new();
+
+	session.toolbar_window_drawn_once = true;
+
+	session.begin_frozen_capture_with_rect(monitor, Some(capture_rect), None, None);
+
+	assert!(!session.toolbar_window_drawn_once);
+	assert!(!session.toolbar_badge_slot_ready);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.sync_frozen_toolbar_state();
+
+	assert!(session.maybe_recenter_frozen_toolbar_default_slot(monitor));
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+	assert_eq!(session.toolbar_state.layout_stable_frames, 0);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn frozen_toolbar_badge_visibility_waits_for_overlay_frame_after_first_toolbar_draw() {
+	let monitor = tests::test_monitor();
+	let capture_rect = RectPoints::new(200, 180, 200, 300);
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let mut session = OverlaySession::new();
+
+	session.begin_frozen_capture_with_rect(monitor, Some(capture_rect), None, None);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.sync_frozen_toolbar_state();
+
+	assert!(session.maybe_recenter_frozen_toolbar_default_slot(monitor));
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+
+	session.toolbar_window_visible = true;
+	session.toolbar_window_drawn_once = true;
+
+	assert!(!session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
+
+	session.toolbar_badge_slot_ready = true;
+
+	assert!(session.frozen_toolbar_badge_visibility(monitor, screen_rect, false));
 }
 
 #[test]
@@ -3489,6 +3547,41 @@ fn pending_frozen_display_handoff_affordance_keeps_drag_border_visible() {
 	state.mode = OverlayMode::Live;
 	state.monitor = Some(monitor);
 	state.frozen_capture_rect = Some(RectPoints::new(100, 120, 240, 320));
+
+	assert!(WindowRenderer::render_pending_frozen_display_handoff_affordance(
+		&ctx,
+		&painter,
+		&state,
+		monitor,
+		Some(monitor),
+		screen_rect,
+		HudTheme::Light,
+		false,
+		1.0,
+		FrozenCaptureSource::DragRegion,
+		&mut selection_flow_geometry_cache,
+		&mut selection_dashed_border_cache,
+	));
+	assert!(selection_dashed_border_cache.key.is_some());
+}
+
+#[test]
+fn pending_frozen_display_handoff_affordance_applies_after_preview_commit_before_toolbar_draw() {
+	let ctx = tests::test_egui_context();
+	let layer = LayerId::new(Order::Foreground, Id::new("pending-frozen-preview-handoff"));
+	let painter = ctx.layer_painter(layer);
+	let monitor = tests::test_monitor();
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let mut selection_dashed_border_cache = SelectionDashedBorderCache::default();
+	let mut state = OverlayState::new();
+	let mut selection_flow_geometry_cache = SelectionFlowGeometryCache::default();
+
+	state.begin_freeze(monitor);
+
+	state.frozen_capture_rect = Some(RectPoints::new(100, 120, 240, 320));
+
+	state.commit_frozen_display_image(monitor, tests::test_frozen_image());
 
 	assert!(WindowRenderer::render_pending_frozen_display_handoff_affordance(
 		&ctx,

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -455,6 +455,13 @@ impl OverlaySession {
 	pub(super) fn set_toolbar_window_hidden(&mut self) {
 		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
 			#[cfg(target_os = "macos")]
+			super::macos_update_capture_window_focus_policy(
+				toolbar_window.window.as_ref(),
+				false,
+				"toolbar_hidden",
+			);
+
+			#[cfg(target_os = "macos")]
 			let _ = toolbar_window.window.set_cursor_hittest(false);
 
 			toolbar_window.window.set_visible(false);
@@ -462,6 +469,7 @@ impl OverlaySession {
 
 		self.toolbar_window_visible = false;
 		self.toolbar_window_drawn_once = false;
+		self.toolbar_badge_slot_ready = false;
 		#[cfg(target_os = "macos")]
 		{
 			self.toolbar_window_cursor_hittest_enabled = false;
@@ -558,8 +566,13 @@ impl OverlaySession {
 
 			draw_result?;
 
+			let first_toolbar_draw = !self.toolbar_window_drawn_once;
+
 			self.toolbar_window_drawn_once = true;
 
+			if first_toolbar_draw {
+				self.note_frozen_transition_toolbar_first_draw(monitor);
+			}
 			if toolbar_became_visible {
 				self.note_frozen_transition_toolbar_visible(monitor);
 			}

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -156,15 +156,26 @@ impl OverlaySession {
 		self.create_hud_window(event_loop)?;
 
 		let hud_window_ms = hud_window_started_at.elapsed().as_millis();
+		#[cfg(target_os = "macos")]
+		let toolbar_window_ms = {
+			let toolbar_window_started_at = Instant::now();
+
+			self.create_toolbar_window(event_loop)?;
+
+			toolbar_window_started_at.elapsed().as_millis()
+		};
+		#[cfg(not(target_os = "macos"))]
+		let toolbar_window_ms = 0;
 
 		tracing::info!(
 			op = "overlay.prewarm_phase_timing",
 			monitor_count = monitors.len(),
 			window_count = self.windows.len(),
-			monitor_enum_ms,
-			gpu_init_ms,
-			overlay_windows_ms,
-			hud_window_ms,
+			monitor_enum_ms = monitor_enum_ms,
+			gpu_init_ms = gpu_init_ms,
+			overlay_windows_ms = overlay_windows_ms,
+			hud_window_ms = hud_window_ms,
+			toolbar_window_ms = toolbar_window_ms,
 			total_ms = prewarm_started_at.elapsed().as_millis(),
 			"Overlay startup resources prewarmed."
 		);
@@ -706,6 +717,9 @@ impl OverlaySession {
 
 	fn activate_prewarmed_overlay_windows(&self) {
 		for window in self.windows.values() {
+			#[cfg(target_os = "macos")]
+			overlay::macos_configure_overlay_window_mouse_moved_events(window.window.as_ref());
+
 			window.window.set_visible(true);
 		}
 	}
@@ -719,12 +733,29 @@ impl OverlaySession {
 	}
 
 	fn discard_prewarmed_startup_resources(&mut self) {
+		#[cfg(target_os = "macos")]
+		{
+			for window in self.windows.values() {
+				overlay::macos_clear_capture_window_focus_policy(window.window.as_ref());
+			}
+
+			if let Some(hud_window) = self.hud_window.as_ref() {
+				overlay::macos_clear_capture_window_focus_policy(hud_window.window.as_ref());
+			}
+			if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+				overlay::macos_clear_capture_window_focus_policy(toolbar_window.window.as_ref());
+			}
+		}
+
 		self.windows.clear();
 
 		self.hud_window = None;
 		self.hud_inner_size_points = None;
 		self.hud_outer_pos = None;
 		self.pending_hud_outer_pos = None;
+		self.toolbar_window = None;
+		self.toolbar_inner_size_points = None;
+		self.toolbar_window_visible = false;
 
 		#[cfg(target_os = "macos")]
 		self.macos_hud_window_config_cache.clear();
@@ -740,6 +771,8 @@ impl OverlaySession {
 			gpu: self.gpu.take(),
 			windows: mem::take(&mut self.windows),
 			hud_window: self.hud_window.take(),
+			toolbar_window: self.toolbar_window.take(),
+			toolbar_inner_size_points: self.toolbar_inner_size_points.take(),
 			#[cfg(target_os = "macos")]
 			macos_hud_window_config_cache: mem::take(&mut self.macos_hud_window_config_cache),
 		})
@@ -757,6 +790,8 @@ impl OverlaySession {
 		self.gpu = resources.gpu;
 		self.windows = resources.windows;
 		self.hud_window = resources.hud_window;
+		self.toolbar_window = resources.toolbar_window;
+		self.toolbar_inner_size_points = resources.toolbar_inner_size_points;
 		#[cfg(target_os = "macos")]
 		{
 			self.macos_hud_window_config_cache = resources.macos_hud_window_config_cache;
@@ -923,7 +958,7 @@ impl OverlaySession {
 		}
 
 		let hide_auxiliary_windows = self.frozen_selection_drag_hides_auxiliary_windows();
-		let hide_live_drag_auxiliary_windows = self.live_drag_hides_auxiliary_windows();
+		let hide_live_drag_auxiliary_windows = self.live_capture_hides_auxiliary_windows();
 		let request_hud_window = !hide_auxiliary_windows
 			&& !hide_live_drag_auxiliary_windows
 			&& self.hud_window.is_some();
@@ -982,7 +1017,7 @@ impl OverlaySession {
 
 	pub(super) fn request_redraw_hud_window(&self) {
 		if self.frozen_selection_drag_hides_auxiliary_windows()
-			|| self.live_drag_hides_auxiliary_windows()
+			|| self.live_capture_hides_auxiliary_windows()
 		{
 			return;
 		}
@@ -1004,7 +1039,7 @@ impl OverlaySession {
 
 	pub(super) fn request_redraw_loupe_window(&self) {
 		if self.frozen_selection_drag_hides_auxiliary_windows()
-			|| self.live_drag_hides_auxiliary_windows()
+			|| self.live_capture_hides_auxiliary_windows()
 		{
 			return;
 		}
@@ -1063,6 +1098,8 @@ struct PrewarmedStartupResources {
 	gpu: Option<GpuContext>,
 	windows: HashMap<WindowId, OverlayWindow>,
 	hud_window: Option<HudOverlayWindow>,
+	toolbar_window: Option<HudOverlayWindow>,
+	toolbar_inner_size_points: Option<(u32, u32)>,
 	#[cfg(target_os = "macos")]
 	macos_hud_window_config_cache: HashMap<WindowId, MacOSHudWindowConfigState>,
 }


### PR DESCRIPTION
## Summary
- prewarm and refresh macOS live snapshots earlier in the press-pending and frozen handoff paths to reduce frozen entry latency
- keep the live-to-frozen handoff visually stable by removing intermediate widget and scrim churn and tightening toolbar and badge sequencing
- restore passive macOS capture-window focus policy after temporary keyboard-focus flows so windows do not stay key-capable across later pointer interactions

## Verification
- cargo make fmt-rust-check
- cargo make lint
- cargo test -p rsnap-overlay --lib

Refs XY-275