### PR TITLE
Refactor macOS capture windows onto native AppKit shells

### DIFF
--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -55,6 +55,8 @@ pub(crate) enum UserEvent {
 	OverlayScrollInput,
 	#[cfg(target_os = "macos")]
 	OverlayWorkerResponse,
+	#[cfg(target_os = "macos")]
+	OverlayNativeCaptureInput,
 }
 
 #[cfg(target_os = "macos")]
@@ -127,6 +129,8 @@ struct App {
 	scroll_input_shared_state: Arc<SharedScrollInputState>,
 	#[cfg(target_os = "macos")]
 	overlay_stream_event_pending: Arc<AtomicBool>,
+	#[cfg(target_os = "macos")]
+	overlay_native_capture_input_event_pending: Arc<AtomicBool>,
 	#[cfg(target_os = "macos")]
 	latest_deferred_ocr_generation: Arc<AtomicU64>,
 	#[cfg(target_os = "macos")]
@@ -212,6 +216,8 @@ impl App {
 			scroll_input_shared_state,
 			#[cfg(target_os = "macos")]
 			overlay_stream_event_pending: Arc::new(AtomicBool::new(false)),
+			#[cfg(target_os = "macos")]
+			overlay_native_capture_input_event_pending: Arc::new(AtomicBool::new(false)),
 			#[cfg(target_os = "macos")]
 			latest_deferred_ocr_generation: Arc::new(AtomicU64::new(0)),
 			#[cfg(target_os = "macos")]

--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -41,7 +41,9 @@ use self::scroll_input_macos::SharedScrollInputState;
 use crate::permissions_macos;
 use crate::settings::AppSettings;
 use crate::settings_window::{SettingsWindow, SettingsWindowEntry};
-use rsnap_overlay::{FrozenGlobalHotkey, OverlaySession};
+#[cfg(target_os = "macos")]
+use rsnap_overlay::FrozenGlobalHotkey;
+use rsnap_overlay::OverlaySession;
 
 pub(crate) enum UserEvent {
 	TrayIcon,

--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -17,7 +17,7 @@ use color_eyre::eyre::Result;
 #[cfg(target_os = "macos")]
 use global_hotkey::Error;
 #[cfg(target_os = "macos")]
-use global_hotkey::hotkey::Code;
+use global_hotkey::hotkey::{Code, Modifiers};
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, hotkey::HotKey};
 #[cfg(target_os = "macos")]
 use objc2::rc::Retained;
@@ -41,7 +41,7 @@ use self::scroll_input_macos::SharedScrollInputState;
 use crate::permissions_macos;
 use crate::settings::AppSettings;
 use crate::settings_window::{SettingsWindow, SettingsWindowEntry};
-use rsnap_overlay::OverlaySession;
+use rsnap_overlay::{FrozenGlobalHotkey, OverlaySession};
 
 pub(crate) enum UserEvent {
 	TrayIcon,
@@ -80,6 +80,28 @@ impl OverlayHotkeyRegistrationState {
 	}
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OverlayFrozenHotkeyBinding {
+	action: FrozenGlobalHotkey,
+	hotkey: HotKey,
+	hotkey_id: u32,
+	registration_state: OverlayHotkeyRegistrationState,
+	label: &'static str,
+}
+#[cfg(target_os = "macos")]
+impl OverlayFrozenHotkeyBinding {
+	fn new(action: FrozenGlobalHotkey, hotkey: HotKey, label: &'static str) -> Self {
+		Self {
+			action,
+			hotkey_id: hotkey.id(),
+			hotkey,
+			registration_state: OverlayHotkeyRegistrationState::Unregistered,
+			label,
+		}
+	}
+}
+
 struct App {
 	capture_hotkey: HotKey,
 	capture_hotkey_id: u32,
@@ -98,6 +120,8 @@ struct App {
 	overlay_loupe_hotkey_id: u32,
 	#[cfg(target_os = "macos")]
 	overlay_loupe_hotkey_registration_state: OverlayHotkeyRegistrationState,
+	#[cfg(target_os = "macos")]
+	overlay_frozen_hotkeys: Vec<OverlayFrozenHotkeyBinding>,
 	capture_hotkey_recording_suspended: bool,
 	tray_icon: Option<TrayIcon>,
 	#[cfg(target_os = "macos")]
@@ -155,6 +179,37 @@ impl App {
 		HotKey::new(None, Code::Tab)
 	}
 
+	#[cfg(target_os = "macos")]
+	fn overlay_frozen_hotkeys() -> Vec<OverlayFrozenHotkeyBinding> {
+		vec![
+			OverlayFrozenHotkeyBinding::new(
+				FrozenGlobalHotkey::Copy,
+				HotKey::new(None, Code::Space),
+				"Space",
+			),
+			OverlayFrozenHotkeyBinding::new(
+				FrozenGlobalHotkey::AutoCenter,
+				HotKey::new(None, Code::KeyC),
+				"C",
+			),
+			OverlayFrozenHotkeyBinding::new(
+				FrozenGlobalHotkey::ToggleToolbar,
+				HotKey::new(None, Code::KeyH),
+				"H",
+			),
+			OverlayFrozenHotkeyBinding::new(
+				FrozenGlobalHotkey::StartScrollCapture,
+				HotKey::new(None, Code::KeyS),
+				"S",
+			),
+			OverlayFrozenHotkeyBinding::new(
+				FrozenGlobalHotkey::Save,
+				HotKey::new(Some(Modifiers::SUPER), Code::KeyS),
+				"Cmd+S",
+			),
+		]
+	}
+
 	#[allow(clippy::too_many_arguments)]
 	fn new(
 		capture_hotkey: HotKey,
@@ -184,6 +239,8 @@ impl App {
 			overlay_loupe_hotkey_id: Self::overlay_loupe_hotkey().id(),
 			#[cfg(target_os = "macos")]
 			overlay_loupe_hotkey_registration_state: OverlayHotkeyRegistrationState::Unregistered,
+			#[cfg(target_os = "macos")]
+			overlay_frozen_hotkeys: Self::overlay_frozen_hotkeys(),
 			capture_hotkey_recording_suspended: false,
 			_hotkey_manager: hotkey_manager,
 			tray_icon: None,
@@ -318,6 +375,8 @@ mod tests {
 	#[cfg(target_os = "macos")]
 	use crate::app::OverlayHotkeyRegistrationState;
 	use crate::app::{self, SettingsWindowEntry};
+	#[cfg(target_os = "macos")]
+	use rsnap_overlay::FrozenGlobalHotkey;
 
 	#[test]
 	fn startup_permission_check_uses_permissions_entry() {
@@ -356,6 +415,24 @@ mod tests {
 
 		assert_eq!(hotkey.key, Code::Tab);
 		assert_eq!(hotkey.mods, Modifiers::empty());
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn overlay_frozen_hotkeys_cover_copy_center_toolbar_scroll_and_save() {
+		let bindings = app::App::overlay_frozen_hotkeys();
+
+		assert_eq!(bindings.len(), 5);
+		assert!(bindings.iter().any(|binding| {
+			binding.action == FrozenGlobalHotkey::Copy
+				&& binding.hotkey.key == Code::Space
+				&& binding.hotkey.mods == Modifiers::empty()
+		}));
+		assert!(bindings.iter().any(|binding| {
+			binding.action == FrozenGlobalHotkey::Save
+				&& binding.hotkey.key == Code::KeyS
+				&& binding.hotkey.mods == Modifiers::SUPER
+		}));
 	}
 
 	#[cfg(target_os = "macos")]

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -366,6 +366,7 @@ impl App {
 			self.overlay_session_prewarm_retry_not_before = None;
 			self.overlay_session_generation = self.overlay_session_generation.wrapping_add(1);
 
+			self.overlay_native_capture_input_event_pending.store(false, Ordering::Release);
 			self.pending_deferred_ocr_generation
 				.store(self.overlay_session_generation, Ordering::Release);
 		}
@@ -603,6 +604,22 @@ impl App {
 					let _ = overlay_proxy.send_event(UserEvent::OverlayWorkerResponse);
 				}
 			}));
+			overlay_session.set_native_capture_input_waker(Arc::new({
+				let overlay_proxy = self.overlay_proxy.clone();
+				let native_input_pending =
+					Arc::clone(&self.overlay_native_capture_input_event_pending);
+
+				move || {
+					if native_input_pending
+						.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+						.is_ok() && overlay_proxy
+						.send_event(UserEvent::OverlayNativeCaptureInput)
+						.is_err()
+					{
+						native_input_pending.store(false, Ordering::Release);
+					}
+				}
+			}));
 			overlay_session.set_external_scroll_input_drain_reader(Arc::new({
 				let shared_state = Arc::clone(&self.scroll_input_shared_state);
 
@@ -650,6 +667,8 @@ impl App {
 			return;
 		};
 
+		#[cfg(target_os = "macos")]
+		self.overlay_native_capture_input_event_pending.store(false, Ordering::Release);
 		#[cfg(target_os = "macos")]
 		{
 			self.unregister_overlay_cancel_hotkey();

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -719,6 +719,7 @@ impl App {
 		{
 			self.unregister_overlay_cancel_hotkey();
 			self.unregister_overlay_loupe_hotkey();
+			self.unregister_overlay_frozen_hotkeys();
 		}
 
 		#[cfg(target_os = "macos")]

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -28,6 +28,8 @@ use winit::event_loop::ActiveEventLoop;
 
 use crate::app::App;
 #[cfg(target_os = "macos")]
+use crate::app::OverlayFrozenHotkeyBinding;
+#[cfg(target_os = "macos")]
 use crate::app::OverlayHotkeyRegistrationState;
 #[cfg(target_os = "macos")]
 use crate::app::UserEvent;
@@ -196,6 +198,20 @@ impl App {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn overlay_frozen_hotkey_spec(binding: &OverlayFrozenHotkeyBinding) -> OverlayHotkeySpec {
+		OverlayHotkeySpec {
+			hotkey: binding.hotkey,
+			hotkey_id: binding.hotkey_id,
+			hotkey_label: binding.label,
+			missing_manager_message: "Frozen overlay hotkeys are unavailable because the global hotkey manager is missing.",
+			register_failure_message: "Failed to register a frozen overlay hotkey.",
+			register_success_message: "Registered a frozen overlay hotkey.",
+			unregister_failure_message: "Failed to unregister a frozen overlay hotkey.",
+			unregister_success_message: "Unregistered a frozen overlay hotkey.",
+		}
+	}
+
+	#[cfg(target_os = "macos")]
 	fn register_overlay_cancel_hotkey(&mut self) {
 		let spec = self.overlay_cancel_hotkey_spec();
 
@@ -228,11 +244,36 @@ impl App {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn register_overlay_frozen_hotkeys(&mut self) {
+		for index in 0..self.overlay_frozen_hotkeys.len() {
+			let binding = self.overlay_frozen_hotkeys[index];
+			let spec = Self::overlay_frozen_hotkey_spec(&binding);
+			let registration_state = self.register_overlay_hotkey(spec, binding.registration_state);
+
+			self.overlay_frozen_hotkeys[index].registration_state = registration_state;
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn unregister_overlay_frozen_hotkeys(&mut self) {
+		for index in 0..self.overlay_frozen_hotkeys.len() {
+			let binding = self.overlay_frozen_hotkeys[index];
+			let spec = Self::overlay_frozen_hotkey_spec(&binding);
+			let registration_state =
+				self.unregister_overlay_hotkey(spec, binding.registration_state);
+
+			self.overlay_frozen_hotkeys[index].registration_state = registration_state;
+		}
+	}
+
+	#[cfg(target_os = "macos")]
 	fn sync_overlay_hotkey_registrations(&mut self) {
 		let should_register_cancel =
 			self.overlay_session.as_ref().is_some_and(OverlaySession::wants_global_cancel_hotkey);
 		let should_register_loupe =
 			self.overlay_session.as_ref().is_some_and(OverlaySession::wants_global_loupe_hotkey);
+		let should_register_frozen =
+			self.overlay_session.as_ref().is_some_and(OverlaySession::wants_global_frozen_hotkeys);
 
 		if should_register_cancel {
 			self.register_overlay_cancel_hotkey();
@@ -243,6 +284,11 @@ impl App {
 			self.register_overlay_loupe_hotkey();
 		} else {
 			self.unregister_overlay_loupe_hotkey();
+		}
+		if should_register_frozen {
+			self.register_overlay_frozen_hotkeys();
+		} else {
+			self.unregister_overlay_frozen_hotkeys();
 		}
 	}
 

--- a/apps/rsnap/src/app/runtime.rs
+++ b/apps/rsnap/src/app/runtime.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 #[cfg(target_os = "macos")]
-use std::sync::Arc;
+use std::sync::{Arc, atomic::Ordering};
 use std::time::{Duration, Instant};
 
 use color_eyre::eyre;
@@ -77,6 +77,16 @@ impl ApplicationHandler<UserEvent> for App {
 			UserEvent::OverlayWorkerResponse => {
 				if let Some(session) = self.overlay_session.as_mut() {
 					let control = session.handle_worker_response_ready();
+
+					self.handle_overlay_control(control);
+				}
+			},
+			#[cfg(target_os = "macos")]
+			UserEvent::OverlayNativeCaptureInput => {
+				self.overlay_native_capture_input_event_pending.store(false, Ordering::Release);
+
+				if let Some(session) = self.overlay_session.as_mut() {
+					let control = session.handle_native_capture_input_ready();
 
 					self.handle_overlay_control(control);
 				}

--- a/apps/rsnap/src/app/shell.rs
+++ b/apps/rsnap/src/app/shell.rs
@@ -256,6 +256,25 @@ impl App {
 
 			return;
 		}
+		#[cfg(target_os = "macos")]
+		if self.overlay_session.is_some()
+			&& let Some(binding) =
+				self.overlay_frozen_hotkeys.iter().find(|binding| binding.hotkey_id == event.id())
+		{
+			tracing::info!(
+				hotkey = binding.label,
+				action = ?binding.action,
+				"Capture frozen action requested from hotkey."
+			);
+
+			if let Some(session) = self.overlay_session.as_mut() {
+				let control = session.handle_global_frozen_hotkey(binding.action);
+
+				self.handle_overlay_control(control);
+			}
+
+			return;
+		}
 		if event.id() == self.capture_hotkey_id {
 			tracing::info!(
 				hotkey = %self.capture_key_label(),

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -47,3 +47,5 @@ Then keep the body descriptive:
   directories
 - `docs/reference/live-sampling.md` for the stream-first live RGB and loupe sampling path
 - `docs/reference/window-hit-testing.md` for live-mode hovered-window targeting strategy
+- `docs/reference/macos-native-capture-window-layer.md` for the passive AppKit shell and
+  explicit key-focus shell boundary on macOS

--- a/docs/reference/macos-native-capture-window-layer.md
+++ b/docs/reference/macos-native-capture-window-layer.md
@@ -1,0 +1,86 @@
+# macOS Native Capture Window Layer
+
+Purpose: Describe the current macOS-native window shell that now owns passive pointer input and
+explicit keyboard-focus routing for rsnap capture sessions.
+
+Read this when: You are changing macOS overlay-window behavior, focus/activation handling, IME
+support, or the app-shell boundary that wakes overlay input.
+
+Inputs: `docs/spec/capture-session.md`, `packages/rsnap-overlay/src/overlay.rs`,
+`packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs`,
+`apps/rsnap/src/app/capture.rs`
+
+Depends on: `docs/spec/capture-session.md`, `docs/reference/workspace-layout.md`
+
+Covers: The current passive AppKit shell model, the explicit key-focus shell, and the app-shell
+event boundary that bridges native input back into Rust.
+
+Spec boundary: `docs/spec/capture-session.md`
+
+## Current model
+
+The Rust overlay session still owns capture state, display/export authority, worker coordination,
+rendering, and output flow. On macOS, window activation and pointer/IME routing are no longer
+owned exclusively by `winit` windows.
+
+Instead, rsnap now uses a split shell model:
+
+- Passive AppKit shells mirror live overlay windows and the frozen toolbar for pointer input.
+- A dedicated key-focus AppKit shell appears only when Frozen text editing or scroll capture
+  needs keyboard ownership.
+- Rust remains the source of truth for session state and input handling; the native shells only
+  gather platform events and wake the overlay session.
+
+## Passive pointer shells
+
+The passive shell layer exists to keep live capture, frozen entry, and toolbar pointer
+interaction from activating rsnap or stealing `key/main` window status from the target app.
+
+Current behavior:
+
+- Live overlay pointer movement and left-click selection come from passive AppKit shells.
+- Frozen toolbar pointer move, drag, hover, and scroll-wheel input also come from passive shells.
+- The mirrored `winit` windows remain the render surfaces, but they are not the macOS pointer
+  interaction authority for these flows.
+
+This is the layer that replaced the older per-window `winit` focus-policy patching path.
+
+## Explicit key-focus shell
+
+Keyboard ownership is now explicit and scoped:
+
+- Frozen text editing uses a dedicated key-focus shell so ASCII input, command keys, and IME
+  composition can flow without turning the pointer shells into key windows.
+- Scroll capture uses the same key-focus shell pattern for `Esc`, `Space`, save shortcuts, and
+  pause/undo controls.
+- When neither text editing nor scroll capture needs keyboard ownership, no capture window should
+  remain key-capable.
+
+The key-focus shell is AppKit-owned and implements the minimal responder and `NSTextInputClient`
+surface needed for rsnap's current text/IME needs.
+
+## App-shell wake boundary
+
+Native AppKit input does not mutate session state directly. The app shell owns the wake path:
+
+- `rsnap-overlay` enqueues passive-shell events in its native capture input queue.
+- `apps/rsnap` installs a native-capture-input waker on session creation.
+- The app shell coalesces wakeups into `UserEvent::OverlayNativeCaptureInput`.
+- The overlay session drains the queue on the main event loop and applies the events through the
+  same Rust input handlers used by the rest of the session.
+
+This keeps the platform boundary at the event-delivery layer instead of pushing session mutations
+into AppKit callbacks.
+
+## What still stays in Rust
+
+The native window layer does not own:
+
+- capture-session state machines
+- display/export authority
+- frozen editing behavior
+- scroll-stitching logic
+- PNG/save/OCR/export decisions
+- toolbar layout rules
+
+Those remain in `rsnap-overlay` and are shared with the non-macOS paths.

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -70,6 +70,9 @@ Key paths:
 - `packages/rsnap-overlay/src/lib.rs`: public session-level surface exported to the app shell
 - `packages/rsnap-overlay/src/overlay.rs`: overlay root plus its focused runtime/rendering support
   modules
+- `packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs`: macOS-only passive
+  AppKit overlay/toolbar shells plus the dedicated key-focus shell bridge for text and scroll
+  interactions
 - `packages/rsnap-overlay/src/scroll_capture.rs`: scroll-capture session entry with focused
   support modules under `scroll_capture/`
 

--- a/docs/runbook/index.md
+++ b/docs/runbook/index.md
@@ -60,3 +60,5 @@ Then structure the body for execution:
 
 - `docs/runbook/performance-validation.md` for repo-native performance and smoke command routing
 - `docs/runbook/scroll-capture-benchmarks.md` for deterministic scroll-capture benchmark usage
+- `docs/runbook/macos-native-capture-window-validation.md` for manual validation of passive
+  pointer shells and explicit key-focus shell behavior on macOS

--- a/docs/runbook/macos-native-capture-window-validation.md
+++ b/docs/runbook/macos-native-capture-window-validation.md
@@ -1,0 +1,47 @@
+# Validate macOS Native Capture Window Layer
+
+Goal: Run the manual validation matrix for the macOS-native passive capture shells and explicit
+key-focus shell.
+
+Read this when: You changed macOS capture-window/focus code, native AppKit shell bridging, or the
+Frozen text/scroll key-focus path and need to verify behavior on a live machine.
+
+Inputs: A macOS machine with Screen Recording permission granted, a build of `rsnap`, and the
+capture-session contract in `docs/spec/capture-session.md`.
+
+Depends on: `docs/spec/capture-session.md`,
+`docs/reference/macos-native-capture-window-layer.md`
+
+Verification: Confirm that pointer capture stays passive, text/scroll keyboard routes still work,
+and no capture flow regresses into visible focus theft or missing IME behavior.
+
+## Validation matrix
+
+1. Live window click
+   - Start capture with another app frontmost.
+   - Hover a target window, then click to enter Frozen mode.
+   - Verify the target app does not remain blurred after selection completes.
+   - Verify rsnap does not need a visible Dock/key-window activation to complete the click flow.
+
+2. Live drag region
+   - Start capture over another app.
+   - Press-drag-release to create a region freeze.
+   - Verify auxiliary live widgets disappear on press and do not reappear during handoff.
+   - Verify the target app remains the apparent frontmost app after selection completes.
+
+3. Frozen text editing
+   - Enter Frozen mode, switch to the text tool, and click to start editing.
+   - Type plain ASCII text.
+   - Verify text appears and `Esc` cancels text editing instead of the whole session.
+   - Use an IME preedit flow and confirm marked text and commit both work.
+
+4. Scroll capture keyboard flow
+   - Enter scroll capture from a dragged-region freeze.
+   - Verify `Space`, save shortcut, pause, undo, and `Esc` still work.
+   - Verify these controls continue working even though live pointer interaction stays passive.
+
+5. Session exit cleanup
+   - Cancel capture from live mode and from Frozen mode.
+   - Restart capture immediately after each exit.
+   - Verify the next session does not inherit stale focus, stale key ownership, or missing
+     pointer input.

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -59,6 +59,12 @@ cross-platform architecture.
     externally capturable by system screenshot and screen-recording tools. Internal self-capture
     correctness comes from rsnap's own exclusion filters and freeze handoff logic, not window
     content protection.
+4b. On macOS, live overlay pointer input and frozen-toolbar pointer input MUST be handled through
+    passive AppKit-owned shells so the pointer path does not require capture windows to become
+    `key`/`main` windows.
+4c. On macOS, explicit keyboard ownership during capture MUST be scoped to a dedicated key-focus
+    shell that is activated only for Frozen text editing and scroll capture. Ordinary live
+    selection and frozen pointer interaction MUST NOT rely on capture windows becoming key.
 5. In live mode, the overlay MUST show a HUD near the cursor with:
    - global cursor coordinates `x,y`
    - pixel color `rgb(r,g,b)` under the cursor

--- a/packages/rsnap-overlay/src/backend.rs
+++ b/packages/rsnap-overlay/src/backend.rs
@@ -40,6 +40,7 @@ use xcap::Window;
 
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
+use crate::macos_color;
 use crate::state::{
 	GlobalPoint, LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb, WindowHit,
 	WindowListSnapshot, WindowRect,
@@ -381,7 +382,7 @@ impl XcapCaptureBackend {
 		let cg_image = objc2_core_graphics::CGDisplayCreateImage(monitor.id)
 			.ok_or_else(|| eyre::eyre!("CGDisplayCreateImage returned null"))?;
 
-		rgba_image_from_cg_image(cg_image.as_ref())
+		rgba_image_from_cg_image_for_display(cg_image.as_ref(), Some(monitor.id))
 			.wrap_err_with(|| format!("failed to decode display image for monitor: {monitor:?}"))
 	}
 
@@ -409,7 +410,7 @@ impl XcapCaptureBackend {
 			return Err(CaptureBackendError::WindowNotFound { window_id }.into());
 		};
 
-		rgba_image_from_cg_image(cg_image)
+		rgba_image_from_cg_image_for_display(cg_image, None)
 			.wrap_err_with(|| format!("Failed to decode window capture bytes: {window_id}"))
 	}
 
@@ -1004,6 +1005,18 @@ fn rgba_image_from_cg_image(cg_image: &CGImage) -> Result<RgbaImage> {
 }
 
 #[cfg(target_os = "macos")]
+fn rgba_image_from_cg_image_for_display(
+	cg_image: &CGImage,
+	display_id: Option<u32>,
+) -> Result<RgbaImage> {
+	if let Some(image) = macos_color::rgba_image_from_cg_image_color_managed(cg_image, display_id) {
+		return Ok(image);
+	}
+
+	rgba_image_from_cg_image(cg_image)
+}
+
+#[cfg(target_os = "macos")]
 fn rgba_image_from_bgra_rows(
 	width: usize,
 	height: usize,
@@ -1058,7 +1071,7 @@ fn capture_monitor_region_with_core_graphics(
 	);
 	let image = objc2_core_graphics::CGDisplayCreateImageForRect(monitor.id, cg_rect)
 		.ok_or_else(|| eyre::eyre!("CGDisplayCreateImageForRect returned null"))?;
-	let image = rgba_image_from_cg_image(image.as_ref())
+	let image = rgba_image_from_cg_image_for_display(image.as_ref(), Some(monitor.id))
 		.wrap_err("failed to decode CGDisplay rect capture")?;
 
 	if image.width() == rect_px.width.max(1) && image.height() == rect_px.height.max(1) {
@@ -1067,7 +1080,7 @@ fn capture_monitor_region_with_core_graphics(
 
 	let full_image = objc2_core_graphics::CGDisplayCreateImage(monitor.id)
 		.ok_or_else(|| eyre::eyre!("CGDisplayCreateImage returned null"))?;
-	let full_image = rgba_image_from_cg_image(full_image.as_ref())
+	let full_image = rgba_image_from_cg_image_for_display(full_image.as_ref(), Some(monitor.id))
 		.wrap_err("failed to decode CGDisplay full-monitor capture")?;
 
 	crop_monitor_image_region(&full_image, rect_px)
@@ -1179,7 +1192,7 @@ fn capture_monitor_region_image_with_screenshot_manager(
 		CGSize::new(f64::from(rect_px.width) / sf, f64::from(rect_px.height) / sf),
 	);
 	let cg_image = capture_screenshot_cg_image(cg_rect)?;
-	let image = rgba_image_from_cg_image(cg_image.as_ref())?;
+	let image = rgba_image_from_cg_image_for_display(cg_image.as_ref(), Some(monitor.id))?;
 
 	// ScreenCaptureKit may round point-space captures by one pixel at non-integer scale edges.
 	// Clamp or extend back to the requested region so the stitcher sees stable dimensions.

--- a/packages/rsnap-overlay/src/backend.rs
+++ b/packages/rsnap-overlay/src/backend.rs
@@ -40,6 +40,7 @@ use xcap::Window;
 
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
+#[cfg(target_os = "macos")]
 use crate::macos_color;
 use crate::state::{
 	GlobalPoint, LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb, WindowHit,

--- a/packages/rsnap-overlay/src/lib.rs
+++ b/packages/rsnap-overlay/src/lib.rs
@@ -29,6 +29,8 @@ mod deferred_text_recognition;
 #[cfg(target_os = "macos")]
 mod live_frame_stream_macos;
 #[cfg(target_os = "macos")]
+mod macos_color;
+#[cfg(target_os = "macos")]
 mod ocr_macos;
 mod overlay;
 mod png;
@@ -45,8 +47,8 @@ pub use crate::deferred_text_recognition::{
 	process_deferred_text_recognition_for_latest_capture,
 };
 pub use crate::overlay::{
-	AltActivationMode, HudAnchor, OutputNaming, OverlayConfig, OverlayControl, OverlayExit,
-	OverlaySession, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode,
+	AltActivationMode, FrozenGlobalHotkey, HudAnchor, OutputNaming, OverlayConfig, OverlayControl,
+	OverlayExit, OverlaySession, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode,
 };
 pub use crate::state::{
 	GlobalPoint, LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb, WindowHit,

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -38,6 +38,7 @@ use objc2_screen_capture_kit::{
 	SCStreamConfiguration, SCStreamDelegate, SCStreamOutput, SCStreamOutputType, SCWindow,
 };
 
+use crate::macos_color;
 use crate::state::{LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb};
 
 objc2::define_class!(
@@ -423,7 +424,8 @@ impl MacLiveFrameStream {
 			return None;
 		};
 		let (width_px, height_px) = pixel_buffer_size_px(&frame.pixel_buffer)?;
-		let image = rgba_image_from_pixel_buffer(&frame.pixel_buffer, width_px, height_px)?;
+		let image =
+			rgba_image_from_pixel_buffer(&frame.pixel_buffer, width_px, height_px, monitor.id)?;
 
 		Some(Arc::new(MonitorImageSnapshot {
 			captured_at: frame.captured_at,
@@ -1749,7 +1751,8 @@ fn reply_with_latest_rgba_snapshot(
 	let snapshot = state.as_ref().and_then(|stream_state| {
 		let frame = stream_state.output.latest_frame()?;
 		let (width_px, height_px) = pixel_buffer_size_px(&frame.pixel_buffer)?;
-		let image = rgba_image_from_pixel_buffer(&frame.pixel_buffer, width_px, height_px)?;
+		let image =
+			rgba_image_from_pixel_buffer(&frame.pixel_buffer, width_px, height_px, monitor.id)?;
 
 		Some(Arc::new(MonitorImageSnapshot {
 			captured_at: frame.captured_at,
@@ -3032,7 +3035,17 @@ fn rgba_image_from_pixel_buffer(
 	pixel_buffer: &CFRetained<CVPixelBuffer>,
 	width_px: u32,
 	height_px: u32,
+	display_id: u32,
 ) -> Option<RgbaImage> {
+	if let Some(image) = macos_color::rgba_image_from_pixel_buffer_color_managed(
+		pixel_buffer,
+		width_px,
+		height_px,
+		Some(display_id),
+	) {
+		return Some(image);
+	}
+
 	let lock_result =
 		unsafe { CVPixelBufferLockBaseAddress(pixel_buffer, CVPixelBufferLockFlags::ReadOnly) };
 

--- a/packages/rsnap-overlay/src/macos_color.rs
+++ b/packages/rsnap-overlay/src/macos_color.rs
@@ -1,0 +1,345 @@
+#[cfg(target_os = "macos")]
+use std::ffi::c_void;
+#[cfg(target_os = "macos")]
+use std::ptr;
+#[cfg(target_os = "macos")]
+use std::slice;
+
+#[cfg(target_os = "macos")]
+use image::RgbaImage;
+#[cfg(target_os = "macos")]
+use objc2_core_foundation::{CFData, CFRetained, CGPoint, CGRect, CGSize};
+#[cfg(target_os = "macos")]
+use objc2_core_graphics::{
+	CGBitmapContextCreate, CGBitmapInfo, CGColorRenderingIntent, CGColorSpace, CGContext,
+	CGDataProvider, CGDirectDisplayID, CGDisplayCopyColorSpace, CGImage, CGImageAlphaInfo,
+	CGImageByteOrderInfo, kCGColorSpaceSRGB,
+};
+#[cfg(target_os = "macos")]
+use objc2_core_video::{
+	CVPixelBuffer, CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow,
+	CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress,
+	kCVImageBufferCGColorSpaceKey, kCVReturnSuccess,
+};
+
+#[cfg(target_os = "macos")]
+fn srgb_color_space() -> Option<CFRetained<CGColorSpace>> {
+	CGColorSpace::with_name(Some(unsafe { kCGColorSpaceSRGB }))
+		.or_else(CGColorSpace::new_device_rgb)
+}
+
+#[cfg(target_os = "macos")]
+fn monitor_color_space(display_id: Option<u32>) -> Option<CFRetained<CGColorSpace>> {
+	display_id.map(|display_id| CGDisplayCopyColorSpace(display_id as CGDirectDisplayID))
+}
+
+#[cfg(target_os = "macos")]
+fn pixel_buffer_color_space(
+	pixel_buffer: &CFRetained<CVPixelBuffer>,
+) -> Option<CFRetained<CGColorSpace>> {
+	let attachment =
+		unsafe { pixel_buffer.attachment(kCVImageBufferCGColorSpaceKey, ptr::null_mut()) }?;
+
+	attachment.downcast::<CGColorSpace>().ok()
+}
+
+#[cfg(target_os = "macos")]
+fn color_managed_rgba_from_bgra_bytes(
+	width: usize,
+	height: usize,
+	bytes_per_row: usize,
+	data: &[u8],
+	src_color_space: Option<&CGColorSpace>,
+	display_id: Option<u32>,
+	_src_bitmap_info: CGBitmapInfo,
+) -> Option<RgbaImage> {
+	if width == 0 || height == 0 {
+		return None;
+	}
+
+	let expected_row_bytes = width.checked_mul(4)?;
+	if bytes_per_row < expected_row_bytes {
+		return None;
+	}
+
+	let required_len = height.checked_mul(bytes_per_row)?;
+	if data.len() < required_len {
+		return None;
+	}
+
+	let fallback_monitor_space = monitor_color_space(display_id);
+	let fallback_srgb_space = srgb_color_space();
+	let src_space =
+		src_color_space.or(fallback_monitor_space.as_deref()).or(fallback_srgb_space.as_deref())?;
+	let dst_space = srgb_color_space()?;
+	let normalized_src_bitmap_info =
+		CGBitmapInfo(CGImageAlphaInfo::NoneSkipFirst.0 | CGImageByteOrderInfo::Order32Little.0);
+	let provider =
+		CGDataProvider::with_cf_data(Some(CFData::from_bytes(&data[..required_len]).as_ref()))?;
+	let source = unsafe {
+		CGImage::new(
+			width,
+			height,
+			8,
+			32,
+			bytes_per_row,
+			Some(src_space),
+			normalized_src_bitmap_info,
+			Some(provider.as_ref()),
+			ptr::null(),
+			false,
+			CGColorRenderingIntent::RenderingIntentDefault,
+		)
+	}?;
+	let mut dst = vec![0_u8; width.checked_mul(height)?.checked_mul(4)?];
+	let dst_bytes_per_row = width.checked_mul(4)?;
+	let context = unsafe {
+		CGBitmapContextCreate(
+			dst.as_mut_ptr().cast::<c_void>(),
+			width,
+			height,
+			8,
+			dst_bytes_per_row,
+			Some(dst_space.as_ref()),
+			(CGBitmapInfo(
+				CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+			))
+			.0,
+		)
+	}?;
+	let draw_rect = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(width as f64, height as f64));
+
+	CGContext::draw_image(Some(context.as_ref()), draw_rect, Some(source.as_ref()));
+
+	for bgra in dst.chunks_exact_mut(4) {
+		bgra.swap(0, 2);
+	}
+
+	RgbaImage::from_raw(width as u32, height as u32, dst)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn rgba_image_from_pixel_buffer_color_managed(
+	pixel_buffer: &CFRetained<CVPixelBuffer>,
+	width_px: u32,
+	height_px: u32,
+	display_id: Option<u32>,
+) -> Option<RgbaImage> {
+	let lock_result =
+		unsafe { CVPixelBufferLockBaseAddress(pixel_buffer, CVPixelBufferLockFlags::ReadOnly) };
+
+	if lock_result != kCVReturnSuccess {
+		return None;
+	}
+
+	let out = (|| {
+		let base = CVPixelBufferGetBaseAddress(pixel_buffer) as *const u8;
+		if base.is_null() {
+			return None;
+		}
+
+		let bytes_per_row = CVPixelBufferGetBytesPerRow(pixel_buffer);
+		let height = height_px.max(1) as usize;
+		let byte_len = height.checked_mul(bytes_per_row)?;
+		let bytes = unsafe { slice::from_raw_parts(base, byte_len) };
+		let src_color_space = pixel_buffer_color_space(pixel_buffer);
+		let src_bitmap_info = CGBitmapInfo(
+			CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+		);
+
+		color_managed_rgba_from_bgra_bytes(
+			width_px.max(1) as usize,
+			height,
+			bytes_per_row,
+			bytes,
+			src_color_space.as_deref(),
+			display_id,
+			src_bitmap_info,
+		)
+	})();
+	let _ =
+		unsafe { CVPixelBufferUnlockBaseAddress(pixel_buffer, CVPixelBufferLockFlags::ReadOnly) };
+
+	out
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn rgba_image_from_cg_image_color_managed(
+	cg_image: &CGImage,
+	display_id: Option<u32>,
+) -> Option<RgbaImage> {
+	let width = CGImage::width(Some(cg_image));
+	let height = CGImage::height(Some(cg_image));
+
+	if width == 0 || height == 0 {
+		return None;
+	}
+
+	let data_provider = CGImage::data_provider(Some(cg_image))?;
+	let data = objc2_core_graphics::CGDataProvider::data(Some(data_provider.as_ref()))?;
+	let bytes = data.to_vec();
+	let bytes_per_row = CGImage::bytes_per_row(Some(cg_image));
+	let src_color_space = CGImage::color_space(Some(cg_image));
+	let src_bitmap_info = CGImage::bitmap_info(Some(cg_image));
+
+	color_managed_rgba_from_bgra_bytes(
+		width,
+		height,
+		bytes_per_row,
+		&bytes,
+		src_color_space.as_deref(),
+		display_id,
+		src_bitmap_info,
+	)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+	use image::{Rgba, RgbaImage};
+	use objc2_core_foundation::{CFData, CGPoint, CGRect, CGSize};
+	use objc2_core_graphics::{
+		CGBitmapContextCreate, CGBitmapInfo, CGColorRenderingIntent, CGColorSpace, CGContext,
+		CGDataProvider, CGImage, CGImageAlphaInfo, CGImageByteOrderInfo,
+	};
+
+	use crate::macos_color::color_managed_rgba_from_bgra_bytes;
+
+	#[test]
+	fn color_managed_bgra_to_rgba_preserves_srgb_identity() {
+		let src_space =
+			CGColorSpace::with_name(Some(unsafe { objc2_core_graphics::kCGColorSpaceSRGB }))
+				.expect("sRGB");
+		let src = [
+			10_u8, 20, 30, 255, // BGRA for RGBA(30,20,10,255)
+			90, 80, 70, 255, // BGRA for RGBA(70,80,90,255)
+		];
+		let image = color_managed_rgba_from_bgra_bytes(
+			2,
+			1,
+			8,
+			&src,
+			Some(src_space.as_ref()),
+			None,
+			objc2_core_graphics::CGBitmapInfo(
+				CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+			),
+		)
+		.expect("converted image");
+
+		let expected = RgbaImage::from_vec(
+			2,
+			1,
+			vec![
+				Rgba([30, 20, 10, 255]).0[0],
+				Rgba([30, 20, 10, 255]).0[1],
+				Rgba([30, 20, 10, 255]).0[2],
+				Rgba([30, 20, 10, 255]).0[3],
+				Rgba([70, 80, 90, 255]).0[0],
+				Rgba([70, 80, 90, 255]).0[1],
+				Rgba([70, 80, 90, 255]).0[2],
+				Rgba([70, 80, 90, 255]).0[3],
+			],
+		)
+		.expect("expected image");
+
+		assert_eq!(image, expected);
+	}
+
+	#[test]
+	fn quartz_color_managed_path_constructs_source_and_context() {
+		let src_space =
+			CGColorSpace::with_name(Some(unsafe { objc2_core_graphics::kCGColorSpaceSRGB }))
+				.expect("sRGB");
+		let src = [
+			10_u8, 20, 30, 255, // BGRA for RGBA(30,20,10,255)
+			90, 80, 70, 255, // BGRA for RGBA(70,80,90,255)
+		];
+		let provider = CGDataProvider::with_cf_data(Some(CFData::from_bytes(&src).as_ref()))
+			.expect("provider");
+		let source = unsafe {
+			CGImage::new(
+				2,
+				1,
+				8,
+				32,
+				8,
+				Some(src_space.as_ref()),
+				CGBitmapInfo(
+					CGImageAlphaInfo::NoneSkipFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+				),
+				Some(provider.as_ref()),
+				std::ptr::null(),
+				false,
+				CGColorRenderingIntent::RenderingIntentDefault,
+			)
+		}
+		.expect("source image");
+		let dst_space =
+			CGColorSpace::with_name(Some(unsafe { objc2_core_graphics::kCGColorSpaceSRGB }))
+				.expect("dst sRGB");
+		let mut dst = vec![0_u8; 8];
+		let context = unsafe {
+			CGBitmapContextCreate(
+				dst.as_mut_ptr().cast(),
+				2,
+				1,
+				8,
+				8,
+				Some(dst_space.as_ref()),
+				(CGBitmapInfo(
+					CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+				))
+				.0,
+			)
+		}
+		.expect("bitmap context");
+		let draw_rect = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(2.0, 1.0));
+
+		CGContext::save_g_state(Some(context.as_ref()));
+		CGContext::translate_ctm(Some(context.as_ref()), 0.0, 1.0);
+		CGContext::scale_ctm(Some(context.as_ref()), 1.0, -1.0);
+		CGContext::draw_image(Some(context.as_ref()), draw_rect, Some(source.as_ref()));
+		CGContext::restore_g_state(Some(context.as_ref()));
+
+		for bgra in dst.chunks_exact_mut(4) {
+			bgra.swap(0, 2);
+		}
+
+		assert_eq!(dst, vec![30, 20, 10, 255, 70, 80, 90, 255]);
+	}
+
+	#[test]
+	fn color_managed_path_preserves_row_order_without_vertical_flip() {
+		let src_space =
+			CGColorSpace::with_name(Some(unsafe { objc2_core_graphics::kCGColorSpaceSRGB }))
+				.expect("sRGB");
+		let src = [
+			10_u8, 20, 30, 255, 40, 50, 60, 255, // top row, BGRA
+			70, 80, 90, 255, 100, 110, 120, 255, // bottom row, BGRA
+		];
+		let image = color_managed_rgba_from_bgra_bytes(
+			2,
+			2,
+			8,
+			&src,
+			Some(src_space.as_ref()),
+			None,
+			objc2_core_graphics::CGBitmapInfo(
+				CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+			),
+		)
+		.expect("converted image");
+
+		let expected = RgbaImage::from_vec(
+			2,
+			2,
+			vec![
+				30, 20, 10, 255, 60, 50, 40, 255, // top row
+				90, 80, 70, 255, 120, 110, 100, 255, // bottom row
+			],
+		)
+		.expect("expected image");
+
+		assert_eq!(image, expected);
+	}
+}

--- a/packages/rsnap-overlay/src/macos_color.rs
+++ b/packages/rsnap-overlay/src/macos_color.rs
@@ -1,204 +1,10 @@
-#[cfg(target_os = "macos")]
-use std::ffi::c_void;
-#[cfg(target_os = "macos")]
-use std::ptr;
-#[cfg(target_os = "macos")]
-use std::slice;
-
-#[cfg(target_os = "macos")]
-use image::RgbaImage;
-#[cfg(target_os = "macos")]
-use objc2_core_foundation::{CFData, CFRetained, CGPoint, CGRect, CGSize};
-#[cfg(target_os = "macos")]
-use objc2_core_graphics::{
-	CGBitmapContextCreate, CGBitmapInfo, CGColorRenderingIntent, CGColorSpace, CGContext,
-	CGDataProvider, CGDirectDisplayID, CGDisplayCopyColorSpace, CGImage, CGImageAlphaInfo,
-	CGImageByteOrderInfo, kCGColorSpaceSRGB,
-};
-#[cfg(target_os = "macos")]
-use objc2_core_video::{
-	CVPixelBuffer, CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow,
-	CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress,
-	kCVImageBufferCGColorSpaceKey, kCVReturnSuccess,
-};
-
-#[cfg(target_os = "macos")]
-fn srgb_color_space() -> Option<CFRetained<CGColorSpace>> {
-	CGColorSpace::with_name(Some(unsafe { kCGColorSpaceSRGB }))
-		.or_else(CGColorSpace::new_device_rgb)
-}
-
-#[cfg(target_os = "macos")]
-fn monitor_color_space(display_id: Option<u32>) -> Option<CFRetained<CGColorSpace>> {
-	display_id.map(|display_id| CGDisplayCopyColorSpace(display_id as CGDirectDisplayID))
-}
-
-#[cfg(target_os = "macos")]
-fn pixel_buffer_color_space(
-	pixel_buffer: &CFRetained<CVPixelBuffer>,
-) -> Option<CFRetained<CGColorSpace>> {
-	let attachment =
-		unsafe { pixel_buffer.attachment(kCVImageBufferCGColorSpaceKey, ptr::null_mut()) }?;
-
-	attachment.downcast::<CGColorSpace>().ok()
-}
-
-#[cfg(target_os = "macos")]
-fn color_managed_rgba_from_bgra_bytes(
-	width: usize,
-	height: usize,
-	bytes_per_row: usize,
-	data: &[u8],
-	src_color_space: Option<&CGColorSpace>,
-	display_id: Option<u32>,
-	_src_bitmap_info: CGBitmapInfo,
-) -> Option<RgbaImage> {
-	if width == 0 || height == 0 {
-		return None;
-	}
-
-	let expected_row_bytes = width.checked_mul(4)?;
-	if bytes_per_row < expected_row_bytes {
-		return None;
-	}
-
-	let required_len = height.checked_mul(bytes_per_row)?;
-	if data.len() < required_len {
-		return None;
-	}
-
-	let fallback_monitor_space = monitor_color_space(display_id);
-	let fallback_srgb_space = srgb_color_space();
-	let src_space =
-		src_color_space.or(fallback_monitor_space.as_deref()).or(fallback_srgb_space.as_deref())?;
-	let dst_space = srgb_color_space()?;
-	let normalized_src_bitmap_info =
-		CGBitmapInfo(CGImageAlphaInfo::NoneSkipFirst.0 | CGImageByteOrderInfo::Order32Little.0);
-	let provider =
-		CGDataProvider::with_cf_data(Some(CFData::from_bytes(&data[..required_len]).as_ref()))?;
-	let source = unsafe {
-		CGImage::new(
-			width,
-			height,
-			8,
-			32,
-			bytes_per_row,
-			Some(src_space),
-			normalized_src_bitmap_info,
-			Some(provider.as_ref()),
-			ptr::null(),
-			false,
-			CGColorRenderingIntent::RenderingIntentDefault,
-		)
-	}?;
-	let mut dst = vec![0_u8; width.checked_mul(height)?.checked_mul(4)?];
-	let dst_bytes_per_row = width.checked_mul(4)?;
-	let context = unsafe {
-		CGBitmapContextCreate(
-			dst.as_mut_ptr().cast::<c_void>(),
-			width,
-			height,
-			8,
-			dst_bytes_per_row,
-			Some(dst_space.as_ref()),
-			(CGBitmapInfo(
-				CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
-			))
-			.0,
-		)
-	}?;
-	let draw_rect = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(width as f64, height as f64));
-
-	CGContext::draw_image(Some(context.as_ref()), draw_rect, Some(source.as_ref()));
-
-	for bgra in dst.chunks_exact_mut(4) {
-		bgra.swap(0, 2);
-	}
-
-	RgbaImage::from_raw(width as u32, height as u32, dst)
-}
-
-#[cfg(target_os = "macos")]
-pub(crate) fn rgba_image_from_pixel_buffer_color_managed(
-	pixel_buffer: &CFRetained<CVPixelBuffer>,
-	width_px: u32,
-	height_px: u32,
-	display_id: Option<u32>,
-) -> Option<RgbaImage> {
-	let lock_result =
-		unsafe { CVPixelBufferLockBaseAddress(pixel_buffer, CVPixelBufferLockFlags::ReadOnly) };
-
-	if lock_result != kCVReturnSuccess {
-		return None;
-	}
-
-	let out = (|| {
-		let base = CVPixelBufferGetBaseAddress(pixel_buffer) as *const u8;
-		if base.is_null() {
-			return None;
-		}
-
-		let bytes_per_row = CVPixelBufferGetBytesPerRow(pixel_buffer);
-		let height = height_px.max(1) as usize;
-		let byte_len = height.checked_mul(bytes_per_row)?;
-		let bytes = unsafe { slice::from_raw_parts(base, byte_len) };
-		let src_color_space = pixel_buffer_color_space(pixel_buffer);
-		let src_bitmap_info = CGBitmapInfo(
-			CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
-		);
-
-		color_managed_rgba_from_bgra_bytes(
-			width_px.max(1) as usize,
-			height,
-			bytes_per_row,
-			bytes,
-			src_color_space.as_deref(),
-			display_id,
-			src_bitmap_info,
-		)
-	})();
-	let _ =
-		unsafe { CVPixelBufferUnlockBaseAddress(pixel_buffer, CVPixelBufferLockFlags::ReadOnly) };
-
-	out
-}
-
-#[cfg(target_os = "macos")]
-pub(crate) fn rgba_image_from_cg_image_color_managed(
-	cg_image: &CGImage,
-	display_id: Option<u32>,
-) -> Option<RgbaImage> {
-	let width = CGImage::width(Some(cg_image));
-	let height = CGImage::height(Some(cg_image));
-
-	if width == 0 || height == 0 {
-		return None;
-	}
-
-	let data_provider = CGImage::data_provider(Some(cg_image))?;
-	let data = objc2_core_graphics::CGDataProvider::data(Some(data_provider.as_ref()))?;
-	let bytes = data.to_vec();
-	let bytes_per_row = CGImage::bytes_per_row(Some(cg_image));
-	let src_color_space = CGImage::color_space(Some(cg_image));
-	let src_bitmap_info = CGImage::bitmap_info(Some(cg_image));
-
-	color_managed_rgba_from_bgra_bytes(
-		width,
-		height,
-		bytes_per_row,
-		&bytes,
-		src_color_space.as_deref(),
-		display_id,
-		src_bitmap_info,
-	)
-}
-
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
+	use std::ptr;
 	use image::{Rgba, RgbaImage};
 	use objc2_core_foundation::{CFData, CGPoint, CGRect, CGSize};
 	use objc2_core_graphics::{
-		CGBitmapContextCreate, CGBitmapInfo, CGColorRenderingIntent, CGColorSpace, CGContext,
+		CGBitmapContextCreate, CGColorRenderingIntent, CGColorSpace, CGContext,
 		CGDataProvider, CGImage, CGImageAlphaInfo, CGImageByteOrderInfo,
 	};
 
@@ -225,7 +31,6 @@ mod tests {
 			),
 		)
 		.expect("converted image");
-
 		let expected = RgbaImage::from_vec(
 			2,
 			1,
@@ -264,11 +69,11 @@ mod tests {
 				32,
 				8,
 				Some(src_space.as_ref()),
-				CGBitmapInfo(
+				objc2_core_graphics::CGBitmapInfo(
 					CGImageAlphaInfo::NoneSkipFirst.0 | CGImageByteOrderInfo::Order32Little.0,
 				),
 				Some(provider.as_ref()),
-				std::ptr::null(),
+				ptr::null(),
 				false,
 				CGColorRenderingIntent::RenderingIntentDefault,
 			)
@@ -286,7 +91,7 @@ mod tests {
 				8,
 				8,
 				Some(dst_space.as_ref()),
-				(CGBitmapInfo(
+				(objc2_core_graphics::CGBitmapInfo(
 					CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
 				))
 				.0,
@@ -329,7 +134,6 @@ mod tests {
 			),
 		)
 		.expect("converted image");
-
 		let expected = RgbaImage::from_vec(
 			2,
 			2,
@@ -342,4 +146,198 @@ mod tests {
 
 		assert_eq!(image, expected);
 	}
+}
+
+#[cfg(target_os = "macos")]
+use std::ffi::c_void;
+#[cfg(target_os = "macos")]
+use std::ptr;
+#[cfg(target_os = "macos")]
+use std::slice;
+
+#[cfg(target_os = "macos")]
+use image::RgbaImage;
+#[cfg(target_os = "macos")]
+use objc2_core_foundation::{CFData, CFRetained, CGPoint, CGRect, CGSize};
+#[cfg(target_os = "macos")]
+use objc2_core_graphics::{self, CGBitmapContextCreate, CGColorRenderingIntent, CGColorSpace, CGContext, CGDataProvider, CGDirectDisplayID, CGDisplayCopyColorSpace, CGImage, CGImageAlphaInfo, CGImageByteOrderInfo};
+#[cfg(target_os = "macos")]
+use objc2_core_video::{
+	CVPixelBuffer, CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow,
+	CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress,
+	kCVImageBufferCGColorSpaceKey, kCVReturnSuccess,
+};
+
+#[cfg(target_os = "macos")]
+pub(crate) fn rgba_image_from_pixel_buffer_color_managed(
+	pixel_buffer: &CFRetained<CVPixelBuffer>,
+	width_px: u32,
+	height_px: u32,
+	display_id: Option<u32>,
+) -> Option<RgbaImage> {
+	let lock_result =
+		unsafe { CVPixelBufferLockBaseAddress(pixel_buffer, CVPixelBufferLockFlags::ReadOnly) };
+
+	if lock_result != kCVReturnSuccess {
+		return None;
+	}
+
+	let out = (|| {
+		let base = CVPixelBufferGetBaseAddress(pixel_buffer) as *const u8;
+
+		if base.is_null() {
+			return None;
+		}
+
+		let bytes_per_row = CVPixelBufferGetBytesPerRow(pixel_buffer);
+		let height = height_px.max(1) as usize;
+		let byte_len = height.checked_mul(bytes_per_row)?;
+		let bytes = unsafe { slice::from_raw_parts(base, byte_len) };
+		let src_color_space = pixel_buffer_color_space(pixel_buffer);
+		let src_bitmap_info = objc2_core_graphics::CGBitmapInfo(
+			CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+		);
+
+		color_managed_rgba_from_bgra_bytes(
+			width_px.max(1) as usize,
+			height,
+			bytes_per_row,
+			bytes,
+			src_color_space.as_deref(),
+			display_id,
+			src_bitmap_info,
+		)
+	})();
+	let _ =
+		unsafe { CVPixelBufferUnlockBaseAddress(pixel_buffer, CVPixelBufferLockFlags::ReadOnly) };
+
+	out
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn rgba_image_from_cg_image_color_managed(
+	cg_image: &CGImage,
+	display_id: Option<u32>,
+) -> Option<RgbaImage> {
+	let width = CGImage::width(Some(cg_image));
+	let height = CGImage::height(Some(cg_image));
+
+	if width == 0 || height == 0 {
+		return None;
+	}
+
+	let data_provider = CGImage::data_provider(Some(cg_image))?;
+	let data = CGDataProvider::data(Some(data_provider.as_ref()))?;
+	let bytes = data.to_vec();
+	let bytes_per_row = CGImage::bytes_per_row(Some(cg_image));
+	let src_color_space = CGImage::color_space(Some(cg_image));
+	let src_bitmap_info = CGImage::bitmap_info(Some(cg_image));
+
+	color_managed_rgba_from_bgra_bytes(
+		width,
+		height,
+		bytes_per_row,
+		&bytes,
+		src_color_space.as_deref(),
+		display_id,
+		src_bitmap_info,
+	)
+}
+
+#[cfg(target_os = "macos")]
+fn srgb_color_space() -> Option<CFRetained<CGColorSpace>> {
+	CGColorSpace::with_name(Some(unsafe { objc2_core_graphics::kCGColorSpaceSRGB }))
+		.or_else(CGColorSpace::new_device_rgb)
+}
+
+#[cfg(target_os = "macos")]
+fn monitor_color_space(display_id: Option<u32>) -> Option<CFRetained<CGColorSpace>> {
+	display_id.map(|display_id| CGDisplayCopyColorSpace(display_id as CGDirectDisplayID))
+}
+
+#[cfg(target_os = "macos")]
+fn pixel_buffer_color_space(
+	pixel_buffer: &CFRetained<CVPixelBuffer>,
+) -> Option<CFRetained<CGColorSpace>> {
+	let attachment =
+		unsafe { pixel_buffer.attachment(kCVImageBufferCGColorSpaceKey, ptr::null_mut()) }?;
+
+	attachment.downcast::<CGColorSpace>().ok()
+}
+
+#[cfg(target_os = "macos")]
+fn color_managed_rgba_from_bgra_bytes(
+	width: usize,
+	height: usize,
+	bytes_per_row: usize,
+	data: &[u8],
+	src_color_space: Option<&CGColorSpace>,
+	display_id: Option<u32>,
+	_src_bitmap_info: objc2_core_graphics::CGBitmapInfo,
+) -> Option<RgbaImage> {
+	if width == 0 || height == 0 {
+		return None;
+	}
+
+	let expected_row_bytes = width.checked_mul(4)?;
+
+	if bytes_per_row < expected_row_bytes {
+		return None;
+	}
+
+	let required_len = height.checked_mul(bytes_per_row)?;
+
+	if data.len() < required_len {
+		return None;
+	}
+
+	let fallback_monitor_space = monitor_color_space(display_id);
+	let fallback_srgb_space = srgb_color_space();
+	let src_space =
+		src_color_space.or(fallback_monitor_space.as_deref()).or(fallback_srgb_space.as_deref())?;
+	let dst_space = srgb_color_space()?;
+	let normalized_src_bitmap_info =
+		objc2_core_graphics::CGBitmapInfo(CGImageAlphaInfo::NoneSkipFirst.0 | CGImageByteOrderInfo::Order32Little.0);
+	let provider =
+		CGDataProvider::with_cf_data(Some(CFData::from_bytes(&data[..required_len]).as_ref()))?;
+	let source = unsafe {
+		CGImage::new(
+			width,
+			height,
+			8,
+			32,
+			bytes_per_row,
+			Some(src_space),
+			normalized_src_bitmap_info,
+			Some(provider.as_ref()),
+			ptr::null(),
+			false,
+			CGColorRenderingIntent::RenderingIntentDefault,
+		)
+	}?;
+	let mut dst = vec![0_u8; width.checked_mul(height)?.checked_mul(4)?];
+	let dst_bytes_per_row = width.checked_mul(4)?;
+	let context = unsafe {
+		CGBitmapContextCreate(
+			dst.as_mut_ptr().cast::<c_void>(),
+			width,
+			height,
+			8,
+			dst_bytes_per_row,
+			Some(dst_space.as_ref()),
+			(objc2_core_graphics::CGBitmapInfo(
+				CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+			))
+			.0,
+		)
+	}?;
+	let draw_rect = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(width as f64, height as f64));
+
+	CGContext::draw_image(Some(context.as_ref()), draw_rect, Some(source.as_ref()));
+
+	for bgra in dst.chunks_exact_mut(4) {
+		bgra.swap(0, 2);
+	}
+
+	RgbaImage::from_raw(width as u32, height as u32, dst)
 }

--- a/packages/rsnap-overlay/src/macos_color.rs
+++ b/packages/rsnap-overlay/src/macos_color.rs
@@ -1,12 +1,12 @@
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
-	use std::ptr;
 	use image::{Rgba, RgbaImage};
 	use objc2_core_foundation::{CFData, CGPoint, CGRect, CGSize};
 	use objc2_core_graphics::{
-		CGBitmapContextCreate, CGColorRenderingIntent, CGColorSpace, CGContext,
-		CGDataProvider, CGImage, CGImageAlphaInfo, CGImageByteOrderInfo,
+		CGBitmapContextCreate, CGColorRenderingIntent, CGColorSpace, CGContext, CGDataProvider,
+		CGImage, CGImageAlphaInfo, CGImageByteOrderInfo,
 	};
+	use std::ptr;
 
 	use crate::macos_color::color_managed_rgba_from_bgra_bytes;
 
@@ -146,6 +146,31 @@ mod tests {
 
 		assert_eq!(image, expected);
 	}
+
+	#[test]
+	fn color_managed_path_preserves_source_alpha() {
+		let src_space =
+			CGColorSpace::with_name(Some(unsafe { objc2_core_graphics::kCGColorSpaceSRGB }))
+				.expect("sRGB");
+		let src = [
+			10_u8, 20, 30, 128, // premultiplied BGRA for RGBA(30,20,10,128)
+		];
+		let image = color_managed_rgba_from_bgra_bytes(
+			1,
+			1,
+			4,
+			&src,
+			Some(src_space.as_ref()),
+			None,
+			objc2_core_graphics::CGBitmapInfo(
+				CGImageAlphaInfo::PremultipliedFirst.0 | CGImageByteOrderInfo::Order32Little.0,
+			),
+		)
+		.expect("converted image");
+		let expected = RgbaImage::from_vec(1, 1, vec![30, 20, 10, 128]).expect("expected image");
+
+		assert_eq!(image, expected);
+	}
 }
 
 #[cfg(target_os = "macos")]
@@ -160,7 +185,10 @@ use image::RgbaImage;
 #[cfg(target_os = "macos")]
 use objc2_core_foundation::{CFData, CFRetained, CGPoint, CGRect, CGSize};
 #[cfg(target_os = "macos")]
-use objc2_core_graphics::{self, CGBitmapContextCreate, CGColorRenderingIntent, CGColorSpace, CGContext, CGDataProvider, CGDirectDisplayID, CGDisplayCopyColorSpace, CGImage, CGImageAlphaInfo, CGImageByteOrderInfo};
+use objc2_core_graphics::{
+	self, CGBitmapContextCreate, CGColorRenderingIntent, CGColorSpace, CGContext, CGDataProvider,
+	CGDirectDisplayID, CGDisplayCopyColorSpace, CGImage, CGImageAlphaInfo, CGImageByteOrderInfo,
+};
 #[cfg(target_os = "macos")]
 use objc2_core_video::{
 	CVPixelBuffer, CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow,
@@ -273,7 +301,7 @@ fn color_managed_rgba_from_bgra_bytes(
 	data: &[u8],
 	src_color_space: Option<&CGColorSpace>,
 	display_id: Option<u32>,
-	_src_bitmap_info: objc2_core_graphics::CGBitmapInfo,
+	src_bitmap_info: objc2_core_graphics::CGBitmapInfo,
 ) -> Option<RgbaImage> {
 	if width == 0 || height == 0 {
 		return None;
@@ -296,8 +324,10 @@ fn color_managed_rgba_from_bgra_bytes(
 	let src_space =
 		src_color_space.or(fallback_monitor_space.as_deref()).or(fallback_srgb_space.as_deref())?;
 	let dst_space = srgb_color_space()?;
-	let normalized_src_bitmap_info =
-		objc2_core_graphics::CGBitmapInfo(CGImageAlphaInfo::NoneSkipFirst.0 | CGImageByteOrderInfo::Order32Little.0);
+	let normalized_src_bitmap_info = objc2_core_graphics::CGBitmapInfo(
+		src_bitmap_info.difference(objc2_core_graphics::CGBitmapInfo::ByteOrderInfoMask).bits()
+			| CGImageByteOrderInfo::Order32Little.0,
+	);
 	let provider =
 		CGDataProvider::with_cf_data(Some(CFData::from_bytes(&data[..required_len]).as_ref()))?;
 	let source = unsafe {

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -32,6 +32,8 @@ mod window_position_runtime;
 mod window_runtime;
 mod worker_runtime;
 
+#[cfg(target_os = "macos")]
+use std::collections::VecDeque;
 #[cfg(not(target_os = "macos"))]
 use std::env;
 #[cfg(target_os = "macos")]
@@ -42,8 +44,6 @@ use std::panic;
 use std::process;
 use std::ptr;
 use std::slice;
-#[cfg(target_os = "macos")]
-use std::collections::VecDeque;
 #[cfg(target_os = "macos")]
 use std::sync::OnceLock;
 use std::{

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -349,10 +349,10 @@ const SELECTION_FLOW_PALETTE: [(u8, u8, u8); 3] =
 	[(196, 226, 255), (228, 198, 255), (176, 244, 224)];
 const SELECTION_FLOW_LIGHT_PALETTE: [(u8, u8, u8); 3] =
 	[(196, 226, 255), (228, 198, 255), (176, 244, 224)];
-const LIVE_DRAG_SELECTION_SCRIM_ALPHA_LIGHT: u8 = 96;
-const LIVE_DRAG_SELECTION_SCRIM_ALPHA_DARK: u8 = 148;
-const FROZEN_SELECTION_SCRIM_ALPHA_LIGHT: u8 = 224;
-const FROZEN_SELECTION_SCRIM_ALPHA_DARK: u8 = 208;
+const LIVE_DRAG_SELECTION_SCRIM_ALPHA_LIGHT: u8 = 120;
+const LIVE_DRAG_SELECTION_SCRIM_ALPHA_DARK: u8 = 176;
+const FROZEN_SELECTION_SCRIM_ALPHA_LIGHT: u8 = LIVE_DRAG_SELECTION_SCRIM_ALPHA_LIGHT;
+const FROZEN_SELECTION_SCRIM_ALPHA_DARK: u8 = LIVE_DRAG_SELECTION_SCRIM_ALPHA_DARK;
 const FROZEN_SELECTION_DASHED_BORDER_WIDTH_PX: f32 = 1.55;
 const SELECTION_DASHED_BORDER_WIDTH_PX: f32 = 3.1;
 const SELECTION_DASHED_BORDER_DASH_LENGTH_PX: f32 = 12.0;
@@ -565,6 +565,8 @@ pub struct OverlaySession {
 	window_list_refresh_interval: Duration,
 	last_live_bg_request_at: Instant,
 	live_bg_request_interval: Duration,
+	#[cfg(target_os = "macos")]
+	last_live_surface_bg_snapshot_at: Option<Instant>,
 	freeze_capture_send_full_count: u64,
 	hit_test_send_full_count: u64,
 	hit_test_send_disconnected_count: u64,
@@ -809,6 +811,8 @@ impl OverlaySession {
 			window_list_refresh_interval: Duration::ZERO,
 			last_live_bg_request_at: now,
 			live_bg_request_interval: Duration::ZERO,
+			#[cfg(target_os = "macos")]
+			last_live_surface_bg_snapshot_at: None,
 			freeze_capture_send_full_count: 0,
 			hit_test_send_full_count: 0,
 			hit_test_send_disconnected_count: 0,
@@ -999,6 +1003,17 @@ impl OverlaySession {
 	#[must_use]
 	pub fn wants_global_loupe_hotkey(&self) -> bool {
 		matches!(self.state.mode, OverlayMode::Live)
+	}
+
+	#[cfg(target_os = "macos")]
+	/// Returns whether the host should register ordinary frozen shortcuts
+	/// while the session runs without a focused key window.
+	#[must_use]
+	pub fn wants_global_frozen_hotkeys(&self) -> bool {
+		self.session_active
+			&& matches!(self.state.mode, OverlayMode::Frozen)
+			&& !self.scroll_capture.active
+			&& self.frozen_text_edit.is_none()
 	}
 
 	#[cfg(target_os = "macos")]
@@ -1212,6 +1227,55 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn clear_live_surface_bg(&mut self) {
+		self.state.live_bg_monitor = None;
+		self.state.live_bg_image = None;
+		self.last_live_surface_bg_snapshot_at = None;
+	}
+
+	#[cfg(target_os = "macos")]
+	fn sync_live_surface_bg_from_stream(&mut self, monitor: MonitorRect) {
+		if !matches!(self.state.mode, OverlayMode::Live) {
+			self.clear_live_surface_bg();
+
+			return;
+		}
+		if self.active_cursor_monitor() != Some(monitor) {
+			return;
+		}
+
+		let Some(stream) = self.live_sample_stream.as_ref() else {
+			return;
+		};
+
+		if !stream.self_capture_filter_complete_for_monitor(monitor) {
+			return;
+		}
+
+		let Some(snapshot) = stream.peek_latest_rgba_snapshot(monitor) else {
+			return;
+		};
+		let allow_refresh = self.frozen_display_handoff_pending();
+
+		if !allow_refresh
+			&& self.state.live_bg_monitor == Some(monitor)
+			&& self.state.live_bg_image.is_some()
+		{
+			return;
+		}
+		if self.state.live_bg_monitor == Some(monitor)
+			&& self.last_live_surface_bg_snapshot_at == Some(snapshot.captured_at)
+		{
+			return;
+		}
+
+		self.state.live_bg_monitor = Some(monitor);
+		self.state.live_bg_image = Some(snapshot.image.as_ref().clone());
+		self.state.live_bg_generation = self.state.live_bg_generation.wrapping_add(1);
+		self.last_live_surface_bg_snapshot_at = Some(snapshot.captured_at);
+	}
+
+	#[cfg(target_os = "macos")]
 	fn macos_hud_window_blur_enabled(&self) -> bool {
 		self.config.show_hud_blur
 	}
@@ -1422,31 +1486,10 @@ impl OverlaySession {
 		self.frozen_display_ready() && self.state.monitor == Some(monitor)
 	}
 
-	#[cfg(target_os = "macos")]
-	fn preserve_live_frozen_entry_affordance(&self) -> bool {
-		!self.scroll_capture.active
-			&& !self.frozen_selection_drag.active
-			&& !self.toolbar_state.dragging
-			&& self.frozen_edit_undo_stack.is_empty()
-			&& self.state.frozen_mosaic_preview_rect.is_none()
-			&& self.frozen_text_edit.is_none()
-			&& self.active_frozen_arrow_preview().is_none()
-			&& self.frozen_spotlight_preview_rect.is_none()
-	}
-
 	fn frozen_visual_handoff_pending_for_monitor(&self, monitor: MonitorRect) -> bool {
-		#[cfg(target_os = "macos")]
-		{
-			self.frozen_display_ready_for_monitor(monitor)
-				&& self.preserve_live_frozen_entry_affordance()
-		}
+		let _ = monitor;
 
-		#[cfg(not(target_os = "macos"))]
-		{
-			let _ = monitor;
-
-			false
-		}
+		false
 	}
 
 	fn frozen_preview_visible(&self) -> bool {
@@ -1958,6 +2001,8 @@ impl OverlaySession {
 		if let Some(cursor) = cursor {
 			self.update_cursor_state(monitor, cursor);
 		}
+
+		self.sync_overlay_cursor_icons();
 	}
 
 	fn seed_frozen_toolbar_default_position(
@@ -3159,6 +3204,34 @@ impl OverlaySession {
 			&& !self.frozen_visual_handoff_pending_for_monitor(overlay_monitor)
 	}
 
+	fn should_draw_live_surface_bg_for_overlay_monitor(
+		&self,
+		overlay_monitor: MonitorRect,
+	) -> bool {
+		matches!(self.state.mode, OverlayMode::Live)
+			&& self.state.live_bg_monitor == Some(overlay_monitor)
+			&& self.state.live_bg_image.is_some()
+	}
+
+	fn should_refresh_live_surface_bg_for_overlay_monitor(
+		&self,
+		overlay_monitor: MonitorRect,
+	) -> bool {
+		if !matches!(self.state.mode, OverlayMode::Live) {
+			return false;
+		}
+		if self.active_cursor_monitor() != Some(overlay_monitor) {
+			return false;
+		}
+		if self.frozen_display_handoff_pending()
+			|| self.frozen_visual_handoff_pending_for_monitor(overlay_monitor)
+		{
+			return true;
+		}
+
+		self.state.live_bg_monitor != Some(overlay_monitor) || self.state.live_bg_image.is_none()
+	}
+
 	fn mark_overlay_window_redraw_progress(
 		&mut self,
 		window_id: WindowId,
@@ -3171,6 +3244,30 @@ impl OverlaySession {
 		self.event_loop_last_progress_monitor_id = Some(overlay_monitor.id);
 	}
 
+	#[cfg(target_os = "macos")]
+	fn maybe_sync_live_surface_bg_for_overlay_redraw(&mut self, overlay_monitor: MonitorRect) {
+		if self.should_refresh_live_surface_bg_for_overlay_monitor(overlay_monitor) {
+			self.sync_live_surface_bg_from_stream(overlay_monitor);
+		}
+	}
+
+	#[cfg(not(target_os = "macos"))]
+	fn maybe_sync_live_surface_bg_for_overlay_redraw(&mut self, _overlay_monitor: MonitorRect) {}
+
+	fn finish_overlay_window_redraw(
+		&mut self,
+		overlay_monitor: MonitorRect,
+		draw_toolbar: bool,
+	) -> OverlayControl {
+		self.maybe_arm_frozen_toolbar_badge_slot_after_overlay_draw(overlay_monitor);
+
+		self.last_present_at = Instant::now();
+
+		self.note_startup_overlay_frame_presented();
+
+		self.handle_capture_and_toolbar_redraw_post(overlay_monitor, draw_toolbar)
+	}
+
 	fn handle_overlay_window_redraw(&mut self, window_id: WindowId) -> OverlayControl {
 		let Some(overlay_monitor) = self.windows.get(&window_id).map(|overlay| overlay.monitor)
 		else {
@@ -3180,6 +3277,7 @@ impl OverlaySession {
 		self.mark_overlay_window_redraw_progress(window_id, overlay_monitor);
 		self.maybe_log_event_loop_stall(Instant::now());
 		self.mark_progress(OverlayEventLoopPhase::OverlayRedraw);
+		self.maybe_sync_live_surface_bg_for_overlay_redraw(overlay_monitor);
 
 		let overlay_screen_rect = self.overlay_window_screen_rect(window_id, overlay_monitor);
 		#[cfg(target_os = "macos")]
@@ -3211,8 +3309,8 @@ impl OverlaySession {
 		let Some(gpu) = self.gpu.as_ref() else {
 			return self.exit(OverlayExit::Error(String::from("Missing GPU context")));
 		};
-		let scroll_capture_active = self.scroll_capture.active;
-		let frozen_text_style = self.toolbar_state.text_style;
+		let (scroll_capture_active, frozen_text_style) =
+			(self.scroll_capture.active, self.toolbar_state.text_style);
 		let visible_frozen_text_annotations: &[FrozenTextAnnotation] =
 			if scroll_capture_active { &[] } else { &self.frozen_text_annotations };
 		let visible_frozen_arrow_annotations: &[FrozenArrowAnnotation] =
@@ -3229,7 +3327,11 @@ impl OverlaySession {
 			self.pending_frozen_display_handoff_state(overlay_monitor);
 		let allow_frozen_surface_bg = self
 			.allow_frozen_surface_bg_for_overlay_monitor(overlay_monitor, scroll_capture_active);
+		let allow_live_surface_bg =
+			self.should_draw_live_surface_bg_for_overlay_monitor(overlay_monitor);
 		let toolbar_state = if draw_toolbar { Some(&mut self.toolbar_state) } else { None };
+		let selection_flow_enabled =
+			self.config.selection_flow_enabled && !cfg!(target_os = "macos");
 
 		{
 			let Some(overlay_window) = self.windows.get_mut(&window_id) else {
@@ -3253,9 +3355,10 @@ impl OverlaySession {
 				self.config.hud_milk_amount,
 				self.config.hud_tint_hue,
 				self.config.theme_mode,
-				self.config.selection_flow_enabled,
+				selection_flow_enabled,
 				self.config.selection_flow_stroke_width_px,
 				allow_frozen_surface_bg,
+				allow_live_surface_bg,
 				pending_frozen_display_handoff,
 				pending_frozen_display_handoff_monitor,
 				scroll_capture_active,
@@ -3279,13 +3382,7 @@ impl OverlaySession {
 			}
 		}
 
-		self.maybe_arm_frozen_toolbar_badge_slot_after_overlay_draw(overlay_monitor);
-
-		self.last_present_at = Instant::now();
-
-		self.note_startup_overlay_frame_presented();
-
-		self.handle_capture_and_toolbar_redraw_post(overlay_monitor, draw_toolbar)
+		self.finish_overlay_window_redraw(overlay_monitor, draw_toolbar)
 	}
 
 	#[cfg(target_os = "macos")]
@@ -3936,6 +4033,22 @@ pub enum OverlayExit {
 	Saved(PathBuf),
 	/// The session failed with a user-visible error message.
 	Error(String),
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Host-routed frozen shortcuts that should work without a focused key window.
+pub enum FrozenGlobalHotkey {
+	/// Copy the current frozen export image.
+	Copy,
+	/// Recenter the drag-region capture rect around detected content.
+	AutoCenter,
+	/// Toggle toolbar visibility while frozen.
+	ToggleToolbar,
+	/// Start scroll capture from an existing frozen selection.
+	StartScrollCapture,
+	/// Save the current frozen export image.
+	Save,
 }
 
 #[derive(Debug)]
@@ -4690,6 +4803,7 @@ fn macos_cursor_object_for_icon(icon: CursorIcon) -> *mut Object {
 		CursorIcon::Crosshair => unsafe { objc::msg_send![cursor_class, crosshairCursor] },
 		CursorIcon::Grab => unsafe { objc::msg_send![cursor_class, openHandCursor] },
 		CursorIcon::Grabbing => unsafe { objc::msg_send![cursor_class, closedHandCursor] },
+		CursorIcon::Text => unsafe { objc::msg_send![cursor_class, IBeamCursor] },
 		CursorIcon::NeswResize => unsafe {
 			let responds: bool = objc::msg_send![cursor_class, respondsToSelector: objc::sel!(_windowResizeNorthEastSouthWestCursor)];
 
@@ -4709,6 +4823,19 @@ fn macos_cursor_object_for_icon(icon: CursorIcon) -> *mut Object {
 			}
 		},
 		_ => unsafe { objc::msg_send![cursor_class, arrowCursor] },
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn macos_set_cursor_icon(icon: CursorIcon) {
+	let cursor = macos_cursor_object_for_icon(icon);
+
+	if cursor.is_null() {
+		return;
+	}
+
+	unsafe {
+		let _: () = objc::msg_send![cursor, set];
 	}
 }
 
@@ -4909,15 +5036,8 @@ fn macos_apply_overlay_cursor_for_current_pointer(overlay_view_key: usize) {
 	else {
 		return;
 	};
-	let cursor = macos_cursor_object_for_icon(icon);
 
-	if cursor.is_null() {
-		return;
-	}
-
-	unsafe {
-		let _: () = objc::msg_send![cursor, set];
-	}
+	macos_set_cursor_icon(icon);
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -43,11 +43,13 @@ use std::process;
 use std::ptr;
 use std::slice;
 #[cfg(target_os = "macos")]
+use std::collections::VecDeque;
+#[cfg(target_os = "macos")]
 use std::sync::OnceLock;
 use std::{
 	borrow::Cow,
 	cmp::Ordering,
-	collections::{HashMap, HashSet, VecDeque},
+	collections::{HashMap, HashSet},
 	path::PathBuf,
 	sync::{Arc, Mutex},
 	time::{Duration, Instant},
@@ -3113,7 +3115,6 @@ impl OverlaySession {
 		);
 	}
 
-	#[cfg(target_os = "macos")]
 	fn maybe_recenter_frozen_toolbar_default_slot(&mut self, monitor: MonitorRect) -> bool {
 		if !matches!(self.state.mode, OverlayMode::Frozen) || self.state.monitor != Some(monitor) {
 			return false;
@@ -4035,7 +4036,6 @@ pub enum OverlayExit {
 	Error(String),
 }
 
-#[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// Host-routed frozen shortcuts that should work without a focused key window.
 pub enum FrozenGlobalHotkey {

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -3214,6 +3214,7 @@ impl OverlaySession {
 			&& self.state.live_bg_image.is_some()
 	}
 
+	#[cfg(target_os = "macos")]
 	fn should_refresh_live_surface_bg_for_overlay_monitor(
 		&self,
 		overlay_monitor: MonitorRect,

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -18,6 +18,8 @@ mod hud_helpers;
 mod hud_runtime;
 mod image_helpers;
 mod input_runtime;
+#[cfg(target_os = "macos")]
+mod macos_native_capture_shell_runtime;
 mod rendering;
 mod scroll_capture_runtime;
 mod scroll_input_runtime;
@@ -45,7 +47,7 @@ use std::sync::OnceLock;
 use std::{
 	borrow::Cow,
 	cmp::Ordering,
-	collections::{HashMap, HashSet},
+	collections::{HashMap, HashSet, VecDeque},
 	path::PathBuf,
 	sync::{Arc, Mutex},
 	time::{Duration, Instant},
@@ -76,7 +78,7 @@ use image::imageops;
 #[cfg(target_os = "macos")]
 use objc::declare::ClassDecl;
 #[cfg(target_os = "macos")]
-use objc::runtime::{self, BOOL, Class, Imp, NO, Object, Sel, YES};
+use objc::runtime::{BOOL, Class, NO, Object, Sel, YES};
 #[cfg(target_os = "macos")]
 use objc::{Encode, Encoding};
 #[cfg(target_os = "macos")]
@@ -137,8 +139,7 @@ use wgpu::TextureViewDimension;
 use wgpu::Trace;
 use wgpu::{self};
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition};
-use winit::event::KeyEvent;
-use winit::event::Modifiers;
+use winit::event::{KeyEvent, Modifiers};
 #[cfg(target_os = "macos")]
 use winit::window::Window;
 use winit::{
@@ -150,6 +151,8 @@ use winit::{
 };
 
 use self::frozen_text_runtime::{FrozenTextInputSource, FrozenTextRecentInput};
+#[cfg(target_os = "macos")]
+use self::macos_native_capture_shell_runtime::MacOSNativeCaptureShells;
 #[cfg(target_os = "macos")]
 use self::rendering::StartupLiveRgbPlan;
 use self::rendering::{
@@ -531,6 +534,8 @@ pub struct OverlaySession {
 	cursor_monitor: Option<MonitorRect>,
 	egui_repaint_deadline: Arc<Mutex<Option<Instant>>>,
 	windows: HashMap<WindowId, OverlayWindow>,
+	#[cfg(target_os = "macos")]
+	native_capture_shells: Option<MacOSNativeCaptureShells>,
 	focused_window_ids: HashSet<WindowId>,
 	pending_focus_loss_cleanup: bool,
 	hud_window: Option<HudOverlayWindow>,
@@ -662,6 +667,10 @@ pub struct OverlaySession {
 	#[cfg(target_os = "macos")]
 	startup_aux_window_waker: Option<Arc<dyn Fn() + Send + Sync>>,
 	#[cfg(target_os = "macos")]
+	native_capture_input_waker: Option<Arc<dyn Fn() + Send + Sync>>,
+	#[cfg(target_os = "macos")]
+	native_capture_input_queue: Arc<Mutex<VecDeque<MacOSNativeCaptureInputEvent>>>,
+	#[cfg(target_os = "macos")]
 	startup_aux_window_creation_pending: bool,
 	#[cfg(target_os = "macos")]
 	startup_aux_window_creation_scheduled: bool,
@@ -782,7 +791,7 @@ impl OverlaySession {
 			state: OverlayState::new(),
 			session_active: false,
 			cursor_monitor: None,
-			windows: HashMap::new(),
+			windows: HashMap::new(), #[cfg(target_os = "macos")] native_capture_shells: None,
 			focused_window_ids: HashSet::new(),
 			pending_focus_loss_cleanup: false,
 			hud_window: None, loupe_window: None, toolbar_window: None, scroll_preview_window: None,
@@ -852,8 +861,7 @@ impl OverlaySession {
 			frozen_text_edit: None, frozen_text_input_generation: 0, frozen_text_recent_input: None, toolbar_state: FrozenToolbarState::default(),
 			toolbar_left_button_down: false, toolbar_left_button_went_down: false, toolbar_left_button_went_up: false,
 			toolbar_pointer_local: None,
-			#[cfg(target_os = "macos")]
-			toolbar_window_cursor_hittest_enabled: false,
+			#[cfg(target_os = "macos")] toolbar_window_cursor_hittest_enabled: false,
 			live_capture_interaction: LiveCaptureInteraction::Idle,
 			frozen_brush: FrozenBrushState::default(), frozen_arrow_drag: FrozenArrowDragState::default(),
 			frozen_selection_drag: FrozenSelectionDragState::default(),
@@ -873,16 +881,13 @@ impl OverlaySession {
 			scroll_capture_starting_hook: None,
 			#[cfg(target_os = "macos")]
 			scroll_capture_started_hook: None,
-			#[cfg(target_os = "macos")]
-			startup_aux_window_waker: None,
-			#[cfg(target_os = "macos")]
-			startup_aux_window_creation_pending: false,
-			#[cfg(target_os = "macos")]
-			startup_aux_window_creation_scheduled: false,
-			#[cfg(target_os = "macos")]
-			pending_startup_aux_live_stream_filter_upgrade: false,
-			#[cfg(target_os = "macos")]
-			frontmost_application_before_start: None,
+			#[cfg(target_os = "macos")] startup_aux_window_waker: None,
+			#[cfg(target_os = "macos")] native_capture_input_waker: None,
+			#[cfg(target_os = "macos")] native_capture_input_queue: Arc::new(Mutex::new(VecDeque::new())),
+			#[cfg(target_os = "macos")] startup_aux_window_creation_pending: false,
+			#[cfg(target_os = "macos")] startup_aux_window_creation_scheduled: false,
+			#[cfg(target_os = "macos")] pending_startup_aux_live_stream_filter_upgrade: false,
+			#[cfg(target_os = "macos")] frontmost_application_before_start: None,
 			response_waker: None,
 		}
 	}
@@ -1003,6 +1008,12 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
+	/// Registers a wake callback for AppKit-native passive capture input.
+	pub fn set_native_capture_input_waker(&mut self, waker: Arc<dyn Fn() + Send + Sync>) {
+		self.native_capture_input_waker = Some(waker);
+	}
+
+	#[cfg(target_os = "macos")]
 	/// Supplies a host-owned guard that must approve scroll capture before it can start.
 	/// Return `Ok(false)` to reject the attempt without surfacing a HUD error.
 	pub fn set_scroll_capture_start_guard(&mut self, guard: ScrollCaptureStartGuard) {
@@ -1025,6 +1036,120 @@ impl OverlaySession {
 	/// Registers a wake callback for worker-thread responses.
 	pub fn set_response_waker(&mut self, waker: Arc<dyn Fn() + Send + Sync>) {
 		self.response_waker = Some(waker);
+	}
+
+	#[cfg(target_os = "macos")]
+	fn native_capture_input_dispatch(&self) -> Option<MacOSNativeCaptureInputDispatch> {
+		self.native_capture_input_waker.as_ref().cloned().map(|waker| {
+			MacOSNativeCaptureInputDispatch {
+				queue: Arc::clone(&self.native_capture_input_queue),
+				waker,
+			}
+		})
+	}
+
+	#[cfg(target_os = "macos")]
+	fn drain_native_capture_input_events(&self) -> Vec<MacOSNativeCaptureInputEvent> {
+		let Ok(mut queue) = self.native_capture_input_queue.lock() else {
+			tracing::warn!(
+				op = "overlay.native_capture_input_queue_poisoned",
+				"Draining native capture input from a poisoned queue."
+			);
+
+			return Vec::new();
+		};
+
+		queue.drain(..).collect()
+	}
+
+	#[cfg(target_os = "macos")]
+	/// Drains and applies any queued passive AppKit capture input events.
+	pub fn handle_native_capture_input_ready(&mut self) -> OverlayControl {
+		let now = Instant::now();
+
+		self.maybe_log_event_loop_stall(now);
+		self.mark_progress_with_detail(
+			OverlayEventLoopPhase::WindowEvent,
+			Some("native_capture_input"),
+		);
+
+		for event in self.drain_native_capture_input_events() {
+			let control = match event {
+				MacOSNativeCaptureInputEvent::OverlayPointerMoved { monitor, global } => {
+					self.handle_native_overlay_pointer_moved(monitor, global)
+				},
+				MacOSNativeCaptureInputEvent::OverlayMouseInput {
+					monitor,
+					global,
+					button,
+					state,
+				} => {
+					self.maybe_stop_frozen_selection_drag_for_mouse_input(state, button);
+
+					match (state, button) {
+						(ElementState::Pressed, MouseButton::Right) => {
+							self.cancel_overlay("native_capture_right_click")
+						},
+						(_, MouseButton::Left) => {
+							self.handle_live_overlay_left_mouse_input(monitor, global, state)
+						},
+						_ => OverlayControl::Continue,
+					}
+				},
+				MacOSNativeCaptureInputEvent::ToolbarPointerMoved {
+					monitor,
+					local,
+					global,
+					outer_position,
+				} => self.handle_native_toolbar_pointer_moved(
+					monitor,
+					local,
+					global,
+					Some(outer_position),
+				),
+				MacOSNativeCaptureInputEvent::ToolbarPointerLeft => {
+					self.handle_toolbar_cursor_left()
+				},
+				MacOSNativeCaptureInputEvent::ToolbarMouseInput { button, state } => {
+					self.maybe_stop_frozen_selection_drag_for_mouse_input(state, button);
+
+					match (state, button) {
+						(ElementState::Pressed, MouseButton::Right) => {
+							self.cancel_overlay("native_toolbar_right_click")
+						},
+						(_, MouseButton::Left) => self.handle_toolbar_mouse_input(state),
+						_ => OverlayControl::Continue,
+					}
+				},
+				MacOSNativeCaptureInputEvent::ToolbarScrollWheel { delta } => {
+					let delta = match delta {
+						MacOSNativeCaptureScrollDelta::Line { x, y } => {
+							MouseScrollDelta::LineDelta(x, y)
+						},
+						MacOSNativeCaptureScrollDelta::Pixel { x, y } => {
+							MouseScrollDelta::PixelDelta(PhysicalPosition::new(x, y))
+						},
+					};
+
+					self.handle_toolbar_mouse_wheel(&delta)
+				},
+				MacOSNativeCaptureInputEvent::KeyboardInput { monitor: _, event } => {
+					self.handle_overlay_keyboard_input_event(&event)
+				},
+				MacOSNativeCaptureInputEvent::Ime { monitor, event } => {
+					self.handle_overlay_ime_event(monitor, &event)
+				},
+				MacOSNativeCaptureInputEvent::ModifiersChanged { state } => {
+					self.handle_modifiers_state_changed(state)
+				},
+			};
+
+			if !matches!(control, OverlayControl::Continue) {
+				return control;
+			}
+		}
+
+		OverlayControl::Continue
 	}
 
 	#[cfg(target_os = "macos")]
@@ -1219,6 +1344,9 @@ impl OverlaySession {
 		}
 
 		self.state.begin_freeze(monitor);
+
+		#[cfg(target_os = "macos")]
+		let _ = self.sync_native_capture_shells();
 
 		self.state.drag_rect = None;
 		self.state.hovered_window_rect = None;
@@ -2932,64 +3060,15 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	fn focus_live_capture_window(&self) {
-		macos_activate_app();
-
-		let target_window = self
-			.active_cursor_monitor()
-			.and_then(|monitor| {
-				self.windows.values().find(|overlay_window| overlay_window.monitor == monitor)
-			})
-			.or_else(|| self.windows.values().next())
-			.map(|overlay_window| overlay_window.window.as_ref());
-		let Some(target_window) = target_window else {
-			tracing::info!(
-				op = "overlay.live_focus_requested",
-				target = "missing_window",
-				window_count = self.windows.len(),
-				"Requested live capture focus, but no overlay window was available."
-			);
-
-			return;
-		};
-
 		tracing::info!(
 			op = "overlay.live_focus_requested",
-			target = "overlay_window",
+			target = "native_passive_shell",
 			window_count = self.windows.len(),
-			cursor_monitor_id = ?self.active_cursor_monitor().map(|monitor| monitor.id),
-			"Requested live capture focus."
+			"Skipped live capture key focus because passive AppKit shells own live pointer input."
 		);
-
-		macos_make_window_key(target_window);
 	}
 
 	#[cfg(target_os = "macos")]
-	fn restore_passive_capture_window_focus_policy_for_pointer_interaction(
-		&self,
-		reason: &'static str,
-	) {
-		for overlay_window in self.windows.values() {
-			macos_update_capture_window_focus_policy(overlay_window.window.as_ref(), false, reason);
-		}
-
-		if let Some(hud_window) = self.hud_window.as_ref() {
-			macos_update_capture_window_focus_policy(hud_window.window.as_ref(), false, reason);
-		}
-		if let Some(loupe_window) = self.loupe_window.as_ref() {
-			macos_update_capture_window_focus_policy(loupe_window.window.as_ref(), false, reason);
-		}
-		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			macos_update_capture_window_focus_policy(toolbar_window.window.as_ref(), false, reason);
-		}
-		if let Some(scroll_preview_window) = self.scroll_preview_window.as_ref() {
-			macos_update_capture_window_focus_policy(
-				scroll_preview_window.window.as_ref(),
-				false,
-				reason,
-			);
-		}
-	}
-
 	fn maybe_recenter_frozen_toolbar_default_slot(&mut self, monitor: MonitorRect) -> bool {
 		if !matches!(self.state.mode, OverlayMode::Frozen) || self.state.monitor != Some(monitor) {
 			return false;
@@ -3519,26 +3598,11 @@ impl OverlaySession {
 		self.set_scroll_overlay_mouse_passthrough(false);
 
 		self.session_active = false;
+
 		#[cfg(target_os = "macos")]
 		{
-			for overlay_window in self.windows.values() {
-				macos_clear_capture_window_focus_policy(overlay_window.window.as_ref());
-			}
-
-			if let Some(hud_window) = self.hud_window.as_ref() {
-				macos_clear_capture_window_focus_policy(hud_window.window.as_ref());
-			}
-			if let Some(loupe_window) = self.loupe_window.as_ref() {
-				macos_clear_capture_window_focus_policy(loupe_window.window.as_ref());
-			}
-			if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-				macos_clear_capture_window_focus_policy(toolbar_window.window.as_ref());
-			}
-			if let Some(scroll_preview_window) = self.scroll_preview_window.as_ref() {
-				macos_clear_capture_window_focus_policy(scroll_preview_window.window.as_ref());
-			}
+			self.destroy_native_capture_shells();
 		}
-
 		self.windows.clear();
 
 		self.hud_window = None;
@@ -3927,6 +3991,95 @@ pub enum WindowCaptureAlphaMode {
 	MatteLight,
 	/// Composite transparency against a dark matte color.
 	MatteDark,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum MacOSNativeCaptureScrollDelta {
+	Line { x: f32, y: f32 },
+	Pixel { x: f64, y: f64 },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct OverlayKeyboardInputEvent {
+	logical_key: Key,
+	text: Option<String>,
+	state: ElementState,
+	repeat: bool,
+}
+impl OverlayKeyboardInputEvent {
+	fn from_winit(event: &KeyEvent) -> Self {
+		Self {
+			logical_key: event.logical_key.clone(),
+			text: event.text.as_deref().map(ToOwned::to_owned),
+			state: event.state,
+			repeat: event.repeat,
+		}
+	}
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug, PartialEq)]
+enum MacOSNativeCaptureInputEvent {
+	OverlayPointerMoved {
+		monitor: MonitorRect,
+		global: GlobalPoint,
+	},
+	OverlayMouseInput {
+		monitor: MonitorRect,
+		global: GlobalPoint,
+		button: MouseButton,
+		state: ElementState,
+	},
+	ToolbarPointerMoved {
+		monitor: MonitorRect,
+		local: Pos2,
+		global: GlobalPoint,
+		outer_position: GlobalPoint,
+	},
+	ToolbarPointerLeft,
+	ToolbarMouseInput {
+		button: MouseButton,
+		state: ElementState,
+	},
+	ToolbarScrollWheel {
+		delta: MacOSNativeCaptureScrollDelta,
+	},
+	KeyboardInput {
+		monitor: Option<MonitorRect>,
+		event: OverlayKeyboardInputEvent,
+	},
+	Ime {
+		monitor: Option<MonitorRect>,
+		event: Ime,
+	},
+	ModifiersChanged {
+		state: ModifiersState,
+	},
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+struct MacOSNativeCaptureInputDispatch {
+	queue: Arc<Mutex<VecDeque<MacOSNativeCaptureInputEvent>>>,
+	waker: Arc<dyn Fn() + Send + Sync>,
+}
+#[cfg(target_os = "macos")]
+impl MacOSNativeCaptureInputDispatch {
+	fn enqueue(&self, event: MacOSNativeCaptureInputEvent) {
+		if let Ok(mut queue) = self.queue.lock() {
+			queue.push_back(event);
+		} else {
+			tracing::warn!(
+				op = "overlay.native_capture_input_queue_poisoned",
+				"Dropping native capture input event because the queue lock was poisoned."
+			);
+
+			return;
+		}
+
+		(self.waker)();
+	}
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4637,114 +4790,6 @@ fn macos_overlay_cursor_view_class() -> *const Class {
 }
 
 #[cfg(target_os = "macos")]
-fn macos_passive_capture_window_keys() -> &'static Mutex<HashSet<usize>> {
-	static WINDOW_KEYS: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
-
-	WINDOW_KEYS.get_or_init(|| Mutex::new(HashSet::new()))
-}
-
-#[cfg(target_os = "macos")]
-fn macos_capture_window_is_passive(window_key: usize) -> bool {
-	macos_passive_capture_window_keys()
-		.lock()
-		.expect("passive capture window key set poisoned")
-		.contains(&window_key)
-}
-
-#[cfg(target_os = "macos")]
-fn macos_update_capture_window_passive_state(window_key: usize, passive: bool) -> bool {
-	let mut window_keys = macos_passive_capture_window_keys()
-		.lock()
-		.expect("passive capture window key set poisoned");
-
-	if passive { window_keys.insert(window_key) } else { window_keys.remove(&window_key) }
-}
-
-#[cfg(target_os = "macos")]
-fn macos_bool_window_method_imp(imp: extern "C" fn(&Object, Sel) -> BOOL) -> Imp {
-	unsafe { mem::transmute::<extern "C" fn(&Object, Sel) -> BOOL, Imp>(imp) }
-}
-
-#[cfg(target_os = "macos")]
-extern "C" fn macos_dynamic_capture_window_can_become_main_window(
-	this: &Object,
-	_cmd: Sel,
-) -> BOOL {
-	if macos_capture_window_is_passive((this as *const Object) as usize) { NO } else { YES }
-}
-
-#[cfg(target_os = "macos")]
-extern "C" fn macos_dynamic_capture_window_can_become_key_window(this: &Object, _cmd: Sel) -> BOOL {
-	if macos_capture_window_is_passive((this as *const Object) as usize) { NO } else { YES }
-}
-
-#[cfg(target_os = "macos")]
-fn macos_install_capture_window_focus_hooks() {
-	static INSTALLED: OnceLock<()> = OnceLock::new();
-	INSTALLED.get_or_init(|| {
-		let window_class = Class::get("WinitWindow").expect("WinitWindow class should exist");
-
-		unsafe {
-			let can_become_main_window =
-				runtime::class_getInstanceMethod(window_class, objc::sel!(canBecomeMainWindow));
-			let can_become_key_window =
-				runtime::class_getInstanceMethod(window_class, objc::sel!(canBecomeKeyWindow));
-
-			assert!(
-				!can_become_main_window.is_null(),
-				"WinitWindow::canBecomeMainWindow should exist"
-			);
-			assert!(
-				!can_become_key_window.is_null(),
-				"WinitWindow::canBecomeKeyWindow should exist"
-			);
-
-			let _: Imp = runtime::method_setImplementation(
-				can_become_main_window.cast_mut(),
-				macos_bool_window_method_imp(macos_dynamic_capture_window_can_become_main_window),
-			);
-			let _: Imp = runtime::method_setImplementation(
-				can_become_key_window.cast_mut(),
-				macos_bool_window_method_imp(macos_dynamic_capture_window_can_become_key_window),
-			);
-		}
-
-		tracing::trace!(
-			op = "overlay.macos_capture_window_focus_hooks_installed",
-			"Installed passive capture window focus hooks on WinitWindow."
-		);
-	});
-}
-
-#[cfg(target_os = "macos")]
-fn macos_set_capture_window_focus_policy(
-	ns_window: *mut Object,
-	allow_key_focus: bool,
-	reason: &'static str,
-) {
-	if ns_window.is_null() {
-		return;
-	}
-
-	macos_install_capture_window_focus_hooks();
-
-	let window_key = ns_window as usize;
-	let changed = macos_update_capture_window_passive_state(window_key, !allow_key_focus);
-
-	if !changed {
-		return;
-	}
-
-	tracing::trace!(
-		op = "overlay.macos_capture_window_focus_policy_changed",
-		reason,
-		allow_key_focus,
-		window_key,
-		"Updated macOS capture window focus policy."
-	);
-}
-
-#[cfg(target_os = "macos")]
 fn macos_overlay_window_ns_view(window: &Window) -> Option<*mut Object> {
 	let Ok(handle) = window.window_handle() else {
 		return None;
@@ -4953,86 +4998,6 @@ fn macos_restore_frontmost_application(target: MacOSFrontmostApplication) -> boo
 }
 
 #[cfg(target_os = "macos")]
-fn macos_make_window_key(window: &Window) {
-	macos_update_capture_window_focus_policy(window, true, "explicit_focus_request");
-
-	let Ok(handle) = window.window_handle() else {
-		return;
-	};
-	let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
-		return;
-	};
-	let ns_view = appkit.ns_view.as_ptr().cast::<Object>();
-
-	unsafe {
-		let ns_window: *mut Object = objc::msg_send![ns_view, window];
-
-		if ns_window.is_null() {
-			return;
-		}
-
-		let nil: *mut Object = ptr::null_mut();
-		let _: () = objc::msg_send![ns_window, makeKeyAndOrderFront: nil];
-	}
-
-	window.focus_window();
-}
-
-#[cfg(target_os = "macos")]
-fn macos_update_capture_window_focus_policy(
-	window: &Window,
-	allow_key_focus: bool,
-	reason: &'static str,
-) {
-	let Ok(handle) = window.window_handle() else {
-		return;
-	};
-	let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
-		return;
-	};
-	let ns_view = appkit.ns_view.as_ptr().cast::<Object>();
-
-	unsafe {
-		let ns_window: *mut Object = objc::msg_send![ns_view, window];
-
-		if ns_window.is_null() {
-			return;
-		}
-
-		macos_set_capture_window_focus_policy(ns_window, allow_key_focus, reason);
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_clear_capture_window_focus_policy(window: &Window) {
-	let Ok(handle) = window.window_handle() else {
-		return;
-	};
-	let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
-		return;
-	};
-	let ns_view = appkit.ns_view.as_ptr().cast::<Object>();
-
-	unsafe {
-		let ns_window: *mut Object = objc::msg_send![ns_view, window];
-
-		if ns_window.is_null() {
-			return;
-		}
-
-		let window_key = ns_window as usize;
-
-		if macos_update_capture_window_passive_state(window_key, false) {
-			tracing::trace!(
-				op = "overlay.macos_capture_window_focus_policy_cleared",
-				window_key,
-				"Cleared macOS capture window passive focus policy."
-			);
-		}
-	}
-}
-
-#[cfg(target_os = "macos")]
 fn macos_post_scroll_wheel_event(
 	delta: MacOSScrollWheelEvent,
 	target_point: GlobalPoint,
@@ -5197,8 +5162,24 @@ fn macos_configure_nonactivating_capture_window_with_ns_window(ns_window: *mut O
 		let _: () = objc::msg_send![ns_window, setStyleMask: style_mask | nonactivating_panel_mask];
 		let _: () = objc::msg_send![ns_window, setHidesOnDeactivate: false];
 	}
+}
 
-	macos_set_capture_window_focus_policy(ns_window, false, "capture_window_configured");
+#[cfg(target_os = "macos")]
+fn macos_set_capture_window_mouse_passthrough(window: &Window, passthrough: bool) {
+	let Some(ns_view) = macos_overlay_window_ns_view(window) else {
+		return;
+	};
+
+	unsafe {
+		let ns_window: *mut Object = objc::msg_send![ns_view, window];
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		let ignores_mouse_events = if passthrough { YES } else { NO };
+		let _: () = objc::msg_send![ns_window, setIgnoresMouseEvents: ignores_mouse_events];
+	}
 }
 
 #[cfg(test)]

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -24,6 +24,7 @@ impl OverlaySession {
 	pub(super) fn hide_capture_windows(&mut self) {
 		self.capture_windows_hidden = true;
 
+		let _ = self.sync_native_capture_shells();
 		let hide_overlay_windows = self.should_hide_overlay_windows_during_capture();
 
 		if hide_overlay_windows {
@@ -88,6 +89,10 @@ impl OverlaySession {
 		}
 
 		self.capture_windows_hidden = false;
+
+		#[cfg(target_os = "macos")]
+		let _ = self.sync_native_capture_shells();
+
 		#[cfg(target_os = "macos")]
 		{
 			for overlay_window in self.windows.values() {
@@ -181,8 +186,6 @@ impl OverlaySession {
 	#[cfg(target_os = "macos")]
 	pub(super) fn destroy_live_only_aux_windows(&mut self) {
 		if let Some(loupe_window) = self.loupe_window.take() {
-			super::macos_clear_capture_window_focus_policy(loupe_window.window.as_ref());
-
 			self.remove_macos_hud_window_config_cache_entry(loupe_window.window.id());
 		}
 

--- a/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
@@ -126,6 +126,35 @@ impl OverlaySession {
 		})
 	}
 
+	fn frozen_capture_display_candidate_from_live_surface_bg(
+		&self,
+		monitor: MonitorRect,
+		cursor: Option<GlobalPoint>,
+		source: &'static str,
+		export_candidate: Option<(Arc<MonitorImageSnapshot>, u128)>,
+		captured_window_id: Option<u32>,
+	) -> Option<FrozenCaptureDisplayCandidate> {
+		let display_image = self
+			.state
+			.live_bg_image
+			.as_ref()
+			.filter(|_| self.state.live_bg_monitor == Some(monitor))
+			.cloned()?;
+		let (export_image, snapshot_age_ms) = match export_candidate {
+			Some((snapshot, age_ms)) => (Some(snapshot.image.as_ref().clone()), age_ms),
+			None => (None, 0),
+		};
+
+		Some(FrozenCaptureDisplayCandidate {
+			display_image,
+			export_image,
+			cursor,
+			source,
+			snapshot_age_ms,
+			captured_window_id,
+		})
+	}
+
 	fn apply_frozen_capture_display_candidate(
 		&mut self,
 		monitor: MonitorRect,
@@ -133,13 +162,16 @@ impl OverlaySession {
 	) {
 		let restore_hidden_capture_windows =
 			self.capture_windows_hidden && candidate.export_image.is_some();
+		let had_display_preview = self.frozen_preview_visible();
 
-		self.commit_frozen_preview(monitor, candidate.display_image, candidate.cursor);
-		self.note_frozen_transition_preview_committed(
-			monitor,
-			candidate.source,
-			Some(candidate.snapshot_age_ms),
-		);
+		if !had_display_preview {
+			self.commit_frozen_preview(monitor, candidate.display_image, candidate.cursor);
+			self.note_frozen_transition_preview_committed(
+				monitor,
+				candidate.source,
+				Some(candidate.snapshot_age_ms),
+			);
+		}
 
 		if let Some(export_image) = candidate.export_image {
 			self.set_frozen_capture_export_ready(monitor);
@@ -239,8 +271,43 @@ impl OverlaySession {
 			.live_sample_stream
 			.as_ref()
 			.and_then(|stream| stream.peek_latest_rgba_snapshot(monitor));
+		let can_finish_from_snapshot = self.snapshot_can_finish_frozen_capture(window_target);
 
-		if self.snapshot_can_finish_frozen_capture(window_target)
+		if let Some(display_candidate) = self.frozen_capture_display_candidate_from_live_surface_bg(
+			monitor,
+			cursor,
+			"live_surface_background_at_freeze_begin",
+			can_finish_from_snapshot
+				.then(|| self.usable_frozen_capture_snapshot(monitor, snapshot.clone()))
+				.flatten(),
+			can_finish_from_snapshot
+				.then(|| window_target.map(|target| target.window_id))
+				.flatten(),
+		) {
+			return FrozenCaptureBackendUpdate {
+				display_candidate: Some(display_candidate),
+				signal: if can_finish_from_snapshot
+					&& self.usable_frozen_capture_snapshot(monitor, snapshot.clone()).is_some()
+				{
+					FrozenCaptureBackendSignal::None
+				} else {
+					let arm_worker = window_target.is_some()
+						&& self.config.window_capture_alpha_mode
+							!= WindowCaptureAlphaMode::Background;
+
+					FrozenCaptureBackendSignal::Wait {
+						reason: if window_target.is_some() {
+							"waiting_for_export_authority"
+						} else {
+							"waiting_for_live_stream_snapshot"
+						},
+						arm_worker,
+					}
+				},
+			};
+		}
+
+		if can_finish_from_snapshot
 			&& let Some(display_candidate) = self.frozen_capture_display_candidate_from_snapshot(
 				monitor,
 				window_target,
@@ -510,8 +577,6 @@ impl OverlaySession {
 			self.update_cursor_state(monitor, cursor);
 		}
 
-		self.state.live_bg_monitor = None;
-		self.state.live_bg_image = None;
 		self.capture_windows_hidden = false;
 
 		let update = self.macos_begin_frozen_capture_backend_update(monitor, window_target, cursor);
@@ -522,6 +587,11 @@ impl OverlaySession {
 			.is_some();
 
 		self.apply_frozen_capture_backend_update(monitor, update);
+
+		if matches!(self.state.mode, OverlayMode::Frozen) {
+			self.state.live_bg_monitor = None;
+			self.state.live_bg_image = None;
+		}
 
 		finished
 	}

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -493,6 +493,9 @@ impl OverlaySession {
 	) -> Vec<OverlayCursorRect> {
 		let overlay_bounds =
 			Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+		let pen_target = (self.toolbar_state.selected_tool == FrozenToolbarTool::Pen)
+			.then(|| self.frozen_brush_capture_target())
+			.flatten();
 
 		if matches!(self.state.mode, OverlayMode::Live) {
 			return vec![OverlayCursorRect::new(overlay_bounds, CursorIcon::Crosshair)];
@@ -501,47 +504,20 @@ impl OverlaySession {
 			return Vec::new();
 		}
 
-		if let Some((target_monitor, capture_rect)) = self.frozen_spotlight_drag_target() {
+		for (target, active) in [
+			(self.frozen_mosaic_drag_target(), self.frozen_mosaic_drag.active),
+			(self.frozen_spotlight_drag_target(), self.frozen_spotlight_drag.active),
+			(self.frozen_arrow_drag_target(), self.frozen_arrow_drag.active),
+			(pen_target, self.frozen_brush.active_stroke.is_some()),
+		] {
+			let Some((target_monitor, capture_rect)) = target else {
+				continue;
+			};
+
 			if target_monitor != monitor {
 				return Vec::new();
 			}
-			if self.frozen_spotlight_drag.active {
-				return vec![OverlayCursorRect::new(overlay_bounds, CursorIcon::Crosshair)];
-			}
-
-			let capture_rect = Rect::from_min_size(
-				Pos2::new(capture_rect.x as f32, capture_rect.y as f32),
-				Vec2::new(capture_rect.width as f32, capture_rect.height as f32),
-			)
-			.intersect(overlay_bounds);
-
-			return (capture_rect.width() > 0.0 && capture_rect.height() > 0.0)
-				.then_some(vec![OverlayCursorRect::new(capture_rect, CursorIcon::Crosshair)])
-				.unwrap_or_default();
-		}
-		if let Some((target_monitor, capture_rect)) = self.frozen_arrow_drag_target() {
-			if target_monitor != monitor {
-				return Vec::new();
-			}
-			if self.frozen_arrow_drag.active {
-				return vec![OverlayCursorRect::new(overlay_bounds, CursorIcon::Crosshair)];
-			}
-
-			let capture_rect = Rect::from_min_size(
-				Pos2::new(capture_rect.x as f32, capture_rect.y as f32),
-				Vec2::new(capture_rect.width as f32, capture_rect.height as f32),
-			)
-			.intersect(overlay_bounds);
-
-			return (capture_rect.width() > 0.0 && capture_rect.height() > 0.0)
-				.then_some(vec![OverlayCursorRect::new(capture_rect, CursorIcon::Crosshair)])
-				.unwrap_or_default();
-		}
-		if let Some((target_monitor, capture_rect)) = self.frozen_mosaic_drag_target() {
-			if target_monitor != monitor {
-				return Vec::new();
-			}
-			if self.frozen_mosaic_drag.active {
+			if active {
 				return vec![OverlayCursorRect::new(overlay_bounds, CursorIcon::Crosshair)];
 			}
 
@@ -573,6 +549,31 @@ impl OverlaySession {
 					vec![OverlayCursorRect::new(overlay_bounds, CursorIcon::Grabbing)]
 				},
 			};
+		}
+
+		if let Some(hit_rect) = self.frozen_text_edit_hit_rect_for_monitor(monitor) {
+			let text_edit_dragging =
+				self.frozen_text_edit.as_ref().is_some_and(|edit| edit.dragging);
+			let rect = hit_rect.intersect(overlay_bounds);
+
+			if rect.width() > 0.0 && rect.height() > 0.0 {
+				return vec![OverlayCursorRect::new(
+					rect,
+					if text_edit_dragging { CursorIcon::Grabbing } else { CursorIcon::Grab },
+				)];
+			}
+		}
+
+		if self.frozen_text_tool_active() {
+			let capture_rect = Rect::from_min_size(
+				Pos2::new(capture_rect.x as f32, capture_rect.y as f32),
+				Vec2::new(capture_rect.width as f32, capture_rect.height as f32),
+			)
+			.intersect(overlay_bounds);
+
+			return (capture_rect.width() > 0.0 && capture_rect.height() > 0.0)
+				.then_some(vec![OverlayCursorRect::new(capture_rect, CursorIcon::Text)])
+				.unwrap_or_default();
 		}
 
 		Self::frozen_selection_hover_cursor_rects(capture_rect)
@@ -698,17 +699,36 @@ impl OverlaySession {
 	}
 
 	pub(super) fn sync_overlay_cursor_icons(&self) {
+		#[cfg(target_os = "macos")]
+		let current_monitor = self.monitor_for_mode().or(self.state.monitor);
+
 		for overlay_window in self.windows.values() {
-			#[cfg(not(target_os = "macos"))]
 			let icon = self.overlay_cursor_icon_for_monitor(overlay_window.monitor);
 
-			#[cfg(not(target_os = "macos"))]
+			tracing::warn!(
+				op = "overlay.sync_overlay_cursor_icons",
+				monitor_id = overlay_window.monitor.id,
+				mode = ?self.state.mode,
+				icon = ?icon,
+				active_monitor_id = ?current_monitor.map(|monitor| monitor.id),
+				cursor = ?self.state.cursor,
+				"Synced overlay cursor icons."
+			);
+
 			overlay_window.window.set_cursor(icon);
 			#[cfg(target_os = "macos")]
-			overlay_window.cursor_rects.sync_cursor_rects(
-				overlay_window.window.as_ref(),
-				&self.frozen_selection_cursor_rects_for_monitor(overlay_window.monitor),
-			);
+			{
+				overlay_window.cursor_rects.sync_cursor_rects(
+					overlay_window.window.as_ref(),
+					&self.frozen_selection_cursor_rects_for_monitor(overlay_window.monitor),
+				);
+
+				if current_monitor == Some(overlay_window.monitor) {
+					super::macos_set_cursor_icon(
+						self.overlay_cursor_icon_for_monitor(overlay_window.monitor),
+					);
+				}
+			}
 		}
 	}
 

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -699,7 +699,6 @@ impl OverlaySession {
 	}
 
 	pub(super) fn sync_overlay_cursor_icons(&self) {
-		#[cfg(target_os = "macos")]
 		let current_monitor = self.monitor_for_mode().or(self.state.monitor);
 
 		for overlay_window in self.windows.values() {

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -704,7 +704,7 @@ impl OverlaySession {
 		for overlay_window in self.windows.values() {
 			let icon = self.overlay_cursor_icon_for_monitor(overlay_window.monitor);
 
-			tracing::warn!(
+			tracing::trace!(
 				op = "overlay.sync_overlay_cursor_icons",
 				monitor_id = overlay_window.monitor.id,
 				mode = ?self.state.mode,

--- a/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
@@ -1,6 +1,5 @@
 use egui::{FontId, Pos2, Rect, Vec2};
 use image::RgbaImage;
-#[cfg(not(target_os = "macos"))]
 use winit::dpi::{LogicalPosition, LogicalSize};
 
 use crate::overlay::{
@@ -40,6 +39,15 @@ impl OverlaySession {
 		#[cfg(target_os = "macos")]
 		{
 			let _ = self.sync_native_capture_shells();
+			let ime_allowed = self.frozen_text_tool_active() && self.frozen_text_edit.is_some();
+
+			for overlay_window in self.windows.values() {
+				overlay_window.window.set_ime_allowed(ime_allowed);
+			}
+
+			if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+				toolbar_window.window.set_ime_allowed(false);
+			}
 		}
 
 		#[cfg(not(target_os = "macos"))]
@@ -59,7 +67,35 @@ impl OverlaySession {
 	pub(super) fn sync_frozen_text_ime_cursor_area(&mut self, monitor: MonitorRect) {
 		#[cfg(target_os = "macos")]
 		{
-			let _ = monitor;
+			let Some(edit_state) = self.frozen_text_edit.as_ref() else {
+				return;
+			};
+			let Some(overlay_window) =
+				self.windows.values().find(|window| window.monitor == monitor)
+			else {
+				return;
+			};
+			let (visible_text, caret_char_index) = edit_state.visible_text_and_caret_char_index();
+			let caret_rect = overlay_window.renderer.frozen_text_edit_caret_rect_for_window(
+				edit_state.anchor,
+				visible_text.as_str(),
+				&FontId::proportional(self.toolbar_state.text_style.font_size_points),
+				caret_char_index.unwrap_or_else(|| visible_text.chars().count()),
+			);
+
+			overlay_window.window.set_ime_cursor_area(
+				LogicalPosition::new(
+					f64::from(caret_rect.min.x.max(0.0)),
+					f64::from(caret_rect.min.y.max(0.0)),
+				),
+				LogicalSize::new(
+					f64::from(caret_rect.width().max(1.0)),
+					f64::from(
+						caret_rect.height().max(self.toolbar_state.text_style.font_size_points),
+					),
+				),
+			);
+
 			let _ = self.sync_native_capture_shells();
 		}
 
@@ -458,7 +494,7 @@ impl OverlaySession {
 	pub(super) fn focus_frozen_text_input_window(&mut self, monitor: Option<MonitorRect>) {
 		tracing::info!(
 			op = "overlay.frozen_text_focus_requested",
-			target = "native_key_focus_shell",
+			target = "key_focus_shell",
 			monitor_id = ?monitor.map(|target| target.id),
 			"Requested frozen text input focus."
 		);

--- a/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_text_runtime.rs
@@ -1,9 +1,8 @@
 use egui::{FontId, Pos2, Rect, Vec2};
 use image::RgbaImage;
+#[cfg(not(target_os = "macos"))]
 use winit::dpi::{LogicalPosition, LogicalSize};
 
-#[cfg(target_os = "macos")]
-use crate::overlay::Window;
 use crate::overlay::{
 	FrozenEditKind, FrozenExportTransform, FrozenTextAnnotation, FrozenTextEditState,
 	FrozenToolbarTool, GlobalPoint, MonitorRect, OverlaySession, WindowRenderer,
@@ -37,27 +36,45 @@ impl OverlaySession {
 		!self.scroll_capture.active && self.toolbar_state.selected_tool == FrozenToolbarTool::Text
 	}
 
-	pub(super) fn sync_text_input_ime_state(&self) {
+	pub(super) fn sync_text_input_ime_state(&mut self) {
+		#[cfg(target_os = "macos")]
+		{
+			let _ = self.sync_native_capture_shells();
+		}
+
+		#[cfg(not(target_os = "macos"))]
 		let ime_allowed = self.frozen_text_tool_active() && self.frozen_text_edit.is_some();
 
+		#[cfg(not(target_os = "macos"))]
 		for overlay_window in self.windows.values() {
 			overlay_window.window.set_ime_allowed(ime_allowed);
 		}
 
+		#[cfg(not(target_os = "macos"))]
 		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
 			toolbar_window.window.set_ime_allowed(ime_allowed);
 		}
 	}
 
-	pub(super) fn sync_frozen_text_ime_cursor_area(&self, monitor: MonitorRect) {
+	pub(super) fn sync_frozen_text_ime_cursor_area(&mut self, monitor: MonitorRect) {
+		#[cfg(target_os = "macos")]
+		{
+			let _ = monitor;
+			let _ = self.sync_native_capture_shells();
+		}
+
+		#[cfg(not(target_os = "macos"))]
 		let Some(edit_state) = self.frozen_text_edit.as_ref() else {
 			return;
 		};
+		#[cfg(not(target_os = "macos"))]
 		let Some(overlay_window) = self.windows.values().find(|window| window.monitor == monitor)
 		else {
 			return;
 		};
+		#[cfg(not(target_os = "macos"))]
 		let (visible_text, caret_char_index) = edit_state.visible_text_and_caret_char_index();
+		#[cfg(not(target_os = "macos"))]
 		let caret_rect = overlay_window.renderer.frozen_text_edit_caret_rect_for_window(
 			edit_state.anchor,
 			visible_text.as_str(),
@@ -65,6 +82,7 @@ impl OverlaySession {
 			caret_char_index.unwrap_or_else(|| visible_text.chars().count()),
 		);
 
+		#[cfg(not(target_os = "macos"))]
 		overlay_window.window.set_ime_cursor_area(
 			LogicalPosition::new(
 				f64::from(caret_rect.min.x.max(0.0)),
@@ -87,7 +105,7 @@ impl OverlaySession {
 	}
 
 	pub(super) fn refresh_frozen_text_ime_cursor_area_for_text_style_change(
-		&self,
+		&mut self,
 		monitor: MonitorRect,
 	) {
 		if self.should_refresh_frozen_text_ime_cursor_area_for_text_style_change(monitor) {
@@ -117,10 +135,6 @@ impl OverlaySession {
 		self.frozen_text_recent_input = None;
 
 		self.sync_text_input_ime_state();
-		#[cfg(target_os = "macos")]
-		self.restore_passive_capture_window_focus_policy_for_pointer_interaction(
-			"frozen_text_edit_finished",
-		);
 
 		had_visible_text
 	}
@@ -441,89 +455,14 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
-	fn frozen_text_input_overlay_window(&self, monitor: Option<MonitorRect>) -> Option<&Window> {
-		monitor
-			.and_then(|target| self.windows.values().find(|window| window.monitor == target))
-			.or_else(|| self.windows.values().next())
-			.map(|overlay_window| overlay_window.window.as_ref())
-	}
-
-	#[cfg(target_os = "macos")]
-	pub(super) fn focus_frozen_text_input_window(&self, monitor: Option<MonitorRect>) {
-		super::macos_activate_app();
-
-		let Some(target_window) = self.frozen_text_input_overlay_window(monitor) else {
-			tracing::info!(
-				op = "overlay.frozen_text_focus_requested",
-				target = "missing_window",
-				monitor_id = ?monitor.map(|target| target.id),
-				"Requested frozen text input focus, but no overlay window was available."
-			);
-
-			return;
-		};
-
+	pub(super) fn focus_frozen_text_input_window(&mut self, monitor: Option<MonitorRect>) {
 		tracing::info!(
 			op = "overlay.frozen_text_focus_requested",
-			target = "overlay_window",
+			target = "native_key_focus_shell",
 			monitor_id = ?monitor.map(|target| target.id),
 			"Requested frozen text input focus."
 		);
 
-		super::macos_make_window_key(target_window);
-	}
-
-	#[cfg(target_os = "macos")]
-	pub(super) fn focus_frozen_keyboard_window(&self) {
-		super::macos_activate_app();
-
-		if self.frozen_text_edit.is_some()
-			&& let Some(target_window) = self.frozen_text_input_overlay_window(self.state.monitor)
-		{
-			tracing::info!(
-				op = "scroll_capture.frozen_focus_requested",
-				target = "overlay_window",
-				state_mode = ?self.state.mode,
-				toolbar_window_visible = self.toolbar_window_visible,
-				monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
-				"Requested frozen keyboard focus for text editing."
-			);
-
-			super::macos_make_window_key(target_window);
-
-			return;
-		}
-
-		let target_window = if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			Some(toolbar_window.window.as_ref())
-		} else {
-			self.windows
-				.values()
-				.find(|overlay_window| Some(overlay_window.monitor) == self.state.monitor)
-				.map(|overlay_window| overlay_window.window.as_ref())
-		};
-		let Some(target_window) = target_window else {
-			tracing::info!(
-				op = "scroll_capture.frozen_focus_requested",
-				target = "missing_window",
-				state_mode = ?self.state.mode,
-				toolbar_window_present = self.toolbar_window.is_some(),
-				monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
-				"Requested frozen keyboard focus, but no target window was available."
-			);
-
-			return;
-		};
-
-		tracing::info!(
-			op = "scroll_capture.frozen_focus_requested",
-			target = if self.toolbar_window.is_some() { "toolbar_window" } else { "overlay_window" },
-			state_mode = ?self.state.mode,
-			toolbar_window_visible = self.toolbar_window_visible,
-			monitor_id = ?self.state.monitor.map(|monitor| monitor.id),
-			"Requested frozen keyboard focus."
-		);
-
-		super::macos_make_window_key(target_window);
+		let _ = self.sync_native_capture_shells();
 	}
 }

--- a/packages/rsnap-overlay/src/overlay/hud_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/hud_runtime.rs
@@ -1,3 +1,5 @@
+use winit::window::Window;
+
 use crate::overlay::{
 	Duration, FrozenCaptureSource, GlobalPoint, HudAnchor, HudPillGeometry, HudRedrawSummary,
 	Instant, LIVE_PRESENT_INTERVAL_MIN, LogicalSize, MonitorRect, OverlayControl,
@@ -28,6 +30,14 @@ impl OverlaySession {
 		_loupe_tile: Option<Rect>,
 	) -> Rect {
 		hud_pill.rect
+	}
+
+	fn ensure_aux_window_visible(window: &Window, visible: &mut bool) {
+		if !*visible {
+			window.set_visible(true);
+
+			*visible = true;
+		}
 	}
 
 	pub(super) fn maybe_skip_hud_redraw(&mut self) -> Option<OverlayControl> {
@@ -110,14 +120,13 @@ impl OverlaySession {
 		let mut summary = HudRedrawSummary::default();
 
 		if let (Some(monitor), Some(hud_window)) = (monitor, self.hud_window.as_mut()) {
-			summary.redraw_window_id = Some(hud_window.window.id());
-			summary.redraw_monitor_id = Some(monitor.id);
+			(summary.redraw_window_id, summary.redraw_monitor_id) =
+				(Some(hud_window.window.id()), Some(monitor.id));
 
-			if !self.hud_window_visible {
-				hud_window.window.set_visible(true);
-
-				self.hud_window_visible = true;
-			}
+			Self::ensure_aux_window_visible(
+				hud_window.window.as_ref(),
+				&mut self.hud_window_visible,
+			);
 
 			let draw_started_at = Instant::now();
 
@@ -141,6 +150,7 @@ impl OverlaySession {
 				self.config.selection_flow_enabled,
 				self.config.selection_flow_stroke_width_px,
 				true,
+				false,
 				false,
 				None,
 				false,

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -2,12 +2,14 @@ use std::time::{Duration, Instant};
 
 #[cfg(not(target_os = "macos"))]
 use device_query::DeviceQuery;
+use winit::event::KeyEvent;
+use winit::keyboard::ModifiersState;
 
 use crate::overlay::{
 	AltActivationMode, CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource,
 	ElementState, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
-	FrozenToolbarTool, GlobalPoint, Ime, Key, KeyEvent, LiveCaptureInteraction,
-	LiveClickCaptureTarget, Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl,
+	FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction, LiveClickCaptureTarget,
+	Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
 	OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId,
 	WindowRenderer,
 };
@@ -177,6 +179,15 @@ impl OverlaySession {
 
 	pub(super) fn handle_modifiers_changed(&mut self, modifiers: &Modifiers) -> OverlayControl {
 		self.keyboard_modifiers = modifiers.state();
+
+		OverlayControl::Continue
+	}
+
+	pub(super) fn handle_modifiers_state_changed(
+		&mut self,
+		modifiers: ModifiersState,
+	) -> OverlayControl {
+		self.keyboard_modifiers = modifiers;
 
 		OverlayControl::Continue
 	}
@@ -493,6 +504,54 @@ impl OverlaySession {
 			scale_factor,
 			window_size,
 		)
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn handle_native_overlay_pointer_moved(
+		&mut self,
+		monitor: MonitorRect,
+		global: GlobalPoint,
+	) -> OverlayControl {
+		let should_trace_frozen_selection_drag_timing =
+			self.should_trace_frozen_selection_drag_timing();
+		let cursor_move_started_at = should_trace_frozen_selection_drag_timing.then(Instant::now);
+		let now = Instant::now();
+		let old_monitor = self.active_cursor_monitor();
+		let old_cursor = self.state.cursor;
+		let source = DeviceCursorPointSource::EventRecentFallback;
+		let trace = CursorMoveTrace {
+			window_id: WindowId::dummy(),
+			position: PhysicalPosition::new(0.0, 0.0),
+			old_cursor,
+			device_cursor: global,
+			event_global: global,
+			monitor,
+			global,
+			source,
+		};
+
+		self.last_event_cursor = Some((monitor, global));
+		self.last_event_cursor_at = Some(now);
+
+		self.trace_cursor_moved_with_mapping(trace);
+
+		let timing = self.run_cursor_move_updates(
+			should_trace_frozen_selection_drag_timing,
+			cursor_move_started_at,
+			old_monitor,
+			monitor,
+			global,
+			global,
+		);
+
+		if should_trace_frozen_selection_drag_timing {
+			self.trace_frozen_selection_drag_cursor_move(monitor, old_monitor, old_cursor, timing);
+		}
+		if self.update_frozen_brush_stroke(global) {
+			self.request_redraw_for_monitor(monitor);
+		}
+
+		OverlayControl::Continue
 	}
 
 	pub(super) fn handle_cursor_moved_with_overlay_window(
@@ -964,12 +1023,6 @@ impl OverlaySession {
 
 		match state {
 			ElementState::Pressed => {
-				if self.live_capture_interaction_is_press_pending()
-					|| self.live_capture_interaction_is_dragging()
-				{
-					return OverlayControl::Continue;
-				}
-
 				let raw_cursor = self.current_device_cursor();
 				let (press_monitor, press_global) = if let Some((press_monitor, press_global, _)) =
 					self.resolve_live_cursor_point(raw_cursor)
@@ -979,21 +1032,7 @@ impl OverlaySession {
 					(monitor, raw_cursor)
 				};
 
-				self.update_cursor_state(press_monitor, press_global);
-				self.update_hud_window_position(press_monitor, press_global);
-				self.begin_live_capture_press(press_monitor, press_global);
-
-				if matches!(
-					self.live_capture_interaction,
-					LiveCaptureInteraction::PressPending { click_target: None, .. }
-				) {
-					self.request_click_capture_hit_test(press_monitor, press_global);
-				}
-
-				self.reset_toolbar_pointer_state();
-				self.request_redraw_for_monitor(press_monitor);
-
-				OverlayControl::Continue
+				self.handle_live_overlay_left_mouse_input(press_monitor, press_global, state)
 			},
 			ElementState::Released => {
 				let raw_cursor = self.current_device_cursor();
@@ -1005,6 +1044,62 @@ impl OverlaySession {
 					raw_cursor
 				};
 
+				self.handle_live_overlay_left_mouse_input(monitor, release_global, state)
+			},
+		}
+	}
+
+	pub(super) fn handle_live_overlay_left_mouse_input(
+		&mut self,
+		monitor: MonitorRect,
+		global: GlobalPoint,
+		state: ElementState,
+	) -> OverlayControl {
+		if matches!(self.state.mode, OverlayMode::Frozen) {
+			self.last_event_cursor = Some((monitor, global));
+			self.last_event_cursor_at = Some(Instant::now());
+
+			self.update_cursor_state(monitor, global);
+
+			return self.handle_frozen_left_mouse_input(monitor, state);
+		}
+		if !matches!(self.state.mode, OverlayMode::Live) {
+			return OverlayControl::Continue;
+		}
+		if self.frozen_display_handoff_pending() {
+			return OverlayControl::Continue;
+		}
+
+		self.maybe_timeout_pending_click_hit_test(Instant::now());
+
+		match state {
+			ElementState::Pressed => {
+				if self.live_capture_interaction_is_press_pending()
+					|| self.live_capture_interaction_is_dragging()
+				{
+					return OverlayControl::Continue;
+				}
+
+				self.last_event_cursor = Some((monitor, global));
+				self.last_event_cursor_at = Some(Instant::now());
+
+				self.update_cursor_state(monitor, global);
+				self.update_hud_window_position(monitor, global);
+				self.begin_live_capture_press(monitor, global);
+
+				if matches!(
+					self.live_capture_interaction,
+					LiveCaptureInteraction::PressPending { click_target: None, .. }
+				) {
+					self.request_click_capture_hit_test(monitor, global);
+				}
+
+				self.reset_toolbar_pointer_state();
+				self.request_redraw_for_monitor(monitor);
+
+				OverlayControl::Continue
+			},
+			ElementState::Released => {
 				match self.live_capture_interaction {
 					LiveCaptureInteraction::PressPending {
 						monitor: press_monitor,
@@ -1013,18 +1108,14 @@ impl OverlaySession {
 						..
 					} => {
 						if let Some(target) = click_target {
-							self.begin_frozen_capture_from_click(
-								press_monitor,
-								target,
-								release_global,
-							);
+							self.begin_frozen_capture_from_click(press_monitor, target, global);
 						} else if self.pending_click_hit_test_request_id.is_some() {
 							self.set_live_capture_interaction(
 								LiveCaptureInteraction::PressPending {
 									monitor: press_monitor,
 									press_global,
 									click_target: None,
-									release_global: Some(release_global),
+									release_global: Some(global),
 									released: true,
 								},
 							);
@@ -1032,7 +1123,7 @@ impl OverlaySession {
 							self.begin_frozen_capture_from_click(
 								press_monitor,
 								LiveClickCaptureTarget::fullscreen_fallback(),
-								release_global,
+								global,
 							);
 						}
 					},
@@ -1040,11 +1131,7 @@ impl OverlaySession {
 						if let Some(drag_rect) =
 							self.state.drag_rect.filter(|rect| rect.monitor_id == monitor.id)
 						{
-							self.begin_frozen_capture_from_drag(
-								monitor,
-								drag_rect.rect,
-								release_global,
-							);
+							self.begin_frozen_capture_from_drag(monitor, drag_rect.rect, global);
 						} else {
 							self.set_live_capture_interaction(LiveCaptureInteraction::Idle);
 						}
@@ -1138,13 +1225,22 @@ impl OverlaySession {
 	}
 
 	pub(super) fn handle_ime_event(&mut self, window_id: WindowId, event: &Ime) -> OverlayControl {
+		let monitor =
+			self.windows.get(&window_id).map(|window| window.monitor).or(self.state.monitor);
+
+		self.handle_overlay_ime_event(monitor, event)
+	}
+
+	pub(super) fn handle_overlay_ime_event(
+		&mut self,
+		monitor: Option<MonitorRect>,
+		event: &Ime,
+	) -> OverlayControl {
 		if !matches!(self.state.mode, OverlayMode::Frozen) || self.frozen_text_edit.is_none() {
 			return OverlayControl::Continue;
 		}
 
-		let Some(monitor) =
-			self.windows.get(&window_id).map(|window| window.monitor).or(self.state.monitor)
-		else {
+		let Some(monitor) = monitor.or(self.state.monitor) else {
 			return OverlayControl::Continue;
 		};
 		let changed = self.apply_frozen_text_ime_event(event);
@@ -1176,7 +1272,10 @@ impl OverlaySession {
 		}
 	}
 
-	fn handle_frozen_text_key_event(&mut self, event: &KeyEvent) -> Option<OverlayControl> {
+	fn handle_frozen_text_key_event(
+		&mut self,
+		event: &OverlayKeyboardInputEvent,
+	) -> Option<OverlayControl> {
 		self.frozen_text_edit.as_ref()?;
 
 		if event.state != ElementState::Pressed {
@@ -1283,6 +1382,13 @@ impl OverlaySession {
 	}
 
 	pub(super) fn handle_key_event(&mut self, event: &KeyEvent) -> OverlayControl {
+		self.handle_overlay_keyboard_input_event(&OverlayKeyboardInputEvent::from_winit(event))
+	}
+
+	pub(super) fn handle_overlay_keyboard_input_event(
+		&mut self,
+		event: &OverlayKeyboardInputEvent,
+	) -> OverlayControl {
 		if matches!(self.state.mode, OverlayMode::Frozen)
 			&& let Some(control) = self.handle_frozen_text_key_event(event)
 		{

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -5,11 +5,13 @@ use device_query::DeviceQuery;
 use winit::event::KeyEvent;
 use winit::keyboard::ModifiersState;
 
+#[cfg(target_os = "macos")]
+use crate::overlay::FrozenGlobalHotkey;
 use crate::overlay::{
 	AltActivationMode, CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource,
-	ElementState, FrozenGlobalHotkey, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState,
-	FrozenTextInputSource, FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction,
-	LiveClickCaptureTarget, Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl,
+	ElementState, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
+	FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction, LiveClickCaptureTarget,
+	Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl,
 	OverlayKeyboardInputEvent, OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize,
 	PngAction, Pos2, Vec2, WindowId, WindowRenderer,
 };
@@ -183,6 +185,7 @@ impl OverlaySession {
 		OverlayControl::Continue
 	}
 
+	#[cfg(target_os = "macos")]
 	pub(super) fn handle_modifiers_state_changed(
 		&mut self,
 		modifiers: ModifiersState,

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -7,11 +7,11 @@ use winit::keyboard::ModifiersState;
 
 use crate::overlay::{
 	AltActivationMode, CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource,
-	ElementState, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
-	FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction, LiveClickCaptureTarget,
-	Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
-	OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId,
-	WindowRenderer,
+	ElementState, FrozenGlobalHotkey, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState,
+	FrozenTextInputSource, FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction,
+	LiveClickCaptureTarget, Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl,
+	OverlayKeyboardInputEvent, OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize,
+	PngAction, Pos2, Vec2, WindowId, WindowRenderer,
 };
 
 impl OverlaySession {
@@ -1381,6 +1381,22 @@ impl OverlaySession {
 		OverlayControl::Continue
 	}
 
+	#[cfg(target_os = "macos")]
+	/// Handles a host-level frozen shortcut while ordinary frozen mode runs without a key window.
+	pub fn handle_global_frozen_hotkey(&mut self, hotkey: FrozenGlobalHotkey) -> OverlayControl {
+		if !self.wants_global_frozen_hotkeys() {
+			return OverlayControl::Continue;
+		}
+
+		match hotkey {
+			FrozenGlobalHotkey::Copy => self.handle_frozen_copy_hotkey(),
+			FrozenGlobalHotkey::AutoCenter => self.handle_frozen_auto_center_hotkey(),
+			FrozenGlobalHotkey::ToggleToolbar => self.toggle_toolbar_visibility_hotkey(),
+			FrozenGlobalHotkey::StartScrollCapture => self.handle_frozen_scroll_capture_hotkey(),
+			FrozenGlobalHotkey::Save => self.handle_frozen_save_hotkey(),
+		}
+	}
+
 	pub(super) fn handle_key_event(&mut self, event: &KeyEvent) -> OverlayControl {
 		self.handle_overlay_keyboard_input_event(&OverlayKeyboardInputEvent::from_winit(event))
 	}
@@ -1419,63 +1435,81 @@ impl OverlaySession {
 				if (key_text == "h" || key_text == "H")
 					&& self.plain_character_shortcut_available() =>
 			{
-				self.toolbar_state.visible = !self.toolbar_state.visible;
-
-				#[cfg(target_os = "macos")]
-				if self.toolbar_state.visible {
-					self.request_aux_window_creation_if_needed();
-				}
-
-				self.request_redraw_all();
-
-				OverlayControl::Continue
+				self.toggle_toolbar_visibility_hotkey()
 			},
 			Key::Character(key_text)
 				if key_text.as_str().eq_ignore_ascii_case("c")
 					&& self.plain_character_shortcut_available() =>
 			{
-				self.auto_center_frozen_capture_rect();
-
-				OverlayControl::Continue
+				self.handle_frozen_auto_center_hotkey()
 			},
 			Key::Character(key_text)
 				if key_text.as_str().eq_ignore_ascii_case("s")
 					&& self.is_save_shortcut_pressed() =>
 			{
-				self.begin_png_action(PngAction::Save);
-
-				OverlayControl::Continue
+				self.handle_frozen_save_hotkey()
 			},
 			Key::Character(key_text)
 				if key_text.as_str().eq_ignore_ascii_case("s")
 					&& self.plain_character_shortcut_available() =>
 			{
-				let available = self.scroll_capture_is_available();
-				let selection_ready = self.scroll_capture_selection_is_ready();
-
-				tracing::info!(
-					op = "scroll_capture.frozen_s_pressed",
-					available,
-					scroll_capture_active = self.scroll_capture.active,
-					selection_ready,
-					frozen_capture_source = ?self.frozen_capture_source,
-					state_mode = ?self.state.mode,
-					"Received `s` while frozen."
-				);
-
-				if selection_ready {
-					return self.start_scroll_capture();
-				}
-
-				OverlayControl::Continue
+				self.handle_frozen_scroll_capture_hotkey()
 			},
-			Key::Named(NamedKey::Space) => {
-				self.begin_png_action(PngAction::Copy);
-
-				OverlayControl::Continue
-			},
+			Key::Named(NamedKey::Space) => self.handle_frozen_copy_hotkey(),
 			_ => OverlayControl::Continue,
 		}
+	}
+
+	fn toggle_toolbar_visibility_hotkey(&mut self) -> OverlayControl {
+		self.toolbar_state.visible = !self.toolbar_state.visible;
+
+		#[cfg(target_os = "macos")]
+		if self.toolbar_state.visible {
+			self.request_aux_window_creation_if_needed();
+		}
+
+		self.request_redraw_all();
+
+		OverlayControl::Continue
+	}
+
+	fn handle_frozen_auto_center_hotkey(&mut self) -> OverlayControl {
+		self.auto_center_frozen_capture_rect();
+
+		OverlayControl::Continue
+	}
+
+	fn handle_frozen_save_hotkey(&mut self) -> OverlayControl {
+		self.begin_png_action(PngAction::Save);
+
+		OverlayControl::Continue
+	}
+
+	fn handle_frozen_scroll_capture_hotkey(&mut self) -> OverlayControl {
+		let available = self.scroll_capture_is_available();
+		let selection_ready = self.scroll_capture_selection_is_ready();
+
+		tracing::info!(
+			op = "scroll_capture.frozen_s_pressed",
+			available,
+			scroll_capture_active = self.scroll_capture.active,
+			selection_ready,
+			frozen_capture_source = ?self.frozen_capture_source,
+			state_mode = ?self.state.mode,
+			"Received `s` while frozen."
+		);
+
+		if selection_ready {
+			return self.start_scroll_capture();
+		}
+
+		OverlayControl::Continue
+	}
+
+	fn handle_frozen_copy_hotkey(&mut self) -> OverlayControl {
+		self.begin_png_action(PngAction::Copy);
+
+		OverlayControl::Continue
 	}
 
 	pub(super) fn is_save_shortcut_pressed(&self) -> bool {

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 #[cfg(not(target_os = "macos"))]
 use device_query::DeviceQuery;
 use winit::event::KeyEvent;
+#[cfg(target_os = "macos")]
 use winit::keyboard::ModifiersState;
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -12,9 +12,9 @@ use crate::overlay::{
 	AltActivationMode, CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource,
 	ElementState, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
 	FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction, LiveClickCaptureTarget,
-	Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl,
-	OverlayKeyboardInputEvent, OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize,
-	PngAction, Pos2, Vec2, WindowId, WindowRenderer,
+	Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
+	OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId,
+	WindowRenderer,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -792,9 +792,13 @@ impl MacOSPassiveShellCallback {
 		}
 	}
 
-	fn dispatch_mouse_exited(&self) {
-		if let Self::Toolbar { dispatch, .. } = self {
-			dispatch.enqueue(MacOSNativeCaptureInputEvent::ToolbarPointerLeft);
+	fn dispatch_mouse_exited(&self, view_key: usize) {
+		match self {
+			Self::Overlay { .. } => macos_update_passive_shell_cursor_point(view_key, None),
+			Self::Toolbar { dispatch, .. } => {
+				dispatch.enqueue(MacOSNativeCaptureInputEvent::ToolbarPointerLeft);
+			},
+			Self::KeyFocus { .. } => {},
 		}
 	}
 
@@ -1191,11 +1195,12 @@ extern "C" fn macos_passive_shell_view_right_mouse_down(
 }
 
 extern "C" fn macos_passive_shell_view_mouse_exited(this: &Object, _cmd: Sel, _event: *mut Object) {
+	let view_key = this as *const Object as usize;
 	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
 		return;
 	};
 
-	callback.dispatch_mouse_exited();
+	callback.dispatch_mouse_exited(view_key);
 }
 
 extern "C" fn macos_passive_shell_view_scroll_wheel(this: &Object, _cmd: Sel, event: *mut Object) {

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -1657,7 +1657,7 @@ fn macos_dispatch_shell_pointer_moved(this: &Object, event: *mut Object) {
 		return;
 	};
 
-	tracing::warn!(
+	tracing::trace!(
 		op = "overlay.macos_passive_shell_pointer_moved",
 		callback = %macos_shell_callback_name(&callback),
 		x = local_point.x,

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -1,0 +1,1769 @@
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::ptr;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use objc::declare::ClassDecl;
+use objc::runtime::{BOOL, Class, NO, Object, Sel, YES};
+use objc::{Encode, Encoding};
+use objc2_foundation::{NSPoint, NSRange, NSRect, NSSize};
+use winit::event::{ElementState, Ime, MouseButton};
+
+use crate::overlay::{
+	CursorIcon, GlobalPoint, MacOSNativeCaptureInputDispatch, MacOSNativeCaptureInputEvent,
+	MacOSNativeCaptureScrollDelta, MonitorRect, OverlayKeyboardInputEvent, OverlayMode,
+	OverlaySession, Pos2, Window,
+};
+use winit::keyboard::{Key, ModifiersState, NamedKey, NativeKey};
+
+macro_rules! sel {
+	($($tt:tt)*) => {
+		objc::sel!($($tt)*)
+	};
+}
+
+macro_rules! sel_impl {
+	($($tt:tt)*) => {
+		objc::sel_impl!($($tt)*)
+	};
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MacOSRange {
+	location: usize,
+	length: usize,
+}
+unsafe impl Encode for MacOSRange {
+	fn encode() -> Encoding {
+		unsafe { Encoding::from_str("{_NSRange=QQ}") }
+	}
+}
+impl From<NSRange> for MacOSRange {
+	fn from(value: NSRange) -> Self {
+		Self { location: value.location, length: value.length }
+	}
+}
+impl From<MacOSRange> for NSRange {
+	fn from(value: MacOSRange) -> Self {
+		Self::new(value.location, value.length)
+	}
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct MacOSSize {
+	width: f64,
+	height: f64,
+}
+unsafe impl Encode for MacOSSize {
+	fn encode() -> Encoding {
+		unsafe { Encoding::from_str("{CGSize=dd}") }
+	}
+}
+impl From<NSSize> for MacOSSize {
+	fn from(value: NSSize) -> Self {
+		Self { width: value.width, height: value.height }
+	}
+}
+impl From<MacOSSize> for NSSize {
+	fn from(value: MacOSSize) -> Self {
+		Self::new(value.width, value.height)
+	}
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct MacOSRect {
+	origin: super::MacOSOverlayPoint,
+	size: MacOSSize,
+}
+unsafe impl Encode for MacOSRect {
+	fn encode() -> Encoding {
+		unsafe { Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}") }
+	}
+}
+impl From<NSRect> for MacOSRect {
+	fn from(value: NSRect) -> Self {
+		Self {
+			origin: super::MacOSOverlayPoint { x: value.origin.x, y: value.origin.y },
+			size: MacOSSize::from(value.size),
+		}
+	}
+}
+impl From<MacOSRect> for NSRect {
+	fn from(value: MacOSRect) -> Self {
+		Self::new(NSPoint::new(value.origin.x, value.origin.y), NSSize::from(value.size))
+	}
+}
+
+pub(super) struct MacOSNativeCaptureShells {
+	overlay_shells: HashMap<u32, MacOSPassiveShellWindow>,
+	toolbar_shell: Option<MacOSPassiveShellWindow>,
+	key_focus_shell: Option<MacOSKeyFocusShellWindow>,
+	key_focus_shell_active: bool,
+	key_focus_shell_target: Option<MacOSKeyFocusShellTarget>,
+	dispatch: MacOSNativeCaptureInputDispatch,
+}
+impl MacOSNativeCaptureShells {
+	fn new(
+		overlay_shells: HashMap<u32, MacOSPassiveShellWindow>,
+		dispatch: MacOSNativeCaptureInputDispatch,
+	) -> Self {
+		Self {
+			overlay_shells,
+			toolbar_shell: None,
+			key_focus_shell: None,
+			key_focus_shell_active: false,
+			key_focus_shell_target: None,
+			dispatch,
+		}
+	}
+
+	fn sync_overlay_shells(
+		&self,
+		windows: &HashMap<winit::window::WindowId, crate::overlay::OverlayWindow>,
+		visible: bool,
+	) {
+		for overlay_window in windows.values() {
+			if let Some(shell) = self.overlay_shells.get(&overlay_window.monitor.id) {
+				shell.sync_from_render_window(overlay_window.window.as_ref(), visible);
+			}
+		}
+	}
+
+	fn ensure_toolbar_shell(
+		&mut self,
+		render_window: &Window,
+	) -> Result<&MacOSPassiveShellWindow, String> {
+		if self.toolbar_shell.is_none() {
+			self.toolbar_shell = Some(macos_create_passive_toolbar_shell_window(
+				render_window,
+				self.dispatch.clone(),
+			)?);
+		}
+
+		self.toolbar_shell
+			.as_ref()
+			.ok_or_else(|| String::from("Toolbar shell should exist after creation"))
+	}
+
+	fn sync_toolbar_shell(
+		&mut self,
+		render_window: &Window,
+		monitor: MonitorRect,
+		outer_position: GlobalPoint,
+		visible: bool,
+	) -> Result<(), String> {
+		let shell = self.ensure_toolbar_shell(render_window)?;
+
+		shell.set_toolbar_state(monitor, outer_position);
+		shell.sync_from_render_window(render_window, visible);
+
+		Ok(())
+	}
+
+	fn clear_toolbar_shell(&mut self) {
+		self.toolbar_shell = None;
+	}
+
+	fn ensure_key_focus_shell(
+		&mut self,
+		render_window: &Window,
+	) -> Result<&MacOSKeyFocusShellWindow, String> {
+		if self.key_focus_shell.is_none() {
+			self.key_focus_shell =
+				Some(macos_create_key_focus_shell_window(render_window, self.dispatch.clone())?);
+		}
+
+		self.key_focus_shell
+			.as_ref()
+			.ok_or_else(|| String::from("Key-focus shell should exist after creation"))
+	}
+
+	fn sync_key_focus_shell(
+		&mut self,
+		render_window: &Window,
+		target: MacOSKeyFocusShellTarget,
+		visible: bool,
+	) -> Result<(), String> {
+		let should_focus = visible
+			&& (!self.key_focus_shell_active || self.key_focus_shell_target != Some(target));
+
+		self.key_focus_shell_active = visible;
+		self.key_focus_shell_target = visible.then_some(target);
+
+		let shell = self.ensure_key_focus_shell(render_window)?;
+
+		shell.sync_from_render_window(render_window, target, visible);
+
+		if should_focus {
+			shell.ensure_key_focus();
+		}
+
+		Ok(())
+	}
+
+	fn clear_key_focus_shell(&mut self) {
+		if let Some(shell) = self.key_focus_shell.as_ref() {
+			shell.clear_target();
+			shell.hide();
+		}
+
+		self.key_focus_shell_active = false;
+		self.key_focus_shell_target = None;
+	}
+}
+
+#[derive(Clone, Copy, Default)]
+struct MacOSPassiveToolbarShellState {
+	monitor: Option<MonitorRect>,
+	outer_position: Option<GlobalPoint>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MacOSKeyFocusShellKind {
+	FrozenText,
+	ScrollCapture,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct MacOSKeyFocusShellTarget {
+	kind: MacOSKeyFocusShellKind,
+	monitor: Option<MonitorRect>,
+	ime_allowed: bool,
+	ime_origin: NSPoint,
+	ime_size: NSSize,
+}
+
+#[derive(Debug)]
+struct MacOSKeyFocusShellState {
+	target: Option<MacOSKeyFocusShellTarget>,
+	keyboard_modifiers: ModifiersState,
+	marked_text: String,
+	forward_key_event_to_app: bool,
+	had_ime_input_during_keydown: bool,
+}
+impl Default for MacOSKeyFocusShellState {
+	fn default() -> Self {
+		Self {
+			target: None,
+			keyboard_modifiers: ModifiersState::empty(),
+			marked_text: String::new(),
+			forward_key_event_to_app: false,
+			had_ime_input_during_keydown: false,
+		}
+	}
+}
+
+#[derive(Clone)]
+enum MacOSPassiveShellCallback {
+	Overlay {
+		monitor: MonitorRect,
+		dispatch: MacOSNativeCaptureInputDispatch,
+	},
+	Toolbar {
+		state: Arc<Mutex<MacOSPassiveToolbarShellState>>,
+		dispatch: MacOSNativeCaptureInputDispatch,
+	},
+	KeyFocus {
+		state: Arc<Mutex<MacOSKeyFocusShellState>>,
+		dispatch: MacOSNativeCaptureInputDispatch,
+	},
+}
+impl MacOSPassiveShellCallback {
+	fn dispatch_pointer_moved(&self, local_point: NSPoint) {
+		match self {
+			Self::Overlay { monitor, dispatch } => {
+				dispatch.enqueue(MacOSNativeCaptureInputEvent::OverlayPointerMoved {
+					monitor: *monitor,
+					global: monitor.clamp_local_point(local_point),
+				});
+			},
+			Self::Toolbar { state, dispatch } => {
+				let Ok(state) = state.lock() else {
+					return;
+				};
+				let (Some(monitor), Some(outer_position)) = (state.monitor, state.outer_position)
+				else {
+					return;
+				};
+				let local = Pos2::new(local_point.x as f32, local_point.y as f32);
+				let global = GlobalPoint::new(
+					outer_position.x.saturating_add(local.x.round() as i32),
+					outer_position.y.saturating_add(local.y.round() as i32),
+				);
+
+				dispatch.enqueue(MacOSNativeCaptureInputEvent::ToolbarPointerMoved {
+					monitor,
+					local,
+					global,
+					outer_position,
+				});
+			},
+			Self::KeyFocus { .. } => {},
+		}
+	}
+
+	fn dispatch_mouse_input(
+		&self,
+		local_point: Option<NSPoint>,
+		button: MouseButton,
+		state: ElementState,
+	) {
+		match self {
+			Self::Overlay { monitor, dispatch } => {
+				let Some(local_point) = local_point else {
+					return;
+				};
+
+				dispatch.enqueue(MacOSNativeCaptureInputEvent::OverlayMouseInput {
+					monitor: *monitor,
+					global: monitor.clamp_local_point(local_point),
+					button,
+					state,
+				});
+			},
+			Self::Toolbar { dispatch, .. } => {
+				dispatch.enqueue(MacOSNativeCaptureInputEvent::ToolbarMouseInput { button, state });
+			},
+			Self::KeyFocus { .. } => {},
+		}
+	}
+
+	fn dispatch_mouse_exited(&self) {
+		if let Self::Toolbar { dispatch, .. } = self {
+			dispatch.enqueue(MacOSNativeCaptureInputEvent::ToolbarPointerLeft);
+		}
+	}
+
+	fn dispatch_scroll_wheel(&self, delta: MacOSNativeCaptureScrollDelta) {
+		if let Self::Toolbar { dispatch, .. } = self {
+			dispatch.enqueue(MacOSNativeCaptureInputEvent::ToolbarScrollWheel { delta });
+		}
+	}
+}
+
+struct MacOSPassiveShellWindow {
+	window_key: usize,
+	view_key: usize,
+	tracking_area_key: usize,
+	toolbar_state: Option<Arc<Mutex<MacOSPassiveToolbarShellState>>>,
+}
+impl MacOSPassiveShellWindow {
+	fn sync_from_render_window(&self, render_window: &Window, visible: bool) {
+		let Some(render_ns_window) = macos_overlay_window_ns_window(render_window) else {
+			return;
+		};
+		let Some(frame) = macos_ns_window_frame(render_ns_window) else {
+			return;
+		};
+
+		self.sync_frame_and_visibility(frame, visible);
+	}
+
+	fn sync_frame_and_visibility(&self, frame: NSRect, visible: bool) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, setFrame: frame display: NO];
+
+			if visible {
+				let _: () = objc::msg_send![ns_window, orderFrontRegardless];
+			} else {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+			}
+		}
+	}
+
+	fn set_toolbar_state(&self, monitor: MonitorRect, outer_position: GlobalPoint) {
+		let Some(state) = self.toolbar_state.as_ref() else {
+			return;
+		};
+		let Ok(mut state) = state.lock() else {
+			return;
+		};
+
+		state.monitor = Some(monitor);
+		state.outer_position = Some(outer_position);
+	}
+}
+
+struct MacOSKeyFocusShellWindow {
+	window_key: usize,
+	view_key: usize,
+	state: Arc<Mutex<MacOSKeyFocusShellState>>,
+}
+impl MacOSKeyFocusShellWindow {
+	fn sync_from_render_window(
+		&self,
+		render_window: &Window,
+		target: MacOSKeyFocusShellTarget,
+		visible: bool,
+	) {
+		let Some(render_ns_window) = macos_overlay_window_ns_window(render_window) else {
+			return;
+		};
+		let Some(frame) = macos_ns_window_frame(render_ns_window) else {
+			return;
+		};
+
+		self.set_target(target);
+		self.sync_frame_and_visibility(frame, visible);
+	}
+
+	fn set_target(&self, target: MacOSKeyFocusShellTarget) {
+		let Ok(mut state) = self.state.lock() else {
+			return;
+		};
+
+		state.target = Some(target);
+
+		let view = self.view_key as *mut Object;
+		if view.is_null() {
+			return;
+		}
+
+		unsafe {
+			let input_context: *mut Object = objc::msg_send![view, inputContext];
+
+			if !input_context.is_null() {
+				let _: () = objc::msg_send![input_context, invalidateCharacterCoordinates];
+			}
+		}
+	}
+
+	fn clear_target(&self) {
+		let Ok(mut state) = self.state.lock() else {
+			return;
+		};
+
+		state.target = None;
+		state.marked_text.clear();
+		state.forward_key_event_to_app = false;
+		state.had_ime_input_during_keydown = false;
+	}
+
+	fn sync_frame_and_visibility(&self, frame: NSRect, visible: bool) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, setFrame: frame display: NO];
+
+			if visible {
+				let _: () = objc::msg_send![ns_window, orderFrontRegardless];
+			} else {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+			}
+		}
+	}
+
+	fn hide(&self) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+		}
+	}
+
+	fn ensure_key_focus(&self) {
+		let ns_window = self.window_key as *mut Object;
+		let view = self.view_key as *mut Object;
+
+		if ns_window.is_null() || view.is_null() {
+			return;
+		}
+
+		super::macos_activate_app();
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, makeFirstResponder: view];
+			let _: () = objc::msg_send![ns_window, makeKeyAndOrderFront: ptr::null_mut::<Object>()];
+		}
+	}
+}
+impl Drop for MacOSKeyFocusShellWindow {
+	fn drop(&mut self) {
+		macos_unregister_shell_callback(self.view_key);
+
+		unsafe {
+			let ns_window = self.window_key as *mut Object;
+			if !ns_window.is_null() {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+				let _: () = objc::msg_send![ns_window, close];
+				let _: () = objc::msg_send![ns_window, release];
+			}
+
+			let view = self.view_key as *mut Object;
+			if !view.is_null() {
+				let _: () = objc::msg_send![view, release];
+			}
+		}
+	}
+}
+impl Drop for MacOSPassiveShellWindow {
+	fn drop(&mut self) {
+		macos_unregister_shell_callback(self.view_key);
+
+		unsafe {
+			let ns_window = self.window_key as *mut Object;
+			if !ns_window.is_null() {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+				let _: () = objc::msg_send![ns_window, close];
+				let _: () = objc::msg_send![ns_window, release];
+			}
+
+			let tracking_area = self.tracking_area_key as *mut Object;
+			if !tracking_area.is_null() {
+				let _: () = objc::msg_send![tracking_area, release];
+			}
+
+			let view = self.view_key as *mut Object;
+			if !view.is_null() {
+				let _: () = objc::msg_send![view, release];
+			}
+		}
+	}
+}
+
+impl OverlaySession {
+	pub(super) fn ensure_native_capture_shells(&mut self) -> Result<(), String> {
+		let Some(dispatch) = self.native_capture_input_dispatch() else {
+			return Ok(());
+		};
+
+		if self.native_capture_shells.is_some() {
+			self.sync_native_capture_shells()?;
+
+			return Ok(());
+		}
+
+		let mut overlay_shells = HashMap::with_capacity(self.windows.len());
+
+		for overlay_window in self.windows.values() {
+			let shell = macos_create_passive_overlay_shell_window(
+				overlay_window.window.as_ref(),
+				overlay_window.monitor,
+				dispatch.clone(),
+			)?;
+			overlay_shells.insert(overlay_window.monitor.id, shell);
+		}
+
+		self.native_capture_shells = Some(MacOSNativeCaptureShells::new(overlay_shells, dispatch));
+		self.sync_native_capture_shells()?;
+
+		Ok(())
+	}
+
+	pub(super) fn sync_native_capture_shells(&mut self) -> Result<(), String> {
+		let live_shell_visible = self.should_host_live_pointer_input_in_native_shell();
+		let toolbar_shell_visible = self.should_host_toolbar_pointer_input_in_native_shell();
+		let toolbar_context = self.toolbar_window.as_ref().map(|toolbar_window| {
+			let monitor = self.state.monitor.or_else(|| self.active_cursor_monitor());
+			let outer_position = Self::toolbar_window_outer_position(toolbar_window)
+				.or(self.pending_toolbar_outer_pos)
+				.or(self.toolbar_outer_pos)
+				.or_else(|| {
+					monitor.and_then(|monitor| {
+						self.toolbar_state.floating_position.map(|floating_position| {
+							self.toolbar_outer_position_from_primary_anchor(
+								monitor,
+								floating_position,
+							)
+						})
+					})
+				});
+
+			(Arc::clone(&toolbar_window.window), monitor, outer_position)
+		});
+		let key_focus_context = self.native_key_focus_shell_context();
+
+		for overlay_window in self.windows.values() {
+			super::macos_set_capture_window_mouse_passthrough(
+				overlay_window.window.as_ref(),
+				live_shell_visible,
+			);
+		}
+
+		let Some(shells) = self.native_capture_shells.as_mut() else {
+			if let Some((toolbar_window, _, _)) = toolbar_context.as_ref() {
+				super::macos_set_capture_window_mouse_passthrough(toolbar_window.as_ref(), false);
+			}
+
+			return Ok(());
+		};
+
+		shells.sync_overlay_shells(&self.windows, live_shell_visible);
+
+		if let Some((toolbar_window, monitor, outer_position)) = toolbar_context {
+			if let (Some(monitor), Some(outer_position)) = (monitor, outer_position) {
+				shells.sync_toolbar_shell(
+					toolbar_window.as_ref(),
+					monitor,
+					outer_position,
+					toolbar_shell_visible,
+				)?;
+				super::macos_set_capture_window_mouse_passthrough(
+					toolbar_window.as_ref(),
+					toolbar_shell_visible,
+				);
+			} else {
+				super::macos_set_capture_window_mouse_passthrough(toolbar_window.as_ref(), false);
+				shells.clear_toolbar_shell();
+			}
+		} else {
+			shells.clear_toolbar_shell();
+		}
+
+		if let Some((render_window, target)) = key_focus_context {
+			shells.sync_key_focus_shell(render_window.as_ref(), target, true)?;
+		} else {
+			shells.clear_key_focus_shell();
+		}
+
+		Ok(())
+	}
+
+	pub(super) fn destroy_native_capture_shells(&mut self) {
+		for overlay_window in self.windows.values() {
+			super::macos_set_capture_window_mouse_passthrough(
+				overlay_window.window.as_ref(),
+				false,
+			);
+		}
+		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+			super::macos_set_capture_window_mouse_passthrough(
+				toolbar_window.window.as_ref(),
+				false,
+			);
+		}
+
+		self.native_capture_shells = None;
+	}
+
+	fn native_key_focus_shell_context(&self) -> Option<(Arc<Window>, MacOSKeyFocusShellTarget)> {
+		if self.scroll_capture.active {
+			let render_window = self
+				.scroll_preview_window
+				.as_ref()
+				.map(|preview_window| Arc::clone(&preview_window.window))
+				.or_else(|| {
+					self.scroll_capture.monitor.and_then(|target_monitor| {
+						self.windows
+							.values()
+							.find(|overlay_window| overlay_window.monitor == target_monitor)
+							.map(|overlay_window| Arc::clone(&overlay_window.window))
+					})
+				})?;
+			let target = MacOSKeyFocusShellTarget {
+				kind: MacOSKeyFocusShellKind::ScrollCapture,
+				monitor: self.scroll_capture.monitor,
+				ime_allowed: false,
+				ime_origin: NSPoint::new(0.0, 0.0),
+				ime_size: NSSize::new(1.0, 1.0),
+			};
+
+			return Some((render_window, target));
+		}
+
+		let edit_state = self.frozen_text_edit.as_ref()?;
+		if !self.frozen_text_tool_active() {
+			return None;
+		}
+
+		let monitor = self.state.monitor?;
+		let overlay_window = self.windows.values().find(|window| window.monitor == monitor)?;
+		let (visible_text, caret_char_index) = edit_state.visible_text_and_caret_char_index();
+		let caret_rect = overlay_window.renderer.frozen_text_edit_caret_rect_for_window(
+			edit_state.anchor,
+			visible_text.as_str(),
+			&egui::FontId::proportional(self.toolbar_state.text_style.font_size_points),
+			caret_char_index.unwrap_or_else(|| visible_text.chars().count()),
+		);
+		let target = MacOSKeyFocusShellTarget {
+			kind: MacOSKeyFocusShellKind::FrozenText,
+			monitor: Some(monitor),
+			ime_allowed: true,
+			ime_origin: NSPoint::new(
+				f64::from(caret_rect.min.x.max(0.0)),
+				f64::from(caret_rect.min.y.max(0.0)),
+			),
+			ime_size: NSSize::new(
+				f64::from(caret_rect.width().max(1.0)),
+				f64::from(caret_rect.height().max(self.toolbar_state.text_style.font_size_points)),
+			),
+		};
+
+		Some((Arc::clone(&overlay_window.window), target))
+	}
+
+	pub(super) fn should_host_live_pointer_input_in_native_shell(&self) -> bool {
+		self.session_active
+			&& !self.capture_windows_hidden
+			&& matches!(self.state.mode, OverlayMode::Live)
+			&& !self.windows.is_empty()
+	}
+
+	pub(super) fn should_host_toolbar_pointer_input_in_native_shell(&self) -> bool {
+		self.session_active
+			&& matches!(self.state.mode, OverlayMode::Frozen)
+			&& self.toolbar_state.visible
+			&& self.toolbar_window_visible
+	}
+}
+
+impl MonitorRect {
+	fn clamp_local_point(self, local_point: NSPoint) -> GlobalPoint {
+		let max_x = self.width.saturating_sub(1) as i32;
+		let max_y = self.height.saturating_sub(1) as i32;
+		let local_x = (local_point.x.round() as i32).clamp(0, max_x);
+		let local_y = (local_point.y.round() as i32).clamp(0, max_y);
+
+		GlobalPoint::new(
+			self.origin.x.saturating_add(local_x),
+			self.origin.y.saturating_add(local_y),
+		)
+	}
+}
+
+fn macos_shell_callbacks() -> &'static Mutex<HashMap<usize, MacOSPassiveShellCallback>> {
+	static CALLBACKS: OnceLock<Mutex<HashMap<usize, MacOSPassiveShellCallback>>> = OnceLock::new();
+
+	CALLBACKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn macos_register_shell_callback(view_key: usize, callback: MacOSPassiveShellCallback) {
+	macos_shell_callbacks().lock().expect("shell callback map poisoned").insert(view_key, callback);
+}
+
+fn macos_unregister_shell_callback(view_key: usize) {
+	macos_shell_callbacks().lock().expect("shell callback map poisoned").remove(&view_key);
+}
+
+fn macos_shell_callback(view_key: usize) -> Option<MacOSPassiveShellCallback> {
+	macos_shell_callbacks().lock().expect("shell callback map poisoned").get(&view_key).cloned()
+}
+
+fn macos_passive_shell_panel_class() -> *const Class {
+	static CLASS: OnceLock<usize> = OnceLock::new();
+
+	(*CLASS.get_or_init(|| {
+		if let Some(class) = Class::get("RsnapPassiveCaptureShellPanel") {
+			return class as *const Class as usize;
+		}
+
+		let superclass = objc::class!(NSPanel);
+		let mut decl = ClassDecl::new("RsnapPassiveCaptureShellPanel", superclass)
+			.expect("passive capture shell panel class");
+
+		unsafe {
+			decl.add_method(
+				objc::sel!(canBecomeMainWindow),
+				macos_passive_shell_can_become_main_window as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(canBecomeKeyWindow),
+				macos_passive_shell_can_become_key_window as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+		}
+
+		decl.register() as *const Class as usize
+	})) as *const Class
+}
+
+fn macos_passive_shell_view_class() -> *const Class {
+	static CLASS: OnceLock<usize> = OnceLock::new();
+
+	(*CLASS.get_or_init(|| {
+		if let Some(class) = Class::get("RsnapPassiveCaptureShellView") {
+			return class as *const Class as usize;
+		}
+
+		let superclass = objc::class!(NSView);
+		let mut decl = ClassDecl::new("RsnapPassiveCaptureShellView", superclass)
+			.expect("passive capture shell view class");
+
+		unsafe {
+			decl.add_method(
+				objc::sel!(isFlipped),
+				macos_passive_shell_view_is_flipped as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(acceptsFirstMouse:),
+				macos_passive_shell_view_accepts_first_mouse
+					as extern "C" fn(&Object, Sel, *mut Object) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(hitTest:),
+				macos_passive_shell_view_hit_test
+					as extern "C" fn(&Object, Sel, super::MacOSOverlayPoint) -> *mut Object,
+			);
+			decl.add_method(
+				objc::sel!(mouseMoved:),
+				macos_passive_shell_view_mouse_moved as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(mouseDragged:),
+				macos_passive_shell_view_mouse_dragged as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(mouseDown:),
+				macos_passive_shell_view_mouse_down as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(mouseUp:),
+				macos_passive_shell_view_mouse_up as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(rightMouseDown:),
+				macos_passive_shell_view_right_mouse_down
+					as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(mouseExited:),
+				macos_passive_shell_view_mouse_exited as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(scrollWheel:),
+				macos_passive_shell_view_scroll_wheel as extern "C" fn(&Object, Sel, *mut Object),
+			);
+		}
+
+		decl.register() as *const Class as usize
+	})) as *const Class
+}
+
+fn macos_key_focus_shell_panel_class() -> *const Class {
+	static CLASS: OnceLock<usize> = OnceLock::new();
+
+	(*CLASS.get_or_init(|| {
+		if let Some(class) = Class::get("RsnapKeyFocusCaptureShellPanel") {
+			return class as *const Class as usize;
+		}
+
+		let superclass = objc::class!(NSPanel);
+		let mut decl = ClassDecl::new("RsnapKeyFocusCaptureShellPanel", superclass)
+			.expect("key-focus capture shell panel class");
+
+		unsafe {
+			decl.add_method(
+				objc::sel!(canBecomeMainWindow),
+				macos_key_focus_shell_can_become_main_window as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(canBecomeKeyWindow),
+				macos_key_focus_shell_can_become_key_window as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+		}
+
+		decl.register() as *const Class as usize
+	})) as *const Class
+}
+
+fn macos_key_focus_shell_view_class() -> *const Class {
+	static CLASS: OnceLock<usize> = OnceLock::new();
+
+	(*CLASS.get_or_init(|| {
+		if let Some(class) = Class::get("RsnapKeyFocusCaptureShellView") {
+			return class as *const Class as usize;
+		}
+
+		let superclass = objc::class!(NSView);
+		let mut decl = ClassDecl::new("RsnapKeyFocusCaptureShellView", superclass)
+			.expect("key-focus capture shell view class");
+
+		unsafe {
+			decl.add_method(
+				objc::sel!(isFlipped),
+				macos_passive_shell_view_is_flipped as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(acceptsFirstResponder),
+				macos_key_focus_shell_view_accepts_first_responder
+					as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(keyDown:),
+				macos_key_focus_shell_view_key_down as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(keyUp:),
+				macos_key_focus_shell_view_key_up as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(flagsChanged:),
+				macos_key_focus_shell_view_flags_changed
+					as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(hasMarkedText),
+				macos_key_focus_shell_view_has_marked_text as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(markedRange),
+				macos_key_focus_shell_view_marked_range
+					as extern "C" fn(&Object, Sel) -> MacOSRange,
+			);
+			decl.add_method(
+				objc::sel!(selectedRange),
+				macos_key_focus_shell_view_selected_range
+					as extern "C" fn(&Object, Sel) -> MacOSRange,
+			);
+			decl.add_method(
+				objc::sel!(setMarkedText:selectedRange:replacementRange:),
+				macos_key_focus_shell_view_set_marked_text
+					as extern "C" fn(&Object, Sel, *mut Object, MacOSRange, MacOSRange),
+			);
+			decl.add_method(
+				objc::sel!(unmarkText),
+				macos_key_focus_shell_view_unmark_text as extern "C" fn(&Object, Sel),
+			);
+			decl.add_method(
+				objc::sel!(validAttributesForMarkedText),
+				macos_key_focus_shell_view_valid_attributes_for_marked_text
+					as extern "C" fn(&Object, Sel) -> *mut Object,
+			);
+			decl.add_method(
+				objc::sel!(attributedSubstringForProposedRange:actualRange:),
+				macos_key_focus_shell_view_attributed_substring_for_proposed_range
+					as extern "C" fn(
+						&Object,
+						Sel,
+						MacOSRange,
+						*mut std::ffi::c_void,
+					) -> *mut Object,
+			);
+			decl.add_method(
+				objc::sel!(characterIndexForPoint:),
+				macos_key_focus_shell_view_character_index_for_point
+					as extern "C" fn(&Object, Sel, super::MacOSOverlayPoint) -> usize,
+			);
+			decl.add_method(
+				objc::sel!(firstRectForCharacterRange:actualRange:),
+				macos_key_focus_shell_view_first_rect_for_character_range
+					as extern "C" fn(&Object, Sel, MacOSRange, *mut std::ffi::c_void) -> MacOSRect,
+			);
+			decl.add_method(
+				objc::sel!(insertText:replacementRange:),
+				macos_key_focus_shell_view_insert_text
+					as extern "C" fn(&Object, Sel, *mut Object, MacOSRange),
+			);
+			decl.add_method(
+				objc::sel!(doCommandBySelector:),
+				macos_key_focus_shell_view_do_command_by_selector
+					as extern "C" fn(&Object, Sel, Sel),
+			);
+		}
+
+		decl.register() as *const Class as usize
+	})) as *const Class
+}
+
+extern "C" fn macos_passive_shell_can_become_main_window(_this: &Object, _cmd: Sel) -> BOOL {
+	NO
+}
+
+extern "C" fn macos_passive_shell_can_become_key_window(_this: &Object, _cmd: Sel) -> BOOL {
+	NO
+}
+
+extern "C" fn macos_key_focus_shell_can_become_main_window(_this: &Object, _cmd: Sel) -> BOOL {
+	YES
+}
+
+extern "C" fn macos_key_focus_shell_can_become_key_window(_this: &Object, _cmd: Sel) -> BOOL {
+	YES
+}
+
+extern "C" fn macos_passive_shell_view_is_flipped(_this: &Object, _cmd: Sel) -> BOOL {
+	YES
+}
+
+extern "C" fn macos_passive_shell_view_accepts_first_mouse(
+	_this: &Object,
+	_cmd: Sel,
+	_event: *mut Object,
+) -> BOOL {
+	YES
+}
+
+extern "C" fn macos_passive_shell_view_hit_test(
+	this: &Object,
+	_cmd: Sel,
+	_point: super::MacOSOverlayPoint,
+) -> *mut Object {
+	this as *const Object as *mut Object
+}
+
+extern "C" fn macos_key_focus_shell_view_accepts_first_responder(
+	_this: &Object,
+	_cmd: Sel,
+) -> BOOL {
+	YES
+}
+
+extern "C" fn macos_passive_shell_view_mouse_moved(this: &Object, _cmd: Sel, event: *mut Object) {
+	macos_dispatch_shell_pointer_moved(this, event);
+}
+
+extern "C" fn macos_passive_shell_view_mouse_dragged(this: &Object, _cmd: Sel, event: *mut Object) {
+	macos_dispatch_shell_pointer_moved(this, event);
+}
+
+extern "C" fn macos_passive_shell_view_mouse_down(this: &Object, _cmd: Sel, event: *mut Object) {
+	macos_dispatch_shell_mouse_input(this, event, MouseButton::Left, ElementState::Pressed);
+}
+
+extern "C" fn macos_passive_shell_view_mouse_up(this: &Object, _cmd: Sel, event: *mut Object) {
+	macos_dispatch_shell_mouse_input(this, event, MouseButton::Left, ElementState::Released);
+}
+
+extern "C" fn macos_passive_shell_view_right_mouse_down(
+	this: &Object,
+	_cmd: Sel,
+	event: *mut Object,
+) {
+	macos_dispatch_shell_mouse_input(this, event, MouseButton::Right, ElementState::Pressed);
+}
+
+extern "C" fn macos_passive_shell_view_mouse_exited(this: &Object, _cmd: Sel, _event: *mut Object) {
+	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
+		return;
+	};
+
+	callback.dispatch_mouse_exited();
+}
+
+extern "C" fn macos_passive_shell_view_scroll_wheel(this: &Object, _cmd: Sel, event: *mut Object) {
+	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
+		return;
+	};
+	let Some(delta) = macos_shell_scroll_delta(event) else {
+		return;
+	};
+
+	callback.dispatch_scroll_wheel(delta);
+}
+
+fn macos_key_focus_shell_state(
+	this: &Object,
+) -> Option<(Arc<Mutex<MacOSKeyFocusShellState>>, MacOSNativeCaptureInputDispatch)> {
+	let callback = macos_shell_callback(this as *const Object as usize)?;
+
+	match callback {
+		MacOSPassiveShellCallback::KeyFocus { state, dispatch } => Some((state, dispatch)),
+		_ => None,
+	}
+}
+
+fn macos_nsstring_to_string(string: *mut Object) -> String {
+	if string.is_null() {
+		return String::new();
+	}
+
+	unsafe {
+		let utf8: *const i8 = objc::msg_send![string, UTF8String];
+
+		if utf8.is_null() {
+			return String::new();
+		}
+
+		CStr::from_ptr(utf8).to_string_lossy().into_owned()
+	}
+}
+
+fn macos_text_input_object_to_string(string: *mut Object) -> String {
+	if string.is_null() {
+		return String::new();
+	}
+
+	unsafe {
+		let attributed_string_class = objc::class!(NSAttributedString);
+		let is_attributed: BOOL = objc::msg_send![string, isKindOfClass: attributed_string_class];
+		let string_object = if is_attributed == YES {
+			let value: *mut Object = objc::msg_send![string, string];
+			value
+		} else {
+			string
+		};
+
+		macos_nsstring_to_string(string_object)
+	}
+}
+
+fn macos_utf16_offset_to_utf8(text: &str, utf16_offset: usize) -> usize {
+	let mut utf16_count = 0;
+
+	for (byte_index, ch) in text.char_indices() {
+		if utf16_count >= utf16_offset {
+			return byte_index;
+		}
+
+		utf16_count += ch.len_utf16();
+
+		if utf16_count >= utf16_offset {
+			return byte_index + ch.len_utf8();
+		}
+	}
+
+	text.len()
+}
+
+fn macos_modifier_state_from_event(event: *mut Object) -> ModifiersState {
+	if event.is_null() {
+		return ModifiersState::empty();
+	}
+
+	const SHIFT: u64 = 1 << 17;
+	const CONTROL: u64 = 1 << 18;
+	const OPTION: u64 = 1 << 19;
+	const COMMAND: u64 = 1 << 20;
+
+	unsafe {
+		let flags: u64 = objc::msg_send![event, modifierFlags];
+		let mut state = ModifiersState::empty();
+
+		state.set(ModifiersState::SHIFT, flags & SHIFT != 0);
+		state.set(ModifiersState::CONTROL, flags & CONTROL != 0);
+		state.set(ModifiersState::ALT, flags & OPTION != 0);
+		state.set(ModifiersState::SUPER, flags & COMMAND != 0);
+
+		state
+	}
+}
+
+fn macos_key_focus_logical_key(event: *mut Object) -> Key {
+	if event.is_null() {
+		return Key::Unidentified(NativeKey::MacOS(0));
+	}
+
+	unsafe {
+		let key_code: u16 = objc::msg_send![event, keyCode];
+
+		match key_code {
+			53 => Key::Named(NamedKey::Escape),
+			36 | 76 => Key::Named(NamedKey::Enter),
+			51 => Key::Named(NamedKey::Backspace),
+			49 => Key::Named(NamedKey::Space),
+			48 => Key::Named(NamedKey::Tab),
+			_ => {
+				let string: *mut Object = objc::msg_send![event, charactersIgnoringModifiers];
+				let text = macos_nsstring_to_string(string);
+
+				if text.is_empty() {
+					Key::Unidentified(NativeKey::MacOS(key_code))
+				} else {
+					Key::Character(text.into())
+				}
+			},
+		}
+	}
+}
+
+fn macos_key_focus_text(event: *mut Object, logical_key: &Key) -> Option<String> {
+	if event.is_null() {
+		return None;
+	}
+
+	match logical_key {
+		Key::Named(NamedKey::Escape | NamedKey::Backspace | NamedKey::Tab) => None,
+		Key::Named(NamedKey::Enter) => Some(String::from("\r")),
+		Key::Named(NamedKey::Space) => Some(String::from(" ")),
+		_ => unsafe {
+			let string: *mut Object = objc::msg_send![event, characters];
+			let text = macos_nsstring_to_string(string);
+
+			(!text.is_empty()).then_some(text)
+		},
+	}
+}
+
+fn macos_key_focus_keyboard_input_from_event(
+	event: *mut Object,
+	state: ElementState,
+) -> OverlayKeyboardInputEvent {
+	let logical_key = macos_key_focus_logical_key(event);
+	let text = macos_key_focus_text(event, &logical_key);
+	let repeat = if event.is_null() {
+		false
+	} else {
+		unsafe {
+			let repeat: BOOL = objc::msg_send![event, isARepeat];
+
+			repeat == YES
+		}
+	};
+
+	OverlayKeyboardInputEvent { logical_key, text, state, repeat }
+}
+
+fn macos_key_focus_target(this: &Object) -> Option<MacOSKeyFocusShellTarget> {
+	let (state, _) = macos_key_focus_shell_state(this)?;
+	let Ok(state) = state.lock() else {
+		return None;
+	};
+
+	state.target
+}
+
+fn macos_key_focus_ime_allowed(this: &Object) -> bool {
+	macos_key_focus_target(this).is_some_and(|target| target.ime_allowed)
+}
+
+fn macos_key_focus_dispatch_keyboard_input(this: &Object, event: *mut Object, state: ElementState) {
+	let Some((shell_state, dispatch)) = macos_key_focus_shell_state(this) else {
+		return;
+	};
+	let overlay_event = macos_key_focus_keyboard_input_from_event(event, state);
+	let monitor =
+		shell_state.lock().ok().and_then(|state| state.target.and_then(|target| target.monitor));
+
+	dispatch.enqueue(MacOSNativeCaptureInputEvent::KeyboardInput { monitor, event: overlay_event });
+}
+
+extern "C" fn macos_key_focus_shell_view_key_down(this: &Object, _cmd: Sel, event: *mut Object) {
+	let Some((shell_state, dispatch)) = macos_key_focus_shell_state(this) else {
+		return;
+	};
+
+	let ime_allowed = macos_key_focus_ime_allowed(this);
+
+	if let Ok(mut state) = shell_state.lock() {
+		state.forward_key_event_to_app = false;
+		state.had_ime_input_during_keydown = false;
+		state.keyboard_modifiers = macos_modifier_state_from_event(event);
+	}
+
+	dispatch.enqueue(MacOSNativeCaptureInputEvent::ModifiersChanged {
+		state: macos_modifier_state_from_event(event),
+	});
+
+	if ime_allowed {
+		unsafe {
+			let array: *mut Object = objc::msg_send![objc::class!(NSArray), arrayWithObject: event];
+			let _: () = objc::msg_send![this, interpretKeyEvents: array];
+		}
+	}
+
+	let should_forward = if let Ok(state) = shell_state.lock() {
+		!state.had_ime_input_during_keydown || state.forward_key_event_to_app
+	} else {
+		true
+	};
+
+	if should_forward {
+		macos_key_focus_dispatch_keyboard_input(this, event, ElementState::Pressed);
+	}
+}
+
+extern "C" fn macos_key_focus_shell_view_key_up(this: &Object, _cmd: Sel, event: *mut Object) {
+	macos_key_focus_dispatch_keyboard_input(this, event, ElementState::Released);
+}
+
+extern "C" fn macos_key_focus_shell_view_flags_changed(
+	this: &Object,
+	_cmd: Sel,
+	event: *mut Object,
+) {
+	let Some((shell_state, dispatch)) = macos_key_focus_shell_state(this) else {
+		return;
+	};
+	let modifiers = macos_modifier_state_from_event(event);
+
+	if let Ok(mut state) = shell_state.lock() {
+		state.keyboard_modifiers = modifiers;
+	}
+
+	dispatch.enqueue(MacOSNativeCaptureInputEvent::ModifiersChanged { state: modifiers });
+}
+
+extern "C" fn macos_key_focus_shell_view_has_marked_text(this: &Object, _cmd: Sel) -> BOOL {
+	let Some((shell_state, _)) = macos_key_focus_shell_state(this) else {
+		return NO;
+	};
+	let Ok(state) = shell_state.lock() else {
+		return NO;
+	};
+
+	if state.marked_text.is_empty() { NO } else { YES }
+}
+
+extern "C" fn macos_key_focus_shell_view_marked_range(this: &Object, _cmd: Sel) -> MacOSRange {
+	let Some((shell_state, _)) = macos_key_focus_shell_state(this) else {
+		return MacOSRange::from(NSRange::new(usize::MAX, 0));
+	};
+	let Ok(state) = shell_state.lock() else {
+		return MacOSRange::from(NSRange::new(usize::MAX, 0));
+	};
+
+	if state.marked_text.is_empty() {
+		MacOSRange::from(NSRange::new(usize::MAX, 0))
+	} else {
+		MacOSRange::from(NSRange::new(0, state.marked_text.encode_utf16().count()))
+	}
+}
+
+extern "C" fn macos_key_focus_shell_view_selected_range(this: &Object, _cmd: Sel) -> MacOSRange {
+	let _ = this;
+
+	MacOSRange::from(NSRange::new(usize::MAX, 0))
+}
+
+extern "C" fn macos_key_focus_shell_view_set_marked_text(
+	this: &Object,
+	_cmd: Sel,
+	string: *mut Object,
+	selected_range: MacOSRange,
+	_replacement_range: MacOSRange,
+) {
+	let Some((shell_state, dispatch)) = macos_key_focus_shell_state(this) else {
+		return;
+	};
+	let text = macos_text_input_object_to_string(string);
+	let selected_range = NSRange::from(selected_range);
+	let cursor_range = if text.is_empty() {
+		None
+	} else {
+		let start = macos_utf16_offset_to_utf8(&text, selected_range.location);
+		let end =
+			macos_utf16_offset_to_utf8(&text, selected_range.location + selected_range.length);
+
+		Some((start, end))
+	};
+	let monitor = if let Ok(mut state) = shell_state.lock() {
+		state.marked_text = text.clone();
+		state.had_ime_input_during_keydown = true;
+		state.target.and_then(|target| target.monitor)
+	} else {
+		None
+	};
+
+	dispatch.enqueue(MacOSNativeCaptureInputEvent::Ime {
+		monitor,
+		event: Ime::Preedit(text, cursor_range),
+	});
+}
+
+extern "C" fn macos_key_focus_shell_view_unmark_text(this: &Object, _cmd: Sel) {
+	let Some((shell_state, dispatch)) = macos_key_focus_shell_state(this) else {
+		return;
+	};
+	let monitor = if let Ok(mut state) = shell_state.lock() {
+		state.marked_text.clear();
+		state.target.and_then(|target| target.monitor)
+	} else {
+		None
+	};
+
+	dispatch.enqueue(MacOSNativeCaptureInputEvent::Ime {
+		monitor,
+		event: Ime::Preedit(String::new(), None),
+	});
+}
+
+extern "C" fn macos_key_focus_shell_view_valid_attributes_for_marked_text(
+	_this: &Object,
+	_cmd: Sel,
+) -> *mut Object {
+	unsafe { objc::msg_send![objc::class!(NSArray), array] }
+}
+
+extern "C" fn macos_key_focus_shell_view_attributed_substring_for_proposed_range(
+	_this: &Object,
+	_cmd: Sel,
+	_range: MacOSRange,
+	_actual_range: *mut std::ffi::c_void,
+) -> *mut Object {
+	ptr::null_mut::<Object>()
+}
+
+extern "C" fn macos_key_focus_shell_view_character_index_for_point(
+	_this: &Object,
+	_cmd: Sel,
+	_point: super::MacOSOverlayPoint,
+) -> usize {
+	0
+}
+
+extern "C" fn macos_key_focus_shell_view_first_rect_for_character_range(
+	this: &Object,
+	_cmd: Sel,
+	_range: MacOSRange,
+	_actual_range: *mut std::ffi::c_void,
+) -> MacOSRect {
+	let Some(target) = macos_key_focus_target(this) else {
+		return MacOSRect::from(NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1.0, 1.0)));
+	};
+	let rect = NSRect::new(target.ime_origin, target.ime_size);
+
+	unsafe {
+		let ns_window: *mut Object = objc::msg_send![this, window];
+
+		if ns_window.is_null() {
+			return rect.into();
+		}
+
+		let view_rect: NSRect =
+			objc::msg_send![this, convertRect: rect toView: ptr::null_mut::<Object>()];
+		let screen_rect: NSRect = objc::msg_send![ns_window, convertRectToScreen: view_rect];
+
+		MacOSRect::from(screen_rect)
+	}
+}
+
+extern "C" fn macos_key_focus_shell_view_insert_text(
+	this: &Object,
+	_cmd: Sel,
+	string: *mut Object,
+	_replacement_range: MacOSRange,
+) {
+	let Some((shell_state, dispatch)) = macos_key_focus_shell_state(this) else {
+		return;
+	};
+	let text = macos_text_input_object_to_string(string);
+
+	if text.is_empty() {
+		return;
+	}
+
+	let monitor = if let Ok(mut state) = shell_state.lock() {
+		state.marked_text.clear();
+		state.had_ime_input_during_keydown = true;
+		state.target.and_then(|target| target.monitor)
+	} else {
+		None
+	};
+
+	dispatch.enqueue(MacOSNativeCaptureInputEvent::Ime {
+		monitor,
+		event: Ime::Preedit(String::new(), None),
+	});
+	dispatch.enqueue(MacOSNativeCaptureInputEvent::Ime { monitor, event: Ime::Commit(text) });
+}
+
+extern "C" fn macos_key_focus_shell_view_do_command_by_selector(
+	this: &Object,
+	_cmd: Sel,
+	_selector: Sel,
+) {
+	let Some((shell_state, _)) = macos_key_focus_shell_state(this) else {
+		return;
+	};
+
+	if let Ok(mut state) = shell_state.lock() {
+		state.forward_key_event_to_app = true;
+	}
+}
+
+fn macos_dispatch_shell_pointer_moved(this: &Object, event: *mut Object) {
+	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
+		return;
+	};
+	let Some(local_point) = macos_shell_local_point(this, event) else {
+		return;
+	};
+
+	match callback {
+		MacOSPassiveShellCallback::Overlay { .. } => macos_set_crosshair_cursor(),
+		MacOSPassiveShellCallback::Toolbar { .. } => macos_set_default_cursor(),
+		MacOSPassiveShellCallback::KeyFocus { .. } => {},
+	}
+
+	callback.dispatch_pointer_moved(local_point);
+}
+
+fn macos_dispatch_shell_mouse_input(
+	this: &Object,
+	event: *mut Object,
+	button: MouseButton,
+	state: ElementState,
+) {
+	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
+		return;
+	};
+	let local_point = macos_shell_local_point(this, event);
+
+	match callback {
+		MacOSPassiveShellCallback::Overlay { .. } => macos_set_crosshair_cursor(),
+		MacOSPassiveShellCallback::Toolbar { .. } => macos_set_default_cursor(),
+		MacOSPassiveShellCallback::KeyFocus { .. } => {},
+	}
+
+	callback.dispatch_mouse_input(local_point, button, state);
+}
+
+fn macos_shell_local_point(this: &Object, event: *mut Object) -> Option<NSPoint> {
+	if event.is_null() {
+		return None;
+	}
+
+	unsafe {
+		let window_point: NSPoint = objc::msg_send![event, locationInWindow];
+		let local_point: NSPoint =
+			objc::msg_send![this, convertPoint: window_point fromView: ptr::null_mut::<Object>()];
+
+		Some(local_point)
+	}
+}
+
+fn macos_shell_scroll_delta(event: *mut Object) -> Option<MacOSNativeCaptureScrollDelta> {
+	if event.is_null() {
+		return None;
+	}
+
+	unsafe {
+		let precise: BOOL = objc::msg_send![event, hasPreciseScrollingDeltas];
+		let delta_x: f64 = if precise == YES {
+			objc::msg_send![event, scrollingDeltaX]
+		} else {
+			objc::msg_send![event, deltaX]
+		};
+		let delta_y: f64 = if precise == YES {
+			objc::msg_send![event, scrollingDeltaY]
+		} else {
+			objc::msg_send![event, deltaY]
+		};
+
+		if precise == YES {
+			Some(MacOSNativeCaptureScrollDelta::Pixel { x: delta_x, y: delta_y })
+		} else {
+			Some(MacOSNativeCaptureScrollDelta::Line { x: delta_x as f32, y: delta_y as f32 })
+		}
+	}
+}
+
+fn macos_set_crosshair_cursor() {
+	unsafe {
+		let cursor = super::macos_cursor_object_for_icon(CursorIcon::Crosshair);
+		let _: () = objc::msg_send![cursor, set];
+	}
+}
+
+fn macos_set_default_cursor() {
+	unsafe {
+		let cursor = super::macos_cursor_object_for_icon(CursorIcon::Default);
+		let _: () = objc::msg_send![cursor, set];
+	}
+}
+
+fn macos_create_passive_overlay_shell_window(
+	render_window: &Window,
+	monitor: MonitorRect,
+	dispatch: MacOSNativeCaptureInputDispatch,
+) -> Result<MacOSPassiveShellWindow, String> {
+	macos_create_passive_shell_window(
+		render_window,
+		MacOSPassiveShellCallback::Overlay { monitor, dispatch },
+		None,
+	)
+}
+
+fn macos_create_passive_toolbar_shell_window(
+	render_window: &Window,
+	dispatch: MacOSNativeCaptureInputDispatch,
+) -> Result<MacOSPassiveShellWindow, String> {
+	let toolbar_state = Arc::new(Mutex::new(MacOSPassiveToolbarShellState::default()));
+
+	macos_create_passive_shell_window(
+		render_window,
+		MacOSPassiveShellCallback::Toolbar { state: Arc::clone(&toolbar_state), dispatch },
+		Some(toolbar_state),
+	)
+}
+
+fn macos_create_key_focus_shell_window(
+	render_window: &Window,
+	dispatch: MacOSNativeCaptureInputDispatch,
+) -> Result<MacOSKeyFocusShellWindow, String> {
+	let render_ns_window = macos_overlay_window_ns_window(render_window)
+		.ok_or_else(|| String::from("Missing macOS render NSWindow for key-focus shell"))?;
+	let frame = macos_ns_window_frame(render_ns_window)
+		.ok_or_else(|| String::from("Missing macOS render frame for key-focus shell"))?;
+	let level = unsafe { macos_ns_window_level(render_ns_window) };
+	let collection_behavior = unsafe { macos_ns_window_collection_behavior(render_ns_window) };
+	let panel_class = macos_key_focus_shell_panel_class();
+	let view_class = macos_key_focus_shell_view_class();
+	let nonactivating_panel_mask: usize = 1 << 7;
+	let backing_buffered: usize = 2;
+	let state = Arc::new(Mutex::new(MacOSKeyFocusShellState::default()));
+
+	unsafe {
+		let ns_window_alloc: *mut Object = objc::msg_send![panel_class, alloc];
+		let ns_window: *mut Object = objc::msg_send![
+			ns_window_alloc,
+			initWithContentRect: frame
+			styleMask: nonactivating_panel_mask
+			backing: backing_buffered
+			defer: NO
+		];
+
+		if ns_window.is_null() {
+			return Err(String::from("Failed to create key-focus capture shell panel"));
+		}
+
+		let clear: *mut Object = objc::msg_send![objc::class!(NSColor), clearColor];
+		let view_alloc: *mut Object = objc::msg_send![view_class, alloc];
+		let view_frame =
+			NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(frame.size.width, frame.size.height));
+		let view: *mut Object = objc::msg_send![view_alloc, initWithFrame: view_frame];
+
+		if view.is_null() {
+			let _: () = objc::msg_send![ns_window, release];
+
+			return Err(String::from("Failed to create key-focus capture shell view"));
+		}
+
+		let _: () = objc::msg_send![ns_window, setContentView: view];
+		let _: () = objc::msg_send![ns_window, setReleasedWhenClosed: NO];
+		let _: () = objc::msg_send![ns_window, setOpaque: NO];
+		let _: () = objc::msg_send![ns_window, setHasShadow: NO];
+		let _: () = objc::msg_send![ns_window, setBackgroundColor: clear];
+		let _: () = objc::msg_send![ns_window, setLevel: level];
+		let _: () = objc::msg_send![ns_window, setCollectionBehavior: collection_behavior];
+		let _: () = objc::msg_send![ns_window, setAcceptsMouseMovedEvents: NO];
+		let _: () = objc::msg_send![ns_window, setIgnoresMouseEvents: YES];
+		let _: () = objc::msg_send![ns_window, setHidesOnDeactivate: NO];
+		let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+
+		macos_register_shell_callback(
+			view as usize,
+			MacOSPassiveShellCallback::KeyFocus { state: Arc::clone(&state), dispatch },
+		);
+
+		Ok(MacOSKeyFocusShellWindow {
+			window_key: ns_window as usize,
+			view_key: view as usize,
+			state,
+		})
+	}
+}
+
+fn macos_create_passive_shell_window(
+	render_window: &Window,
+	callback: MacOSPassiveShellCallback,
+	toolbar_state: Option<Arc<Mutex<MacOSPassiveToolbarShellState>>>,
+) -> Result<MacOSPassiveShellWindow, String> {
+	let render_ns_window = macos_overlay_window_ns_window(render_window)
+		.ok_or_else(|| String::from("Missing macOS render NSWindow for passive shell"))?;
+	let frame = macos_ns_window_frame(render_ns_window)
+		.ok_or_else(|| String::from("Missing macOS render frame for passive shell"))?;
+	let level = unsafe { macos_ns_window_level(render_ns_window) };
+	let collection_behavior = unsafe { macos_ns_window_collection_behavior(render_ns_window) };
+	let panel_class = macos_passive_shell_panel_class();
+	let view_class = macos_passive_shell_view_class();
+	let nonactivating_panel_mask: usize = 1 << 7;
+	let backing_buffered: usize = 2;
+
+	unsafe {
+		let ns_window_alloc: *mut Object = objc::msg_send![panel_class, alloc];
+		let ns_window: *mut Object = objc::msg_send![
+			ns_window_alloc,
+			initWithContentRect: frame
+			styleMask: nonactivating_panel_mask
+			backing: backing_buffered
+			defer: NO
+		];
+
+		if ns_window.is_null() {
+			return Err(String::from("Failed to create passive capture shell panel"));
+		}
+
+		let clear: *mut Object = objc::msg_send![objc::class!(NSColor), clearColor];
+		let view_alloc: *mut Object = objc::msg_send![view_class, alloc];
+		let view_frame =
+			NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(frame.size.width, frame.size.height));
+		let view: *mut Object = objc::msg_send![view_alloc, initWithFrame: view_frame];
+
+		if view.is_null() {
+			let _: () = objc::msg_send![ns_window, release];
+
+			return Err(String::from("Failed to create passive capture shell view"));
+		}
+
+		let tracking_area_alloc: *mut Object = objc::msg_send![objc::class!(NSTrackingArea), alloc];
+		let tracking_options: usize = 0x01 | 0x02 | 0x80 | 0x200 | 0x400;
+		let tracking_rect = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0));
+		let tracking_area: *mut Object = objc::msg_send![
+			tracking_area_alloc,
+			initWithRect: tracking_rect
+			options: tracking_options
+			owner: view
+			userInfo: ptr::null_mut::<Object>()
+		];
+
+		if tracking_area.is_null() {
+			let _: () = objc::msg_send![view, release];
+			let _: () = objc::msg_send![ns_window, release];
+
+			return Err(String::from("Failed to create passive capture shell tracking area"));
+		}
+
+		let _: () = objc::msg_send![view, addTrackingArea: tracking_area];
+		let _: () = objc::msg_send![ns_window, setContentView: view];
+		let _: () = objc::msg_send![ns_window, setReleasedWhenClosed: NO];
+		let _: () = objc::msg_send![ns_window, setOpaque: NO];
+		let _: () = objc::msg_send![ns_window, setHasShadow: NO];
+		let _: () = objc::msg_send![ns_window, setBackgroundColor: clear];
+		let _: () = objc::msg_send![ns_window, setLevel: level];
+		let _: () = objc::msg_send![ns_window, setCollectionBehavior: collection_behavior];
+		let _: () = objc::msg_send![ns_window, setAcceptsMouseMovedEvents: YES];
+		let _: () = objc::msg_send![ns_window, setIgnoresMouseEvents: NO];
+		let _: () = objc::msg_send![ns_window, setHidesOnDeactivate: NO];
+		let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+
+		macos_register_shell_callback(view as usize, callback);
+
+		Ok(MacOSPassiveShellWindow {
+			window_key: ns_window as usize,
+			view_key: view as usize,
+			tracking_area_key: tracking_area as usize,
+			toolbar_state,
+		})
+	}
+}
+
+fn macos_overlay_window_ns_window(window: &Window) -> Option<*mut Object> {
+	let ns_view = super::macos_overlay_window_ns_view(window)?;
+
+	unsafe {
+		let ns_window: *mut Object = objc::msg_send![ns_view, window];
+
+		(!ns_window.is_null()).then_some(ns_window)
+	}
+}
+
+fn macos_ns_window_frame(ns_window: *mut Object) -> Option<NSRect> {
+	if ns_window.is_null() {
+		return None;
+	}
+
+	unsafe {
+		let frame: NSRect = objc::msg_send![ns_window, frame];
+
+		Some(frame)
+	}
+}
+
+unsafe fn macos_ns_window_level(ns_window: *mut Object) -> i64 {
+	let level: i64 = objc::msg_send![ns_window, level];
+
+	level
+}
+
+unsafe fn macos_ns_window_collection_behavior(ns_window: *mut Object) -> usize {
+	let behavior: usize = objc::msg_send![ns_window, collectionBehavior];
+
+	behavior
+}

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -57,7 +57,7 @@ impl MacOSNativeCaptureShells {
 	}
 
 	fn sync_overlay_shells(&self, windows: &HashMap<WindowId, OverlayWindow>, visible: bool) {
-		tracing::warn!(
+		tracing::trace!(
 			op = "overlay.macos_passive_shell_sync_overlay_shells",
 			visible,
 			window_count = windows.len(),
@@ -1154,7 +1154,7 @@ extern "C" fn macos_passive_shell_view_cursor_update(
 		return;
 	};
 
-	tracing::warn!(
+	tracing::trace!(
 		op = "overlay.macos_passive_shell_cursor_update",
 		callback = %macos_shell_callback_name(&callback),
 		"Passive shell received cursorUpdate."

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -1,20 +1,25 @@
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::ffi::c_void;
 use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
+use egui::FontId;
 use objc::declare::ClassDecl;
 use objc::runtime::{BOOL, Class, NO, Object, Sel, YES};
 use objc::{Encode, Encoding};
 use objc2_foundation::{NSPoint, NSRange, NSRect, NSSize};
 use winit::event::{ElementState, Ime, MouseButton};
+use winit::keyboard::{Key, ModifiersState, NamedKey, NativeKey};
+use winit::window::WindowId;
 
+use crate::overlay::OverlayWindow;
 use crate::overlay::{
 	CursorIcon, GlobalPoint, MacOSNativeCaptureInputDispatch, MacOSNativeCaptureInputEvent,
 	MacOSNativeCaptureScrollDelta, MonitorRect, OverlayKeyboardInputEvent, OverlayMode,
 	OverlaySession, Pos2, Window,
 };
-use winit::keyboard::{Key, ModifiersState, NamedKey, NativeKey};
 
 macro_rules! sel {
 	($($tt:tt)*) => {
@@ -26,75 +31,6 @@ macro_rules! sel_impl {
 	($($tt:tt)*) => {
 		objc::sel_impl!($($tt)*)
 	};
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct MacOSRange {
-	location: usize,
-	length: usize,
-}
-unsafe impl Encode for MacOSRange {
-	fn encode() -> Encoding {
-		unsafe { Encoding::from_str("{_NSRange=QQ}") }
-	}
-}
-impl From<NSRange> for MacOSRange {
-	fn from(value: NSRange) -> Self {
-		Self { location: value.location, length: value.length }
-	}
-}
-impl From<MacOSRange> for NSRange {
-	fn from(value: MacOSRange) -> Self {
-		Self::new(value.location, value.length)
-	}
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct MacOSSize {
-	width: f64,
-	height: f64,
-}
-unsafe impl Encode for MacOSSize {
-	fn encode() -> Encoding {
-		unsafe { Encoding::from_str("{CGSize=dd}") }
-	}
-}
-impl From<NSSize> for MacOSSize {
-	fn from(value: NSSize) -> Self {
-		Self { width: value.width, height: value.height }
-	}
-}
-impl From<MacOSSize> for NSSize {
-	fn from(value: MacOSSize) -> Self {
-		Self::new(value.width, value.height)
-	}
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct MacOSRect {
-	origin: super::MacOSOverlayPoint,
-	size: MacOSSize,
-}
-unsafe impl Encode for MacOSRect {
-	fn encode() -> Encoding {
-		unsafe { Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}") }
-	}
-}
-impl From<NSRect> for MacOSRect {
-	fn from(value: NSRect) -> Self {
-		Self {
-			origin: super::MacOSOverlayPoint { x: value.origin.x, y: value.origin.y },
-			size: MacOSSize::from(value.size),
-		}
-	}
-}
-impl From<MacOSRect> for NSRect {
-	fn from(value: MacOSRect) -> Self {
-		Self::new(NSPoint::new(value.origin.x, value.origin.y), NSSize::from(value.size))
-	}
 }
 
 pub(super) struct MacOSNativeCaptureShells {
@@ -120,15 +56,24 @@ impl MacOSNativeCaptureShells {
 		}
 	}
 
-	fn sync_overlay_shells(
-		&self,
-		windows: &HashMap<winit::window::WindowId, crate::overlay::OverlayWindow>,
-		visible: bool,
-	) {
+	fn sync_overlay_shells(&self, windows: &HashMap<WindowId, OverlayWindow>, visible: bool) {
+		tracing::warn!(
+			op = "overlay.macos_passive_shell_sync_overlay_shells",
+			visible,
+			window_count = windows.len(),
+			"Synced passive overlay shells."
+		);
+
+		macos_set_system_cursor_hidden(visible);
+
 		for overlay_window in windows.values() {
 			if let Some(shell) = self.overlay_shells.get(&overlay_window.monitor.id) {
 				shell.sync_from_render_window(overlay_window.window.as_ref(), visible);
 			}
+		}
+
+		if visible {
+			macos_set_crosshair_cursor();
 		}
 	}
 
@@ -188,7 +133,9 @@ impl MacOSNativeCaptureShells {
 		visible: bool,
 	) -> Result<(), String> {
 		let should_focus = visible
-			&& (!self.key_focus_shell_active || self.key_focus_shell_target != Some(target));
+			&& (!self.key_focus_shell_active
+				|| self.key_focus_shell_target != Some(target)
+				|| matches!(target.kind, MacOSKeyFocusShellKind::FrozenText));
 
 		self.key_focus_shell_active = visible;
 		self.key_focus_shell_target = visible.then_some(target);
@@ -215,16 +162,67 @@ impl MacOSNativeCaptureShells {
 	}
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MacOSRange {
+	location: usize,
+	length: usize,
+}
+unsafe impl Encode for MacOSRange {
+	fn encode() -> Encoding {
+		unsafe { Encoding::from_str("{_NSRange=QQ}") }
+	}
+}
+
+impl From<NSRange> for MacOSRange {
+	fn from(value: NSRange) -> Self {
+		Self { location: value.location, length: value.length }
+	}
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct MacOSSize {
+	width: f64,
+	height: f64,
+}
+unsafe impl Encode for MacOSSize {
+	fn encode() -> Encoding {
+		unsafe { Encoding::from_str("{CGSize=dd}") }
+	}
+}
+
+impl From<NSSize> for MacOSSize {
+	fn from(value: NSSize) -> Self {
+		Self { width: value.width, height: value.height }
+	}
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct MacOSRect {
+	origin: super::MacOSOverlayPoint,
+	size: MacOSSize,
+}
+unsafe impl Encode for MacOSRect {
+	fn encode() -> Encoding {
+		unsafe { Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}") }
+	}
+}
+
+impl From<NSRect> for MacOSRect {
+	fn from(value: NSRect) -> Self {
+		Self {
+			origin: super::MacOSOverlayPoint { x: value.origin.x, y: value.origin.y },
+			size: MacOSSize::from(value.size),
+		}
+	}
+}
+
 #[derive(Clone, Copy, Default)]
 struct MacOSPassiveToolbarShellState {
 	monitor: Option<MonitorRect>,
 	outer_position: Option<GlobalPoint>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum MacOSKeyFocusShellKind {
-	FrozenText,
-	ScrollCapture,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -254,6 +252,469 @@ impl Default for MacOSKeyFocusShellState {
 			had_ime_input_during_keydown: false,
 		}
 	}
+}
+
+struct MacOSPassiveShellWindow {
+	window_key: usize,
+	view_key: usize,
+	tracking_area_key: usize,
+	toolbar_state: Option<Arc<Mutex<MacOSPassiveToolbarShellState>>>,
+}
+impl MacOSPassiveShellWindow {
+	fn sync_from_render_window(&self, render_window: &Window, visible: bool) {
+		let Some(render_ns_window) = macos_overlay_window_ns_window(render_window) else {
+			return;
+		};
+		let Some(frame) = macos_ns_window_frame(render_ns_window) else {
+			return;
+		};
+
+		self.sync_frame_and_visibility(frame, visible);
+	}
+
+	fn sync_frame_and_visibility(&self, frame: NSRect, visible: bool) {
+		let ns_window = self.window_key as *mut Object;
+		let view = self.view_key as *mut Object;
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, setFrame: frame display: NO];
+
+			if visible {
+				let _: () = objc::msg_send![ns_window, orderFrontRegardless];
+			} else {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+			}
+			if !view.is_null() {
+				let _: () = objc::msg_send![ns_window, invalidateCursorRectsForView: view];
+			}
+		}
+
+		if let Some(callback) = macos_shell_callback(self.view_key) {
+			match callback {
+				MacOSPassiveShellCallback::Overlay { .. } => {
+					let seeded_point = visible
+						.then(|| macos_seed_passive_shell_cursor_point(ns_window, view))
+						.flatten();
+
+					macos_update_passive_shell_cursor_point(self.view_key, seeded_point);
+				},
+				MacOSPassiveShellCallback::Toolbar { .. }
+				| MacOSPassiveShellCallback::KeyFocus { .. } => {
+					macos_update_passive_shell_cursor_point(self.view_key, None);
+				},
+			}
+		}
+	}
+
+	fn set_toolbar_state(&self, monitor: MonitorRect, outer_position: GlobalPoint) {
+		let Some(state) = self.toolbar_state.as_ref() else {
+			return;
+		};
+		let Ok(mut state) = state.lock() else {
+			return;
+		};
+
+		state.monitor = Some(monitor);
+		state.outer_position = Some(outer_position);
+	}
+}
+
+impl Drop for MacOSPassiveShellWindow {
+	fn drop(&mut self) {
+		macos_unregister_shell_callback(self.view_key);
+		macos_clear_passive_shell_cursor_point(self.view_key);
+
+		unsafe {
+			let ns_window = self.window_key as *mut Object;
+
+			if !ns_window.is_null() {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+				let _: () = objc::msg_send![ns_window, close];
+				let _: () = objc::msg_send![ns_window, release];
+			}
+
+			let tracking_area = self.tracking_area_key as *mut Object;
+
+			if !tracking_area.is_null() {
+				let _: () = objc::msg_send![tracking_area, release];
+			}
+
+			let view = self.view_key as *mut Object;
+
+			if !view.is_null() {
+				let _: () = objc::msg_send![view, release];
+			}
+		}
+	}
+}
+
+struct MacOSKeyFocusShellWindow {
+	window_key: usize,
+	view_key: usize,
+	state: Arc<Mutex<MacOSKeyFocusShellState>>,
+}
+impl MacOSKeyFocusShellWindow {
+	fn sync_from_render_window(
+		&self,
+		render_window: &Window,
+		target: MacOSKeyFocusShellTarget,
+		visible: bool,
+	) {
+		let Some(render_ns_window) = macos_overlay_window_ns_window(render_window) else {
+			return;
+		};
+		let Some(frame) = macos_ns_window_frame(render_ns_window) else {
+			return;
+		};
+
+		self.set_target(target);
+		self.sync_frame_and_visibility(frame, visible);
+	}
+
+	fn set_target(&self, target: MacOSKeyFocusShellTarget) {
+		let Ok(mut state) = self.state.lock() else {
+			return;
+		};
+
+		state.target = Some(target);
+
+		let view = self.view_key as *mut Object;
+
+		if view.is_null() {
+			return;
+		}
+
+		unsafe {
+			let input_context: *mut Object = objc::msg_send![view, inputContext];
+
+			if !input_context.is_null() {
+				let _: () = objc::msg_send![input_context, invalidateCharacterCoordinates];
+			}
+		}
+	}
+
+	fn clear_target(&self) {
+		let Ok(mut state) = self.state.lock() else {
+			return;
+		};
+
+		state.target = None;
+
+		state.marked_text.clear();
+
+		state.forward_key_event_to_app = false;
+		state.had_ime_input_during_keydown = false;
+	}
+
+	fn sync_frame_and_visibility(&self, frame: NSRect, visible: bool) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, setFrame: frame display: NO];
+
+			if visible {
+				let _: () = objc::msg_send![ns_window, orderFrontRegardless];
+			} else {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+			}
+		}
+	}
+
+	fn hide(&self) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+		}
+	}
+
+	fn ensure_key_focus(&self) {
+		let ns_window = self.window_key as *mut Object;
+		let view = self.view_key as *mut Object;
+
+		if ns_window.is_null() || view.is_null() {
+			return;
+		}
+
+		super::macos_activate_app();
+
+		unsafe {
+			let input_context: *mut Object = objc::msg_send![view, inputContext];
+
+			if !input_context.is_null() {
+				let _: () = objc::msg_send![input_context, activate];
+				let _: () = objc::msg_send![input_context, invalidateCharacterCoordinates];
+			}
+
+			let _: () = objc::msg_send![ns_window, makeFirstResponder: view];
+			let _: () = objc::msg_send![ns_window, makeKeyAndOrderFront: ptr::null_mut::<Object>()];
+		}
+	}
+}
+
+impl Drop for MacOSKeyFocusShellWindow {
+	fn drop(&mut self) {
+		macos_unregister_shell_callback(self.view_key);
+
+		unsafe {
+			let ns_window = self.window_key as *mut Object;
+
+			if !ns_window.is_null() {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+				let _: () = objc::msg_send![ns_window, close];
+				let _: () = objc::msg_send![ns_window, release];
+			}
+
+			let view = self.view_key as *mut Object;
+
+			if !view.is_null() {
+				let _: () = objc::msg_send![view, release];
+			}
+		}
+	}
+}
+
+impl From<MacOSRange> for NSRange {
+	fn from(value: MacOSRange) -> Self {
+		Self::new(value.location, value.length)
+	}
+}
+
+impl From<MacOSSize> for NSSize {
+	fn from(value: MacOSSize) -> Self {
+		Self::new(value.width, value.height)
+	}
+}
+
+impl From<MacOSRect> for NSRect {
+	fn from(value: MacOSRect) -> Self {
+		Self::new(NSPoint::new(value.origin.x, value.origin.y), NSSize::from(value.size))
+	}
+}
+
+impl OverlaySession {
+	pub(super) fn ensure_native_capture_shells(&mut self) -> Result<(), String> {
+		let Some(dispatch) = self.native_capture_input_dispatch() else {
+			return Ok(());
+		};
+
+		if self.native_capture_shells.is_some() {
+			self.sync_native_capture_shells()?;
+
+			return Ok(());
+		}
+
+		let mut overlay_shells = HashMap::with_capacity(self.windows.len());
+
+		for overlay_window in self.windows.values() {
+			let shell = macos_create_passive_overlay_shell_window(
+				overlay_window.window.as_ref(),
+				overlay_window.monitor,
+				dispatch.clone(),
+			)?;
+
+			overlay_shells.insert(overlay_window.monitor.id, shell);
+		}
+
+		self.native_capture_shells = Some(MacOSNativeCaptureShells::new(overlay_shells, dispatch));
+
+		self.sync_native_capture_shells()?;
+
+		Ok(())
+	}
+
+	pub(super) fn sync_native_capture_shells(&mut self) -> Result<(), String> {
+		let live_shell_visible = self.should_host_live_pointer_input_in_native_shell();
+		let toolbar_shell_visible = self.should_host_toolbar_pointer_input_in_native_shell();
+		let toolbar_context = self.toolbar_window.as_ref().map(|toolbar_window| {
+			let monitor = self.state.monitor.or_else(|| self.active_cursor_monitor());
+			let outer_position = Self::toolbar_window_outer_position(toolbar_window)
+				.or(self.pending_toolbar_outer_pos)
+				.or(self.toolbar_outer_pos)
+				.or_else(|| {
+					monitor.and_then(|monitor| {
+						self.toolbar_state.floating_position.map(|floating_position| {
+							self.toolbar_outer_position_from_primary_anchor(
+								monitor,
+								floating_position,
+							)
+						})
+					})
+				});
+
+			(Arc::clone(&toolbar_window.window), monitor, outer_position)
+		});
+		let key_focus_context = self.native_key_focus_shell_context();
+
+		for overlay_window in self.windows.values() {
+			super::macos_set_capture_window_mouse_passthrough(
+				overlay_window.window.as_ref(),
+				live_shell_visible,
+			);
+		}
+
+		let Some(shells) = self.native_capture_shells.as_mut() else {
+			if let Some((toolbar_window, _, _)) = toolbar_context.as_ref() {
+				super::macos_set_capture_window_mouse_passthrough(toolbar_window.as_ref(), false);
+			}
+
+			return Ok(());
+		};
+
+		shells.sync_overlay_shells(&self.windows, live_shell_visible);
+
+		if let Some((toolbar_window, monitor, outer_position)) = toolbar_context {
+			if let (Some(monitor), Some(outer_position)) = (monitor, outer_position) {
+				shells.sync_toolbar_shell(
+					toolbar_window.as_ref(),
+					monitor,
+					outer_position,
+					toolbar_shell_visible,
+				)?;
+
+				super::macos_set_capture_window_mouse_passthrough(
+					toolbar_window.as_ref(),
+					toolbar_shell_visible,
+				);
+			} else {
+				super::macos_set_capture_window_mouse_passthrough(toolbar_window.as_ref(), false);
+
+				shells.clear_toolbar_shell();
+			}
+		} else {
+			shells.clear_toolbar_shell();
+		}
+		if let Some((render_window, target)) = key_focus_context {
+			shells.sync_key_focus_shell(render_window.as_ref(), target, true)?;
+		} else {
+			shells.clear_key_focus_shell();
+		}
+
+		Ok(())
+	}
+
+	pub(super) fn destroy_native_capture_shells(&mut self) {
+		macos_set_system_cursor_hidden(false);
+
+		for overlay_window in self.windows.values() {
+			super::macos_set_capture_window_mouse_passthrough(
+				overlay_window.window.as_ref(),
+				false,
+			);
+		}
+
+		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+			super::macos_set_capture_window_mouse_passthrough(
+				toolbar_window.window.as_ref(),
+				false,
+			);
+		}
+
+		self.native_capture_shells = None;
+	}
+
+	fn native_key_focus_shell_context(&self) -> Option<(Arc<Window>, MacOSKeyFocusShellTarget)> {
+		if self.scroll_capture.active {
+			let render_window = self
+				.scroll_preview_window
+				.as_ref()
+				.map(|preview_window| Arc::clone(&preview_window.window))
+				.or_else(|| {
+					self.scroll_capture.monitor.and_then(|target_monitor| {
+						self.windows
+							.values()
+							.find(|overlay_window| overlay_window.monitor == target_monitor)
+							.map(|overlay_window| Arc::clone(&overlay_window.window))
+					})
+				})?;
+			let target = MacOSKeyFocusShellTarget {
+				kind: MacOSKeyFocusShellKind::ScrollCapture,
+				monitor: self.scroll_capture.monitor,
+				ime_allowed: false,
+				ime_origin: NSPoint::new(0.0, 0.0),
+				ime_size: NSSize::new(1.0, 1.0),
+			};
+
+			return Some((render_window, target));
+		}
+
+		let edit_state = self.frozen_text_edit.as_ref()?;
+
+		if !self.frozen_text_tool_active() {
+			return None;
+		}
+
+		let monitor = self.state.monitor?;
+		let overlay_window = self.windows.values().find(|window| window.monitor == monitor)?;
+		let (visible_text, caret_char_index) = edit_state.visible_text_and_caret_char_index();
+		let caret_rect = overlay_window.renderer.frozen_text_edit_caret_rect_for_window(
+			edit_state.anchor,
+			visible_text.as_str(),
+			&FontId::proportional(self.toolbar_state.text_style.font_size_points),
+			caret_char_index.unwrap_or_else(|| visible_text.chars().count()),
+		);
+		let target = MacOSKeyFocusShellTarget {
+			kind: MacOSKeyFocusShellKind::FrozenText,
+			monitor: Some(monitor),
+			ime_allowed: true,
+			ime_origin: NSPoint::new(
+				f64::from(caret_rect.min.x.max(0.0)),
+				f64::from(caret_rect.min.y.max(0.0)),
+			),
+			ime_size: NSSize::new(
+				f64::from(caret_rect.width().max(1.0)),
+				f64::from(caret_rect.height().max(self.toolbar_state.text_style.font_size_points)),
+			),
+		};
+
+		Some((Arc::clone(&overlay_window.window), target))
+	}
+
+	pub(super) fn should_host_live_pointer_input_in_native_shell(&self) -> bool {
+		self.session_active
+			&& !self.capture_windows_hidden
+			&& matches!(self.state.mode, OverlayMode::Live)
+			&& !self.windows.is_empty()
+	}
+
+	pub(super) fn should_host_toolbar_pointer_input_in_native_shell(&self) -> bool {
+		self.session_active
+			&& matches!(self.state.mode, OverlayMode::Frozen)
+			&& self.toolbar_state.visible
+			&& self.toolbar_window_visible
+	}
+}
+
+impl MonitorRect {
+	fn clamp_local_point(self, local_point: NSPoint) -> GlobalPoint {
+		let max_x = self.width.saturating_sub(1) as i32;
+		let max_y = self.height.saturating_sub(1) as i32;
+		let local_x = (local_point.x.round() as i32).clamp(0, max_x);
+		let local_y = (local_point.y.round() as i32).clamp(0, max_y);
+
+		GlobalPoint::new(
+			self.origin.x.saturating_add(local_x),
+			self.origin.y.saturating_add(local_y),
+		)
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MacOSKeyFocusShellKind {
+	FrozenText,
+	ScrollCapture,
 }
 
 #[derive(Clone)]
@@ -344,400 +805,6 @@ impl MacOSPassiveShellCallback {
 	}
 }
 
-struct MacOSPassiveShellWindow {
-	window_key: usize,
-	view_key: usize,
-	tracking_area_key: usize,
-	toolbar_state: Option<Arc<Mutex<MacOSPassiveToolbarShellState>>>,
-}
-impl MacOSPassiveShellWindow {
-	fn sync_from_render_window(&self, render_window: &Window, visible: bool) {
-		let Some(render_ns_window) = macos_overlay_window_ns_window(render_window) else {
-			return;
-		};
-		let Some(frame) = macos_ns_window_frame(render_ns_window) else {
-			return;
-		};
-
-		self.sync_frame_and_visibility(frame, visible);
-	}
-
-	fn sync_frame_and_visibility(&self, frame: NSRect, visible: bool) {
-		let ns_window = self.window_key as *mut Object;
-
-		if ns_window.is_null() {
-			return;
-		}
-
-		unsafe {
-			let _: () = objc::msg_send![ns_window, setFrame: frame display: NO];
-
-			if visible {
-				let _: () = objc::msg_send![ns_window, orderFrontRegardless];
-			} else {
-				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
-			}
-		}
-	}
-
-	fn set_toolbar_state(&self, monitor: MonitorRect, outer_position: GlobalPoint) {
-		let Some(state) = self.toolbar_state.as_ref() else {
-			return;
-		};
-		let Ok(mut state) = state.lock() else {
-			return;
-		};
-
-		state.monitor = Some(monitor);
-		state.outer_position = Some(outer_position);
-	}
-}
-
-struct MacOSKeyFocusShellWindow {
-	window_key: usize,
-	view_key: usize,
-	state: Arc<Mutex<MacOSKeyFocusShellState>>,
-}
-impl MacOSKeyFocusShellWindow {
-	fn sync_from_render_window(
-		&self,
-		render_window: &Window,
-		target: MacOSKeyFocusShellTarget,
-		visible: bool,
-	) {
-		let Some(render_ns_window) = macos_overlay_window_ns_window(render_window) else {
-			return;
-		};
-		let Some(frame) = macos_ns_window_frame(render_ns_window) else {
-			return;
-		};
-
-		self.set_target(target);
-		self.sync_frame_and_visibility(frame, visible);
-	}
-
-	fn set_target(&self, target: MacOSKeyFocusShellTarget) {
-		let Ok(mut state) = self.state.lock() else {
-			return;
-		};
-
-		state.target = Some(target);
-
-		let view = self.view_key as *mut Object;
-		if view.is_null() {
-			return;
-		}
-
-		unsafe {
-			let input_context: *mut Object = objc::msg_send![view, inputContext];
-
-			if !input_context.is_null() {
-				let _: () = objc::msg_send![input_context, invalidateCharacterCoordinates];
-			}
-		}
-	}
-
-	fn clear_target(&self) {
-		let Ok(mut state) = self.state.lock() else {
-			return;
-		};
-
-		state.target = None;
-		state.marked_text.clear();
-		state.forward_key_event_to_app = false;
-		state.had_ime_input_during_keydown = false;
-	}
-
-	fn sync_frame_and_visibility(&self, frame: NSRect, visible: bool) {
-		let ns_window = self.window_key as *mut Object;
-
-		if ns_window.is_null() {
-			return;
-		}
-
-		unsafe {
-			let _: () = objc::msg_send![ns_window, setFrame: frame display: NO];
-
-			if visible {
-				let _: () = objc::msg_send![ns_window, orderFrontRegardless];
-			} else {
-				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
-			}
-		}
-	}
-
-	fn hide(&self) {
-		let ns_window = self.window_key as *mut Object;
-
-		if ns_window.is_null() {
-			return;
-		}
-
-		unsafe {
-			let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
-		}
-	}
-
-	fn ensure_key_focus(&self) {
-		let ns_window = self.window_key as *mut Object;
-		let view = self.view_key as *mut Object;
-
-		if ns_window.is_null() || view.is_null() {
-			return;
-		}
-
-		super::macos_activate_app();
-
-		unsafe {
-			let _: () = objc::msg_send![ns_window, makeFirstResponder: view];
-			let _: () = objc::msg_send![ns_window, makeKeyAndOrderFront: ptr::null_mut::<Object>()];
-		}
-	}
-}
-impl Drop for MacOSKeyFocusShellWindow {
-	fn drop(&mut self) {
-		macos_unregister_shell_callback(self.view_key);
-
-		unsafe {
-			let ns_window = self.window_key as *mut Object;
-			if !ns_window.is_null() {
-				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
-				let _: () = objc::msg_send![ns_window, close];
-				let _: () = objc::msg_send![ns_window, release];
-			}
-
-			let view = self.view_key as *mut Object;
-			if !view.is_null() {
-				let _: () = objc::msg_send![view, release];
-			}
-		}
-	}
-}
-impl Drop for MacOSPassiveShellWindow {
-	fn drop(&mut self) {
-		macos_unregister_shell_callback(self.view_key);
-
-		unsafe {
-			let ns_window = self.window_key as *mut Object;
-			if !ns_window.is_null() {
-				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
-				let _: () = objc::msg_send![ns_window, close];
-				let _: () = objc::msg_send![ns_window, release];
-			}
-
-			let tracking_area = self.tracking_area_key as *mut Object;
-			if !tracking_area.is_null() {
-				let _: () = objc::msg_send![tracking_area, release];
-			}
-
-			let view = self.view_key as *mut Object;
-			if !view.is_null() {
-				let _: () = objc::msg_send![view, release];
-			}
-		}
-	}
-}
-
-impl OverlaySession {
-	pub(super) fn ensure_native_capture_shells(&mut self) -> Result<(), String> {
-		let Some(dispatch) = self.native_capture_input_dispatch() else {
-			return Ok(());
-		};
-
-		if self.native_capture_shells.is_some() {
-			self.sync_native_capture_shells()?;
-
-			return Ok(());
-		}
-
-		let mut overlay_shells = HashMap::with_capacity(self.windows.len());
-
-		for overlay_window in self.windows.values() {
-			let shell = macos_create_passive_overlay_shell_window(
-				overlay_window.window.as_ref(),
-				overlay_window.monitor,
-				dispatch.clone(),
-			)?;
-			overlay_shells.insert(overlay_window.monitor.id, shell);
-		}
-
-		self.native_capture_shells = Some(MacOSNativeCaptureShells::new(overlay_shells, dispatch));
-		self.sync_native_capture_shells()?;
-
-		Ok(())
-	}
-
-	pub(super) fn sync_native_capture_shells(&mut self) -> Result<(), String> {
-		let live_shell_visible = self.should_host_live_pointer_input_in_native_shell();
-		let toolbar_shell_visible = self.should_host_toolbar_pointer_input_in_native_shell();
-		let toolbar_context = self.toolbar_window.as_ref().map(|toolbar_window| {
-			let monitor = self.state.monitor.or_else(|| self.active_cursor_monitor());
-			let outer_position = Self::toolbar_window_outer_position(toolbar_window)
-				.or(self.pending_toolbar_outer_pos)
-				.or(self.toolbar_outer_pos)
-				.or_else(|| {
-					monitor.and_then(|monitor| {
-						self.toolbar_state.floating_position.map(|floating_position| {
-							self.toolbar_outer_position_from_primary_anchor(
-								monitor,
-								floating_position,
-							)
-						})
-					})
-				});
-
-			(Arc::clone(&toolbar_window.window), monitor, outer_position)
-		});
-		let key_focus_context = self.native_key_focus_shell_context();
-
-		for overlay_window in self.windows.values() {
-			super::macos_set_capture_window_mouse_passthrough(
-				overlay_window.window.as_ref(),
-				live_shell_visible,
-			);
-		}
-
-		let Some(shells) = self.native_capture_shells.as_mut() else {
-			if let Some((toolbar_window, _, _)) = toolbar_context.as_ref() {
-				super::macos_set_capture_window_mouse_passthrough(toolbar_window.as_ref(), false);
-			}
-
-			return Ok(());
-		};
-
-		shells.sync_overlay_shells(&self.windows, live_shell_visible);
-
-		if let Some((toolbar_window, monitor, outer_position)) = toolbar_context {
-			if let (Some(monitor), Some(outer_position)) = (monitor, outer_position) {
-				shells.sync_toolbar_shell(
-					toolbar_window.as_ref(),
-					monitor,
-					outer_position,
-					toolbar_shell_visible,
-				)?;
-				super::macos_set_capture_window_mouse_passthrough(
-					toolbar_window.as_ref(),
-					toolbar_shell_visible,
-				);
-			} else {
-				super::macos_set_capture_window_mouse_passthrough(toolbar_window.as_ref(), false);
-				shells.clear_toolbar_shell();
-			}
-		} else {
-			shells.clear_toolbar_shell();
-		}
-
-		if let Some((render_window, target)) = key_focus_context {
-			shells.sync_key_focus_shell(render_window.as_ref(), target, true)?;
-		} else {
-			shells.clear_key_focus_shell();
-		}
-
-		Ok(())
-	}
-
-	pub(super) fn destroy_native_capture_shells(&mut self) {
-		for overlay_window in self.windows.values() {
-			super::macos_set_capture_window_mouse_passthrough(
-				overlay_window.window.as_ref(),
-				false,
-			);
-		}
-		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			super::macos_set_capture_window_mouse_passthrough(
-				toolbar_window.window.as_ref(),
-				false,
-			);
-		}
-
-		self.native_capture_shells = None;
-	}
-
-	fn native_key_focus_shell_context(&self) -> Option<(Arc<Window>, MacOSKeyFocusShellTarget)> {
-		if self.scroll_capture.active {
-			let render_window = self
-				.scroll_preview_window
-				.as_ref()
-				.map(|preview_window| Arc::clone(&preview_window.window))
-				.or_else(|| {
-					self.scroll_capture.monitor.and_then(|target_monitor| {
-						self.windows
-							.values()
-							.find(|overlay_window| overlay_window.monitor == target_monitor)
-							.map(|overlay_window| Arc::clone(&overlay_window.window))
-					})
-				})?;
-			let target = MacOSKeyFocusShellTarget {
-				kind: MacOSKeyFocusShellKind::ScrollCapture,
-				monitor: self.scroll_capture.monitor,
-				ime_allowed: false,
-				ime_origin: NSPoint::new(0.0, 0.0),
-				ime_size: NSSize::new(1.0, 1.0),
-			};
-
-			return Some((render_window, target));
-		}
-
-		let edit_state = self.frozen_text_edit.as_ref()?;
-		if !self.frozen_text_tool_active() {
-			return None;
-		}
-
-		let monitor = self.state.monitor?;
-		let overlay_window = self.windows.values().find(|window| window.monitor == monitor)?;
-		let (visible_text, caret_char_index) = edit_state.visible_text_and_caret_char_index();
-		let caret_rect = overlay_window.renderer.frozen_text_edit_caret_rect_for_window(
-			edit_state.anchor,
-			visible_text.as_str(),
-			&egui::FontId::proportional(self.toolbar_state.text_style.font_size_points),
-			caret_char_index.unwrap_or_else(|| visible_text.chars().count()),
-		);
-		let target = MacOSKeyFocusShellTarget {
-			kind: MacOSKeyFocusShellKind::FrozenText,
-			monitor: Some(monitor),
-			ime_allowed: true,
-			ime_origin: NSPoint::new(
-				f64::from(caret_rect.min.x.max(0.0)),
-				f64::from(caret_rect.min.y.max(0.0)),
-			),
-			ime_size: NSSize::new(
-				f64::from(caret_rect.width().max(1.0)),
-				f64::from(caret_rect.height().max(self.toolbar_state.text_style.font_size_points)),
-			),
-		};
-
-		Some((Arc::clone(&overlay_window.window), target))
-	}
-
-	pub(super) fn should_host_live_pointer_input_in_native_shell(&self) -> bool {
-		self.session_active
-			&& !self.capture_windows_hidden
-			&& matches!(self.state.mode, OverlayMode::Live)
-			&& !self.windows.is_empty()
-	}
-
-	pub(super) fn should_host_toolbar_pointer_input_in_native_shell(&self) -> bool {
-		self.session_active
-			&& matches!(self.state.mode, OverlayMode::Frozen)
-			&& self.toolbar_state.visible
-			&& self.toolbar_window_visible
-	}
-}
-
-impl MonitorRect {
-	fn clamp_local_point(self, local_point: NSPoint) -> GlobalPoint {
-		let max_x = self.width.saturating_sub(1) as i32;
-		let max_y = self.height.saturating_sub(1) as i32;
-		let local_x = (local_point.x.round() as i32).clamp(0, max_x);
-		let local_y = (local_point.y.round() as i32).clamp(0, max_y);
-
-		GlobalPoint::new(
-			self.origin.x.saturating_add(local_x),
-			self.origin.y.saturating_add(local_y),
-		)
-	}
-}
-
 fn macos_shell_callbacks() -> &'static Mutex<HashMap<usize, MacOSPassiveShellCallback>> {
 	static CALLBACKS: OnceLock<Mutex<HashMap<usize, MacOSPassiveShellCallback>>> = OnceLock::new();
 
@@ -811,8 +878,20 @@ fn macos_passive_shell_view_class() -> *const Class {
 					as extern "C" fn(&Object, Sel, super::MacOSOverlayPoint) -> *mut Object,
 			);
 			decl.add_method(
+				objc::sel!(drawRect:),
+				macos_passive_shell_view_draw_rect as extern "C" fn(&Object, Sel, MacOSRect),
+			);
+			decl.add_method(
+				objc::sel!(resetCursorRects),
+				macos_passive_shell_view_reset_cursor_rects as extern "C" fn(&Object, Sel),
+			);
+			decl.add_method(
 				objc::sel!(mouseMoved:),
 				macos_passive_shell_view_mouse_moved as extern "C" fn(&Object, Sel, *mut Object),
+			);
+			decl.add_method(
+				objc::sel!(cursorUpdate:),
+				macos_passive_shell_view_cursor_update as extern "C" fn(&Object, Sel, *mut Object),
 			);
 			decl.add_method(
 				objc::sel!(mouseDragged:),
@@ -853,7 +932,7 @@ fn macos_key_focus_shell_panel_class() -> *const Class {
 			return class as *const Class as usize;
 		}
 
-		let superclass = objc::class!(NSPanel);
+		let superclass = objc::class!(NSWindow);
 		let mut decl = ClassDecl::new("RsnapKeyFocusCaptureShellPanel", superclass)
 			.expect("key-focus capture shell panel class");
 
@@ -938,12 +1017,7 @@ fn macos_key_focus_shell_view_class() -> *const Class {
 			decl.add_method(
 				objc::sel!(attributedSubstringForProposedRange:actualRange:),
 				macos_key_focus_shell_view_attributed_substring_for_proposed_range
-					as extern "C" fn(
-						&Object,
-						Sel,
-						MacOSRange,
-						*mut std::ffi::c_void,
-					) -> *mut Object,
+					as extern "C" fn(&Object, Sel, MacOSRange, *mut c_void) -> *mut Object,
 			);
 			decl.add_method(
 				objc::sel!(characterIndexForPoint:),
@@ -953,7 +1027,7 @@ fn macos_key_focus_shell_view_class() -> *const Class {
 			decl.add_method(
 				objc::sel!(firstRectForCharacterRange:actualRange:),
 				macos_key_focus_shell_view_first_rect_for_character_range
-					as extern "C" fn(&Object, Sel, MacOSRange, *mut std::ffi::c_void) -> MacOSRect,
+					as extern "C" fn(&Object, Sel, MacOSRange, *mut c_void) -> MacOSRect,
 			);
 			decl.add_method(
 				objc::sel!(insertText:replacementRange:),
@@ -1007,6 +1081,58 @@ extern "C" fn macos_passive_shell_view_hit_test(
 	this as *const Object as *mut Object
 }
 
+extern "C" fn macos_passive_shell_view_draw_rect(
+	this: &Object,
+	_cmd: Sel,
+	dirty_rect: MacOSRect,
+) {
+	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
+		return;
+	};
+
+	if !matches!(callback, MacOSPassiveShellCallback::Overlay { .. }) {
+		return;
+	}
+
+	let clear: *mut Object = unsafe { objc::msg_send![objc::class!(NSColor), clearColor] };
+
+	if !clear.is_null() {
+		unsafe {
+			let _: () = objc::msg_send![clear, setFill];
+			let _: () = objc::msg_send![objc::class!(NSBezierPath), fillRect: NSRect::from(dirty_rect)];
+		}
+	}
+
+	let Some(point) = macos_passive_shell_cursor_point(this as *const Object as usize) else {
+		return;
+	};
+
+	macos_draw_passive_shell_crosshair(point);
+}
+
+extern "C" fn macos_passive_shell_view_reset_cursor_rects(this: &Object, _cmd: Sel) {
+	let bounds: NSRect = unsafe { objc::msg_send![this, bounds] };
+	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
+		return;
+	};
+	let cursor = match callback {
+		MacOSPassiveShellCallback::Overlay { .. } => {
+			super::macos_cursor_object_for_icon(CursorIcon::Crosshair)
+		},
+		MacOSPassiveShellCallback::Toolbar { .. } | MacOSPassiveShellCallback::KeyFocus { .. } => {
+			super::macos_cursor_object_for_icon(CursorIcon::Default)
+		},
+	};
+
+	if cursor.is_null() {
+		return;
+	}
+
+	unsafe {
+		let _: () = objc::msg_send![this, addCursorRect: bounds cursor: cursor];
+	}
+}
+
 extern "C" fn macos_key_focus_shell_view_accepts_first_responder(
 	_this: &Object,
 	_cmd: Sel,
@@ -1016,6 +1142,32 @@ extern "C" fn macos_key_focus_shell_view_accepts_first_responder(
 
 extern "C" fn macos_passive_shell_view_mouse_moved(this: &Object, _cmd: Sel, event: *mut Object) {
 	macos_dispatch_shell_pointer_moved(this, event);
+}
+
+extern "C" fn macos_passive_shell_view_cursor_update(
+	this: &Object,
+	_cmd: Sel,
+	_event: *mut Object,
+) {
+	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
+		return;
+	};
+
+	tracing::warn!(
+		op = "overlay.macos_passive_shell_cursor_update",
+		callback = %macos_shell_callback_name(&callback),
+		"Passive shell received cursorUpdate."
+	);
+
+	match callback {
+		MacOSPassiveShellCallback::Overlay { .. } => {
+			super::macos_set_cursor_icon(CursorIcon::Crosshair);
+		},
+		MacOSPassiveShellCallback::Toolbar { .. } => {
+			super::macos_set_cursor_icon(CursorIcon::Default);
+		},
+		MacOSPassiveShellCallback::KeyFocus { .. } => {},
+	}
 }
 
 extern "C" fn macos_passive_shell_view_mouse_dragged(this: &Object, _cmd: Sel, event: *mut Object) {
@@ -1094,6 +1246,7 @@ fn macos_text_input_object_to_string(string: *mut Object) -> String {
 		let is_attributed: BOOL = objc::msg_send![string, isKindOfClass: attributed_string_class];
 		let string_object = if is_attributed == YES {
 			let value: *mut Object = objc::msg_send![string, string];
+
 			value
 		} else {
 			string
@@ -1130,7 +1283,6 @@ fn macos_modifier_state_from_event(event: *mut Object) -> ModifiersState {
 	const CONTROL: u64 = 1 << 18;
 	const OPTION: u64 = 1 << 19;
 	const COMMAND: u64 = 1 << 20;
-
 	unsafe {
 		let flags: u64 = objc::msg_send![event, modifierFlags];
 		let mut state = ModifiersState::empty();
@@ -1237,7 +1389,6 @@ extern "C" fn macos_key_focus_shell_view_key_down(this: &Object, _cmd: Sel, even
 	let Some((shell_state, dispatch)) = macos_key_focus_shell_state(this) else {
 		return;
 	};
-
 	let ime_allowed = macos_key_focus_ime_allowed(this);
 
 	if let Ok(mut state) = shell_state.lock() {
@@ -1345,10 +1496,18 @@ extern "C" fn macos_key_focus_shell_view_set_marked_text(
 	let monitor = if let Ok(mut state) = shell_state.lock() {
 		state.marked_text = text.clone();
 		state.had_ime_input_during_keydown = true;
+
 		state.target.and_then(|target| target.monitor)
 	} else {
 		None
 	};
+
+	tracing::info!(
+		op = "overlay.macos_key_focus_shell_set_marked_text",
+		monitor_id = ?monitor.map(|target| target.id),
+		text_len = text.chars().count(),
+		"Received marked text from the native key-focus shell."
+	);
 
 	dispatch.enqueue(MacOSNativeCaptureInputEvent::Ime {
 		monitor,
@@ -1362,10 +1521,19 @@ extern "C" fn macos_key_focus_shell_view_unmark_text(this: &Object, _cmd: Sel) {
 	};
 	let monitor = if let Ok(mut state) = shell_state.lock() {
 		state.marked_text.clear();
+
 		state.target.and_then(|target| target.monitor)
 	} else {
 		None
 	};
+
+	unsafe {
+		let input_context: *mut Object = objc::msg_send![this, inputContext];
+
+		if !input_context.is_null() {
+			let _: () = objc::msg_send![input_context, discardMarkedText];
+		}
+	}
 
 	dispatch.enqueue(MacOSNativeCaptureInputEvent::Ime {
 		monitor,
@@ -1384,7 +1552,7 @@ extern "C" fn macos_key_focus_shell_view_attributed_substring_for_proposed_range
 	_this: &Object,
 	_cmd: Sel,
 	_range: MacOSRange,
-	_actual_range: *mut std::ffi::c_void,
+	_actual_range: *mut c_void,
 ) -> *mut Object {
 	ptr::null_mut::<Object>()
 }
@@ -1401,7 +1569,7 @@ extern "C" fn macos_key_focus_shell_view_first_rect_for_character_range(
 	this: &Object,
 	_cmd: Sel,
 	_range: MacOSRange,
-	_actual_range: *mut std::ffi::c_void,
+	_actual_range: *mut c_void,
 ) -> MacOSRect {
 	let Some(target) = macos_key_focus_target(this) else {
 		return MacOSRect::from(NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1.0, 1.0)));
@@ -1440,11 +1608,20 @@ extern "C" fn macos_key_focus_shell_view_insert_text(
 
 	let monitor = if let Ok(mut state) = shell_state.lock() {
 		state.marked_text.clear();
+
 		state.had_ime_input_during_keydown = true;
+
 		state.target.and_then(|target| target.monitor)
 	} else {
 		None
 	};
+
+	tracing::info!(
+		op = "overlay.macos_key_focus_shell_insert_text",
+		monitor_id = ?monitor.map(|target| target.id),
+		text_len = text.chars().count(),
+		"Committed text from the native key-focus shell."
+	);
 
 	dispatch.enqueue(MacOSNativeCaptureInputEvent::Ime {
 		monitor,
@@ -1475,10 +1652,28 @@ fn macos_dispatch_shell_pointer_moved(this: &Object, event: *mut Object) {
 		return;
 	};
 
+	tracing::warn!(
+		op = "overlay.macos_passive_shell_pointer_moved",
+		callback = %macos_shell_callback_name(&callback),
+		x = local_point.x,
+		y = local_point.y,
+		"Passive shell received pointer movement."
+	);
+
 	match callback {
-		MacOSPassiveShellCallback::Overlay { .. } => macos_set_crosshair_cursor(),
-		MacOSPassiveShellCallback::Toolbar { .. } => macos_set_default_cursor(),
-		MacOSPassiveShellCallback::KeyFocus { .. } => {},
+		MacOSPassiveShellCallback::Overlay { .. } => {
+			macos_update_passive_shell_cursor_point(this as *const Object as usize, Some(local_point));
+
+			super::macos_set_cursor_icon(CursorIcon::Crosshair);
+		},
+		MacOSPassiveShellCallback::Toolbar { .. } => {
+			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
+
+			super::macos_set_cursor_icon(CursorIcon::Default);
+		},
+		MacOSPassiveShellCallback::KeyFocus { .. } => {
+			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
+		},
 	}
 
 	callback.dispatch_pointer_moved(local_point);
@@ -1496,9 +1691,19 @@ fn macos_dispatch_shell_mouse_input(
 	let local_point = macos_shell_local_point(this, event);
 
 	match callback {
-		MacOSPassiveShellCallback::Overlay { .. } => macos_set_crosshair_cursor(),
-		MacOSPassiveShellCallback::Toolbar { .. } => macos_set_default_cursor(),
-		MacOSPassiveShellCallback::KeyFocus { .. } => {},
+		MacOSPassiveShellCallback::Overlay { .. } => {
+			macos_update_passive_shell_cursor_point(this as *const Object as usize, local_point);
+
+			super::macos_set_cursor_icon(CursorIcon::Crosshair);
+		},
+		MacOSPassiveShellCallback::Toolbar { .. } => {
+			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
+
+			super::macos_set_cursor_icon(CursorIcon::Default);
+		},
+		MacOSPassiveShellCallback::KeyFocus { .. } => {
+			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
+		},
 	}
 
 	callback.dispatch_mouse_input(local_point, button, state);
@@ -1545,16 +1750,203 @@ fn macos_shell_scroll_delta(event: *mut Object) -> Option<MacOSNativeCaptureScro
 }
 
 fn macos_set_crosshair_cursor() {
-	unsafe {
-		let cursor = super::macos_cursor_object_for_icon(CursorIcon::Crosshair);
-		let _: () = objc::msg_send![cursor, set];
+	super::macos_set_cursor_icon(CursorIcon::Crosshair);
+}
+
+fn macos_passive_shell_cursor_points() -> &'static Mutex<HashMap<usize, Option<NSPoint>>> {
+	static POINTS: OnceLock<Mutex<HashMap<usize, Option<NSPoint>>>> = OnceLock::new();
+
+	POINTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn macos_passive_shell_cursor_point(view_key: usize) -> Option<NSPoint> {
+	let points = macos_passive_shell_cursor_points();
+
+	match points.lock() {
+		Ok(guard) => guard.get(&view_key).copied().flatten(),
+		Err(poisoned) => poisoned.into_inner().get(&view_key).copied().flatten(),
 	}
 }
 
-fn macos_set_default_cursor() {
+fn macos_clear_passive_shell_cursor_point(view_key: usize) {
+	let points = macos_passive_shell_cursor_points();
+
+	match points.lock() {
+		Ok(mut guard) => {
+			guard.remove(&view_key);
+		},
+		Err(poisoned) => {
+			poisoned.into_inner().remove(&view_key);
+		},
+	}
+}
+
+fn macos_update_passive_shell_cursor_point(view_key: usize, next_point: Option<NSPoint>) {
+	let previous = {
+		let points = macos_passive_shell_cursor_points();
+
+		match points.lock() {
+			Ok(mut guard) => {
+				let previous = guard.get(&view_key).copied().flatten();
+
+				if previous == next_point {
+					return;
+				}
+				if next_point.is_some() {
+					guard.insert(view_key, next_point);
+				} else {
+					guard.remove(&view_key);
+				}
+
+				previous
+			},
+			Err(poisoned) => {
+				let mut guard = poisoned.into_inner();
+				let previous = guard.get(&view_key).copied().flatten();
+
+				if previous == next_point {
+					return;
+				}
+				if next_point.is_some() {
+					guard.insert(view_key, next_point);
+				} else {
+					guard.remove(&view_key);
+				}
+
+				previous
+			},
+		}
+	};
+	let view = view_key as *mut Object;
+
+	if view.is_null() {
+		return;
+	}
+
 	unsafe {
-		let cursor = super::macos_cursor_object_for_icon(CursorIcon::Default);
-		let _: () = objc::msg_send![cursor, set];
+		if let Some(previous) = previous {
+			let _: () = objc::msg_send![
+				view,
+				setNeedsDisplayInRect: macos_passive_shell_cursor_dirty_rect(previous)
+			];
+		}
+		if let Some(next) = next_point {
+			let _: () =
+				objc::msg_send![view, setNeedsDisplayInRect: macos_passive_shell_cursor_dirty_rect(next)];
+		}
+	}
+}
+
+fn macos_passive_shell_cursor_dirty_rect(point: NSPoint) -> NSRect {
+	const CURSOR_DIRTY_RADIUS: f64 = 18.0;
+
+	NSRect::new(
+		NSPoint::new(point.x - CURSOR_DIRTY_RADIUS, point.y - CURSOR_DIRTY_RADIUS),
+		NSSize::new(CURSOR_DIRTY_RADIUS * 2.0, CURSOR_DIRTY_RADIUS * 2.0),
+	)
+}
+
+fn macos_seed_passive_shell_cursor_point(ns_window: *mut Object, view: *mut Object) -> Option<NSPoint> {
+	if ns_window.is_null() || view.is_null() {
+		return None;
+	}
+
+	let global = super::macos_mouse_location()?;
+
+	unsafe {
+		let screen_point = NSPoint::new(f64::from(global.x), f64::from(global.y));
+		let window_point: NSPoint = objc::msg_send![ns_window, convertPointFromScreen: screen_point];
+		let local_point: NSPoint =
+			objc::msg_send![view, convertPoint: window_point fromView: ptr::null_mut::<Object>()];
+		let bounds: NSRect = objc::msg_send![view, bounds];
+		let contains = local_point.x >= bounds.origin.x
+			&& local_point.y >= bounds.origin.y
+			&& local_point.x <= bounds.origin.x + bounds.size.width
+			&& local_point.y <= bounds.origin.y + bounds.size.height;
+
+		contains.then_some(local_point)
+	}
+}
+
+fn macos_draw_passive_shell_crosshair(point: NSPoint) {
+	let outline_color: *mut Object =
+		unsafe { objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 0.0 alpha: 0.95] };
+	let fill_color: *mut Object = unsafe {
+		objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 1.0 alpha: 0.95]
+	};
+
+	macos_fill_passive_shell_crosshair_segments(outline_color, point, 3.0);
+	macos_fill_passive_shell_crosshair_segments(fill_color, point, 1.0);
+}
+
+fn macos_fill_passive_shell_crosshair_segments(color: *mut Object, point: NSPoint, thickness: f64) {
+	if color.is_null() {
+		return;
+	}
+
+	const EXTENT: f64 = 11.0;
+	const GAP: f64 = 3.0;
+
+	let rects = [
+		NSRect::new(
+			NSPoint::new(point.x - EXTENT, point.y - thickness * 0.5),
+			NSSize::new(EXTENT - GAP, thickness),
+		),
+		NSRect::new(
+			NSPoint::new(point.x + GAP, point.y - thickness * 0.5),
+			NSSize::new(EXTENT - GAP, thickness),
+		),
+		NSRect::new(
+			NSPoint::new(point.x - thickness * 0.5, point.y - EXTENT),
+			NSSize::new(thickness, EXTENT - GAP),
+		),
+		NSRect::new(
+			NSPoint::new(point.x - thickness * 0.5, point.y + GAP),
+			NSSize::new(thickness, EXTENT - GAP),
+		),
+	];
+
+	unsafe {
+		let _: () = objc::msg_send![color, setFill];
+
+		for rect in rects {
+			let _: () = objc::msg_send![objc::class!(NSBezierPath), fillRect: rect];
+		}
+	}
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+	fn CGMainDisplayID() -> u32;
+	fn CGDisplayHideCursor(display: u32) -> i32;
+	fn CGDisplayShowCursor(display: u32) -> i32;
+}
+
+fn macos_set_system_cursor_hidden(hidden: bool) {
+	static CURSOR_HIDDEN: AtomicBool = AtomicBool::new(false);
+
+	let previous = CURSOR_HIDDEN.swap(hidden, Ordering::SeqCst);
+
+	if previous == hidden {
+		return;
+	}
+
+	unsafe {
+		if hidden {
+			let _ = CGDisplayHideCursor(CGMainDisplayID());
+			let _: () = objc::msg_send![objc::class!(NSCursor), hide];
+		} else {
+			let _: () = objc::msg_send![objc::class!(NSCursor), unhide];
+			let _ = CGDisplayShowCursor(CGMainDisplayID());
+		}
+	}
+}
+
+fn macos_shell_callback_name(callback: &MacOSPassiveShellCallback) -> &'static str {
+	match callback {
+		MacOSPassiveShellCallback::Overlay { .. } => "overlay",
+		MacOSPassiveShellCallback::Toolbar { .. } => "toolbar",
+		MacOSPassiveShellCallback::KeyFocus { .. } => "key_focus",
 	}
 }
 
@@ -1595,7 +1987,7 @@ fn macos_create_key_focus_shell_window(
 	let collection_behavior = unsafe { macos_ns_window_collection_behavior(render_ns_window) };
 	let panel_class = macos_key_focus_shell_panel_class();
 	let view_class = macos_key_focus_shell_view_class();
-	let nonactivating_panel_mask: usize = 1 << 7;
+	let borderless_panel_mask: usize = 0;
 	let backing_buffered: usize = 2;
 	let state = Arc::new(Mutex::new(MacOSKeyFocusShellState::default()));
 
@@ -1604,7 +1996,7 @@ fn macos_create_key_focus_shell_window(
 		let ns_window: *mut Object = objc::msg_send![
 			ns_window_alloc,
 			initWithContentRect: frame
-			styleMask: nonactivating_panel_mask
+			styleMask: borderless_panel_mask
 			backing: backing_buffered
 			defer: NO
 		];
@@ -1693,7 +2085,7 @@ fn macos_create_passive_shell_window(
 		}
 
 		let tracking_area_alloc: *mut Object = objc::msg_send![objc::class!(NSTrackingArea), alloc];
-		let tracking_options: usize = 0x01 | 0x02 | 0x80 | 0x200 | 0x400;
+		let tracking_options: usize = 0x01 | 0x02 | 0x04 | 0x80 | 0x200 | 0x400;
 		let tracking_rect = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0));
 		let tracking_area: *mut Object = objc::msg_send![
 			tracking_area_alloc,

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -1085,11 +1085,7 @@ extern "C" fn macos_passive_shell_view_hit_test(
 	this as *const Object as *mut Object
 }
 
-extern "C" fn macos_passive_shell_view_draw_rect(
-	this: &Object,
-	_cmd: Sel,
-	dirty_rect: MacOSRect,
-) {
+extern "C" fn macos_passive_shell_view_draw_rect(this: &Object, _cmd: Sel, dirty_rect: MacOSRect) {
 	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
 		return;
 	};
@@ -1103,7 +1099,8 @@ extern "C" fn macos_passive_shell_view_draw_rect(
 	if !clear.is_null() {
 		unsafe {
 			let _: () = objc::msg_send![clear, setFill];
-			let _: () = objc::msg_send![objc::class!(NSBezierPath), fillRect: NSRect::from(dirty_rect)];
+			let _: () =
+				objc::msg_send![objc::class!(NSBezierPath), fillRect: NSRect::from(dirty_rect)];
 		}
 	}
 
@@ -1667,7 +1664,10 @@ fn macos_dispatch_shell_pointer_moved(this: &Object, event: *mut Object) {
 
 	match callback {
 		MacOSPassiveShellCallback::Overlay { .. } => {
-			macos_update_passive_shell_cursor_point(this as *const Object as usize, Some(local_point));
+			macos_update_passive_shell_cursor_point(
+				this as *const Object as usize,
+				Some(local_point),
+			);
 
 			super::macos_set_cursor_icon(CursorIcon::Crosshair);
 		},
@@ -1836,8 +1836,7 @@ fn macos_update_passive_shell_cursor_point(view_key: usize, next_point: Option<N
 			];
 		}
 		if let Some(next) = next_point {
-			let _: () =
-				objc::msg_send![view, setNeedsDisplayInRect: macos_passive_shell_cursor_dirty_rect(next)];
+			let _: () = objc::msg_send![view, setNeedsDisplayInRect: macos_passive_shell_cursor_dirty_rect(next)];
 		}
 	}
 }
@@ -1851,7 +1850,10 @@ fn macos_passive_shell_cursor_dirty_rect(point: NSPoint) -> NSRect {
 	)
 }
 
-fn macos_seed_passive_shell_cursor_point(ns_window: *mut Object, view: *mut Object) -> Option<NSPoint> {
+fn macos_seed_passive_shell_cursor_point(
+	ns_window: *mut Object,
+	view: *mut Object,
+) -> Option<NSPoint> {
 	if ns_window.is_null() || view.is_null() {
 		return None;
 	}
@@ -1860,7 +1862,8 @@ fn macos_seed_passive_shell_cursor_point(ns_window: *mut Object, view: *mut Obje
 
 	unsafe {
 		let screen_point = NSPoint::new(f64::from(global.x), f64::from(global.y));
-		let window_point: NSPoint = objc::msg_send![ns_window, convertPointFromScreen: screen_point];
+		let window_point: NSPoint =
+			objc::msg_send![ns_window, convertPointFromScreen: screen_point];
 		let local_point: NSPoint =
 			objc::msg_send![view, convertPoint: window_point fromView: ptr::null_mut::<Object>()];
 		let bounds: NSRect = objc::msg_send![view, bounds];
@@ -1874,8 +1877,9 @@ fn macos_seed_passive_shell_cursor_point(ns_window: *mut Object, view: *mut Obje
 }
 
 fn macos_draw_passive_shell_crosshair(point: NSPoint) {
-	let outline_color: *mut Object =
-		unsafe { objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 0.0 alpha: 0.95] };
+	let outline_color: *mut Object = unsafe {
+		objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 0.0 alpha: 0.95]
+	};
 	let fill_color: *mut Object = unsafe {
 		objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 1.0 alpha: 0.95]
 	};

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -716,7 +716,7 @@ impl WindowRenderer {
 		selection_flow_enabled: bool,
 		selection_flow_stroke_width_px: f32,
 		pending_frozen_display_handoff: bool,
-		needs_frozen_surface_bg: bool,
+		needs_surface_bg: bool,
 		show_frozen_capture_affordance: bool,
 		frozen_selection_resize_handles_enabled: bool,
 		frozen_capture_source: FrozenCaptureSource,
@@ -809,7 +809,7 @@ impl WindowRenderer {
 			}
 			if matches!(state.mode, OverlayMode::Frozen)
 				&& !pending_frozen_display_handoff
-				&& (needs_frozen_surface_bg || show_frozen_capture_affordance)
+				&& (needs_surface_bg || show_frozen_capture_affordance)
 				&& state.monitor == Some(monitor)
 				&& state.frozen_capture_rect.is_some()
 			{
@@ -1417,6 +1417,7 @@ impl WindowRenderer {
 		selection_flow_enabled: bool,
 		selection_flow_stroke_width_px: f32,
 		allow_frozen_surface_bg: bool,
+		allow_live_surface_bg: bool,
 		pending_frozen_display_handoff: bool,
 		pending_frozen_display_handoff_monitor: Option<MonitorRect>,
 		show_frozen_capture_affordance: bool,
@@ -1456,6 +1457,7 @@ impl WindowRenderer {
 			monitor,
 			draw_hud,
 			allow_frozen_surface_bg,
+			allow_live_surface_bg,
 			toolbar_active,
 			show_hud_blur,
 			hud_opaque,
@@ -1488,7 +1490,7 @@ impl WindowRenderer {
 			selection_flow_enabled,
 			selection_flow_stroke_width_px,
 			pending_frozen_display_handoff,
-			hud_cfg.needs_frozen_surface_bg,
+			hud_cfg.needs_surface_bg,
 			show_frozen_capture_affordance,
 			frozen_selection_resize_handles_enabled,
 			frozen_capture_source,
@@ -1533,10 +1535,6 @@ impl WindowRenderer {
 
 		phase_timings.tessellate = tessellate_started_at.elapsed();
 
-		let draw_frozen_bg = hud_cfg.needs_frozen_surface_bg
-			&& state.monitor == Some(monitor)
-			&& state.frozen_display_surface_image().is_some();
-
 		self.finish_window_renderer_draw(
 			gpu,
 			state,
@@ -1547,10 +1545,26 @@ impl WindowRenderer {
 			draw_started_at,
 			&mut phase_timings,
 			paint_jobs,
-			draw_frozen_bg,
+			Self::should_draw_surface_bg(state, monitor, hud_cfg.needs_surface_bg),
 			hud_shader_blur_active,
 			toolbar_active,
 		)
+	}
+
+	fn should_draw_surface_bg(
+		state: &OverlayState,
+		monitor: MonitorRect,
+		needs_surface_bg: bool,
+	) -> bool {
+		needs_surface_bg
+			&& match state.mode {
+				OverlayMode::Live => {
+					state.live_bg_monitor == Some(monitor) && state.live_bg_image.is_some()
+				},
+				OverlayMode::Frozen => {
+					state.monitor == Some(monitor) && state.frozen_display_surface_image().is_some()
+				},
+			}
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
@@ -611,9 +611,12 @@ pub(in crate::overlay) struct HudPillGeometry {
 
 #[cfg(test)]
 mod tests {
+	#[cfg(target_os = "macos")]
 	use image::{Rgba, RgbaImage};
 
+	#[cfg(target_os = "macos")]
 	use crate::overlay::WindowRenderer;
+	#[cfg(target_os = "macos")]
 	use crate::state::{GlobalPoint, MonitorRect, OverlayMode, OverlayState};
 
 	#[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
@@ -42,18 +42,27 @@ impl WindowRenderer {
 				);
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	pub(in crate::overlay::rendering) fn resolve_hud_draw_config(
 		state: &OverlayState,
 		monitor: MonitorRect,
 		draw_hud: bool,
 		allow_frozen_surface_bg: bool,
+		allow_live_surface_bg: bool,
 		toolbar_active: bool,
 		show_hud_blur: bool,
 		hud_opaque: bool,
 	) -> HudDrawConfig {
 		let can_draw_hud = draw_hud && Self::should_draw_hud(state, monitor);
-		let needs_frozen_surface_bg =
-			allow_frozen_surface_bg && !draw_hud && matches!(state.mode, OverlayMode::Frozen);
+		let needs_surface_bg = !draw_hud
+			&& match state.mode {
+				OverlayMode::Frozen => allow_frozen_surface_bg,
+				OverlayMode::Live => {
+					allow_live_surface_bg
+						&& state.live_bg_monitor == Some(monitor)
+						&& state.live_bg_image.is_some()
+				},
+			};
 		// `show_hud_blur` is a UX toggle for "glass mode".
 		// - On macOS: HUD uses native compositor blur; toolbar uses native HUD windowing, so shader
 		//   blur stays tied to monitor-aligned overlay windows.
@@ -64,12 +73,7 @@ impl WindowRenderer {
 		let needs_shader_blur_bg =
 			toolbar_glass_active || (hud_glass_active && use_shader_blur_for_hud);
 
-		HudDrawConfig {
-			can_draw_hud,
-			needs_frozen_surface_bg,
-			needs_shader_blur_bg,
-			hud_glass_active,
-		}
+		HudDrawConfig { can_draw_hud, needs_surface_bg, needs_shader_blur_bg, hud_glass_active }
 	}
 
 	pub(in crate::overlay::rendering) fn sync_or_clear_hud_bg(
@@ -79,7 +83,7 @@ impl WindowRenderer {
 		monitor: MonitorRect,
 		hud_cfg: HudDrawConfig,
 	) -> Result<()> {
-		if hud_cfg.needs_frozen_surface_bg || hud_cfg.needs_shader_blur_bg {
+		if hud_cfg.needs_surface_bg || hud_cfg.needs_shader_blur_bg {
 			return self.sync_hud_bg(gpu, state, monitor);
 		}
 
@@ -133,7 +137,7 @@ impl WindowRenderer {
 			&& !hud_opaque;
 		let hud_cfg = HudDrawConfig {
 			can_draw_hud: false,
-			needs_frozen_surface_bg: false,
+			needs_surface_bg: false,
 			needs_shader_blur_bg: shader_blur_active,
 			hud_glass_active: shader_blur_active,
 		};
@@ -391,12 +395,12 @@ impl WindowRenderer {
 		state: &OverlayState,
 		monitor: MonitorRect,
 	) -> Result<()> {
-		let (target_generation, target_image) = match state.mode {
+		let (target_generation, target_image, live_surface_bg) = match state.mode {
 			OverlayMode::Live if state.live_bg_monitor == Some(monitor) => {
-				(state.live_bg_generation, state.live_bg_image.as_ref())
+				(state.live_bg_generation, state.live_bg_image.as_ref(), true)
 			},
 			OverlayMode::Frozen if state.monitor == Some(monitor) => {
-				(state.frozen_generation, state.frozen_display_surface_image())
+				(state.frozen_generation, state.frozen_display_surface_image(), false)
 			},
 			OverlayMode::Live => {
 				self.hud_bg = None;
@@ -429,7 +433,26 @@ impl WindowRenderer {
 			return Ok(());
 		};
 
+		if live_surface_bg {
+			return self.render_live_bg_to_texture(gpu, image, target_generation);
+		}
+
 		self.render_frozen_bg_to_texture(gpu, image, target_generation)
+	}
+
+	pub(in crate::overlay::rendering) fn render_live_bg_to_texture(
+		&mut self,
+		gpu: &GpuContext,
+		image: &RgbaImage,
+		target_generation: u64,
+	) -> Result<()> {
+		self.render_hud_bg_to_texture(
+			gpu,
+			image,
+			target_generation,
+			gpu.device.limits().max_texture_dimension_2d,
+			false,
+		)
 	}
 
 	pub(in crate::overlay::rendering) fn render_frozen_bg_to_texture(
@@ -438,13 +461,27 @@ impl WindowRenderer {
 		image: &RgbaImage,
 		target_generation: u64,
 	) -> Result<()> {
-		let upload_image = image_helpers::downscale_for_gpu_upload(
+		self.render_hud_bg_to_texture(
+			gpu,
 			image,
+			target_generation,
 			gpu.device.limits().max_texture_dimension_2d,
-		);
+			true,
+		)
+	}
+
+	fn render_hud_bg_to_texture(
+		&mut self,
+		gpu: &GpuContext,
+		image: &RgbaImage,
+		target_generation: u64,
+		max_side: u32,
+		generate_mipmaps: bool,
+	) -> Result<()> {
+		let upload_image = image_helpers::downscale_for_gpu_upload(image, max_side);
 		let (width, height) = upload_image.dimensions();
-		let max_side = gpu.device.limits().max_texture_dimension_2d;
-		let mip_level_count = Self::mip_level_count(width, height).min(10);
+		let mip_level_count =
+			if generate_mipmaps { Self::mip_level_count(width, height).min(10) } else { 1 };
 
 		debug_assert!(width <= max_side && height <= max_side);
 
@@ -496,7 +533,10 @@ impl WindowRenderer {
 			},
 			wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
 		);
-		self.generate_mipmaps(gpu, &texture, mip_level_count);
+
+		if generate_mipmaps {
+			self.generate_mipmaps(gpu, &texture, mip_level_count);
+		}
 
 		let view = texture.create_view(&TextureViewDescriptor::default());
 		let hud_blur_bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -567,4 +607,83 @@ impl HudBlurUniformRaw {
 pub(in crate::overlay) struct HudPillGeometry {
 	pub(in crate::overlay) rect: Rect,
 	pub(in crate::overlay) radius_points: f32,
+}
+
+#[cfg(test)]
+mod tests {
+	use image::{Rgba, RgbaImage};
+
+	use crate::overlay::WindowRenderer;
+	use crate::state::{GlobalPoint, MonitorRect, OverlayMode, OverlayState};
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn resolve_hud_draw_config_uses_surface_bg_for_live_cached_monitor_image() {
+		let monitor = MonitorRect {
+			id: 7,
+			origin: GlobalPoint::new(0, 0),
+			width: 1_440,
+			height: 900,
+			scale_factor_x1000: 2_000,
+		};
+		let mut state = OverlayState::new();
+
+		state.mode = OverlayMode::Live;
+		state.live_bg_monitor = Some(monitor);
+		state.live_bg_image = Some(RgbaImage::from_pixel(2, 2, Rgba([0, 0, 0, 255])));
+
+		let cfg = WindowRenderer::resolve_hud_draw_config(
+			&state, monitor, false, false, true, false, false, false,
+		);
+
+		assert!(cfg.needs_surface_bg);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn resolve_hud_draw_config_skips_surface_bg_when_live_overlay_surface_is_disallowed() {
+		let monitor = MonitorRect {
+			id: 7,
+			origin: GlobalPoint::new(0, 0),
+			width: 1_440,
+			height: 900,
+			scale_factor_x1000: 2_000,
+		};
+		let mut state = OverlayState::new();
+
+		state.mode = OverlayMode::Live;
+		state.live_bg_monitor = Some(monitor);
+		state.live_bg_image = Some(RgbaImage::from_pixel(2, 2, Rgba([0, 0, 0, 255])));
+
+		let cfg = WindowRenderer::resolve_hud_draw_config(
+			&state, monitor, false, false, false, false, false, false,
+		);
+
+		assert!(!cfg.needs_surface_bg);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn resolve_hud_draw_config_skips_surface_bg_when_live_hud_is_visible() {
+		let monitor = MonitorRect {
+			id: 7,
+			origin: GlobalPoint::new(0, 0),
+			width: 1_440,
+			height: 900,
+			scale_factor_x1000: 2_000,
+		};
+		let mut state = OverlayState::new();
+
+		state.mode = OverlayMode::Live;
+		state.live_bg_monitor = Some(monitor);
+		state.live_bg_image = Some(RgbaImage::from_pixel(2, 2, Rgba([0, 0, 0, 255])));
+		state.cursor = Some(GlobalPoint::new(10, 10));
+
+		let cfg = WindowRenderer::resolve_hud_draw_config(
+			&state, monitor, true, false, true, false, false, false,
+		);
+
+		assert!(cfg.can_draw_hud);
+		assert!(!cfg.needs_surface_bg);
+	}
 }

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -8,8 +8,8 @@ use image::RgbaImage;
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::MacLiveFrameStream;
 use crate::overlay::{
-	FrozenCaptureSource, Key, KeyEvent, MonitorRect, NamedKey, OverlayControl, OverlayMode,
-	OverlaySession, PngAction, Pos2, Rect, SCROLL_CAPTURE_INPUT_FRESHNESS,
+	FrozenCaptureSource, Key, MonitorRect, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
+	OverlayMode, OverlaySession, PngAction, Pos2, Rect, SCROLL_CAPTURE_INPUT_FRESHNESS,
 	SCROLL_CAPTURE_SAMPLE_INTERVAL, ScrollDirection, ScrollObserveOutcome, Vec2, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
@@ -122,7 +122,10 @@ impl OverlaySession {
 		self.request_redraw_all();
 	}
 
-	pub(super) fn handle_scroll_capture_key_event(&mut self, event: &KeyEvent) -> OverlayControl {
+	pub(super) fn handle_scroll_capture_key_event(
+		&mut self,
+		event: &OverlayKeyboardInputEvent,
+	) -> OverlayControl {
 		match &event.logical_key {
 			Key::Named(NamedKey::Escape) => self.cancel_overlay("scroll_capture_escape_key"),
 			Key::Named(NamedKey::Space) => {
@@ -554,24 +557,10 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
-	fn focus_scroll_keyboard_window(&self) {
+	fn focus_scroll_keyboard_window(&mut self) {
 		super::macos_activate_app();
 
-		let target_window = if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			Some(toolbar_window.window.as_ref())
-		} else if let Some(preview_window) = self.scroll_preview_window.as_ref() {
-			Some(preview_window.window.as_ref())
-		} else {
-			self.windows
-				.values()
-				.find(|overlay_window| Some(overlay_window.monitor) == self.scroll_capture.monitor)
-				.map(|overlay_window| overlay_window.window.as_ref())
-		};
-		let Some(target_window) = target_window else {
-			return;
-		};
-
-		super::macos_make_window_key(target_window);
+		let _ = self.sync_native_capture_shells();
 	}
 
 	pub(super) fn update_scroll_toolbar_default_position(&mut self, monitor: MonitorRect) {

--- a/packages/rsnap-overlay/src/overlay/session_state.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state.rs
@@ -171,7 +171,7 @@ pub(super) struct FrozenSelectionDragCursorMoveTiming {
 #[derive(Clone, Copy, Debug)]
 pub(super) struct HudDrawConfig {
 	pub(super) can_draw_hud: bool,
-	pub(super) needs_frozen_surface_bg: bool,
+	pub(super) needs_surface_bg: bool,
 	pub(super) needs_shader_blur_bg: bool,
 	pub(super) hud_glass_active: bool,
 }

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -189,27 +189,6 @@ fn session_inflight_freeze_capture(session: &OverlaySession) -> Option<MonitorRe
 	}
 }
 
-#[cfg(target_os = "macos")]
-#[test]
-fn passive_capture_window_policy_tracks_window_membership() {
-	let first_window_key = 0x1001usize;
-	let second_window_key = 0x2002usize;
-
-	assert!(!overlay::macos_capture_window_is_passive(first_window_key));
-	assert!(!overlay::macos_capture_window_is_passive(second_window_key));
-	assert!(overlay::macos_update_capture_window_passive_state(first_window_key, true));
-	assert!(overlay::macos_capture_window_is_passive(first_window_key));
-	assert!(!overlay::macos_capture_window_is_passive(second_window_key));
-	assert!(!overlay::macos_update_capture_window_passive_state(first_window_key, true));
-	assert!(overlay::macos_update_capture_window_passive_state(second_window_key, true));
-	assert!(overlay::macos_capture_window_is_passive(second_window_key));
-	assert!(overlay::macos_update_capture_window_passive_state(first_window_key, false));
-	assert!(!overlay::macos_capture_window_is_passive(first_window_key));
-	assert!(overlay::macos_capture_window_is_passive(second_window_key));
-	assert!(overlay::macos_update_capture_window_passive_state(second_window_key, false));
-	assert!(!overlay::macos_capture_window_is_passive(second_window_key));
-}
-
 fn session_pending_window_freeze_capture(
 	session: &OverlaySession,
 ) -> Option<crate::overlay::session_state::WindowFreezeCaptureTarget> {

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -61,21 +61,22 @@ use crate::overlay::{
 	FrozenCommittedOverlay, FrozenEditKind, FrozenExportTransform, FrozenImagePatch,
 	FrozenMosaicEdit, FrozenSelectionDragState, FrozenSpotlightAnnotation, FrozenTextAnnotation,
 	FrozenTextEditState, FrozenTextInputSource, FrozenToolbarState, FrozenToolbarTool,
-	HUD_LOUPE_STRIP_GAP_POINTS, HudRedrawSummary, HudTheme, OCCLUDED_FRAME_REDRAW_RETRY_WINDOW,
-	OverlaySession, Pos2, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL, SELECTION_SIZE_BADGE_GAP_PX,
-	SELECTION_SIZE_BADGE_INSIDE_MARGIN_PX, SELECTION_SIZE_BADGE_SCREEN_MARGIN_PX,
-	SelectionDashedBorderCache, SelectionFlowGeometryCache, SelectionSizeBadgeTarget,
-	SurfaceFrameSkipReason, TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement,
-	Vec2, WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
+	HUD_LOUPE_STRIP_GAP_POINTS, HudRedrawSummary, HudTheme, LiveCaptureInteraction,
+	OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, OverlaySession, Pos2, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL,
+	SELECTION_SIZE_BADGE_GAP_PX, SELECTION_SIZE_BADGE_INSIDE_MARGIN_PX,
+	SELECTION_SIZE_BADGE_SCREEN_MARGIN_PX, SelectionDashedBorderCache, SelectionFlowGeometryCache,
+	SelectionSizeBadgeTarget, SurfaceFrameSkipReason, TOOLBAR_CAPTURE_GAP_PX,
+	TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Vec2, WindowCaptureAlphaMode, WindowRenderer,
+	hud_helpers,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
 	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry,
-	InflightScrollCaptureObservation, KCG_SCROLL_EVENT_UNIT_PIXEL, LiveCaptureInteraction,
-	LiveSampleApplyResult, LiveStreamStaleGrace, MacOSScrollPixelResidual, OverlayControl,
-	OverlayExit, SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
-	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES,
-	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE, ScrollCaptureFrameSource, StartupLiveRgbPlan,
+	InflightScrollCaptureObservation, KCG_SCROLL_EVENT_UNIT_PIXEL, LiveSampleApplyResult,
+	LiveStreamStaleGrace, MacOSScrollPixelResidual, OverlayControl, OverlayExit,
+	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW, SCROLL_CAPTURE_INPUT_FRESHNESS,
+	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES, SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
+	ScrollCaptureFrameSource, StartupLiveRgbPlan,
 };
 use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
 #[cfg(target_os = "macos")]
@@ -651,6 +652,33 @@ fn configured_session_with_macos_worker() -> (OverlaySession, u64) {
 	session.config.self_capture_exception_window_ids = vec![17];
 
 	(session, worker_debug_id)
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn sync_live_surface_bg_from_stream_promotes_clean_live_snapshot() {
+	let monitor = test_monitor();
+	let stream = MacLiveFrameStream::new();
+	let captured_at = Instant::now();
+	let mut session = OverlaySession::new();
+
+	stream.debug_set_active_stream_generation(monitor.id, 1);
+	stream.debug_set_self_capture_filter_complete(monitor.id, true);
+	stream.debug_store_test_snapshot_with_metadata(monitor, 7, 1, captured_at);
+
+	session.live_sample_stream = Some(stream);
+	session.cursor_monitor = Some(monitor);
+
+	session.sync_live_surface_bg_from_stream(monitor);
+
+	assert_eq!(session.state.live_bg_monitor, Some(monitor));
+	assert!(session.state.live_bg_image.is_some());
+	assert_eq!(session.last_live_surface_bg_snapshot_at, Some(captured_at));
+	assert_eq!(session.state.live_bg_generation, 1);
+
+	session.sync_live_surface_bg_from_stream(monitor);
+
+	assert_eq!(session.state.live_bg_generation, 1);
 }
 
 #[cfg(target_os = "macos")]
@@ -3774,28 +3802,20 @@ fn toolbar_window_stays_visible_while_final_capture_is_pending() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn frozen_visual_handoff_stays_pending_while_frozen_entry_is_still_idle() {
+fn frozen_visual_handoff_ends_once_display_is_ready() {
 	let monitor = test_monitor();
 	let mut session = OverlaySession::new();
 
 	session.state.begin_freeze(monitor);
 
 	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
-
-	assert!(session.frozen_visual_handoff_pending_for_monitor(monitor));
-
-	session.toolbar_window_drawn_once = true;
-
-	assert!(session.frozen_visual_handoff_pending_for_monitor(monitor));
-
-	session.frozen_edit_undo_stack.push(FrozenEditKind::BrushStroke);
 
 	assert!(!session.frozen_visual_handoff_pending_for_monitor(monitor));
 }
 
 #[cfg(target_os = "macos")]
 #[test]
-fn frozen_surface_bg_stays_locked_during_idle_frozen_entry() {
+fn frozen_surface_bg_unlocks_as_soon_as_display_is_ready() {
 	let monitor = test_monitor();
 	let mut session = OverlaySession::new();
 
@@ -3803,11 +3823,57 @@ fn frozen_surface_bg_stays_locked_during_idle_frozen_entry() {
 
 	finish_frozen_display_state(&mut session, monitor, test_frozen_image());
 
-	assert!(!session.allow_frozen_surface_bg_for_overlay_monitor(monitor, false));
-
-	session.frozen_edit_undo_stack.push(FrozenEditKind::BrushStroke);
-
 	assert!(session.allow_frozen_surface_bg_for_overlay_monitor(monitor, false));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn live_surface_bg_refresh_disables_during_drag_capture_and_loupe() {
+	let monitor = test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.mode = OverlayMode::Live;
+	session.cursor_monitor = Some(monitor);
+
+	assert!(!session.should_draw_live_surface_bg_for_overlay_monitor(monitor));
+	assert!(session.should_refresh_live_surface_bg_for_overlay_monitor(monitor));
+
+	session.state.live_bg_monitor = Some(monitor);
+	session.state.live_bg_image = Some(test_frozen_image());
+
+	assert!(session.should_draw_live_surface_bg_for_overlay_monitor(monitor));
+	assert!(!session.should_refresh_live_surface_bg_for_overlay_monitor(monitor));
+
+	session.state.alt_held = true;
+
+	assert!(session.should_draw_live_surface_bg_for_overlay_monitor(monitor));
+	assert!(!session.should_refresh_live_surface_bg_for_overlay_monitor(monitor));
+
+	session.set_live_capture_interaction(LiveCaptureInteraction::PressPending {
+		monitor,
+		press_global: monitor.origin,
+		click_target: None,
+		release_global: None,
+		released: false,
+	});
+
+	assert!(session.should_draw_live_surface_bg_for_overlay_monitor(monitor));
+	assert!(!session.should_refresh_live_surface_bg_for_overlay_monitor(monitor));
+
+	session.set_live_capture_interaction(LiveCaptureInteraction::DraggingSelection {
+		monitor,
+		press_global: monitor.origin,
+		current_global: monitor.origin,
+	});
+
+	assert!(session.should_draw_live_surface_bg_for_overlay_monitor(monitor));
+	assert!(!session.should_refresh_live_surface_bg_for_overlay_monitor(monitor));
+
+	session.state.live_bg_monitor = None;
+	session.state.live_bg_image = None;
+
+	assert!(!session.should_draw_live_surface_bg_for_overlay_monitor(monitor));
+	assert!(session.should_refresh_live_surface_bg_for_overlay_monitor(monitor));
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -3828,6 +3894,16 @@ fn handle_capture_redraw_does_not_rearm_inflight_freeze_capture() {
 	assert!(session_pending_freeze_capture(&session).is_none());
 	assert!(!session_frozen_capture_armed(&session));
 	assert!(session.capture_windows_hidden);
+}
+
+#[test]
+fn frozen_selection_scrim_matches_live_drag_scrim() {
+	for theme in [HudTheme::Dark, HudTheme::Light] {
+		assert_eq!(
+			WindowRenderer::frozen_selection_scrim_color(theme),
+			WindowRenderer::live_drag_selection_scrim_color(theme),
+		);
+	}
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -61,7 +61,7 @@ use crate::overlay::{
 	FrozenCommittedOverlay, FrozenEditKind, FrozenExportTransform, FrozenImagePatch,
 	FrozenMosaicEdit, FrozenSelectionDragState, FrozenSpotlightAnnotation, FrozenTextAnnotation,
 	FrozenTextEditState, FrozenTextInputSource, FrozenToolbarState, FrozenToolbarTool,
-	HUD_LOUPE_STRIP_GAP_POINTS, HudRedrawSummary, HudTheme, LiveCaptureInteraction,
+	HUD_LOUPE_STRIP_GAP_POINTS, HudRedrawSummary, HudTheme,
 	OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, OverlaySession, Pos2, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL,
 	SELECTION_SIZE_BADGE_GAP_PX, SELECTION_SIZE_BADGE_INSIDE_MARGIN_PX,
 	SELECTION_SIZE_BADGE_SCREEN_MARGIN_PX, SelectionDashedBorderCache, SelectionFlowGeometryCache,
@@ -69,6 +69,8 @@ use crate::overlay::{
 	TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Vec2, WindowCaptureAlphaMode, WindowRenderer,
 	hud_helpers,
 };
+#[cfg(target_os = "macos")]
+use crate::overlay::LiveCaptureInteraction;
 #[cfg(target_os = "macos")]
 use crate::overlay::{
 	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry,

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -46,6 +46,8 @@ use crate::backend::CaptureBackend;
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::MacLiveFrameStream;
 use crate::overlay::FrozenCaptureSource;
+#[cfg(target_os = "macos")]
+use crate::overlay::LiveCaptureInteraction;
 #[cfg(not(target_os = "macos"))]
 use crate::overlay::OverlayConfig;
 use crate::overlay::PngAction;
@@ -61,16 +63,13 @@ use crate::overlay::{
 	FrozenCommittedOverlay, FrozenEditKind, FrozenExportTransform, FrozenImagePatch,
 	FrozenMosaicEdit, FrozenSelectionDragState, FrozenSpotlightAnnotation, FrozenTextAnnotation,
 	FrozenTextEditState, FrozenTextInputSource, FrozenToolbarState, FrozenToolbarTool,
-	HUD_LOUPE_STRIP_GAP_POINTS, HudRedrawSummary, HudTheme,
-	OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, OverlaySession, Pos2, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL,
-	SELECTION_SIZE_BADGE_GAP_PX, SELECTION_SIZE_BADGE_INSIDE_MARGIN_PX,
-	SELECTION_SIZE_BADGE_SCREEN_MARGIN_PX, SelectionDashedBorderCache, SelectionFlowGeometryCache,
-	SelectionSizeBadgeTarget, SurfaceFrameSkipReason, TOOLBAR_CAPTURE_GAP_PX,
-	TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Vec2, WindowCaptureAlphaMode, WindowRenderer,
-	hud_helpers,
+	HUD_LOUPE_STRIP_GAP_POINTS, HudRedrawSummary, HudTheme, OCCLUDED_FRAME_REDRAW_RETRY_WINDOW,
+	OverlaySession, Pos2, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL, SELECTION_SIZE_BADGE_GAP_PX,
+	SELECTION_SIZE_BADGE_INSIDE_MARGIN_PX, SELECTION_SIZE_BADGE_SCREEN_MARGIN_PX,
+	SelectionDashedBorderCache, SelectionFlowGeometryCache, SelectionSizeBadgeTarget,
+	SurfaceFrameSkipReason, TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement,
+	Vec2, WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
 };
-#[cfg(target_os = "macos")]
-use crate::overlay::LiveCaptureInteraction;
 #[cfg(target_os = "macos")]
 use crate::overlay::{
 	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry,

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -36,9 +36,7 @@ use crate::overlay::tests::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{FrozenGlobalHotkey, PngAction};
-use crate::overlay::{
-	LiveCaptureInteraction, LiveClickCaptureTarget, OverlayControl,
-};
+use crate::overlay::{LiveCaptureInteraction, LiveClickCaptureTarget, OverlayControl};
 #[cfg(target_os = "macos")]
 use crate::state::{WindowHit, WindowRect};
 

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -15,14 +15,18 @@ use crate::overlay::FrozenCaptureSource;
 #[cfg(target_os = "macos")]
 use crate::overlay::FrozenToolbarTool;
 #[cfg(target_os = "macos")]
+use crate::overlay::MacOSNativeCaptureInputEvent;
+#[cfg(target_os = "macos")]
+use crate::overlay::OverlayKeyboardInputEvent;
+#[cfg(target_os = "macos")]
 use crate::overlay::PENDING_CLICK_HIT_TEST_TIMEOUT;
 use crate::overlay::tests;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::WorkerResponse;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::{
-	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, LiveCursorSample,
-	LiveSampleApplyResult, ModifiersState, OverlayExit, StartupLiveRgbPlan, WindowId,
+	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, Ime, Key, LiveCursorSample,
+	LiveSampleApplyResult, ModifiersState, NamedKey, OverlayExit, StartupLiveRgbPlan, WindowId,
 	WindowListSnapshot,
 };
 use crate::overlay::tests::{
@@ -122,6 +126,153 @@ fn frozen_cursor_tracking_keeps_toolbar_hover_cursor_without_resampling_device_p
 
 	assert_eq!(session.state.cursor, Some(expected_cursor));
 	assert_eq!(session.cursor_monitor, Some(monitor));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_toolbar_pointer_move_starts_manual_drag_without_winit_window_events() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.session_active = true;
+	session.state.monitor = Some(monitor);
+	session.toolbar_state.visible = true;
+	session.toolbar_window_visible = true;
+	session.toolbar_left_button_down = true;
+	session.toolbar_state.drag_start_eligible = true;
+	session.toolbar_state.drag_anchor = Some(Pos2::new(8.0, 8.0));
+	session.toolbar_outer_pos = Some(GlobalPoint::new(160, 140));
+
+	assert!(matches!(
+		session.handle_native_toolbar_pointer_moved(
+			monitor,
+			Pos2::new(40.0, 26.0),
+			GlobalPoint::new(200, 166),
+			Some(GlobalPoint::new(160, 140)),
+		),
+		OverlayControl::Continue
+	));
+	assert!(session.toolbar_state.dragging);
+	assert_eq!(session.toolbar_pointer_local, Some(Pos2::new(40.0, 26.0)));
+	assert_eq!(session.state.cursor, Some(GlobalPoint::new(200, 166)));
+	assert!(session.pending_toolbar_outer_pos.is_some());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_capture_input_ready_routes_toolbar_pointer_left_without_window_id() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.toolbar_state.visible = true;
+	session.toolbar_pointer_local = Some(Pos2::new(12.0, 10.0));
+
+	session
+		.native_capture_input_queue
+		.lock()
+		.expect("native capture input queue")
+		.push_back(MacOSNativeCaptureInputEvent::ToolbarPointerLeft);
+
+	assert!(matches!(session.handle_native_capture_input_ready(), OverlayControl::Continue));
+	assert_eq!(session.toolbar_pointer_local, None);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_capture_input_ready_routes_keyboard_input_to_frozen_text_edit() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	assert!(session.begin_frozen_text_edit_at(monitor, GlobalPoint::new(140, 160)));
+
+	session.native_capture_input_queue.lock().expect("native capture input queue").push_back(
+		MacOSNativeCaptureInputEvent::KeyboardInput {
+			monitor: Some(monitor),
+			event: OverlayKeyboardInputEvent {
+				logical_key: Key::Character(String::from("A").into()),
+				text: Some(String::from("A")),
+				state: ElementState::Pressed,
+				repeat: false,
+			},
+		},
+	);
+
+	assert!(matches!(session.handle_native_capture_input_ready(), OverlayControl::Continue));
+	assert_eq!(session.frozen_text_edit.as_ref().map(|edit| edit.text.as_str()), Some("A"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_capture_input_ready_routes_ime_preedit_to_frozen_text_edit() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	assert!(session.begin_frozen_text_edit_at(monitor, GlobalPoint::new(140, 160)));
+
+	session.native_capture_input_queue.lock().expect("native capture input queue").push_back(
+		MacOSNativeCaptureInputEvent::Ime {
+			monitor: Some(monitor),
+			event: Ime::Preedit(String::from("汉"), Some((0, 0))),
+		},
+	);
+
+	assert!(matches!(session.handle_native_capture_input_ready(), OverlayControl::Continue));
+	assert_eq!(
+		session.frozen_text_edit.as_ref().and_then(|edit| edit.ime_preedit.as_deref()),
+		Some("汉")
+	);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_capture_input_ready_routes_scroll_capture_escape_without_winit_window_events() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.scroll_capture.active = true;
+
+	session.native_capture_input_queue.lock().expect("native capture input queue").push_back(
+		MacOSNativeCaptureInputEvent::KeyboardInput {
+			monitor: Some(monitor),
+			event: OverlayKeyboardInputEvent {
+				logical_key: Key::Named(NamedKey::Escape),
+				text: None,
+				state: ElementState::Pressed,
+				repeat: false,
+			},
+		},
+	);
+
+	assert!(matches!(
+		session.handle_native_capture_input_ready(),
+		OverlayControl::Exit(OverlayExit::Cancelled)
+	));
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -34,8 +34,10 @@ use crate::overlay::tests::{
 	OverlayMode, OverlaySession, OverlayState, Pos2, Rect, RectPoints, Rgb, Vec2, WindowRenderer,
 	hud_helpers,
 };
+#[cfg(target_os = "macos")]
+use crate::overlay::{FrozenGlobalHotkey, PngAction};
 use crate::overlay::{
-	FrozenGlobalHotkey, LiveCaptureInteraction, LiveClickCaptureTarget, OverlayControl, PngAction,
+	LiveCaptureInteraction, LiveClickCaptureTarget, OverlayControl,
 };
 #[cfg(target_os = "macos")]
 use crate::state::{WindowHit, WindowRect};

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -34,7 +34,9 @@ use crate::overlay::tests::{
 	OverlayMode, OverlaySession, OverlayState, Pos2, Rect, RectPoints, Rgb, Vec2, WindowRenderer,
 	hud_helpers,
 };
-use crate::overlay::{LiveCaptureInteraction, LiveClickCaptureTarget, OverlayControl};
+use crate::overlay::{
+	FrozenGlobalHotkey, LiveCaptureInteraction, LiveClickCaptureTarget, OverlayControl, PngAction,
+};
 #[cfg(target_os = "macos")]
 use crate::state::{WindowHit, WindowRect};
 
@@ -1500,6 +1502,37 @@ fn wants_global_loupe_hotkey_only_in_live_mode() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn wants_global_frozen_hotkeys_only_in_plain_frozen_mode() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	assert!(!session.wants_global_frozen_hotkeys());
+
+	session.session_active = true;
+	session.state.mode = OverlayMode::Live;
+
+	assert!(!session.wants_global_frozen_hotkeys());
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_display_state(&mut session, monitor, tests::test_frozen_image());
+
+	assert!(session.wants_global_frozen_hotkeys());
+
+	session.scroll_capture.active = true;
+
+	assert!(!session.wants_global_frozen_hotkeys());
+
+	session.scroll_capture.active = false;
+	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	assert!(session.begin_frozen_text_edit_at(monitor, GlobalPoint::new(140, 160)));
+	assert!(!session.wants_global_frozen_hotkeys());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn global_escape_hotkey_cancels_live_capture() {
 	let mut session = OverlaySession::new();
 
@@ -1538,6 +1571,48 @@ fn global_loupe_hotkey_tracks_live_hold_state() {
 	assert!(matches!(session.handle_global_loupe_hotkey(false), OverlayControl::Continue));
 	assert!(!session.state.alt_held);
 	assert!(!session.loupe_activation_key_down);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn global_frozen_copy_hotkey_queues_copy_without_key_window() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.session_active = true;
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_ready_state(&mut session, monitor, tests::test_frozen_image());
+
+	assert!(matches!(
+		session.handle_global_frozen_hotkey(FrozenGlobalHotkey::Copy),
+		OverlayControl::Continue
+	));
+	assert_eq!(session.pending_png_action, Some(PngAction::Copy));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn global_frozen_copy_hotkey_ignores_active_text_edit() {
+	let monitor = tests::test_monitor();
+	let mut session = OverlaySession::new();
+
+	session.session_active = true;
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_ready_state(&mut session, monitor, tests::test_frozen_image());
+
+	session.state.frozen_capture_rect = Some(RectPoints::new(100, 120, 220, 180));
+	session.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+
+	assert!(session.begin_frozen_text_edit_at(monitor, GlobalPoint::new(140, 160)));
+	assert!(matches!(
+		session.handle_global_frozen_hotkey(FrozenGlobalHotkey::Copy),
+		OverlayControl::Continue
+	));
+	assert_eq!(session.pending_png_action, None);
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -752,7 +752,7 @@ fn frozen_selection_drag_defers_pending_toolbar_window_move() {
 }
 
 #[test]
-fn frozen_selection_drag_skips_toolbar_focus_even_before_first_show() {
+fn frozen_selection_drag_keeps_toolbar_show_unfocused_even_before_first_show() {
 	let monitor = tests::test_monitor();
 	let capture_rect = RectPoints::new(100, 120, 200, 240);
 	let mut session = OverlaySession::new();
@@ -767,7 +767,7 @@ fn frozen_selection_drag_skips_toolbar_focus_even_before_first_show() {
 
 	assert!(!session.toolbar_window_visible);
 	assert!(!session.skip_toolbar_focus_on_next_show);
-	assert!(session.should_focus_frozen_toolbar_window_on_show());
+	assert!(!session.should_focus_frozen_toolbar_window_on_show());
 	assert!(session.begin_frozen_selection_drag(GlobalPoint::new(150, 180)));
 	assert!(session.skip_toolbar_focus_on_next_show);
 	assert!(!session.should_focus_frozen_toolbar_window_on_show());

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -352,6 +352,81 @@ fn live_snapshot_followup_can_finish_background_capture_before_timeout() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn background_capture_prefers_live_surface_bg_for_initial_display_handoff() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let live_image = RgbaImage::from_pixel(8, 8, Rgba([91, 27, 63, 255]));
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.state.live_bg_monitor = Some(monitor);
+	session.state.live_bg_image = Some(live_image.clone());
+
+	session
+		.live_sample_stream
+		.as_ref()
+		.unwrap()
+		.debug_set_self_capture_filter_complete(monitor.id, true);
+	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
+		monitor,
+		2,
+		1,
+		Instant::now(),
+	);
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
+		None,
+		Some(cursor),
+	);
+
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&live_image));
+	assert!(session.state.frozen_export_image.is_some());
+	assert!(tests::session_export_authority_ready(&session));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn background_capture_followup_export_does_not_overwrite_live_surface_preview() {
+	let monitor = tests::test_monitor();
+	let cursor = GlobalPoint::new(120, 180);
+	let live_image = RgbaImage::from_pixel(8, 8, Rgba([101, 31, 79, 255]));
+	let (mut session, _original_worker_debug_id) = tests::configured_session_with_macos_worker();
+
+	session.state.live_bg_monitor = Some(monitor);
+	session.state.live_bg_image = Some(live_image.clone());
+
+	session.begin_frozen_capture_with_rect(
+		monitor,
+		Some(RectPoints::new(100, 140, 320, 240)),
+		None,
+		Some(cursor),
+	);
+
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&live_image));
+	assert!(session.state.frozen_export_image.is_none());
+	assert!(!tests::session_export_authority_ready(&session));
+
+	session
+		.live_sample_stream
+		.as_ref()
+		.unwrap()
+		.debug_set_self_capture_filter_complete(monitor.id, true);
+	session.live_sample_stream.as_ref().unwrap().debug_store_test_snapshot_with_metadata(
+		monitor,
+		4,
+		1,
+		Instant::now(),
+	);
+
+	let _ = session.about_to_wait();
+
+	assert_eq!(session.state.frozen_display_image.as_ref(), Some(&live_image));
+	assert!(session.state.frozen_export_image.is_some());
+	assert!(tests::session_export_authority_ready(&session));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn window_matte_capture_seeds_preview_and_arms_worker_without_hiding_overlay_windows() {
 	let monitor = tests::test_monitor();
 	let cursor = GlobalPoint::new(120, 180);

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -45,6 +45,10 @@ impl OverlaySession {
 		} else {
 			self.last_toolbar_window_move_at = Instant::now();
 		}
+
+		#[cfg(target_os = "macos")]
+		let _ = self.sync_native_capture_shells();
+
 		if changed {
 			self.request_redraw_toolbar_window();
 		}
@@ -124,9 +128,6 @@ impl OverlaySession {
 
 		let cursor_local =
 			Pos2::new((position.x / toolbar_scale) as f32, (position.y / toolbar_scale) as f32);
-
-		self.toolbar_pointer_local = Some(cursor_local);
-
 		let cached_toolbar_outer_pos = self.toolbar_outer_pos;
 		let monitor = match self.state.monitor.or_else(|| self.active_cursor_monitor()) {
 			Some(monitor) => monitor,
@@ -138,81 +139,15 @@ impl OverlaySession {
 			cached_toolbar_outer_pos,
 			self.toolbar_state.floating_position,
 		);
-		let global_cursor = toolbar_outer_pos
-			.map(|outer| Self::toolbar_cursor_global_position_from_outer(outer, cursor_local));
 
-		if self.handle_toolbar_cursor_move_for_active_selection(global_cursor) {
-			return OverlayControl::Continue;
-		}
-
-		self.update_toolbar_cursor_event_from_global(
+		self.handle_toolbar_pointer_moved_from_positions(
 			monitor,
 			cursor_local,
-			global_cursor,
+			toolbar_outer_pos
+				.map(|outer| Self::toolbar_cursor_global_position_from_outer(outer, cursor_local)),
 			cached_toolbar_outer_pos,
 			window_toolbar_outer_pos,
-		);
-
-		#[cfg(not(target_os = "macos"))]
-		let drag_monitor = global_cursor.and_then(|cursor| self.monitor_at(cursor)).unwrap_or(monitor);
-		#[cfg(target_os = "macos")]
-		let mouse_drag = self.toolbar_left_button_down && self.toolbar_state.dragging;
-		#[cfg(not(target_os = "macos"))]
-		let mut mouse_drag = self.toolbar_left_button_down && self.toolbar_state.dragging;
-
-		if self.toolbar_left_button_down
-			&& self.toolbar_state.drag_start_eligible
-			&& self.toolbar_state.drag_anchor.is_none()
-		{
-			self.toolbar_state.drag_anchor = Some(cursor_local);
-		}
-		if !mouse_drag
-			&& let Some(drag_anchor) = self.toolbar_state.drag_anchor
-			&& Self::toolbar_drag_threshold_reached(cursor_local, drag_anchor)
-		{
-			#[cfg(target_os = "macos")]
-			{
-				return self.begin_native_toolbar_drag();
-			}
-
-			#[cfg(not(target_os = "macos"))]
-			if let (Some(global_cursor), Some(toolbar_outer_pos)) =
-				(global_cursor, toolbar_outer_pos)
-			{
-				self.toolbar_state.drag_offset = Vec2::new(
-					global_cursor.x as f32 - toolbar_outer_pos.x as f32,
-					global_cursor.y as f32 - toolbar_outer_pos.y as f32,
-				);
-				self.toolbar_state.dragging = true;
-				self.toolbar_state.drag_start_eligible = false;
-				self.toolbar_state.drag_anchor = None;
-				mouse_drag = true;
-			}
-		}
-		#[cfg(not(target_os = "macos"))]
-		if mouse_drag && global_cursor.is_none() {
-			mouse_drag = false;
-		}
-		#[cfg(not(target_os = "macos"))]
-		if mouse_drag && let Some(global_cursor) = global_cursor {
-			let desired_global = Pos2::new(
-				global_cursor.x as f32 - self.toolbar_state.drag_offset.x,
-				global_cursor.y as f32 - self.toolbar_state.drag_offset.y,
-			);
-			let desired_local = Pos2::new(
-				desired_global.x - drag_monitor.origin.x as f32,
-				desired_global.y - drag_monitor.origin.y as f32,
-			);
-			let _ = self.update_toolbar_outer_position(drag_monitor, desired_local);
-		}
-		#[cfg(target_os = "macos")]
-		if self.toolbar_state.dragging {
-			return OverlayControl::Continue;
-		}
-
-		self.request_redraw_toolbar_window();
-
-		OverlayControl::Continue
+		)
 	}
 
 	fn handle_toolbar_cursor_move_for_active_selection(
@@ -264,6 +199,116 @@ impl OverlaySession {
 			return OverlayControl::Continue;
 		};
 		let _ = toolbar_window_handle.drag_window();
+
+		OverlayControl::Continue
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn handle_native_toolbar_pointer_moved(
+		&mut self,
+		monitor: MonitorRect,
+		cursor_local: Pos2,
+		global_cursor: GlobalPoint,
+		toolbar_outer_pos: Option<GlobalPoint>,
+	) -> OverlayControl {
+		if !matches!(self.state.mode, OverlayMode::Frozen) || !self.toolbar_state.visible {
+			return OverlayControl::Continue;
+		}
+
+		self.handle_toolbar_pointer_moved_from_positions(
+			monitor,
+			cursor_local,
+			Some(global_cursor),
+			self.toolbar_outer_pos,
+			toolbar_outer_pos,
+		)
+	}
+
+	fn handle_toolbar_pointer_moved_from_positions(
+		&mut self,
+		monitor: MonitorRect,
+		cursor_local: Pos2,
+		global_cursor: Option<GlobalPoint>,
+		cached_toolbar_outer_pos: Option<GlobalPoint>,
+		window_toolbar_outer_pos: Option<GlobalPoint>,
+	) -> OverlayControl {
+		self.toolbar_pointer_local = Some(cursor_local);
+
+		if self.handle_toolbar_cursor_move_for_active_selection(global_cursor) {
+			return OverlayControl::Continue;
+		}
+
+		self.update_toolbar_cursor_event_from_global(
+			monitor,
+			cursor_local,
+			global_cursor,
+			cached_toolbar_outer_pos,
+			window_toolbar_outer_pos,
+		);
+
+		let drag_monitor =
+			global_cursor.and_then(|cursor| self.monitor_at(cursor)).unwrap_or(monitor);
+		#[cfg(target_os = "macos")]
+		let manual_toolbar_drag = self.should_host_toolbar_pointer_input_in_native_shell();
+		#[cfg(not(target_os = "macos"))]
+		let manual_toolbar_drag = true;
+		let mut mouse_drag = self.toolbar_left_button_down && self.toolbar_state.dragging;
+
+		if self.toolbar_left_button_down
+			&& self.toolbar_state.drag_start_eligible
+			&& self.toolbar_state.drag_anchor.is_none()
+		{
+			self.toolbar_state.drag_anchor = Some(cursor_local);
+		}
+		if !mouse_drag
+			&& let Some(drag_anchor) = self.toolbar_state.drag_anchor
+			&& Self::toolbar_drag_threshold_reached(cursor_local, drag_anchor)
+		{
+			if manual_toolbar_drag {
+				if let (Some(global_cursor), Some(toolbar_outer_pos)) =
+					(global_cursor, window_toolbar_outer_pos.or(cached_toolbar_outer_pos))
+				{
+					self.toolbar_state.drag_offset = Vec2::new(
+						global_cursor.x as f32 - toolbar_outer_pos.x as f32,
+						global_cursor.y as f32 - toolbar_outer_pos.y as f32,
+					);
+					self.toolbar_state.dragging = true;
+					self.toolbar_state.drag_start_eligible = false;
+					self.toolbar_state.drag_anchor = None;
+					mouse_drag = true;
+				}
+			} else {
+				#[cfg(target_os = "macos")]
+				{
+					return self.begin_native_toolbar_drag();
+				}
+			}
+		}
+		if mouse_drag && global_cursor.is_none() {
+			mouse_drag = false;
+		}
+		if mouse_drag && let Some(global_cursor) = global_cursor {
+			let desired_global = Pos2::new(
+				global_cursor.x as f32 - self.toolbar_state.drag_offset.x,
+				global_cursor.y as f32 - self.toolbar_state.drag_offset.y,
+			);
+			let desired_local = Pos2::new(
+				desired_global.x - drag_monitor.origin.x as f32,
+				desired_global.y - drag_monitor.origin.y as f32,
+			);
+			let _ = self.update_toolbar_outer_position(drag_monitor, desired_local);
+
+			self.force_apply_pending_toolbar_window_move();
+
+			#[cfg(target_os = "macos")]
+			let _ = self.sync_native_capture_shells();
+		}
+		#[cfg(target_os = "macos")]
+		if !manual_toolbar_drag && self.toolbar_state.dragging {
+			return OverlayControl::Continue;
+		}
+
+		self.request_redraw_toolbar_window();
 
 		OverlayControl::Continue
 	}
@@ -444,23 +489,13 @@ impl OverlaySession {
 			|| !self.toolbar_state.visible
 	}
 
-	#[cfg(any(target_os = "macos", test))]
+	#[cfg(test)]
 	pub(super) fn should_focus_frozen_toolbar_window_on_show(&self) -> bool {
-		!self.toolbar_window_visible
-			&& !self.skip_toolbar_focus_on_next_show
-			&& matches!(self.state.mode, OverlayMode::Frozen)
-			&& !self.scroll_capture.active
+		false
 	}
 
 	pub(super) fn set_toolbar_window_hidden(&mut self) {
 		if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-			#[cfg(target_os = "macos")]
-			super::macos_update_capture_window_focus_policy(
-				toolbar_window.window.as_ref(),
-				false,
-				"toolbar_hidden",
-			);
-
 			#[cfg(target_os = "macos")]
 			let _ = toolbar_window.window.set_cursor_hittest(false);
 
@@ -476,6 +511,9 @@ impl OverlaySession {
 		}
 		self.toolbar_window_warmup_redraws_remaining = 0;
 		self.last_present_at = Instant::now();
+
+		#[cfg(target_os = "macos")]
+		let _ = self.sync_native_capture_shells();
 	}
 
 	pub(super) fn draw_toolbar_window_frame(
@@ -583,8 +621,6 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	fn prepare_toolbar_window_for_draw(&mut self, monitor: MonitorRect) -> Option<bool> {
-		let should_focus_frozen_keyboard = self.should_focus_frozen_toolbar_window_on_show();
-
 		if !self.toolbar_window_visible {
 			self.maybe_apply_pending_startup_aux_live_stream_filter_upgrade(monitor);
 		}
@@ -609,9 +645,8 @@ impl OverlaySession {
 				"toolbar_first_show",
 			);
 		}
-		if should_focus_frozen_keyboard {
-			self.focus_frozen_keyboard_window();
-		}
+
+		let _ = self.sync_native_capture_shells();
 
 		Some(toolbar_became_visible)
 	}
@@ -702,6 +737,16 @@ impl OverlaySession {
 		&mut self,
 		current_cursor: Option<GlobalPoint>,
 	) {
+		if self.should_host_toolbar_pointer_input_in_native_shell() {
+			self.toolbar_window_cursor_hittest_enabled = false;
+
+			if let Some(toolbar_window) = self.toolbar_window.as_ref() {
+				let _ = toolbar_window.window.set_cursor_hittest(false);
+			}
+
+			return;
+		}
+
 		let enabled = self.toolbar_window_cursor_hittest_should_be_enabled(current_cursor);
 		let Some(toolbar_window) = self.toolbar_window.as_ref() else {
 			self.toolbar_window_cursor_hittest_enabled = false;

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -581,6 +581,7 @@ impl OverlaySession {
 				self.config.selection_flow_stroke_width_px,
 				false,
 				false,
+				false,
 				None,
 				false,
 				false,

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -54,6 +54,10 @@ impl OverlaySession {
 		self.prime_startup_live_stream_nonblocking(startup_monitor);
 
 		let startup_stream_prime_ms = startup_stream_prime_started_at.elapsed().as_millis();
+		#[cfg(target_os = "macos")]
+		let startup_live_bg_seed_ms = self.seed_startup_live_surface_bg(startup_monitor);
+		#[cfg(not(target_os = "macos"))]
+		let startup_live_bg_seed_ms = 0;
 		let gpu_init_started_at = Instant::now();
 
 		if self.gpu.is_none() {
@@ -101,6 +105,7 @@ impl OverlaySession {
 			worker_setup_ms,
 			monitor_enum_ms,
 			startup_stream_prime_ms,
+			startup_live_bg_seed_ms,
 			gpu_init_ms,
 			overlay_windows_ms = window_creation.overlay_windows_ms,
 			hud_window_ms = window_creation.hud_window_ms,
@@ -183,6 +188,38 @@ impl OverlaySession {
 		);
 
 		Ok(())
+	}
+
+	#[cfg(target_os = "macos")]
+	fn seed_startup_live_surface_bg(&mut self, startup_monitor: Option<MonitorRect>) -> u128 {
+		let started_at = Instant::now();
+		let Some(monitor) = startup_monitor else {
+			return 0;
+		};
+		let mut backend = backend::default_capture_backend_with_self_capture_exception_window_ids(
+			self.config.self_capture_exception_window_ids.clone(),
+		);
+
+		match backend.capture_monitor(monitor) {
+			Ok(image) => {
+				self.state.live_bg_monitor = Some(monitor);
+				self.state.live_bg_image = Some(image);
+				self.state.live_bg_generation = self.state.live_bg_generation.wrapping_add(1);
+				#[cfg(target_os = "macos")]
+				{
+					self.last_live_surface_bg_snapshot_at = None;
+				}
+			},
+			Err(err) => {
+				tracing::debug!(
+					monitor_id = monitor.id,
+					error = ?err,
+					"Failed to seed startup live surface background."
+				);
+			},
+		}
+
+		started_at.elapsed().as_millis()
 	}
 
 	fn setup_startup_worker(&mut self) -> u128 {

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -85,6 +85,8 @@ impl OverlaySession {
 
 		self.session_active = true;
 
+		#[cfg(target_os = "macos")]
+		self.ensure_native_capture_shells()?;
 		self.request_redraw_all();
 
 		let request_redraw_ms = request_redraw_started_at.elapsed().as_millis();
@@ -469,6 +471,8 @@ impl OverlaySession {
 		#[cfg(target_os = "macos")]
 		let startup_aux_window_waker = self.startup_aux_window_waker.clone();
 		#[cfg(target_os = "macos")]
+		let native_capture_input_waker = self.native_capture_input_waker.clone();
+		#[cfg(target_os = "macos")]
 		let external_scroll_input_drain_reader =
 			self.scroll_capture.external_scroll_input_drain_reader.clone();
 
@@ -484,6 +488,7 @@ impl OverlaySession {
 			self.scroll_capture_starting_hook = scroll_capture_starting_hook;
 			self.scroll_capture_started_hook = scroll_capture_started_hook;
 			self.startup_aux_window_waker = startup_aux_window_waker;
+			self.native_capture_input_waker = native_capture_input_waker;
 			self.pending_startup_aux_live_stream_filter_upgrade = false;
 			self.scroll_capture.external_scroll_input_drain_reader =
 				external_scroll_input_drain_reader;
@@ -733,20 +738,6 @@ impl OverlaySession {
 	}
 
 	fn discard_prewarmed_startup_resources(&mut self) {
-		#[cfg(target_os = "macos")]
-		{
-			for window in self.windows.values() {
-				overlay::macos_clear_capture_window_focus_policy(window.window.as_ref());
-			}
-
-			if let Some(hud_window) = self.hud_window.as_ref() {
-				overlay::macos_clear_capture_window_focus_policy(hud_window.window.as_ref());
-			}
-			if let Some(toolbar_window) = self.toolbar_window.as_ref() {
-				overlay::macos_clear_capture_window_focus_policy(toolbar_window.window.as_ref());
-			}
-		}
-
 		self.windows.clear();
 
 		self.hud_window = None;


### PR DESCRIPTION
## Summary
- move macOS live overlay and frozen toolbar pointer input onto passive AppKit shells instead of winit-owned focus policy hooks
- add a dedicated native key-focus shell for Frozen text editing and scroll capture, while keeping Rust capture/session/render/export logic intact
- bridge native shell input back through the app-shell event loop, add regression coverage, and document the new macOS capture-window contract and validation matrix

## Verification
- cargo make fmt-rust-check
- cargo make lint
- cargo test -p rsnap-overlay --lib
- cargo build --profile final-release -p rsnap
- cargo run --profile final-release -p rsnap

## Issues
- XY-277
- XY-278
- XY-279
- XY-280
- XY-281
