### PR TITLE
Complete single-root macOS capture owner

### DIFF
--- a/apps/rsnap/src/settings_window.rs
+++ b/apps/rsnap/src/settings_window.rs
@@ -19,7 +19,6 @@ use egui_wgpu::Renderer;
 use global_hotkey::hotkey::HotKey;
 use wgpu::Surface;
 use wgpu::SurfaceConfiguration;
-use winit::event::ElementState;
 use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::ModifiersState;
@@ -228,17 +227,14 @@ impl SettingsWindow {
 
 				self.window.request_redraw();
 			},
-			WindowEvent::KeyboardInput { event, .. } if self.capture_hotkey_recording => {
-				if event.state == ElementState::Pressed {
-					self.handle_capture_hotkey_recording_input(event);
-				}
-			},
 			WindowEvent::ThemeChanged(_) => {
 				// Follow system theme changes when ThemeMode::System is active.
 				self.window.request_redraw();
 			},
 			WindowEvent::KeyboardInput { event, .. } => {
-				if platform::should_close_from_keyboard(self.modifiers, event) {
+				if self.capture_hotkey_recording && event.state.is_pressed() {
+					self.handle_capture_hotkey_recording_input(event);
+				} else if platform::should_close_from_keyboard(self.modifiers, event) {
 					return SettingsControl::CloseRequested;
 				}
 			},

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -47,5 +47,5 @@ Then keep the body descriptive:
   directories
 - `docs/reference/live-sampling.md` for the stream-first live RGB and loupe sampling path
 - `docs/reference/window-hit-testing.md` for live-mode hovered-window targeting strategy
-- `docs/reference/macos-native-capture-window-layer.md` for the passive AppKit shell and
-  explicit key-focus shell boundary on macOS
+- `docs/reference/macos-native-capture-window-layer.md` for the single AppKit root-owner capture
+  topology, passive pointer shells, and explicit key-focus shell boundary on macOS

--- a/docs/reference/macos-native-capture-window-layer.md
+++ b/docs/reference/macos-native-capture-window-layer.md
@@ -73,6 +73,9 @@ Keyboard ownership is now explicit and scoped:
   composition can flow without turning the pointer shells into key windows.
 - Scroll capture uses the same key-focus shell pattern for `Esc`, `Space`, save shortcuts, and
   pause/undo controls.
+- During scroll capture that key-focus shell stays nonactivating while the full-screen frozen
+  overlay windows switch into mouse passthrough, so the target app keeps receiving the real
+  scroll gesture.
 - When neither text editing nor scroll capture needs keyboard ownership, no capture window should
   remain key-capable.
 

--- a/docs/reference/macos-native-capture-window-layer.md
+++ b/docs/reference/macos-native-capture-window-layer.md
@@ -1,7 +1,8 @@
 # macOS Native Capture Window Layer
 
-Purpose: Describe the current macOS-native window shell that now owns passive pointer input and
-explicit keyboard-focus routing for rsnap capture sessions.
+Purpose: Describe the current macOS-native capture window layer that owns the single AppKit root
+window topology plus passive pointer input and explicit keyboard-focus routing for rsnap capture
+sessions.
 
 Read this when: You are changing macOS overlay-window behavior, focus/activation handling, IME
 support, or the app-shell boundary that wakes overlay input.
@@ -12,8 +13,8 @@ Inputs: `docs/spec/capture-session.md`, `packages/rsnap-overlay/src/overlay.rs`,
 
 Depends on: `docs/spec/capture-session.md`, `docs/reference/workspace-layout.md`
 
-Covers: The current passive AppKit shell model, the explicit key-focus shell, and the app-shell
-event boundary that bridges native input back into Rust.
+Covers: The current single-root AppKit capture topology, the passive pointer shells, the explicit
+key-focus shell, and the app-shell event boundary that bridges native input back into Rust.
 
 Spec boundary: `docs/spec/capture-session.md`
 
@@ -23,13 +24,32 @@ The Rust overlay session still owns capture state, display/export authority, wor
 rendering, and output flow. On macOS, window activation and pointer/IME routing are no longer
 owned exclusively by `winit` windows.
 
-Instead, rsnap now uses a split shell model:
+Instead, rsnap now uses a single native AppKit root-owner topology:
 
+- A single transparent AppKit root-owner window tracks the union frame of the active capture
+  surfaces and owns the native child-window topology.
+- The mirrored `winit` overlay, HUD, loupe, toolbar, and scroll-preview windows attach under that
+  root owner as child windows and remain the render surfaces.
 - Passive AppKit shells mirror live overlay windows and the frozen toolbar for pointer input.
 - A dedicated key-focus AppKit shell appears only when Frozen text editing or scroll capture
   needs keyboard ownership.
 - Rust remains the source of truth for session state and input handling; the native shells only
   gather platform events and wake the overlay session.
+
+## Single native root owner
+
+The root owner exists so macOS capture windows no longer behave like unrelated top-level surfaces.
+
+Current behavior:
+
+- The root owner is a transparent non-activating AppKit window created from the first live capture
+  surface and kept in sync with the union of the active overlay/HUD/loupe/toolbar/scroll-preview
+  frames.
+- Overlay render windows, auxiliary HUD windows, passive pointer shells, and the key-focus shell
+  attach under the same root owner through AppKit child-window ownership.
+- Window creation, deferred startup auxiliary-window creation, prewarm discard, and session exit
+  all rebuild or tear down that topology from `OverlaySession` instead of leaving orphan native
+  windows behind.
 
 ## Passive pointer shells
 
@@ -40,8 +60,8 @@ Current behavior:
 
 - Live overlay pointer movement and left-click selection come from passive AppKit shells.
 - Frozen toolbar pointer move, drag, hover, and scroll-wheel input also come from passive shells.
-- The mirrored `winit` windows remain the render surfaces, but they are not the macOS pointer
-  interaction authority for these flows.
+- The mirrored `winit` windows remain the render surfaces under the root owner, but they are not
+  the macOS pointer interaction authority for these flows.
 
 This is the layer that replaced the older per-window `winit` focus-policy patching path.
 
@@ -57,7 +77,8 @@ Keyboard ownership is now explicit and scoped:
   remain key-capable.
 
 The key-focus shell is AppKit-owned and implements the minimal responder and `NSTextInputClient`
-surface needed for rsnap's current text/IME needs.
+surface needed for rsnap's current text/IME needs. It also lives under the same native root owner
+instead of floating as an unrelated top-level capture window.
 
 ## App-shell wake boundary
 

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -70,9 +70,9 @@ Key paths:
 - `packages/rsnap-overlay/src/lib.rs`: public session-level surface exported to the app shell
 - `packages/rsnap-overlay/src/overlay.rs`: overlay root plus its focused runtime/rendering support
   modules
-- `packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs`: macOS-only passive
-  AppKit overlay/toolbar shells plus the dedicated key-focus shell bridge for text and scroll
-  interactions
+- `packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs`: macOS-only native
+  capture root owner plus passive AppKit overlay/toolbar shells and the dedicated key-focus shell
+  bridge for text and scroll interactions
 - `packages/rsnap-overlay/src/scroll_capture.rs`: scroll-capture session entry with focused
   support modules under `scroll_capture/`
 

--- a/docs/runbook/index.md
+++ b/docs/runbook/index.md
@@ -60,5 +60,6 @@ Then structure the body for execution:
 
 - `docs/runbook/performance-validation.md` for repo-native performance and smoke command routing
 - `docs/runbook/scroll-capture-benchmarks.md` for deterministic scroll-capture benchmark usage
-- `docs/runbook/macos-native-capture-window-validation.md` for manual validation of passive
-  pointer shells and explicit key-focus shell behavior on macOS
+- `docs/runbook/macos-native-capture-window-validation.md` for manual validation of the single
+  native root-owner capture layer, passive pointer shells, and explicit key-focus shell behavior
+  on macOS

--- a/docs/runbook/macos-native-capture-window-validation.md
+++ b/docs/runbook/macos-native-capture-window-validation.md
@@ -27,6 +27,8 @@ theft or missing IME behavior.
 2. Live drag region
    - Start capture over another app.
    - Press-drag-release to create a region freeze.
+   - Verify the live selection cursor stays a single native crosshair and no duplicate custom
+     cursor overlay appears during the drag.
    - Verify auxiliary live widgets disappear on press and do not reappear during handoff.
    - Verify the target app remains the apparent frontmost app after selection completes.
 

--- a/docs/runbook/macos-native-capture-window-validation.md
+++ b/docs/runbook/macos-native-capture-window-validation.md
@@ -1,7 +1,7 @@
 # Validate macOS Native Capture Window Layer
 
-Goal: Run the manual validation matrix for the macOS-native passive capture shells and explicit
-key-focus shell.
+Goal: Run the manual validation matrix for the macOS-native single root-owner capture layer,
+passive capture shells, and explicit key-focus shell.
 
 Read this when: You changed macOS capture-window/focus code, native AppKit shell bridging, or the
 Frozen text/scroll key-focus path and need to verify behavior on a live machine.
@@ -12,8 +12,9 @@ capture-session contract in `docs/spec/capture-session.md`.
 Depends on: `docs/spec/capture-session.md`,
 `docs/reference/macos-native-capture-window-layer.md`
 
-Verification: Confirm that pointer capture stays passive, text/scroll keyboard routes still work,
-and no capture flow regresses into visible focus theft or missing IME behavior.
+Verification: Confirm that the native root-owner topology stays intact, pointer capture stays
+passive, text/scroll keyboard routes still work, and no capture flow regresses into visible focus
+theft or missing IME behavior.
 
 ## Validation matrix
 
@@ -29,18 +30,26 @@ and no capture flow regresses into visible focus theft or missing IME behavior.
    - Verify auxiliary live widgets disappear on press and do not reappear during handoff.
    - Verify the target app remains the apparent frontmost app after selection completes.
 
-3. Frozen text editing
+3. Native root-owner topology
+   - Start capture, move the cursor enough to show HUD and loupe, then enter Frozen mode and show
+     the toolbar.
+   - Verify overlay, HUD, loupe, and toolbar continue moving as one capture layer without stray
+     z-order splits or independent activation.
+   - If scroll capture is available, start it once and verify the scroll-preview window also joins
+     the same layer without surfacing as a separate frontmost app window.
+
+4. Frozen text editing
    - Enter Frozen mode, switch to the text tool, and click to start editing.
    - Type plain ASCII text.
    - Verify text appears and `Esc` cancels text editing instead of the whole session.
    - Use an IME preedit flow and confirm marked text and commit both work.
 
-4. Scroll capture keyboard flow
+5. Scroll capture keyboard flow
    - Enter scroll capture from a dragged-region freeze.
    - Verify `Space`, save shortcut, pause, undo, and `Esc` still work.
    - Verify these controls continue working even though live pointer interaction stays passive.
 
-5. Session exit cleanup
+6. Session exit cleanup
    - Cancel capture from live mode and from Frozen mode.
    - Restart capture immediately after each exit.
    - Verify the next session does not inherit stale focus, stale key ownership, or missing

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -119,10 +119,13 @@ cross-platform architecture.
    - Scroll capture is macOS-only. Other platforms must treat this flow as unsupported
      until they have their own native contract.
    - It requires Screen Recording permission for live capture imagery.
-   - Entering scroll capture additionally requires Accessibility because rsnap forwards
-     scroll input into the target app.
+   - Entering scroll capture additionally requires Accessibility because rsnap still
+     retains a macOS wheel-forwarding fallback for cases where the overlay receives the
+     event instead of the target app.
    - Entering scroll capture additionally requires Input Monitoring because rsnap listens
-     for global scroll-wheel input through a native macOS listen-event tap.
+     for global scroll-wheel input through a native macOS listen-event tap while the
+     frozen overlay windows switch into mouse passthrough so the target app normally
+     receives the real scroll gesture directly.
    - Entry is dragged-region-only. Window freezes and fullscreen fallbacks must not arm
      scroll capture, even if a frozen image exists.
    - The frozen toolbar may expose `Scroll Capture ↓`, and plain `s` may start scroll

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -59,10 +59,13 @@ cross-platform architecture.
     externally capturable by system screenshot and screen-recording tools. Internal self-capture
     correctness comes from rsnap's own exclusion filters and freeze handoff logic, not window
     content protection.
-4b. On macOS, live overlay pointer input and frozen-toolbar pointer input MUST be handled through
+4b. On macOS, overlay, HUD, loupe, frozen toolbar, scroll preview, and any native capture shells
+    MUST be owned under a single transparent AppKit root window that tracks the active capture
+    surface bounds instead of behaving as unrelated top-level capture windows.
+4c. On macOS, live overlay pointer input and frozen-toolbar pointer input MUST be handled through
     passive AppKit-owned shells so the pointer path does not require capture windows to become
     `key`/`main` windows.
-4c. On macOS, explicit keyboard ownership during capture MUST be scoped to a dedicated key-focus
+4d. On macOS, explicit keyboard ownership during capture MUST be scoped to a dedicated key-focus
     shell that is activated only for Frozen text editing and scroll capture. Ordinary live
     selection and frozen pointer interaction MUST NOT rely on capture windows becoming key.
 5. In live mode, the overlay MUST show a HUD near the cursor with:

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -154,7 +154,9 @@ use winit::{
 
 use self::frozen_text_runtime::{FrozenTextInputSource, FrozenTextRecentInput};
 #[cfg(target_os = "macos")]
-use self::macos_native_capture_shell_runtime::MacOSNativeCaptureShells;
+use self::macos_native_capture_shell_runtime::{
+	MacOSNativeCaptureRootOwner, MacOSNativeCaptureShells,
+};
 #[cfg(target_os = "macos")]
 use self::rendering::StartupLiveRgbPlan;
 use self::rendering::{
@@ -537,6 +539,8 @@ pub struct OverlaySession {
 	egui_repaint_deadline: Arc<Mutex<Option<Instant>>>,
 	windows: HashMap<WindowId, OverlayWindow>,
 	#[cfg(target_os = "macos")]
+	native_capture_root_owner: Option<MacOSNativeCaptureRootOwner>,
+	#[cfg(target_os = "macos")]
 	native_capture_shells: Option<MacOSNativeCaptureShells>,
 	focused_window_ids: HashSet<WindowId>,
 	pending_focus_loss_cleanup: bool,
@@ -795,7 +799,9 @@ impl OverlaySession {
 			state: OverlayState::new(),
 			session_active: false,
 			cursor_monitor: None,
-			windows: HashMap::new(), #[cfg(target_os = "macos")] native_capture_shells: None,
+			windows: HashMap::new(),
+			#[cfg(target_os = "macos")] native_capture_root_owner: None,
+			#[cfg(target_os = "macos")] native_capture_shells: None,
 			focused_window_ids: HashSet::new(),
 			pending_focus_loss_cleanup: false,
 			hud_window: None, loupe_window: None, toolbar_window: None, scroll_preview_window: None,

--- a/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/capture_window_runtime.rs
@@ -118,7 +118,16 @@ impl OverlaySession {
 				return;
 			}
 
+			if let Some(hud_window) = &self.hud_window {
+				hud_window.window.set_visible(false);
+			}
+
 			self.hud_window_visible = false;
+
+			if let Some(loupe_window) = &self.loupe_window {
+				loupe_window.window.set_visible(false);
+			}
+
 			self.loupe_window_visible = false;
 
 			if let Some(toolbar_window) = &self.toolbar_window {
@@ -185,6 +194,15 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	pub(super) fn destroy_live_only_aux_windows(&mut self) {
+		if let Some(hud_window) = self.hud_window.take() {
+			self.remove_macos_hud_window_config_cache_entry(hud_window.window.id());
+		}
+
+		self.hud_inner_size_points = None;
+		self.hud_outer_pos = None;
+		self.pending_hud_outer_pos = None;
+		self.hud_window_visible = false;
+
 		if let Some(loupe_window) = self.loupe_window.take() {
 			self.remove_macos_hud_window_config_cache_entry(loupe_window.window.id());
 		}

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use egui::FontId;
@@ -63,8 +62,6 @@ impl MacOSNativeCaptureShells {
 			window_count = windows.len(),
 			"Synced passive overlay shells."
 		);
-
-		macos_set_system_cursor_hidden(visible);
 
 		for overlay_window in windows.values() {
 			if let Some(shell) = self.overlay_shells.get(&overlay_window.monitor.id) {
@@ -370,22 +367,6 @@ impl MacOSPassiveShellWindow {
 				let _: () = objc::msg_send![ns_window, invalidateCursorRectsForView: view];
 			}
 		}
-
-		if let Some(callback) = macos_shell_callback(self.view_key) {
-			match callback {
-				MacOSPassiveShellCallback::Overlay { .. } => {
-					let seeded_point = visible
-						.then(|| macos_seed_passive_shell_cursor_point(ns_window, view))
-						.flatten();
-
-					macos_update_passive_shell_cursor_point(self.view_key, seeded_point);
-				},
-				MacOSPassiveShellCallback::Toolbar { .. }
-				| MacOSPassiveShellCallback::KeyFocus { .. } => {
-					macos_update_passive_shell_cursor_point(self.view_key, None);
-				},
-			}
-		}
 	}
 
 	fn set_toolbar_state(&self, monitor: MonitorRect, outer_position: GlobalPoint) {
@@ -404,7 +385,6 @@ impl MacOSPassiveShellWindow {
 impl Drop for MacOSPassiveShellWindow {
 	fn drop(&mut self) {
 		macos_unregister_shell_callback(self.view_key);
-		macos_clear_passive_shell_cursor_point(self.view_key);
 
 		unsafe {
 			let ns_window = self.window_key as *mut Object;
@@ -529,8 +509,6 @@ impl MacOSKeyFocusShellWindow {
 		if ns_window.is_null() || view.is_null() {
 			return;
 		}
-
-		super::macos_activate_app();
 
 		unsafe {
 			let input_context: *mut Object = objc::msg_send![view, inputContext];
@@ -789,6 +767,8 @@ impl OverlaySession {
 	pub(super) fn sync_native_capture_shells(&mut self) -> Result<(), String> {
 		let live_shell_visible = self.should_host_live_pointer_input_in_native_shell();
 		let toolbar_shell_visible = self.should_host_toolbar_pointer_input_in_native_shell();
+		let overlay_mouse_passthrough =
+			live_shell_visible || self.scroll_capture.overlay_mouse_passthrough_active;
 		let toolbar_context = self.toolbar_window.as_ref().map(|toolbar_window| {
 			let monitor = self.state.monitor.or_else(|| self.active_cursor_monitor());
 			let outer_position = Self::toolbar_window_outer_position(toolbar_window)
@@ -812,7 +792,7 @@ impl OverlaySession {
 		for overlay_window in self.windows.values() {
 			super::macos_set_capture_window_mouse_passthrough(
 				overlay_window.window.as_ref(),
-				live_shell_visible,
+				overlay_mouse_passthrough,
 			);
 		}
 
@@ -859,8 +839,6 @@ impl OverlaySession {
 	}
 
 	pub(super) fn destroy_native_capture_shells(&mut self) {
-		macos_set_system_cursor_hidden(false);
-
 		for overlay_window in self.windows.values() {
 			super::macos_set_capture_window_mouse_passthrough(
 				overlay_window.window.as_ref(),
@@ -1049,7 +1027,9 @@ impl MacOSPassiveShellCallback {
 
 	fn dispatch_mouse_exited(&self, view_key: usize) {
 		match self {
-			Self::Overlay { .. } => macos_update_passive_shell_cursor_point(view_key, None),
+			Self::Overlay { .. } => {
+				let _ = view_key;
+			},
 			Self::Toolbar { dispatch, .. } => {
 				dispatch.enqueue(MacOSNativeCaptureInputEvent::ToolbarPointerLeft);
 			},
@@ -1341,29 +1321,8 @@ extern "C" fn macos_passive_shell_view_hit_test(
 }
 
 extern "C" fn macos_passive_shell_view_draw_rect(this: &Object, _cmd: Sel, dirty_rect: MacOSRect) {
-	let Some(callback) = macos_shell_callback(this as *const Object as usize) else {
-		return;
-	};
-
-	if !matches!(callback, MacOSPassiveShellCallback::Overlay { .. }) {
-		return;
-	}
-
-	let clear: *mut Object = unsafe { objc::msg_send![objc::class!(NSColor), clearColor] };
-
-	if !clear.is_null() {
-		unsafe {
-			let _: () = objc::msg_send![clear, setFill];
-			let _: () =
-				objc::msg_send![objc::class!(NSBezierPath), fillRect: NSRect::from(dirty_rect)];
-		}
-	}
-
-	let Some(point) = macos_passive_shell_cursor_point(this as *const Object as usize) else {
-		return;
-	};
-
-	macos_draw_passive_shell_crosshair(point);
+	let _ = this;
+	let _ = dirty_rect;
 }
 
 extern "C" fn macos_passive_shell_view_reset_cursor_rects(this: &Object, _cmd: Sel) {
@@ -1919,21 +1878,12 @@ fn macos_dispatch_shell_pointer_moved(this: &Object, event: *mut Object) {
 
 	match callback {
 		MacOSPassiveShellCallback::Overlay { .. } => {
-			macos_update_passive_shell_cursor_point(
-				this as *const Object as usize,
-				Some(local_point),
-			);
-
 			super::macos_set_cursor_icon(CursorIcon::Crosshair);
 		},
 		MacOSPassiveShellCallback::Toolbar { .. } => {
-			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
-
 			super::macos_set_cursor_icon(CursorIcon::Default);
 		},
-		MacOSPassiveShellCallback::KeyFocus { .. } => {
-			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
-		},
+		MacOSPassiveShellCallback::KeyFocus { .. } => {},
 	}
 
 	callback.dispatch_pointer_moved(local_point);
@@ -1952,18 +1902,12 @@ fn macos_dispatch_shell_mouse_input(
 
 	match callback {
 		MacOSPassiveShellCallback::Overlay { .. } => {
-			macos_update_passive_shell_cursor_point(this as *const Object as usize, local_point);
-
 			super::macos_set_cursor_icon(CursorIcon::Crosshair);
 		},
 		MacOSPassiveShellCallback::Toolbar { .. } => {
-			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
-
 			super::macos_set_cursor_icon(CursorIcon::Default);
 		},
-		MacOSPassiveShellCallback::KeyFocus { .. } => {
-			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
-		},
+		MacOSPassiveShellCallback::KeyFocus { .. } => {},
 	}
 
 	callback.dispatch_mouse_input(local_point, button, state);
@@ -2011,199 +1955,6 @@ fn macos_shell_scroll_delta(event: *mut Object) -> Option<MacOSNativeCaptureScro
 
 fn macos_set_crosshair_cursor() {
 	super::macos_set_cursor_icon(CursorIcon::Crosshair);
-}
-
-fn macos_passive_shell_cursor_points() -> &'static Mutex<HashMap<usize, Option<NSPoint>>> {
-	static POINTS: OnceLock<Mutex<HashMap<usize, Option<NSPoint>>>> = OnceLock::new();
-
-	POINTS.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn macos_passive_shell_cursor_point(view_key: usize) -> Option<NSPoint> {
-	let points = macos_passive_shell_cursor_points();
-
-	match points.lock() {
-		Ok(guard) => guard.get(&view_key).copied().flatten(),
-		Err(poisoned) => poisoned.into_inner().get(&view_key).copied().flatten(),
-	}
-}
-
-fn macos_clear_passive_shell_cursor_point(view_key: usize) {
-	let points = macos_passive_shell_cursor_points();
-
-	match points.lock() {
-		Ok(mut guard) => {
-			guard.remove(&view_key);
-		},
-		Err(poisoned) => {
-			poisoned.into_inner().remove(&view_key);
-		},
-	}
-}
-
-fn macos_update_passive_shell_cursor_point(view_key: usize, next_point: Option<NSPoint>) {
-	let previous = {
-		let points = macos_passive_shell_cursor_points();
-
-		match points.lock() {
-			Ok(mut guard) => {
-				let previous = guard.get(&view_key).copied().flatten();
-
-				if previous == next_point {
-					return;
-				}
-				if next_point.is_some() {
-					guard.insert(view_key, next_point);
-				} else {
-					guard.remove(&view_key);
-				}
-
-				previous
-			},
-			Err(poisoned) => {
-				let mut guard = poisoned.into_inner();
-				let previous = guard.get(&view_key).copied().flatten();
-
-				if previous == next_point {
-					return;
-				}
-				if next_point.is_some() {
-					guard.insert(view_key, next_point);
-				} else {
-					guard.remove(&view_key);
-				}
-
-				previous
-			},
-		}
-	};
-	let view = view_key as *mut Object;
-
-	if view.is_null() {
-		return;
-	}
-
-	unsafe {
-		if let Some(previous) = previous {
-			let _: () = objc::msg_send![
-				view,
-				setNeedsDisplayInRect: macos_passive_shell_cursor_dirty_rect(previous)
-			];
-		}
-		if let Some(next) = next_point {
-			let _: () = objc::msg_send![view, setNeedsDisplayInRect: macos_passive_shell_cursor_dirty_rect(next)];
-		}
-	}
-}
-
-fn macos_passive_shell_cursor_dirty_rect(point: NSPoint) -> NSRect {
-	const CURSOR_DIRTY_RADIUS: f64 = 18.0;
-
-	NSRect::new(
-		NSPoint::new(point.x - CURSOR_DIRTY_RADIUS, point.y - CURSOR_DIRTY_RADIUS),
-		NSSize::new(CURSOR_DIRTY_RADIUS * 2.0, CURSOR_DIRTY_RADIUS * 2.0),
-	)
-}
-
-fn macos_seed_passive_shell_cursor_point(
-	ns_window: *mut Object,
-	view: *mut Object,
-) -> Option<NSPoint> {
-	if ns_window.is_null() || view.is_null() {
-		return None;
-	}
-
-	let global = super::macos_mouse_location()?;
-
-	unsafe {
-		let screen_point = NSPoint::new(f64::from(global.x), f64::from(global.y));
-		let window_point: NSPoint =
-			objc::msg_send![ns_window, convertPointFromScreen: screen_point];
-		let local_point: NSPoint =
-			objc::msg_send![view, convertPoint: window_point fromView: ptr::null_mut::<Object>()];
-		let bounds: NSRect = objc::msg_send![view, bounds];
-		let contains = local_point.x >= bounds.origin.x
-			&& local_point.y >= bounds.origin.y
-			&& local_point.x <= bounds.origin.x + bounds.size.width
-			&& local_point.y <= bounds.origin.y + bounds.size.height;
-
-		contains.then_some(local_point)
-	}
-}
-
-fn macos_draw_passive_shell_crosshair(point: NSPoint) {
-	let outline_color: *mut Object = unsafe {
-		objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 0.0 alpha: 0.95]
-	};
-	let fill_color: *mut Object = unsafe {
-		objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 1.0 alpha: 0.95]
-	};
-
-	macos_fill_passive_shell_crosshair_segments(outline_color, point, 3.0);
-	macos_fill_passive_shell_crosshair_segments(fill_color, point, 1.0);
-}
-
-fn macos_fill_passive_shell_crosshair_segments(color: *mut Object, point: NSPoint, thickness: f64) {
-	if color.is_null() {
-		return;
-	}
-
-	const EXTENT: f64 = 11.0;
-	const GAP: f64 = 3.0;
-
-	let rects = [
-		NSRect::new(
-			NSPoint::new(point.x - EXTENT, point.y - thickness * 0.5),
-			NSSize::new(EXTENT - GAP, thickness),
-		),
-		NSRect::new(
-			NSPoint::new(point.x + GAP, point.y - thickness * 0.5),
-			NSSize::new(EXTENT - GAP, thickness),
-		),
-		NSRect::new(
-			NSPoint::new(point.x - thickness * 0.5, point.y - EXTENT),
-			NSSize::new(thickness, EXTENT - GAP),
-		),
-		NSRect::new(
-			NSPoint::new(point.x - thickness * 0.5, point.y + GAP),
-			NSSize::new(thickness, EXTENT - GAP),
-		),
-	];
-
-	unsafe {
-		let _: () = objc::msg_send![color, setFill];
-
-		for rect in rects {
-			let _: () = objc::msg_send![objc::class!(NSBezierPath), fillRect: rect];
-		}
-	}
-}
-
-#[link(name = "CoreGraphics", kind = "framework")]
-unsafe extern "C" {
-	fn CGMainDisplayID() -> u32;
-	fn CGDisplayHideCursor(display: u32) -> i32;
-	fn CGDisplayShowCursor(display: u32) -> i32;
-}
-
-fn macos_set_system_cursor_hidden(hidden: bool) {
-	static CURSOR_HIDDEN: AtomicBool = AtomicBool::new(false);
-
-	let previous = CURSOR_HIDDEN.swap(hidden, Ordering::SeqCst);
-
-	if previous == hidden {
-		return;
-	}
-
-	unsafe {
-		if hidden {
-			let _ = CGDisplayHideCursor(CGMainDisplayID());
-			let _: () = objc::msg_send![objc::class!(NSCursor), hide];
-		} else {
-			let _: () = objc::msg_send![objc::class!(NSCursor), unhide];
-			let _ = CGDisplayShowCursor(CGMainDisplayID());
-		}
-	}
 }
 
 fn macos_shell_callback_name(callback: &MacOSPassiveShellCallback) -> &'static str {

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -162,6 +162,80 @@ impl MacOSNativeCaptureShells {
 	}
 }
 
+pub(super) struct MacOSNativeCaptureRootOwner {
+	window_key: usize,
+}
+impl MacOSNativeCaptureRootOwner {
+	fn sync_frame_and_visibility(&self, frame: NSRect, visible: bool) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let _: () = objc::msg_send![ns_window, setFrame: frame display: NO];
+
+			if visible {
+				let _: () = objc::msg_send![ns_window, orderFrontRegardless];
+			} else {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+			}
+		}
+	}
+
+	fn attach_child_window(&self, child_window: *mut Object) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() || child_window.is_null() || ns_window == child_window {
+			return;
+		}
+
+		unsafe {
+			let current_parent: *mut Object = objc::msg_send![child_window, parentWindow];
+
+			if current_parent == ns_window {
+				return;
+			}
+			if !current_parent.is_null() {
+				let _: () = objc::msg_send![current_parent, removeChildWindow: child_window];
+			}
+
+			let _: () = objc::msg_send![ns_window, addChildWindow: child_window ordered: 1_isize];
+		}
+	}
+
+	fn detach_child_window(&self, child_window: *mut Object) {
+		let ns_window = self.window_key as *mut Object;
+
+		if ns_window.is_null() || child_window.is_null() {
+			return;
+		}
+
+		unsafe {
+			let current_parent: *mut Object = objc::msg_send![child_window, parentWindow];
+
+			if current_parent == ns_window {
+				let _: () = objc::msg_send![ns_window, removeChildWindow: child_window];
+			}
+		}
+	}
+}
+
+impl Drop for MacOSNativeCaptureRootOwner {
+	fn drop(&mut self) {
+		unsafe {
+			let ns_window = self.window_key as *mut Object;
+
+			if !ns_window.is_null() {
+				let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+				let _: () = objc::msg_send![ns_window, close];
+				let _: () = objc::msg_send![ns_window, release];
+			}
+		}
+	}
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct MacOSRange {
@@ -261,6 +335,10 @@ struct MacOSPassiveShellWindow {
 	toolbar_state: Option<Arc<Mutex<MacOSPassiveToolbarShellState>>>,
 }
 impl MacOSPassiveShellWindow {
+	fn ns_window(&self) -> *mut Object {
+		self.window_key as *mut Object
+	}
+
 	fn sync_from_render_window(&self, render_window: &Window, visible: bool) {
 		let Some(render_ns_window) = macos_overlay_window_ns_window(render_window) else {
 			return;
@@ -358,6 +436,10 @@ struct MacOSKeyFocusShellWindow {
 	state: Arc<Mutex<MacOSKeyFocusShellState>>,
 }
 impl MacOSKeyFocusShellWindow {
+	fn ns_window(&self) -> *mut Object {
+		self.window_key as *mut Object
+	}
+
 	fn sync_from_render_window(
 		&self,
 		render_window: &Window,
@@ -505,6 +587,175 @@ impl From<MacOSRect> for NSRect {
 }
 
 impl OverlaySession {
+	pub(super) fn ensure_native_capture_root_owner(&mut self) -> Result<(), String> {
+		if self.native_capture_root_owner.is_some() {
+			return Ok(());
+		}
+
+		let Some(reference_window) = self.native_capture_root_owner_reference_window() else {
+			return Ok(());
+		};
+		let render_ns_window = macos_overlay_window_ns_window(reference_window)
+			.ok_or_else(|| String::from("Missing macOS render NSWindow for native capture root"))?;
+		let frame = macos_ns_window_frame(render_ns_window)
+			.ok_or_else(|| String::from("Missing macOS render frame for native capture root"))?;
+		let level = unsafe { macos_ns_window_level(render_ns_window) };
+		let collection_behavior = unsafe { macos_ns_window_collection_behavior(render_ns_window) };
+
+		self.native_capture_root_owner =
+			Some(macos_create_native_capture_root_owner(frame, level, collection_behavior)?);
+
+		Ok(())
+	}
+
+	pub(super) fn sync_native_capture_root_owner(&mut self) -> Result<(), String> {
+		self.ensure_native_capture_root_owner()?;
+
+		let Some(root_owner) = self.native_capture_root_owner.as_ref() else {
+			return Ok(());
+		};
+
+		if let Some(frame) = self.native_capture_root_owner_frame() {
+			root_owner.sync_frame_and_visibility(frame, self.session_active);
+		} else {
+			root_owner.sync_frame_and_visibility(
+				NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1.0, 1.0)),
+				false,
+			);
+
+			return Ok(());
+		}
+
+		for overlay_window in self.windows.values() {
+			if let Some(ns_window) = macos_overlay_window_ns_window(overlay_window.window.as_ref())
+			{
+				root_owner.attach_child_window(ns_window);
+			}
+		}
+		for aux_window in [
+			self.hud_window.as_ref().map(|window| window.window.as_ref()),
+			self.loupe_window.as_ref().map(|window| window.window.as_ref()),
+			self.toolbar_window.as_ref().map(|window| window.window.as_ref()),
+			self.scroll_preview_window.as_ref().map(|window| window.window.as_ref()),
+		]
+		.into_iter()
+		.flatten()
+		{
+			if let Some(ns_window) = macos_overlay_window_ns_window(aux_window) {
+				root_owner.attach_child_window(ns_window);
+			}
+		}
+
+		if let Some(shells) = self.native_capture_shells.as_ref() {
+			for shell in shells.overlay_shells.values() {
+				root_owner.attach_child_window(shell.ns_window());
+			}
+
+			if let Some(shell) = shells.toolbar_shell.as_ref() {
+				root_owner.attach_child_window(shell.ns_window());
+			}
+			if let Some(shell) = shells.key_focus_shell.as_ref() {
+				root_owner.attach_child_window(shell.ns_window());
+			}
+		}
+
+		Ok(())
+	}
+
+	pub(super) fn destroy_native_capture_root_owner(&mut self) {
+		self.detach_native_capture_root_owned_windows();
+
+		self.native_capture_root_owner = None;
+	}
+
+	fn detach_native_capture_root_owned_windows(&self) {
+		let Some(root_owner) = self.native_capture_root_owner.as_ref() else {
+			return;
+		};
+
+		for overlay_window in self.windows.values() {
+			if let Some(ns_window) = macos_overlay_window_ns_window(overlay_window.window.as_ref())
+			{
+				root_owner.detach_child_window(ns_window);
+			}
+		}
+		for aux_window in [
+			self.hud_window.as_ref().map(|window| window.window.as_ref()),
+			self.loupe_window.as_ref().map(|window| window.window.as_ref()),
+			self.toolbar_window.as_ref().map(|window| window.window.as_ref()),
+			self.scroll_preview_window.as_ref().map(|window| window.window.as_ref()),
+		]
+		.into_iter()
+		.flatten()
+		{
+			if let Some(ns_window) = macos_overlay_window_ns_window(aux_window) {
+				root_owner.detach_child_window(ns_window);
+			}
+		}
+
+		if let Some(shells) = self.native_capture_shells.as_ref() {
+			for shell in shells.overlay_shells.values() {
+				root_owner.detach_child_window(shell.ns_window());
+			}
+
+			if let Some(shell) = shells.toolbar_shell.as_ref() {
+				root_owner.detach_child_window(shell.ns_window());
+			}
+			if let Some(shell) = shells.key_focus_shell.as_ref() {
+				root_owner.detach_child_window(shell.ns_window());
+			}
+		}
+	}
+
+	fn native_capture_root_owner_reference_window(&self) -> Option<&Window> {
+		self.windows
+			.values()
+			.next()
+			.map(|window| window.window.as_ref())
+			.or_else(|| self.hud_window.as_ref().map(|window| window.window.as_ref()))
+			.or_else(|| self.loupe_window.as_ref().map(|window| window.window.as_ref()))
+			.or_else(|| self.toolbar_window.as_ref().map(|window| window.window.as_ref()))
+			.or_else(|| self.scroll_preview_window.as_ref().map(|window| window.window.as_ref()))
+	}
+
+	fn native_capture_root_owner_frame(&self) -> Option<NSRect> {
+		let mut union_frame: Option<NSRect> = None;
+
+		for ns_window in self
+			.windows
+			.values()
+			.filter_map(|window| macos_overlay_window_ns_window(window.window.as_ref()))
+			.chain(
+				[
+					self.hud_window
+						.as_ref()
+						.and_then(|window| macos_overlay_window_ns_window(window.window.as_ref())),
+					self.loupe_window
+						.as_ref()
+						.and_then(|window| macos_overlay_window_ns_window(window.window.as_ref())),
+					self.toolbar_window
+						.as_ref()
+						.and_then(|window| macos_overlay_window_ns_window(window.window.as_ref())),
+					self.scroll_preview_window
+						.as_ref()
+						.and_then(|window| macos_overlay_window_ns_window(window.window.as_ref())),
+				]
+				.into_iter()
+				.flatten(),
+			) {
+			let Some(frame) = macos_ns_window_frame(ns_window) else {
+				continue;
+			};
+
+			union_frame = Some(match union_frame {
+				Some(current_union) => macos_union_ns_rect(current_union, frame),
+				None => frame,
+			});
+		}
+
+		union_frame
+	}
+
 	pub(super) fn ensure_native_capture_shells(&mut self) -> Result<(), String> {
 		let Some(dispatch) = self.native_capture_input_dispatch() else {
 			return Ok(());
@@ -570,7 +821,7 @@ impl OverlaySession {
 				super::macos_set_capture_window_mouse_passthrough(toolbar_window.as_ref(), false);
 			}
 
-			return Ok(());
+			return self.sync_native_capture_root_owner();
 		};
 
 		shells.sync_overlay_shells(&self.windows, live_shell_visible);
@@ -602,6 +853,8 @@ impl OverlaySession {
 			shells.clear_key_focus_shell();
 		}
 
+		self.sync_native_capture_root_owner()?;
+
 		Ok(())
 	}
 
@@ -621,6 +874,8 @@ impl OverlaySession {
 				false,
 			);
 		}
+
+		self.destroy_native_capture_root_owner();
 
 		self.native_capture_shells = None;
 	}
@@ -1971,6 +2226,48 @@ fn macos_create_passive_overlay_shell_window(
 	)
 }
 
+fn macos_create_native_capture_root_owner(
+	frame: NSRect,
+	level: i64,
+	collection_behavior: usize,
+) -> Result<MacOSNativeCaptureRootOwner, String> {
+	let panel_class = macos_passive_shell_panel_class();
+	let nonactivating_panel_mask: usize = 1 << 7;
+	let backing_buffered: usize = 2;
+
+	unsafe {
+		let ns_window_alloc: *mut Object = objc::msg_send![panel_class, alloc];
+		let ns_window: *mut Object = objc::msg_send![
+			ns_window_alloc,
+			initWithContentRect: frame
+			styleMask: nonactivating_panel_mask
+			backing: backing_buffered
+			defer: NO
+		];
+
+		if ns_window.is_null() {
+			return Err(String::from("Failed to create native capture root owner window"));
+		}
+
+		let clear: *mut Object = objc::msg_send![objc::class!(NSColor), clearColor];
+
+		super::macos_configure_nonactivating_capture_window_with_ns_window(ns_window);
+
+		let _: () = objc::msg_send![ns_window, setReleasedWhenClosed: NO];
+		let _: () = objc::msg_send![ns_window, setOpaque: NO];
+		let _: () = objc::msg_send![ns_window, setHasShadow: NO];
+		let _: () = objc::msg_send![ns_window, setBackgroundColor: clear];
+		let _: () = objc::msg_send![ns_window, setLevel: level];
+		let _: () = objc::msg_send![ns_window, setCollectionBehavior: collection_behavior];
+		let _: () = objc::msg_send![ns_window, setAcceptsMouseMovedEvents: NO];
+		let _: () = objc::msg_send![ns_window, setIgnoresMouseEvents: YES];
+		let _: () = objc::msg_send![ns_window, setHidesOnDeactivate: NO];
+		let _: () = objc::msg_send![ns_window, orderOut: ptr::null_mut::<Object>()];
+
+		Ok(MacOSNativeCaptureRootOwner { window_key: ns_window as usize })
+	}
+}
+
 fn macos_create_passive_toolbar_shell_window(
 	render_window: &Window,
 	dispatch: MacOSNativeCaptureInputDispatch,
@@ -2167,4 +2464,13 @@ unsafe fn macos_ns_window_collection_behavior(ns_window: *mut Object) -> usize {
 	let behavior: usize = objc::msg_send![ns_window, collectionBehavior];
 
 	behavior
+}
+
+fn macos_union_ns_rect(lhs: NSRect, rhs: NSRect) -> NSRect {
+	let min_x = lhs.origin.x.min(rhs.origin.x);
+	let min_y = lhs.origin.y.min(rhs.origin.y);
+	let max_x = (lhs.origin.x + lhs.size.width).max(rhs.origin.x + rhs.size.width);
+	let max_y = (lhs.origin.y + lhs.size.height).max(rhs.origin.y + rhs.size.height);
+
+	NSRect::new(NSPoint::new(min_x, min_y), NSSize::new(max_x - min_x, max_y - min_y))
 }

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -558,8 +558,6 @@ impl OverlaySession {
 
 	#[cfg(target_os = "macos")]
 	fn focus_scroll_keyboard_window(&mut self) {
-		super::macos_activate_app();
-
 		let _ = self.sync_native_capture_shells();
 	}
 

--- a/packages/rsnap-overlay/src/overlay/scroll_input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_input_runtime.rs
@@ -583,6 +583,8 @@ impl OverlaySession {
 
 		self.scroll_capture.overlay_mouse_passthrough_active = passthrough;
 
+		let _ = self.sync_native_capture_shells();
+
 		tracing::info!(
 			op = if passthrough {
 				"scroll_capture.mouse_passthrough_armed"

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -656,11 +656,20 @@ fn configured_session_with_macos_worker() -> (OverlaySession, u64) {
 }
 
 #[cfg(target_os = "macos")]
+fn fresh_live_stream_snapshot_captured_at() -> Instant {
+	// Keep test snapshots comfortably inside the stream freshness window even when
+	// full-suite nextest scheduling briefly stalls this process.
+	Instant::now()
+		+ crate::live_frame_stream_macos::STREAM_REGION_FRAME_MAX_AGE
+		+ Duration::from_millis(250)
+}
+
+#[cfg(target_os = "macos")]
 #[test]
 fn sync_live_surface_bg_from_stream_promotes_clean_live_snapshot() {
 	let monitor = test_monitor();
 	let stream = MacLiveFrameStream::new();
-	let captured_at = Instant::now();
+	let captured_at = fresh_live_stream_snapshot_captured_at();
 	let mut session = OverlaySession::new();
 
 	stream.debug_set_active_stream_generation(monitor.id, 1);

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -3289,6 +3289,35 @@ fn reset_for_start_clears_reused_session_transient_flags() {
 	assert_eq!(session.toolbar_window_warmup_redraws_remaining, 0);
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn destroy_live_only_aux_windows_clears_live_widget_state() {
+	let mut session = OverlaySession {
+		hud_outer_pos: Some(GlobalPoint::new(12, 34)),
+		pending_hud_outer_pos: Some(GlobalPoint::new(56, 78)),
+		hud_inner_size_points: Some((320, 48)),
+		hud_window_visible: true,
+		loupe_outer_pos: Some(GlobalPoint::new(90, 120)),
+		pending_loupe_outer_pos: Some(GlobalPoint::new(130, 160)),
+		loupe_inner_size_points: Some((96, 96)),
+		loupe_window_visible: true,
+		..OverlaySession::default()
+	};
+
+	session.destroy_live_only_aux_windows();
+
+	assert!(session.hud_window.is_none());
+	assert!(session.hud_outer_pos.is_none());
+	assert!(session.pending_hud_outer_pos.is_none());
+	assert!(session.hud_inner_size_points.is_none());
+	assert!(!session.hud_window_visible);
+	assert!(session.loupe_window.is_none());
+	assert!(session.loupe_outer_pos.is_none());
+	assert!(session.pending_loupe_outer_pos.is_none());
+	assert!(session.loupe_inner_size_points.is_none());
+	assert!(!session.loupe_window_visible);
+}
+
 #[test]
 fn is_active_tracks_explicit_session_state() {
 	let inactive = OverlaySession::default();

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -270,7 +270,7 @@ fn pending_frozen_handoff_keeps_live_mode_and_hover_until_first_display_image_ar
 		monitor,
 		1,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 
 	let _ = session.about_to_wait();
@@ -297,7 +297,7 @@ fn begin_frozen_capture_background_snapshot_finishes_without_hiding_overlay_wind
 		monitor,
 		1,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 	session.begin_frozen_capture_with_rect(
 		monitor,
@@ -337,7 +337,7 @@ fn live_snapshot_followup_can_finish_background_capture_before_timeout() {
 		monitor,
 		51,
 		2,
-		Instant::now() + Duration::from_millis(1),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 
 	let _ = session.about_to_wait();
@@ -370,7 +370,7 @@ fn background_capture_prefers_live_surface_bg_for_initial_display_handoff() {
 		monitor,
 		2,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 	session.begin_frozen_capture_with_rect(
 		monitor,
@@ -415,7 +415,7 @@ fn background_capture_followup_export_does_not_overwrite_live_surface_preview() 
 		monitor,
 		4,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 
 	let _ = session.about_to_wait();
@@ -443,7 +443,7 @@ fn window_matte_capture_seeds_preview_and_arms_worker_without_hiding_overlay_win
 		monitor,
 		1,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 	session.begin_frozen_capture_with_rect(
 		monitor,
@@ -482,7 +482,7 @@ fn window_matte_capture_dispatches_worker_without_hiding_overlay_windows() {
 		monitor,
 		1,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 	session.begin_frozen_capture_with_rect(
 		monitor,
@@ -520,7 +520,7 @@ fn window_matte_capture_miss_keeps_preview_and_surfaces_export_error() {
 		monitor,
 		1,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 	session.begin_frozen_capture_with_rect(
 		monitor,
@@ -698,7 +698,7 @@ fn background_capture_without_initial_snapshot_waits_for_live_stream_followup_wi
 		monitor,
 		2,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 
 	let _ = session.about_to_wait();
@@ -727,7 +727,7 @@ fn incomplete_self_capture_filter_blocks_display_first_snapshot_handoff() {
 		monitor,
 		2,
 		1,
-		Instant::now(),
+		tests::fresh_live_stream_snapshot_captured_at(),
 	);
 
 	let _ = session.about_to_wait();

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -406,6 +406,8 @@ impl OverlaySession {
 			self.request_redraw_scroll_preview_window();
 		}
 
+		let _ = self.sync_native_capture_shells();
+
 		Ok(())
 	}
 
@@ -775,6 +777,8 @@ impl OverlaySession {
 	}
 
 	fn discard_prewarmed_startup_resources(&mut self) {
+		#[cfg(target_os = "macos")]
+		self.destroy_native_capture_root_owner();
 		self.windows.clear();
 
 		self.hud_window = None;
@@ -793,6 +797,9 @@ impl OverlaySession {
 		if !self.has_prewarmed_startup_resources() {
 			return None;
 		}
+
+		#[cfg(target_os = "macos")]
+		self.destroy_native_capture_root_owner();
 
 		Some(PrewarmedStartupResources {
 			egui_repaint_deadline: Arc::clone(&self.egui_repaint_deadline),

--- a/packages/rsnap-overlay/src/scroll_capture/support.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/support.rs
@@ -65,7 +65,7 @@ pub(crate) fn scroll_capture_fingerprint_delta(left: &[u8], right: &[u8]) -> u32
 		comparisons = comparisons.saturating_add(4);
 	}
 
-	if comparisons == 0 { u32::MAX } else { (total_abs_diff / comparisons) as u32 }
+	total_abs_diff.checked_div(comparisons).map_or(u32::MAX, |average| average as u32)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a single transparent AppKit root owner that owns macOS capture child-window topology
- keep overlay, HUD, loupe, toolbar, scroll preview, passive shells, and key-focus shell subordinate to that native root
- harden macOS frozen-entry live snapshot tests and update docs/validation for the single-root model

## Verification
- cargo make checks

## Linear
- XY-282
- XY-280
- XY-281
- XY-283
- XY-284
- XY-285
- XY-263