### PR TITLE
XY-299 Add app-level coverage for host-backed native capture input dispatch

### DIFF
--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -66,6 +66,27 @@ pub(crate) enum UserEvent {
 }
 
 #[cfg(target_os = "macos")]
+#[derive(Clone)]
+struct OverlayEventProxy {
+	sender: Arc<dyn Fn(UserEvent) -> Result<(), ()> + Send + Sync>,
+}
+#[cfg(target_os = "macos")]
+impl OverlayEventProxy {
+	fn new(proxy: EventLoopProxy<UserEvent>) -> Self {
+		Self { sender: Arc::new(move |event| proxy.send_event(event).map_err(|_| ())) }
+	}
+
+	fn send_event(&self, event: UserEvent) -> Result<(), ()> {
+		(self.sender)(event)
+	}
+
+	#[cfg(test)]
+	fn for_test(sender: Arc<dyn Fn(UserEvent) -> Result<(), ()> + Send + Sync>) -> Self {
+		Self { sender }
+	}
+}
+
+#[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OverlayHotkeyRegistrationState {
 	Unregistered,
@@ -154,7 +175,7 @@ struct App {
 	#[cfg(target_os = "macos")]
 	capture_success_sound: Option<Retained<NSSound>>,
 	#[cfg(target_os = "macos")]
-	overlay_proxy: EventLoopProxy<UserEvent>,
+	overlay_proxy: OverlayEventProxy,
 	#[cfg(target_os = "macos")]
 	scroll_input_observer_lifecycle: Arc<ScrollInputObserverLifecycle>,
 	#[cfg(target_os = "macos")]
@@ -224,7 +245,7 @@ impl App {
 		settings: AppSettings,
 		settings_hotkey: Option<HotKey>,
 		hotkey_manager: Option<GlobalHotKeyManager>,
-		#[cfg(target_os = "macos")] overlay_proxy: EventLoopProxy<UserEvent>,
+		#[cfg(target_os = "macos")] overlay_proxy: OverlayEventProxy,
 		#[cfg(target_os = "macos")] scroll_input_observer_lifecycle: Arc<
 			ScrollInputObserverLifecycle,
 		>,

--- a/apps/rsnap/src/app/capture_host_macos.rs
+++ b/apps/rsnap/src/app/capture_host_macos.rs
@@ -121,6 +121,13 @@ impl App {
 		OverlayControl::Continue
 	}
 
+	#[cfg(test)]
+	pub(super) fn handle_overlay_native_capture_input_user_event_for_test(&mut self) {
+		let control = self.handle_overlay_native_capture_input_ready();
+
+		self.handle_overlay_control(control);
+	}
+
 	pub(super) fn reset_overlay_native_capture_input_dispatch(&self) {
 		self.overlay_native_capture_input_buffer.reset();
 	}
@@ -150,8 +157,83 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+	use std::sync::Arc;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+	use std::time::{Duration, Instant};
+
+	use winit::event::{ElementState, MouseButton};
+
 	use crate::app::capture_host_macos::OverlayNativeCaptureInputBuffer;
-	use rsnap_overlay::MacOSNativeCaptureInputEvent;
+	use crate::app::scroll_input_macos::{ScrollInputObserverLifecycle, SharedScrollInputState};
+	use crate::app::{App, OverlayEventProxy, UserEvent};
+	use crate::settings::AppSettings;
+	use rsnap_overlay::{
+		GlobalPoint, MacOSNativeCaptureInputEvent, MonitorRect, OverlayConfig, OverlaySession,
+		RectPoints, WindowListSnapshot, WindowRect,
+	};
+
+	fn test_monitor() -> MonitorRect {
+		MonitorRect {
+			id: 1,
+			origin: GlobalPoint::new(0, 0),
+			width: 1_000,
+			height: 800,
+			scale_factor_x1000: 1_000,
+		}
+	}
+
+	fn single_window_list_snapshot(
+		monitor: MonitorRect,
+		capture_rect: RectPoints,
+		window_id: u32,
+	) -> Arc<WindowListSnapshot> {
+		Arc::new(WindowListSnapshot {
+			captured_at: Instant::now(),
+			windows: Arc::new(vec![WindowRect {
+				window_id: Some(window_id),
+				x: i64::from(monitor.origin.x) + i64::from(capture_rect.x),
+				y: i64::from(monitor.origin.y) + i64::from(capture_rect.y),
+				width: i64::from(capture_rect.width),
+				height: i64::from(capture_rect.height),
+			}]),
+		})
+	}
+
+	fn test_app() -> (App, Arc<AtomicUsize>) {
+		let wake_count = Arc::new(AtomicUsize::new(0));
+		let settings = AppSettings::default();
+		let capture_hotkey = settings.capture_hotkey();
+		let overlay_proxy = OverlayEventProxy::for_test(Arc::new({
+			let wake_count = Arc::clone(&wake_count);
+
+			move |event| {
+				if matches!(event, UserEvent::OverlayNativeCaptureInput) {
+					wake_count.fetch_add(1, Ordering::AcqRel);
+				}
+
+				Ok(())
+			}
+		}));
+		let app = App::new(
+			capture_hotkey,
+			settings,
+			None,
+			None,
+			overlay_proxy,
+			Arc::new(ScrollInputObserverLifecycle::default()),
+			Arc::new(SharedScrollInputState::default()),
+		);
+
+		(app, wake_count)
+	}
+
+	fn queued_native_input_count(app: &App) -> usize {
+		app.overlay_native_capture_input_buffer
+			.queue
+			.lock()
+			.expect("native input queue lock should be available")
+			.len()
+	}
 
 	#[test]
 	fn native_capture_input_buffer_coalesces_multiple_events_behind_one_wakeup() {
@@ -181,5 +263,158 @@ mod tests {
 
 		assert!(buffer.drain().is_empty());
 		assert!(buffer.enqueue(6, MacOSNativeCaptureInputEvent::ToolbarPointerLeft));
+	}
+
+	#[test]
+	fn host_buffered_native_input_user_event_drains_into_active_overlay_session() {
+		let (mut app, wake_count) = test_app();
+		let monitor = test_monitor();
+		let capture_rect = RectPoints::new(100, 120, 240, 320);
+		let first_cursor = GlobalPoint::new(180, 220);
+		let second_cursor = GlobalPoint::new(260, 310);
+		let mut session = OverlaySession::with_config(OverlayConfig::default());
+
+		session.debug_prepare_live_test_session(monitor);
+		session.debug_set_window_list_snapshot(single_window_list_snapshot(
+			monitor,
+			capture_rect,
+			42,
+		));
+
+		app.overlay_session_generation = 7;
+		app.overlay_session = Some(session);
+
+		let host = app.build_overlay_capture_host();
+
+		host.debug_dispatch_native_capture_input(
+			MacOSNativeCaptureInputEvent::OverlayPointerMoved { monitor, global: first_cursor },
+		);
+		host.debug_dispatch_native_capture_input(
+			MacOSNativeCaptureInputEvent::OverlayPointerMoved { monitor, global: second_cursor },
+		);
+
+		assert_eq!(queued_native_input_count(&app), 2);
+		assert!(app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+		assert_eq!(wake_count.load(Ordering::Acquire), 1);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		assert_eq!(queued_native_input_count(&app), 0);
+		assert!(!app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+
+		let session = app.overlay_session.as_ref().expect("overlay session should still be active");
+
+		assert_eq!(session.debug_cursor(), Some(second_cursor));
+		assert_eq!(session.debug_hovered_window_rect(), Some((monitor.id, capture_rect)));
+	}
+
+	#[test]
+	fn host_buffered_native_input_drops_stale_generation_events_for_newer_session() {
+		let (mut app, wake_count) = test_app();
+		let monitor = test_monitor();
+		let stale_cursor = GlobalPoint::new(180, 220);
+		let mut session = OverlaySession::with_config(OverlayConfig::default());
+
+		session.debug_prepare_live_test_session(monitor);
+
+		app.overlay_session_generation = 7;
+		app.overlay_session = Some(session);
+
+		let host = app.build_overlay_capture_host();
+
+		host.debug_dispatch_native_capture_input(
+			MacOSNativeCaptureInputEvent::OverlayPointerMoved { monitor, global: stale_cursor },
+		);
+
+		assert_eq!(queued_native_input_count(&app), 1);
+		assert!(app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+		assert_eq!(wake_count.load(Ordering::Acquire), 1);
+
+		app.overlay_session_generation = 8;
+
+		let mut newer_session = OverlaySession::with_config(OverlayConfig::default());
+
+		newer_session.debug_prepare_live_test_session(monitor);
+
+		app.overlay_session = Some(newer_session);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		assert_eq!(queued_native_input_count(&app), 0);
+		assert!(!app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+
+		let session =
+			app.overlay_session.as_ref().expect("newer overlay session should still be active");
+
+		assert_eq!(session.debug_cursor(), None);
+		assert_eq!(session.debug_hovered_window_rect(), None);
+	}
+
+	#[test]
+	fn host_buffered_native_drag_selection_commits_display_first_frozen_entry() {
+		let (mut app, wake_count) = test_app();
+		let monitor = test_monitor();
+		let press_global = GlobalPoint::new(180, 220);
+		let drag_global = GlobalPoint::new(420, 460);
+		let capture_rect = monitor
+			.local_rect_from_points(press_global, drag_global)
+			.expect("drag should produce a capture rect");
+		let mut session = OverlaySession::with_config(OverlayConfig::default());
+
+		session.debug_prepare_live_test_session(monitor);
+		session.debug_seed_macos_live_stream_snapshot(
+			monitor,
+			Instant::now() + Duration::from_secs(1),
+		);
+
+		app.overlay_session_generation = 11;
+		app.overlay_session = Some(session);
+
+		let host = app.build_overlay_capture_host();
+
+		host.debug_dispatch_native_capture_input(MacOSNativeCaptureInputEvent::OverlayMouseInput {
+			monitor,
+			global: press_global,
+			button: MouseButton::Left,
+			state: ElementState::Pressed,
+		});
+
+		assert_eq!(wake_count.load(Ordering::Acquire), 1);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+		host.debug_dispatch_native_capture_input(
+			MacOSNativeCaptureInputEvent::OverlayPointerMoved { monitor, global: drag_global },
+		);
+
+		assert_eq!(wake_count.load(Ordering::Acquire), 2);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		let session =
+			app.overlay_session.as_ref().expect("overlay session should remain active during drag");
+
+		assert_eq!(session.debug_drag_rect(), Some((monitor.id, capture_rect)));
+
+		host.debug_dispatch_native_capture_input(MacOSNativeCaptureInputEvent::OverlayMouseInput {
+			monitor,
+			global: drag_global,
+			button: MouseButton::Left,
+			state: ElementState::Released,
+		});
+
+		assert_eq!(wake_count.load(Ordering::Acquire), 3);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		let session = app
+			.overlay_session
+			.as_ref()
+			.expect("overlay session should remain active after frozen handoff");
+
+		assert!(session.debug_is_frozen_mode());
+		assert_eq!(session.debug_frozen_capture_rect(), Some(capture_rect));
+		assert!(session.debug_has_frozen_display_image());
+		assert!(session.debug_has_frozen_export_image());
+		assert!(!session.debug_capture_windows_hidden());
 	}
 }

--- a/apps/rsnap/src/app/runtime.rs
+++ b/apps/rsnap/src/app/runtime.rs
@@ -20,10 +20,10 @@ use winit::{
 };
 
 #[cfg(target_os = "macos")]
+use crate::app::OverlayEventProxy;
+#[cfg(target_os = "macos")]
 use crate::app::scroll_input_macos::{ScrollInputObserverLifecycle, SharedScrollInputState};
 use crate::app::{App, UserEvent};
-#[cfg(target_os = "macos")]
-use crate::app::OverlayEventProxy;
 use crate::settings::AppSettings;
 use crate::settings_window::{CaptureHotkeyNotice, SettingsControl, SettingsWindowAction};
 #[cfg(target_os = "macos")]

--- a/apps/rsnap/src/app/runtime.rs
+++ b/apps/rsnap/src/app/runtime.rs
@@ -21,7 +21,7 @@ use winit::{
 
 #[cfg(target_os = "macos")]
 use crate::app::scroll_input_macos::{ScrollInputObserverLifecycle, SharedScrollInputState};
-use crate::app::{App, UserEvent};
+use crate::app::{App, OverlayEventProxy, UserEvent};
 use crate::settings::AppSettings;
 use crate::settings_window::{CaptureHotkeyNotice, SettingsControl, SettingsWindowAction};
 #[cfg(target_os = "macos")]
@@ -303,7 +303,7 @@ pub(super) fn run() -> Result<()> {
 		settings_hotkey,
 		hotkey_manager,
 		#[cfg(target_os = "macos")]
-		overlay_proxy,
+		OverlayEventProxy::new(overlay_proxy),
 		#[cfg(target_os = "macos")]
 		scroll_input_observer_lifecycle,
 		#[cfg(target_os = "macos")]

--- a/apps/rsnap/src/app/runtime.rs
+++ b/apps/rsnap/src/app/runtime.rs
@@ -21,7 +21,9 @@ use winit::{
 
 #[cfg(target_os = "macos")]
 use crate::app::scroll_input_macos::{ScrollInputObserverLifecycle, SharedScrollInputState};
-use crate::app::{App, OverlayEventProxy, UserEvent};
+use crate::app::{App, UserEvent};
+#[cfg(target_os = "macos")]
+use crate::app::OverlayEventProxy;
 use crate::settings::AppSettings;
 use crate::settings_window::{CaptureHotkeyNotice, SettingsControl, SettingsWindowAction};
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -6,9 +6,7 @@
 use std::collections::VecDeque;
 use std::ops::Deref;
 use std::process;
-#[cfg(test)]
 use std::ptr;
-#[cfg(test)]
 use std::ptr::NonNull;
 use std::slice;
 use std::sync::{
@@ -277,17 +275,14 @@ impl MacLiveFrameStream {
 		}
 	}
 
-	#[cfg(test)]
 	pub(crate) fn debug_set_self_capture_filter_complete(&self, monitor_id: u32, complete: bool) {
 		self.shared_latest_frame.set_stream_filter_status(monitor_id, complete);
 	}
 
-	#[cfg(test)]
 	pub(crate) fn debug_store_test_snapshot(&self, monitor: MonitorRect, captured_at: Instant) {
 		self.debug_store_test_snapshot_with_metadata(monitor, 1, 1, captured_at);
 	}
 
-	#[cfg(test)]
 	pub(crate) fn debug_store_test_snapshot_with_metadata(
 		&self,
 		monitor: MonitorRect,
@@ -327,7 +322,6 @@ impl MacLiveFrameStream {
 		}
 	}
 
-	#[cfg(test)]
 	fn debug_test_pixel_buffer() -> SharedPixelBuffer {
 		let mut buffer = ptr::null_mut();
 		let res = unsafe {

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -988,6 +988,82 @@ impl OverlaySession {
 		self.response_waker = Some(waker);
 	}
 
+	#[doc(hidden)]
+	pub fn debug_prepare_live_test_session(&mut self, monitor: MonitorRect) {
+		self.state.mode = OverlayMode::Live;
+		self.state.monitor = Some(monitor);
+		self.state.cursor = None;
+		self.state.hovered_window_rect = None;
+		self.state.drag_rect = None;
+		self.state.frozen_capture_rect = None;
+		self.state.frozen_display_image = None;
+		self.state.frozen_export_image = None;
+		self.last_event_cursor = None;
+		self.last_event_cursor_at = None;
+		self.live_capture_interaction = LiveCaptureInteraction::Idle;
+		self.capture_windows_hidden = false;
+	}
+
+	#[doc(hidden)]
+	pub fn debug_set_window_list_snapshot(&mut self, snapshot: Arc<WindowListSnapshot>) {
+		self.window_list_snapshot = Some(snapshot);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[doc(hidden)]
+	pub fn debug_seed_macos_live_stream_snapshot(
+		&mut self,
+		monitor: MonitorRect,
+		captured_at: Instant,
+	) {
+		let stream = self.live_sample_stream.get_or_insert_with(MacLiveFrameStream::new);
+
+		stream.debug_set_self_capture_filter_complete(monitor.id, true);
+		stream.debug_store_test_snapshot(monitor, captured_at);
+	}
+
+	#[doc(hidden)]
+	pub fn debug_cursor(&self) -> Option<GlobalPoint> {
+		self.state.cursor
+	}
+
+	#[doc(hidden)]
+	pub fn debug_hovered_window_rect(&self) -> Option<(u32, RectPoints)> {
+		self.state
+			.hovered_window_rect
+			.map(|hovered_window_rect| (hovered_window_rect.monitor_id, hovered_window_rect.rect))
+	}
+
+	#[doc(hidden)]
+	pub fn debug_drag_rect(&self) -> Option<(u32, RectPoints)> {
+		self.state.drag_rect.map(|drag_rect| (drag_rect.monitor_id, drag_rect.rect))
+	}
+
+	#[doc(hidden)]
+	pub fn debug_frozen_capture_rect(&self) -> Option<RectPoints> {
+		self.state.frozen_capture_rect
+	}
+
+	#[doc(hidden)]
+	pub fn debug_is_frozen_mode(&self) -> bool {
+		matches!(self.state.mode, OverlayMode::Frozen)
+	}
+
+	#[doc(hidden)]
+	pub fn debug_has_frozen_display_image(&self) -> bool {
+		self.state.frozen_display_image.is_some()
+	}
+
+	#[doc(hidden)]
+	pub fn debug_has_frozen_export_image(&self) -> bool {
+		self.state.frozen_export_image.is_some()
+	}
+
+	#[doc(hidden)]
+	pub fn debug_capture_windows_hidden(&self) -> bool {
+		self.capture_windows_hidden
+	}
+
 	#[cfg(target_os = "macos")]
 	/// Applies one host-routed passive AppKit capture input event.
 	pub fn handle_native_capture_input_event(

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -202,6 +202,11 @@ impl MacOSCaptureHost {
 		self.restore_frontmost_application_after_exit(target);
 	}
 
+	#[doc(hidden)]
+	pub fn debug_dispatch_native_capture_input(&self, event: MacOSNativeCaptureInputEvent) {
+		self.native_capture_input_dispatch.enqueue(event);
+	}
+
 	fn ensure_native_capture_shells(&mut self, session: &mut OverlaySession) -> Result<(), String> {
 		if self.native_capture_shells.is_some() {
 			self.sync_native_capture_shells(session)?;


### PR DESCRIPTION
## Summary
- add app-level macOS tests for buffered host-backed native input wakeup, drain, generation filtering, and display-first frozen entry
- inject overlay user events through a lightweight `OverlayEventProxy` so app tests can exercise the real dispatch chain without constructing a main-thread winit event loop
- expose narrow overlay debug harness hooks needed to seed live snapshots and observe session state from the app test layer

## Testing
- cargo make lint
- cargo test -p rsnap capture_host_macos --lib
- cargo test -p rsnap host_buffered_native_ --lib
- cargo make test

Linear: https://linear.app/hack-ink/issue/XY-299/add-app-level-coverage-for-host-backed-native-capture-input-dispatch