### PR TITLE
XY-302: add app-level coverage for host-owned text, IME, and keyboard dispatch

### DIFF
--- a/apps/rsnap/src/app/capture_host_macos.rs
+++ b/apps/rsnap/src/app/capture_host_macos.rs
@@ -161,7 +161,8 @@ mod tests {
 	use std::sync::atomic::{AtomicUsize, Ordering};
 	use std::time::{Duration, Instant};
 
-	use winit::event::{ElementState, MouseButton};
+	use winit::event::{ElementState, Ime, MouseButton};
+	use winit::keyboard::{Key, NamedKey};
 
 	use crate::app::capture_host_macos::OverlayNativeCaptureInputBuffer;
 	use crate::app::scroll_input_macos::{ScrollInputObserverLifecycle, SharedScrollInputState};
@@ -233,6 +234,52 @@ mod tests {
 			.lock()
 			.expect("native input queue lock should be available")
 			.len()
+	}
+
+	fn frozen_text_capture_rect() -> RectPoints {
+		RectPoints::new(100, 120, 220, 180)
+	}
+
+	fn frozen_text_cursor(monitor: MonitorRect, capture_rect: RectPoints) -> GlobalPoint {
+		GlobalPoint::new(
+			monitor.origin.x + capture_rect.x as i32 + 40,
+			monitor.origin.y + capture_rect.y as i32 + 40,
+		)
+	}
+
+	fn app_with_frozen_text_session() -> (App, Arc<AtomicUsize>, MonitorRect) {
+		let (mut app, wake_count) = test_app();
+		let monitor = test_monitor();
+		let capture_rect = frozen_text_capture_rect();
+		let cursor = frozen_text_cursor(monitor, capture_rect);
+		let mut session = OverlaySession::with_config(OverlayConfig::default());
+
+		session.debug_prepare_frozen_text_test_session(monitor, capture_rect, cursor);
+
+		app.overlay_session_generation = 13;
+		app.overlay_session = Some(session);
+		app.overlay_capture_host = Some(app.build_overlay_capture_host());
+
+		(app, wake_count, monitor)
+	}
+
+	fn dispatch_native_capture_input(app: &App, event: MacOSNativeCaptureInputEvent) {
+		app.overlay_capture_host
+			.as_ref()
+			.expect("overlay capture host should be attached for app-level dispatch tests")
+			.debug_dispatch_native_capture_input(event);
+	}
+
+	fn dispatch_keyboard_input(
+		app: &App,
+		monitor: MonitorRect,
+		logical_key: Key,
+		text: Option<&str>,
+	) {
+		app.overlay_capture_host
+			.as_ref()
+			.expect("overlay capture host should be attached for app-level dispatch tests")
+			.debug_dispatch_keyboard_input(Some(monitor), logical_key, text);
 	}
 
 	#[test]
@@ -416,5 +463,111 @@ mod tests {
 		assert!(session.debug_has_frozen_display_image());
 		assert!(session.debug_has_frozen_export_image());
 		assert!(!session.debug_capture_windows_hidden());
+	}
+
+	#[test]
+	fn host_buffered_native_text_input_reaches_frozen_text_edit_through_app_dispatch() {
+		let (mut app, wake_count, monitor) = app_with_frozen_text_session();
+
+		assert!(
+			app.overlay_session
+				.as_ref()
+				.expect("overlay session should be active")
+				.debug_wants_macos_frozen_text_host_focus()
+		);
+
+		dispatch_keyboard_input(&app, monitor, Key::Character(String::from("A").into()), Some("A"));
+
+		assert_eq!(queued_native_input_count(&app), 1);
+		assert!(app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+		assert_eq!(wake_count.load(Ordering::Acquire), 1);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		assert_eq!(queued_native_input_count(&app), 0);
+		assert!(!app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+
+		let session = app.overlay_session.as_ref().expect("overlay session should remain active");
+		let host =
+			app.overlay_capture_host.as_ref().expect("overlay capture host should remain attached");
+
+		assert_eq!(session.debug_frozen_text_edit_text(), Some("A"));
+		assert_eq!(session.debug_frozen_text_annotation_count(), 0);
+		assert!(session.debug_wants_macos_frozen_text_host_focus());
+		assert!(host.debug_last_synced_frozen_mode());
+	}
+
+	#[test]
+	fn host_buffered_native_ime_preedit_reaches_frozen_text_edit_through_app_dispatch() {
+		let (mut app, wake_count, monitor) = app_with_frozen_text_session();
+
+		dispatch_native_capture_input(
+			&app,
+			MacOSNativeCaptureInputEvent::Ime {
+				monitor: Some(monitor),
+				event: Ime::Preedit(String::from("汉"), Some((0, 0))),
+			},
+		);
+
+		assert_eq!(queued_native_input_count(&app), 1);
+		assert!(app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+		assert_eq!(wake_count.load(Ordering::Acquire), 1);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		let session = app.overlay_session.as_ref().expect("overlay session should remain active");
+
+		assert_eq!(session.debug_frozen_text_ime_preedit(), Some("汉"));
+		assert!(session.debug_wants_macos_frozen_text_host_focus());
+	}
+
+	#[test]
+	fn host_buffered_native_ime_commit_reaches_frozen_text_edit_through_app_dispatch() {
+		let (mut app, wake_count, monitor) = app_with_frozen_text_session();
+
+		dispatch_native_capture_input(
+			&app,
+			MacOSNativeCaptureInputEvent::Ime {
+				monitor: Some(monitor),
+				event: Ime::Commit(String::from("汉")),
+			},
+		);
+
+		assert_eq!(queued_native_input_count(&app), 1);
+		assert!(app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+		assert_eq!(wake_count.load(Ordering::Acquire), 1);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		let session = app.overlay_session.as_ref().expect("overlay session should remain active");
+
+		assert_eq!(session.debug_frozen_text_edit_text(), Some("汉"));
+		assert!(session.debug_wants_macos_frozen_text_host_focus());
+	}
+
+	#[test]
+	fn host_buffered_native_escape_cancels_frozen_text_edit_and_releases_host_focus() {
+		let (mut app, wake_count, monitor) = app_with_frozen_text_session();
+
+		dispatch_keyboard_input(&app, monitor, Key::Character(String::from("A").into()), Some("A"));
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		dispatch_keyboard_input(&app, monitor, Key::Named(NamedKey::Escape), None);
+
+		assert_eq!(queued_native_input_count(&app), 1);
+		assert!(app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+		assert_eq!(wake_count.load(Ordering::Acquire), 2);
+
+		app.handle_overlay_native_capture_input_user_event_for_test();
+
+		assert_eq!(queued_native_input_count(&app), 0);
+		assert!(!app.overlay_native_capture_input_buffer.event_pending.load(Ordering::Acquire));
+
+		let session = app.overlay_session.as_ref().expect("overlay session should remain active");
+
+		assert!(!session.debug_has_frozen_text_edit());
+		assert_eq!(session.debug_frozen_text_annotation_count(), 0);
+		assert!(!session.debug_wants_macos_frozen_text_host_focus());
 	}
 }

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1038,6 +1038,37 @@ impl OverlaySession {
 	}
 
 	#[doc(hidden)]
+	pub fn debug_prepare_frozen_text_test_session(
+		&mut self,
+		monitor: MonitorRect,
+		capture_rect: RectPoints,
+		cursor: GlobalPoint,
+	) {
+		self.debug_prepare_live_test_session(monitor);
+
+		self.session_active = true;
+
+		self.state.begin_freeze(monitor);
+
+		self.state.frozen_capture_rect = Some(capture_rect);
+
+		let frozen_image = RgbaImage::from_pixel(
+			capture_rect.width.max(1),
+			capture_rect.height.max(1),
+			image::Rgba([0, 0, 0, 255]),
+		);
+
+		self.state.commit_frozen_display_image(monitor, frozen_image.clone());
+		self.state.commit_frozen_export_image(frozen_image);
+
+		self.toolbar_state.selected_tool = FrozenToolbarTool::Text;
+		self.toolbar_state.visible = true;
+		self.toolbar_window_visible = true;
+
+		let _ = self.begin_frozen_text_edit_at(monitor, cursor);
+	}
+
+	#[doc(hidden)]
 	pub fn debug_cursor(&self) -> Option<GlobalPoint> {
 		self.state.cursor
 	}
@@ -1072,6 +1103,34 @@ impl OverlaySession {
 	#[doc(hidden)]
 	pub fn debug_has_frozen_export_image(&self) -> bool {
 		self.state.frozen_export_image.is_some()
+	}
+
+	#[doc(hidden)]
+	pub fn debug_has_frozen_text_edit(&self) -> bool {
+		self.frozen_text_edit.is_some()
+	}
+
+	#[doc(hidden)]
+	pub fn debug_frozen_text_edit_text(&self) -> Option<&str> {
+		self.frozen_text_edit.as_ref().map(|edit| edit.text.as_str())
+	}
+
+	#[doc(hidden)]
+	pub fn debug_frozen_text_ime_preedit(&self) -> Option<&str> {
+		self.frozen_text_edit.as_ref().and_then(|edit| edit.ime_preedit.as_deref())
+	}
+
+	#[doc(hidden)]
+	pub fn debug_frozen_text_annotation_count(&self) -> usize {
+		self.frozen_text_annotations.len()
+	}
+
+	#[cfg(target_os = "macos")]
+	#[doc(hidden)]
+	pub fn debug_wants_macos_frozen_text_host_focus(&self) -> bool {
+		matches!(self.state.mode, OverlayMode::Frozen)
+			&& self.frozen_text_tool_active()
+			&& self.frozen_text_edit.is_some()
 	}
 
 	#[doc(hidden)]

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -216,6 +216,29 @@ impl MacOSCaptureHost {
 		self.native_capture_input_dispatch.enqueue(event);
 	}
 
+	#[doc(hidden)]
+	pub fn debug_dispatch_keyboard_input(
+		&self,
+		monitor: Option<MonitorRect>,
+		logical_key: Key,
+		text: Option<&str>,
+	) {
+		self.native_capture_input_dispatch.enqueue(MacOSNativeCaptureInputEvent::KeyboardInput {
+			monitor,
+			event: OverlayKeyboardInputEvent {
+				logical_key,
+				text: text.map(String::from),
+				state: ElementState::Pressed,
+				repeat: false,
+			},
+		});
+	}
+
+	#[doc(hidden)]
+	pub fn debug_last_synced_frozen_mode(&self) -> bool {
+		self.last_synced_frozen_mode
+	}
+
 	/// Synchronizes native macOS capture shells from explicit host/core state.
 	pub fn sync(&mut self, state: MacOSCaptureHostSyncState) -> Result<(), String> {
 		if self.native_capture_shells.is_some() {


### PR DESCRIPTION
## Summary
- add app-level coverage for the host-owned frozen text boundary through the real app buffer, wakeup, and drain path
- cover text input, IME preedit, IME commit, and Escape cancellation in the app-owned dispatch path
- keep the new test seam narrow with debug-only helpers and assert that frozen-mode host sync still runs after app dispatch

## Validation
- cargo make lint
- cargo make test

## Notes
- this PR stays on the app-owned host boundary and does not widen into separate AppKit key translation or global hotkey integration slices