### PR TITLE
XY-295: move scroll capture capability ownership into app host

### DIFF
--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -47,7 +47,7 @@ use crate::settings::AppSettings;
 use crate::settings_window::{SettingsWindow, SettingsWindowEntry};
 use rsnap_overlay::OverlaySession;
 #[cfg(target_os = "macos")]
-use rsnap_overlay::{FrozenGlobalHotkey, MacOSCaptureHost};
+use rsnap_overlay::{FrozenGlobalHotkey, MacOSCaptureHost, MacOSScrollCaptureCapability};
 
 pub(crate) enum UserEvent {
 	TrayIcon,
@@ -167,6 +167,8 @@ struct App {
 	overlay_session: Option<OverlaySession>,
 	#[cfg(target_os = "macos")]
 	overlay_capture_host: Option<MacOSCaptureHost>,
+	#[cfg(target_os = "macos")]
+	overlay_scroll_capture_capability: Option<MacOSScrollCaptureCapability>,
 	#[cfg(target_os = "macos")]
 	prewarmed_overlay_session: Option<OverlaySession>,
 	settings_window: Option<SettingsWindow>,
@@ -289,6 +291,8 @@ impl App {
 			overlay_session: None,
 			#[cfg(target_os = "macos")]
 			overlay_capture_host: None,
+			#[cfg(target_os = "macos")]
+			overlay_scroll_capture_capability: None,
 			#[cfg(target_os = "macos")]
 			prewarmed_overlay_session: None,
 			settings_window: None,

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -57,6 +57,8 @@ use crate::settings;
 #[cfg(target_os = "macos")]
 use rsnap_overlay::{
 	DeferredTextRecognitionOutcomeKind, DeferredTextRecognitionRequest, MacOSCaptureHost,
+	MacOSScrollCaptureCapability, MacOSScrollCaptureCapabilityEvent, ScrollCaptureHostAdapter,
+	ScrollCaptureHostFrameRequestError,
 };
 use rsnap_overlay::{
 	HudAnchor, OutputNaming, OverlayConfig, OverlayControl, OverlayExit, OverlayHostEffectRequest,
@@ -476,6 +478,9 @@ impl App {
 		}
 
 		let scroll_input_reset_ms = self.reset_scroll_input_for_capture_start();
+
+		self.prepare_scroll_capture_capability_for_capture_start();
+
 		let hook_wiring_started_at = Instant::now();
 
 		self.wire_capture_session_hooks(&mut overlay_session);
@@ -576,8 +581,34 @@ impl App {
 	}
 
 	#[cfg(target_os = "macos")]
+	fn build_overlay_scroll_capture_capability(&self) -> MacOSScrollCaptureCapability {
+		MacOSScrollCaptureCapability::new(
+			self.self_capture_exception_window_ids(),
+			Some(Arc::new({
+				let overlay_proxy = self.overlay_proxy.clone();
+
+				move || {
+					let _ = overlay_proxy.send_event(UserEvent::OverlayWorkerResponse);
+				}
+			})),
+		)
+	}
+
+	#[cfg(target_os = "macos")]
+	fn prepare_scroll_capture_capability_for_capture_start(&mut self) {
+		self.overlay_scroll_capture_capability =
+			Some(self.build_overlay_scroll_capture_capability());
+	}
+
+	#[cfg(not(target_os = "macos"))]
+	fn prepare_scroll_capture_capability_for_capture_start(&mut self) {}
+
+	#[cfg(target_os = "macos")]
 	fn reset_capture_start_after_failure(&mut self) {
 		self.reset_overlay_native_capture_input_dispatch();
+
+		self.overlay_scroll_capture_capability = None;
+
 		self.pending_deferred_ocr_generation.store(0, Ordering::Release);
 		self.scroll_input_shared_state.set_enabled(false);
 		self.scroll_input_shared_state.set_event_waker(None);
@@ -747,30 +778,89 @@ impl App {
 					let _ = overlay_proxy.send_event(UserEvent::OverlayWorkerResponse);
 				}
 			}));
-			overlay_session.set_external_scroll_input_drain_reader(Arc::new({
+
+			let external_scroll_input_drain_reader = Arc::new({
 				let shared_state = Arc::clone(&self.scroll_input_shared_state);
 
 				move |after_seq, through| shared_state.replay_after_seq_through(after_seq, through)
-			}));
+			});
+			let scroll_capture_capability_for_start =
+				self.overlay_scroll_capture_capability.clone();
+			let scroll_capture_capability_for_request =
+				self.overlay_scroll_capture_capability.clone();
 
-			overlay_session
-				.set_scroll_capture_start_guard(Arc::new(Self::ensure_scroll_capture_permissions));
+			overlay_session.set_scroll_capture_host_adapter(ScrollCaptureHostAdapter::new(
+				Arc::new({
+					let shared_state = Arc::clone(&self.scroll_input_shared_state);
+					let observer_lifecycle = Arc::clone(&self.scroll_input_observer_lifecycle);
 
-			overlay_session.set_scroll_capture_starting_hook(Arc::new({
-				let shared_state = Arc::clone(&self.scroll_input_shared_state);
-				let observer_lifecycle = Arc::clone(&self.scroll_input_observer_lifecycle);
+					move |request| {
+						let _ = request;
+						let Some(_capability) = scroll_capture_capability_for_start.as_ref() else {
+							return Err(eyre::eyre!("Scroll capture capability is unavailable."));
+						};
 
-				move || Self::prepare_external_scroll_input(&shared_state, &observer_lifecycle)
-			}));
-			overlay_session.set_scroll_capture_started_hook(Arc::new({
-				let shared_state = Arc::clone(&self.scroll_input_shared_state);
+						if !Self::ensure_scroll_capture_permissions()? {
+							return Ok(false);
+						}
 
-				move || Self::enable_external_scroll_input(&shared_state)
-			}));
+						Self::prepare_external_scroll_input(&shared_state, &observer_lifecycle)?;
+						Self::enable_external_scroll_input(&shared_state);
+
+						Ok(true)
+					}
+				}),
+				Arc::new({
+					let shared_state = Arc::clone(&self.scroll_input_shared_state);
+
+					move || {
+						shared_state.set_enabled(false);
+						shared_state.clear();
+					}
+				}),
+				Arc::new(move |monitor, rect_px, request_id| {
+					let Some(capability) = scroll_capture_capability_for_request.as_ref() else {
+						return Err(ScrollCaptureHostFrameRequestError::Unavailable(String::from(
+							"Scroll capture capability is unavailable.",
+						)));
+					};
+
+					capability.request_frame(monitor, rect_px, request_id)
+				}),
+				external_scroll_input_drain_reader,
+			));
 		}
 		#[cfg(not(target_os = "macos"))]
 		{
 			let _ = overlay_session;
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn drain_overlay_scroll_capture_capability_events(&mut self) {
+		let Some(capability) = self.overlay_scroll_capture_capability.as_ref() else {
+			return;
+		};
+		let events = capability.drain_events();
+		let Some(session) = self.overlay_session.as_mut() else {
+			return;
+		};
+
+		for event in events {
+			match event {
+				MacOSScrollCaptureCapabilityEvent::Frame {
+					monitor,
+					rect_px,
+					request_id,
+					image,
+				} => session.handle_host_scroll_capture_frame(monitor, rect_px, request_id, image),
+				MacOSScrollCaptureCapabilityEvent::NoNewFrame { monitor, rect_px, request_id } => {
+					session.handle_host_scroll_capture_no_frame(monitor, rect_px, request_id)
+				},
+				MacOSScrollCaptureCapabilityEvent::Failure { message } => {
+					session.report_scroll_capture_capability_error(message);
+				},
+			}
 		}
 	}
 
@@ -824,6 +914,7 @@ impl App {
 		#[cfg(target_os = "macos")]
 		{
 			self.prewarmed_overlay_session = None;
+			self.overlay_scroll_capture_capability = None;
 			self.overlay_session_prewarm_requested = true;
 			self.overlay_session_prewarm_retry_not_before = None;
 

--- a/apps/rsnap/src/app/runtime.rs
+++ b/apps/rsnap/src/app/runtime.rs
@@ -79,6 +79,8 @@ impl ApplicationHandler<UserEvent> for App {
 			},
 			#[cfg(target_os = "macos")]
 			UserEvent::OverlayWorkerResponse => {
+				self.drain_overlay_scroll_capture_capability_events();
+
 				if let Some(session) = self.overlay_session.as_mut() {
 					let control = session.handle_worker_response_ready();
 

--- a/apps/rsnap/src/app/scroll_input_macos/decode.rs
+++ b/apps/rsnap/src/app/scroll_input_macos/decode.rs
@@ -7,6 +7,9 @@ const KCG_SCROLL_WHEEL_EVENT_IS_CONTINUOUS_FIELD: u32 = 88;
 const KCG_SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1_FIELD: u32 = 96;
 const KCG_SCROLL_WHEEL_EVENT_SCROLL_PHASE_FIELD: u32 = 99;
 const KCG_SCROLL_WHEEL_EVENT_MOMENTUM_PHASE_FIELD: u32 = 123;
+const MACOS_SCROLL_PIXEL_WRAP_MODULUS: f64 = 4_294_967_296.0;
+const MACOS_SCROLL_PIXEL_WRAP_THRESHOLD: f64 = 1_000_000.0;
+const MACOS_SCROLL_PIXEL_DELTA_CLAMP: f64 = 240.0;
 const NSEVENT_PHASE_BEGAN: u64 = 0x1 << 0;
 const NSEVENT_PHASE_STATIONARY: u64 = 0x1 << 1;
 const NSEVENT_PHASE_CHANGED: u64 = 0x1 << 2;
@@ -35,7 +38,12 @@ pub(super) fn decode_scroll_input_from_cg_event(
 	cg_event: CGEventRef,
 ) -> Option<DecodedScrollInput> {
 	let location = unsafe { CGEventGetLocation(cg_event) };
-	let raw_delta_y = scroll_delta_y_from_cg_event(cg_event);
+	let (raw_delta_y, is_continuous) = scroll_delta_y_from_cg_event(cg_event);
+	let delta_y = if is_continuous {
+		normalize_macos_scroll_pixel_component(raw_delta_y)
+	} else {
+		raw_delta_y
+	};
 	let scroll_phase = scroll_phase_bits_from_cg_event(cg_event);
 	let momentum_phase = scroll_momentum_phase_bits_from_cg_event(cg_event);
 	let gesture_active =
@@ -55,27 +63,25 @@ pub(super) fn decode_scroll_input_from_cg_event(
 		"Decoded native macOS scroll input event."
 	);
 
-	decode_scroll_input_from_fields(raw_delta_y, location, gesture_active, gesture_ended)
+	decode_scroll_input_from_parts(raw_delta_y, delta_y, location, gesture_active, gesture_ended)
 }
 
-pub(super) fn decode_scroll_input_from_fields(
-	raw_delta_y: f64,
-	location: MacOSCGPoint,
-	gesture_active: bool,
-	gesture_ended: bool,
-) -> Option<DecodedScrollInput> {
-	if raw_delta_y == 0.0 && !gesture_ended {
-		return None;
+pub(super) fn normalize_macos_scroll_pixel_component(value: f64) -> f64 {
+	if !value.is_finite() {
+		return 0.0;
 	}
 
-	Some(DecodedScrollInput {
-		raw_delta_y,
-		delta_y: raw_delta_y,
-		global_x: location.x,
-		global_y: location.y,
-		gesture_active,
-		gesture_ended,
-	})
+	let normalized = if value.abs() > MACOS_SCROLL_PIXEL_WRAP_THRESHOLD {
+		if value.is_sign_positive() {
+			value - MACOS_SCROLL_PIXEL_WRAP_MODULUS
+		} else {
+			value + MACOS_SCROLL_PIXEL_WRAP_MODULUS
+		}
+	} else {
+		value
+	};
+
+	normalized.clamp(-MACOS_SCROLL_PIXEL_DELTA_CLAMP, MACOS_SCROLL_PIXEL_DELTA_CLAMP)
 }
 
 pub(super) fn scroll_phase_bits_are_active(phase_bits: u64) -> bool {
@@ -91,17 +97,65 @@ pub(super) fn scroll_phase_bits_are_terminal(phase_bits: u64) -> bool {
 	phase_bits & (NSEVENT_PHASE_ENDED | NSEVENT_PHASE_CANCELLED) != 0
 }
 
-fn scroll_delta_y_from_cg_event(cg_event: CGEventRef) -> f64 {
+#[cfg(test)]
+fn decode_scroll_input_from_fields(
+	raw_delta_y: f64,
+	location: MacOSCGPoint,
+	gesture_active: bool,
+	gesture_ended: bool,
+) -> Option<DecodedScrollInput> {
+	decode_scroll_input_from_parts(
+		raw_delta_y,
+		raw_delta_y,
+		location,
+		gesture_active,
+		gesture_ended,
+	)
+}
+
+fn decode_scroll_input_from_parts(
+	raw_delta_y: f64,
+	delta_y: f64,
+	location: MacOSCGPoint,
+	gesture_active: bool,
+	gesture_ended: bool,
+) -> Option<DecodedScrollInput> {
+	if raw_delta_y == 0.0 && !gesture_ended {
+		return None;
+	}
+
+	Some(DecodedScrollInput {
+		raw_delta_y,
+		delta_y,
+		global_x: location.x,
+		global_y: location.y,
+		gesture_active,
+		gesture_ended,
+	})
+}
+
+fn scroll_delta_y_from_cg_event(cg_event: CGEventRef) -> (f64, bool) {
 	let is_continuous = unsafe {
 		CGEventGetIntegerValueField(cg_event, KCG_SCROLL_WHEEL_EVENT_IS_CONTINUOUS_FIELD)
 	} != 0;
 
 	if is_continuous {
-		unsafe {
-			CGEventGetDoubleValueField(cg_event, KCG_SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1_FIELD)
-		}
+		(
+			unsafe {
+				CGEventGetDoubleValueField(
+					cg_event,
+					KCG_SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1_FIELD,
+				)
+			},
+			true,
+		)
 	} else {
-		unsafe { CGEventGetDoubleValueField(cg_event, KCG_SCROLL_WHEEL_EVENT_DELTA_AXIS_1_FIELD) }
+		(
+			unsafe {
+				CGEventGetDoubleValueField(cg_event, KCG_SCROLL_WHEEL_EVENT_DELTA_AXIS_1_FIELD)
+			},
+			false,
+		)
 	}
 }
 
@@ -164,5 +218,17 @@ mod tests {
 		assert!(decode::scroll_phase_bits_are_terminal(NSEVENT_PHASE_ENDED));
 		assert!(decode::scroll_phase_bits_are_terminal(NSEVENT_PHASE_CANCELLED));
 		assert!(!decode::scroll_phase_bits_are_terminal(NSEVENT_PHASE_BEGAN));
+	}
+
+	#[test]
+	fn normalize_scroll_input_wraps_large_pixel_deltas_back_into_signed_range() {
+		assert_eq!(decode::normalize_macos_scroll_pixel_component(4_294_967_294.0), -2.0);
+		assert_eq!(decode::normalize_macos_scroll_pixel_component(4_294_967_290.0), -6.0);
+	}
+
+	#[test]
+	fn normalize_scroll_input_clamps_continuous_pixel_delta_magnitude() {
+		assert_eq!(decode::normalize_macos_scroll_pixel_component(512.0), 240.0);
+		assert_eq!(decode::normalize_macos_scroll_pixel_component(-512.0), -240.0);
 	}
 }

--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -62,6 +62,15 @@ comfortable, such as:
 - filing or landing cleanup that only splits files without clarifying the future boundary
 - hard-coding product behavior around a specific platform shell implementation
 
+Current reset posture for the scroll-capture slice:
+
+- the native app host owns scroll-capture permission checks, external scroll-input observer
+  lifecycle, native scroll-input normalization, and screenshot capability acquisition
+- the Rust overlay core owns scroll-capture session state, overlap proof, stitching, and
+  fail-closed product semantics
+- capability start/stop, frame delivery, and host-side failures must cross the boundary as explicit
+  host/core protocol calls instead of implicit worker ownership inside the overlay runtime
+
 ## Vertical-slice model
 
 The reset is intended to land as vertical slices rather than as one giant rewrite.

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -31,7 +31,7 @@ For the active target architecture and migration direction, read:
 | Path | Role |
 | --- | --- |
 | `apps/rsnap/` | Desktop app-shell crate: tray/menubar startup, hotkeys, settings window, permissions, logging, and session handoff into `rsnap-overlay` |
-| `packages/rsnap-overlay/` | Current overlay/runtime crate: capture-session logic, overlay rendering, capture backend integration, worker runtime, and scroll capture |
+| `packages/rsnap-overlay/` | Current overlay/runtime crate: capture-session logic, overlay rendering, capture backend integration, worker runtime, and scroll-capture stitching/replay semantics |
 | `docs/` | Agent-facing repository docs split into `spec`, `runbook`, `reference`, and `decisions` |
 | `assets/` | Shared app-icon and tray-icon source plus generated bundle/runtime assets |
 | `scripts/` | Packaging and dedicated macOS smoke helpers |
@@ -55,7 +55,9 @@ It owns:
 - app-level logging/bootstrap
 - macOS native capture-host shell lifecycle for pointer, first-responder, keyboard, and IME
   routing into the overlay core
-- macOS external scroll-input normalization before handing events to the overlay session
+- macOS external scroll-input normalization and observer lifecycle before handing replayable input
+  into the overlay session
+- macOS scroll-capture screenshot capability acquisition and host-side capability error delivery
 - deferred OCR generation tracking around overlay exits
 
 Key paths:

--- a/packages/rsnap-overlay/src/lib.rs
+++ b/packages/rsnap-overlay/src/lib.rs
@@ -35,6 +35,8 @@ mod ocr_macos;
 mod overlay;
 mod png;
 mod scroll_capture;
+#[cfg(target_os = "macos")]
+mod scroll_capture_capability_macos;
 mod state;
 mod system_fonts;
 mod text_rendering;
@@ -54,7 +56,12 @@ pub use crate::overlay::{
 #[cfg(target_os = "macos")]
 pub use crate::overlay::{
 	MacOSCaptureHost, MacOSCaptureHostSyncState, MacOSNativeCaptureInputEvent,
-	MacOSNativeCaptureScrollDelta,
+	MacOSNativeCaptureScrollDelta, ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
+	ScrollCaptureHostStartRequest,
+};
+#[cfg(target_os = "macos")]
+pub use crate::scroll_capture_capability_macos::{
+	MacOSScrollCaptureCapability, MacOSScrollCaptureCapabilityEvent,
 };
 pub use crate::state::{
 	GlobalPoint, LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb, WindowHit,

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -230,12 +230,30 @@ type ExternalScrollInputDrainReader =
 	Arc<dyn Fn(u64, Instant) -> Vec<ExternalScrollInputEvent> + Send + Sync>;
 
 #[cfg(target_os = "macos")]
+type ScrollCaptureHostStart =
+	Arc<dyn Fn(ScrollCaptureHostStartRequest) -> color_eyre::eyre::Result<bool> + Send + Sync>;
+
+#[cfg(target_os = "macos")]
+type ScrollCaptureHostStop = Arc<dyn Fn() + Send + Sync>;
+
+#[cfg(target_os = "macos")]
+type ScrollCaptureHostFrameRequest = Arc<
+	dyn Fn(
+			MonitorRect,
+			RectPoints,
+			u64,
+		) -> std::result::Result<(), ScrollCaptureHostFrameRequestError>
+		+ Send
+		+ Sync,
+>;
+
+#[cfg(all(test, target_os = "macos"))]
 type ScrollCaptureStartGuard = Arc<dyn Fn() -> color_eyre::eyre::Result<bool> + Send + Sync>;
 
-#[cfg(target_os = "macos")]
+#[cfg(all(test, target_os = "macos"))]
 type ScrollCaptureStartingHook = Arc<dyn Fn() -> color_eyre::eyre::Result<()> + Send + Sync>;
 
-#[cfg(target_os = "macos")]
+#[cfg(all(test, target_os = "macos"))]
 type ScrollCaptureStartedHook = Arc<dyn Fn() + Send + Sync>;
 
 type Result<T, E = Report> = std::result::Result<T, E>;
@@ -413,41 +431,556 @@ const SCROLL_CAPTURE_PREVIEW_WIDTH_PX: u32 = 320;
 const KCG_EVENT_SOURCE_STATE_HID_SYSTEM_STATE: u32 = 0;
 
 #[cfg(target_os = "macos")]
-pub(super) struct MacOSOverlayCursorRectSupport {
-	view_key: usize,
-}
-#[cfg(target_os = "macos")]
-impl MacOSOverlayCursorRectSupport {
-	const fn new(view_key: usize) -> Self {
-		Self { view_key }
-	}
-
-	fn sync_cursor_rects(&self, window: &Window, rects: &[OverlayCursorRect]) {
-		macos_resize_overlay_cursor_view(window, self.view_key);
-
-		if macos_set_overlay_view_cursor_rects(self.view_key, rects) {
-			macos_invalidate_overlay_cursor_rects(self.view_key);
-		}
-
-		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
-	}
+#[derive(Debug)]
+/// Failure contract for one host-owned scroll-capture frame request.
+pub enum ScrollCaptureHostFrameRequestError {
+	/// The host capability is temporarily busy; the core should back off and retry.
+	Busy,
+	/// The host capability is unavailable and the session must fail closed with this message.
+	Unavailable(String),
 }
 
-#[cfg(target_os = "macos")]
-impl Drop for MacOSOverlayCursorRectSupport {
-	fn drop(&mut self) {
-		let rects = macos_overlay_view_cursor_rects();
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Selects how the live HUD should be positioned.
+pub enum HudAnchor {
+	/// Pin the HUD cluster to the current cursor position.
+	Cursor,
+}
 
-		match rects.lock() {
-			Ok(mut guard) => {
-				guard.remove(&self.view_key);
-			},
-			Err(poisoned) => {
-				poisoned.into_inner().remove(&self.view_key);
-			},
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Chooses the requested HUD and chrome theme.
+pub enum ThemeMode {
+	#[default]
+	/// Follow the host window or operating-system theme.
+	System,
+	/// Force the dark theme variant.
+	Dark,
+	/// Force the light theme variant.
+	Light,
+}
+
+#[derive(Debug)]
+/// A host-owned side-effect request emitted by the overlay core.
+pub enum OverlayHostEffectRequest {
+	/// Copy the encoded PNG for the completed capture to the host clipboard.
+	CopyPng {
+		/// Immutable encoded PNG payload prepared from the authoritative export image.
+		png_bytes: Vec<u8>,
+	},
+	/// Save the encoded PNG for the completed capture through the host-owned output path.
+	SavePng {
+		/// Immutable encoded PNG payload prepared from the authoritative export image.
+		png_bytes: Vec<u8>,
+		/// Output directory snapshot captured when the save request was issued.
+		output_dir: PathBuf,
+		/// Filename prefix snapshot captured when the save request was issued.
+		output_filename_prefix: String,
+		/// Naming policy snapshot captured when the save request was issued.
+		output_naming: OutputNaming,
+	},
+	/// Run deferred OCR for the completed capture through the native host.
+	#[cfg(target_os = "macos")]
+	DeferredTextRecognition(DeferredTextRecognitionRequest),
+}
+
+#[derive(Debug)]
+/// Describes how an overlay session finished.
+pub enum OverlayExit {
+	/// The user cancelled the session without producing output.
+	Cancelled,
+	/// The session completed by handing a host-owned side effect to the caller.
+	HostEffect(OverlayHostEffectRequest),
+	/// The session failed with a user-visible error message.
+	Error(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Host-routed frozen shortcuts that should work without a focused key window.
+pub enum FrozenGlobalHotkey {
+	/// Copy the current frozen export image.
+	Copy,
+	/// Recenter the drag-region capture rect around detected content.
+	AutoCenter,
+	/// Toggle toolbar visibility while frozen.
+	ToggleToolbar,
+	/// Start scroll capture from an existing frozen selection.
+	StartScrollCapture,
+	/// Save the current frozen export image.
+	Save,
+}
+
+#[derive(Debug)]
+/// Signals whether the caller should keep driving the overlay event loop.
+pub enum OverlayControl {
+	/// Keep the session alive and continue processing events.
+	Continue,
+	/// Execute the requested host-owned side effect before deciding whether to exit.
+	HostEffect(OverlayHostEffectRequest),
+	/// Exit the session with the provided terminal outcome.
+	Exit(OverlayExit),
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Controls how the Tab-triggered loupe interaction is activated.
+pub enum AltActivationMode {
+	#[default]
+	/// Enable the loupe only while Tab is held.
+	Hold,
+	/// Toggle the loupe on and off with Tab presses.
+	Toggle,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Chooses where the frozen toolbar is anchored relative to the capture.
+pub enum ToolbarPlacement {
+	/// Render the toolbar above the frozen capture.
+	Top,
+	#[default]
+	/// Render the toolbar below the frozen capture.
+	Bottom,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Selects how saved captures are named on disk.
+pub enum OutputNaming {
+	#[default]
+	/// Use the current Unix timestamp in milliseconds.
+	Timestamp,
+	/// Use a zero-padded incrementing sequence number.
+	Sequence,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Controls how transparent window captures are composited before export.
+pub enum WindowCaptureAlphaMode {
+	#[default]
+	/// Preserve the observed screen background behind transparent pixels.
+	Background,
+	/// Composite transparency against a light matte color.
+	MatteLight,
+	/// Composite transparency against a dark matte color.
+	MatteDark,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+/// Scroll-wheel delta routed from the native passive capture host.
+pub enum MacOSNativeCaptureScrollDelta {
+	/// A line-based scroll delta measured in lines along the x/y axes.
+	Line {
+		/// Horizontal line delta.
+		x: f32,
+		/// Vertical line delta.
+		y: f32,
+	},
+	/// A pixel-based scroll delta measured in pixels along the x/y axes.
+	Pixel {
+		/// Horizontal pixel delta.
+		x: f64,
+		/// Vertical pixel delta.
+		y: f64,
+	},
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug, PartialEq)]
+/// Input event routed from the app-owned macOS passive capture host into the overlay core.
+pub enum MacOSNativeCaptureInputEvent {
+	/// Pointer movement over a passive overlay shell.
+	OverlayPointerMoved {
+		/// Monitor whose passive shell observed the pointer movement.
+		monitor: MonitorRect,
+		/// Pointer location in global desktop coordinates.
+		global: GlobalPoint,
+	},
+	/// Mouse-button activity observed by a passive overlay shell.
+	OverlayMouseInput {
+		/// Monitor whose passive shell observed the mouse input.
+		monitor: MonitorRect,
+		/// Pointer location in global desktop coordinates.
+		global: GlobalPoint,
+		/// Mouse button that changed state.
+		button: MouseButton,
+		/// New state for the button.
+		state: ElementState,
+	},
+	/// Pointer movement over a passive toolbar shell.
+	ToolbarPointerMoved {
+		/// Monitor that currently anchors the toolbar shell.
+		monitor: MonitorRect,
+		/// Pointer location in toolbar-local coordinates.
+		local: Pos2,
+		/// Pointer location in global desktop coordinates.
+		global: GlobalPoint,
+		/// Toolbar shell origin in global desktop coordinates.
+		outer_position: GlobalPoint,
+	},
+	/// Pointer exit from the passive toolbar shell.
+	ToolbarPointerLeft,
+	/// Mouse-button activity observed by the passive toolbar shell.
+	ToolbarMouseInput {
+		/// Mouse button that changed state.
+		button: MouseButton,
+		/// New state for the button.
+		state: ElementState,
+	},
+	/// Scroll-wheel input observed by the passive toolbar shell.
+	ToolbarScrollWheel {
+		/// Scroll delta reported by the native host.
+		delta: MacOSNativeCaptureScrollDelta,
+	},
+	/// Keyboard input forwarded from the passive key-focus shell.
+	KeyboardInput {
+		/// Monitor associated with the active key-focus shell, if any.
+		monitor: Option<MonitorRect>,
+		/// Opaque keyboard event payload translated from winit/native state.
+		event: OverlayKeyboardInputEvent,
+	},
+	/// IME input forwarded from the passive key-focus shell.
+	Ime {
+		/// Monitor associated with the active key-focus shell, if any.
+		monitor: Option<MonitorRect>,
+		/// IME payload to apply inside the overlay session.
+		event: Ime,
+	},
+	/// Modifier-key state update forwarded from the native host.
+	ModifiersChanged {
+		/// Current modifier-key state.
+		state: ModifiersState,
+	},
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+/// Single source of truth for live capture entry.
+///
+/// State flow:
+/// `Idle` -> `HoverWindow` -> `PressPending` -> `DraggingSelection` -> `FrozenFromDrag`
+/// `Idle` -> `HoverWindow` -> `PressPending` -> `FrozenFromClick`
+///
+/// Hover and drag visuals are derived from this state instead of being coordinated through
+/// separate button, hover, and drag flags.
+enum LiveCaptureInteraction {
+	#[default]
+	Idle,
+	HoverWindow {
+		monitor: MonitorRect,
+		target: LiveClickCaptureTarget,
+	},
+	PressPending {
+		monitor: MonitorRect,
+		press_global: GlobalPoint,
+		click_target: Option<LiveClickCaptureTarget>,
+		release_global: Option<GlobalPoint>,
+		released: bool,
+	},
+	DraggingSelection {
+		monitor: MonitorRect,
+		press_global: GlobalPoint,
+		current_global: GlobalPoint,
+	},
+	FrozenFromClick {
+		monitor: MonitorRect,
+		target: LiveClickCaptureTarget,
+	},
+	FrozenFromDrag {
+		monitor: MonitorRect,
+		capture_rect: RectPoints,
+	},
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlayEventLoopPhase {
+	Idle,
+	WindowEvent,
+	AboutToWait,
+	RedrawDispatch,
+	HudRedraw,
+	LoupeRedraw,
+	ToolbarRedraw,
+	OverlayRedraw,
+}
+impl OverlayEventLoopPhase {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Idle => "idle",
+			Self::WindowEvent => "window_event",
+			Self::AboutToWait => "about_to_wait",
+			Self::RedrawDispatch => "redraw_dispatch",
+			Self::HudRedraw => "hud_redraw",
+			Self::LoupeRedraw => "loupe_redraw",
+			Self::ToolbarRedraw => "toolbar_redraw",
+			Self::OverlayRedraw => "overlay_window_redraw",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HudTheme {
+	Dark,
+	Light,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FrozenToolbarTool {
+	Pointer,
+	Pen,
+	Arrow,
+	Text,
+	Mosaic,
+	Spotlight,
+	Undo,
+	Redo,
+	AutoCenter,
+	Scroll,
+	#[cfg(target_os = "macos")]
+	Ocr,
+	Copy,
+	Save,
+}
+impl FrozenToolbarTool {
+	const fn label(self) -> &'static str {
+		match self {
+			Self::Pointer => "Pointer",
+			Self::Pen => "Pen",
+			Self::Arrow => "Arrow",
+			Self::Text => "Text",
+			Self::Mosaic => "Mosaic",
+			Self::Spotlight => "Spotlight",
+			Self::Undo => "Undo",
+			Self::Redo => "Redo",
+			Self::AutoCenter => "Auto-center (C)",
+			Self::Scroll => "Scroll Capture",
+			#[cfg(target_os = "macos")]
+			Self::Ocr => "Recognize Text",
+			Self::Copy => "Copy",
+			Self::Save => "Save",
+		}
+	}
+
+	const fn icon(self) -> &'static str {
+		match self {
+			Self::Pointer => regular::CURSOR,
+			Self::Pen => regular::PENCIL_SIMPLE,
+			Self::Arrow => regular::ARROW_UP_RIGHT,
+			Self::Text => regular::TEXT_T,
+			Self::Mosaic => regular::CHECKERBOARD,
+			Self::Spotlight => regular::FRAME_CORNERS,
+			Self::Undo => regular::ARROW_COUNTER_CLOCKWISE,
+			Self::Redo => regular::ARROW_CLOCKWISE,
+			Self::AutoCenter => regular::ARROWS_IN_CARDINAL,
+			Self::Scroll => regular::ARROWS_DOWN_UP,
+			#[cfg(target_os = "macos")]
+			Self::Ocr => regular::FILE_TEXT,
+			Self::Copy => regular::COPY,
+			Self::Save => regular::FLOPPY_DISK,
+		}
+	}
+
+	const fn is_mode_tool(self) -> bool {
+		matches!(
+			self,
+			Self::Pointer | Self::Pen | Self::Arrow | Self::Text | Self::Mosaic | Self::Spotlight
+		)
+	}
+
+	const fn requires_final_capture(self) -> bool {
+		match self {
+			Self::Pointer
+			| Self::Pen
+			| Self::Arrow
+			| Self::Text
+			| Self::AutoCenter
+			| Self::Spotlight => false,
+			Self::Mosaic | Self::Undo | Self::Redo => true,
+			Self::Scroll | Self::Copy | Self::Save => true,
+			#[cfg(target_os = "macos")]
+			Self::Ocr => true,
+		}
+	}
+
+	fn is_available(self, toolbar_state: &FrozenToolbarState) -> bool {
+		match self {
+			Self::Undo => toolbar_state.undo_available,
+			Self::Redo => toolbar_state.redo_available,
+			_ => true,
+		}
+	}
+
+	fn unavailable_label(self, toolbar_state: &FrozenToolbarState) -> &'static str {
+		if self.requires_final_capture() && !toolbar_state.final_capture_ready {
+			return "Preparing capture...";
 		}
 
-		macos_remove_overlay_cursor_view(self.view_key);
+		match self {
+			Self::Undo => "Nothing to undo",
+			Self::Redo => "Nothing to redo",
+			_ => "Preparing capture...",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScrollCaptureFrameSource {
+	Worker { request_id: u64 },
+	LiveStream { frame_seq: u64 },
+}
+impl ScrollCaptureFrameSource {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Worker { .. } => "worker",
+			Self::LiveStream { .. } => "live_stream",
+		}
+	}
+
+	const fn worker_request_id(self) -> Option<u64> {
+		match self {
+			Self::Worker { request_id } => Some(request_id),
+			Self::LiveStream { .. } => None,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PngAction {
+	Copy,
+	Save,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum FrozenCaptureSource {
+	#[default]
+	None,
+	DragRegion,
+	Window,
+	FullscreenFallback,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FrozenSelectionCorner {
+	TopLeft,
+	TopRight,
+	BottomLeft,
+	BottomRight,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum FrozenSelectionInteractionKind {
+	#[default]
+	Move,
+	Resize(FrozenSelectionCorner),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeviceCursorPointSource {
+	DevicePoints,
+	DevicePixelsFallback,
+	EventRecentFallback,
+}
+impl DeviceCursorPointSource {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::DevicePoints => "device_points",
+			Self::DevicePixelsFallback => "device_pixels_fallback",
+			Self::EventRecentFallback => "event_recent_fallback",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SelectionFlowStyle {
+	Band,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum WindowRendererPath {
+	Overlay,
+	LoupeTile,
+}
+impl WindowRendererPath {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Overlay => "overlay",
+			Self::LoupeTile => "loupe_tile",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SurfaceFrameSkipReason {
+	Timeout,
+	Occluded,
+}
+impl SurfaceFrameSkipReason {
+	const fn as_str(self) -> &'static str {
+		match self {
+			Self::Timeout => "timeout",
+			Self::Occluded => "occluded",
+		}
+	}
+
+	const fn should_request_redraw(self) -> bool {
+		matches!(self, Self::Timeout)
+	}
+}
+
+enum AcquiredSurfaceFrame {
+	Ready(SurfaceTexture),
+	Skipped(SurfaceFrameSkipReason),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FrozenEditKind {
+	BrushStroke,
+	MosaicEdit,
+	TextAnnotation,
+	ArrowAnnotation,
+	SpotlightAnnotation,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FrozenCommittedOverlay<'a> {
+	Brush(&'a FrozenBrushStroke),
+	Text(&'a FrozenTextAnnotation),
+	Arrow(&'a FrozenArrowAnnotation),
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug)]
+/// Host-owned scroll-capture start request emitted by the core.
+pub struct ScrollCaptureHostStartRequest {
+	/// Target monitor for the scroll-capture session.
+	pub monitor: MonitorRect,
+	/// Scroll-capture rect in point-space.
+	pub capture_rect_points: RectPoints,
+	/// Scroll-capture rect in monitor-local pixels.
+	pub capture_rect_pixels: RectPoints,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+/// Explicit host/core seam for scroll-capture capability ownership.
+pub struct ScrollCaptureHostAdapter {
+	start: ScrollCaptureHostStart,
+	stop: ScrollCaptureHostStop,
+	request_frame: ScrollCaptureHostFrameRequest,
+	external_input_drain_reader: ExternalScrollInputDrainReader,
+}
+#[cfg(target_os = "macos")]
+impl ScrollCaptureHostAdapter {
+	#[must_use]
+	/// Creates the host-owned scroll-capture capability adapter for the overlay core.
+	pub fn new(
+		start: ScrollCaptureHostStart,
+		stop: ScrollCaptureHostStop,
+		request_frame: ScrollCaptureHostFrameRequest,
+		external_input_drain_reader: ExternalScrollInputDrainReader,
+	) -> Self {
+		Self { start, stop, request_frame, external_input_drain_reader }
 	}
 }
 
@@ -659,10 +1192,12 @@ pub struct OverlaySession {
 	#[cfg(target_os = "macos")]
 	scroll_frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
 	#[cfg(target_os = "macos")]
+	scroll_capture_host_adapter: Option<ScrollCaptureHostAdapter>,
+	#[cfg(all(test, target_os = "macos"))]
 	scroll_capture_start_guard: Option<ScrollCaptureStartGuard>,
-	#[cfg(target_os = "macos")]
+	#[cfg(all(test, target_os = "macos"))]
 	scroll_capture_starting_hook: Option<ScrollCaptureStartingHook>,
-	#[cfg(target_os = "macos")]
+	#[cfg(all(test, target_os = "macos"))]
 	scroll_capture_started_hook: Option<ScrollCaptureStartedHook>,
 	#[cfg(target_os = "macos")]
 	startup_aux_window_waker: Option<Arc<dyn Fn() + Send + Sync>>,
@@ -872,10 +1407,12 @@ impl OverlaySession {
 			#[cfg(target_os = "macos")]
 			scroll_frame_waker: None,
 			#[cfg(target_os = "macos")]
+			scroll_capture_host_adapter: None,
+			#[cfg(all(test, target_os = "macos"))]
 			scroll_capture_start_guard: None,
-			#[cfg(target_os = "macos")]
+			#[cfg(all(test, target_os = "macos"))]
 			scroll_capture_starting_hook: None,
-			#[cfg(target_os = "macos")]
+			#[cfg(all(test, target_os = "macos"))]
 			scroll_capture_started_hook: None,
 			#[cfg(target_os = "macos")] startup_aux_window_waker: None,
 			#[cfg(target_os = "macos")] startup_aux_window_creation_pending: false,
@@ -963,21 +1500,38 @@ impl OverlaySession {
 	}
 
 	#[cfg(target_os = "macos")]
-	/// Supplies a host-owned guard that must approve scroll capture before it can start.
-	/// Return `Ok(false)` to reject the attempt without surfacing a HUD error.
+	/// Supplies the explicit host-owned scroll-capture capability boundary.
+	pub fn set_scroll_capture_host_adapter(&mut self, adapter: ScrollCaptureHostAdapter) {
+		self.scroll_capture_host_adapter = Some(adapter);
+	}
+
+	#[cfg(target_os = "macos")]
+	/// Supplies a reader that replays recorded external scroll input into the session.
+	pub fn set_external_scroll_input_drain_reader(
+		&mut self,
+		reader: ExternalScrollInputDrainReader,
+	) {
+		self.scroll_capture.external_scroll_input_drain_reader = Some(reader.clone());
+
+		if let Some(adapter) = self.scroll_capture_host_adapter.as_mut() {
+			adapter.external_input_drain_reader = reader;
+		}
+	}
+
+	#[cfg(all(test, target_os = "macos"))]
+	/// Test-only compatibility shim for older scroll-capture preflight guards.
 	pub fn set_scroll_capture_start_guard(&mut self, guard: ScrollCaptureStartGuard) {
 		self.scroll_capture_start_guard = Some(guard);
 	}
 
-	#[cfg(target_os = "macos")]
-	/// Registers a host-owned callback that fires after preflight succeeds but before
-	/// scroll capture becomes active.
+	#[cfg(all(test, target_os = "macos"))]
+	/// Test-only compatibility shim for older scroll-capture start hooks.
 	pub fn set_scroll_capture_starting_hook(&mut self, hook: ScrollCaptureStartingHook) {
 		self.scroll_capture_starting_hook = Some(hook);
 	}
 
-	#[cfg(target_os = "macos")]
-	/// Registers a host-owned callback that fires only after scroll capture actually starts.
+	#[cfg(all(test, target_os = "macos"))]
+	/// Test-only compatibility shim for older scroll-capture started hooks.
 	pub fn set_scroll_capture_started_hook(&mut self, hook: ScrollCaptureStartedHook) {
 		self.scroll_capture_started_hook = Some(hook);
 	}
@@ -1177,15 +1731,6 @@ impl OverlaySession {
 		waker();
 	}
 
-	#[cfg(target_os = "macos")]
-	/// Supplies a reader that replays recorded external scroll input into the session.
-	pub fn set_external_scroll_input_drain_reader(
-		&mut self,
-		reader: ExternalScrollInputDrainReader,
-	) {
-		self.scroll_capture.external_scroll_input_drain_reader = Some(reader);
-	}
-
 	/// Replays a single external scroll-input delta into the active scroll-capture session.
 	pub fn handle_external_scroll_input_delta_y(
 		&mut self,
@@ -1208,6 +1753,36 @@ impl OverlaySession {
 	#[must_use]
 	pub(crate) fn is_active(&self) -> bool {
 		self.session_active
+	}
+
+	#[cfg(target_os = "macos")]
+	/// Applies one host-owned scroll-capture frame back into the core.
+	pub fn handle_host_scroll_capture_frame(
+		&mut self,
+		monitor: MonitorRect,
+		rect_px: RectPoints,
+		request_id: u64,
+		image: RgbaImage,
+	) {
+		self.handle_captured_scroll_region(monitor, rect_px, request_id, image);
+	}
+
+	#[cfg(target_os = "macos")]
+	/// Applies one host-owned "no new frame" result back into the core.
+	pub fn handle_host_scroll_capture_no_frame(
+		&mut self,
+		monitor: MonitorRect,
+		rect_px: RectPoints,
+		request_id: u64,
+	) {
+		self.handle_missing_scroll_region(monitor, rect_px, request_id);
+	}
+
+	#[cfg(target_os = "macos")]
+	/// Surfaces an explicit host-owned capability failure into the core.
+	pub fn report_scroll_capture_capability_error(&mut self, message: impl Into<String>) {
+		self.clear_scroll_capture_inflight_request();
+		self.scroll_capture_set_error(message.into());
 	}
 
 	fn has_prewarmed_startup_resources(&self) -> bool {
@@ -3684,6 +4259,13 @@ impl OverlaySession {
 
 	fn reset_runtime_for_exit(&mut self) {
 		#[cfg(target_os = "macos")]
+		if self.scroll_capture.active
+			&& let Some(host_adapter) = self.scroll_capture_host_adapter.as_ref()
+		{
+			(host_adapter.stop)();
+		}
+
+		#[cfg(target_os = "macos")]
 		self.set_scroll_overlay_mouse_passthrough(false);
 
 		self.session_active = false;
@@ -3814,6 +4396,45 @@ impl OverlayKeyboardInputEvent {
 			state: event.state,
 			repeat: event.repeat,
 		}
+	}
+}
+
+#[cfg(target_os = "macos")]
+pub(super) struct MacOSOverlayCursorRectSupport {
+	view_key: usize,
+}
+#[cfg(target_os = "macos")]
+impl MacOSOverlayCursorRectSupport {
+	const fn new(view_key: usize) -> Self {
+		Self { view_key }
+	}
+
+	fn sync_cursor_rects(&self, window: &Window, rects: &[OverlayCursorRect]) {
+		macos_resize_overlay_cursor_view(window, self.view_key);
+
+		if macos_set_overlay_view_cursor_rects(self.view_key, rects) {
+			macos_invalidate_overlay_cursor_rects(self.view_key);
+		}
+
+		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
+	}
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for MacOSOverlayCursorRectSupport {
+	fn drop(&mut self) {
+		let rects = macos_overlay_view_cursor_rects();
+
+		match rects.lock() {
+			Ok(mut guard) => {
+				guard.remove(&self.view_key);
+			},
+			Err(poisoned) => {
+				poisoned.into_inner().remove(&self.view_key);
+			},
+		}
+
+		macos_remove_overlay_cursor_view(self.view_key);
 	}
 }
 
@@ -4010,515 +4631,6 @@ impl MacOSNativeCaptureInputDispatch {
 	fn enqueue(&self, event: MacOSNativeCaptureInputEvent) {
 		(self.sink)(event);
 	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-/// Selects how the live HUD should be positioned.
-pub enum HudAnchor {
-	/// Pin the HUD cluster to the current cursor position.
-	Cursor,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Chooses the requested HUD and chrome theme.
-pub enum ThemeMode {
-	#[default]
-	/// Follow the host window or operating-system theme.
-	System,
-	/// Force the dark theme variant.
-	Dark,
-	/// Force the light theme variant.
-	Light,
-}
-
-#[derive(Debug)]
-/// A host-owned side-effect request emitted by the overlay core.
-pub enum OverlayHostEffectRequest {
-	/// Copy the encoded PNG for the completed capture to the host clipboard.
-	CopyPng {
-		/// Immutable encoded PNG payload prepared from the authoritative export image.
-		png_bytes: Vec<u8>,
-	},
-	/// Save the encoded PNG for the completed capture through the host-owned output path.
-	SavePng {
-		/// Immutable encoded PNG payload prepared from the authoritative export image.
-		png_bytes: Vec<u8>,
-		/// Output directory snapshot captured when the save request was issued.
-		output_dir: PathBuf,
-		/// Filename prefix snapshot captured when the save request was issued.
-		output_filename_prefix: String,
-		/// Naming policy snapshot captured when the save request was issued.
-		output_naming: OutputNaming,
-	},
-	/// Run deferred OCR for the completed capture through the native host.
-	#[cfg(target_os = "macos")]
-	DeferredTextRecognition(DeferredTextRecognitionRequest),
-}
-
-#[derive(Debug)]
-/// Describes how an overlay session finished.
-pub enum OverlayExit {
-	/// The user cancelled the session without producing output.
-	Cancelled,
-	/// The session completed by handing a host-owned side effect to the caller.
-	HostEffect(OverlayHostEffectRequest),
-	/// The session failed with a user-visible error message.
-	Error(String),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-/// Host-routed frozen shortcuts that should work without a focused key window.
-pub enum FrozenGlobalHotkey {
-	/// Copy the current frozen export image.
-	Copy,
-	/// Recenter the drag-region capture rect around detected content.
-	AutoCenter,
-	/// Toggle toolbar visibility while frozen.
-	ToggleToolbar,
-	/// Start scroll capture from an existing frozen selection.
-	StartScrollCapture,
-	/// Save the current frozen export image.
-	Save,
-}
-
-#[derive(Debug)]
-/// Signals whether the caller should keep driving the overlay event loop.
-pub enum OverlayControl {
-	/// Keep the session alive and continue processing events.
-	Continue,
-	/// Execute the requested host-owned side effect before deciding whether to exit.
-	HostEffect(OverlayHostEffectRequest),
-	/// Exit the session with the provided terminal outcome.
-	Exit(OverlayExit),
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Controls how the Tab-triggered loupe interaction is activated.
-pub enum AltActivationMode {
-	#[default]
-	/// Enable the loupe only while Tab is held.
-	Hold,
-	/// Toggle the loupe on and off with Tab presses.
-	Toggle,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Chooses where the frozen toolbar is anchored relative to the capture.
-pub enum ToolbarPlacement {
-	/// Render the toolbar above the frozen capture.
-	Top,
-	#[default]
-	/// Render the toolbar below the frozen capture.
-	Bottom,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Selects how saved captures are named on disk.
-pub enum OutputNaming {
-	#[default]
-	/// Use the current Unix timestamp in milliseconds.
-	Timestamp,
-	/// Use a zero-padded incrementing sequence number.
-	Sequence,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-/// Controls how transparent window captures are composited before export.
-pub enum WindowCaptureAlphaMode {
-	#[default]
-	/// Preserve the observed screen background behind transparent pixels.
-	Background,
-	/// Composite transparency against a light matte color.
-	MatteLight,
-	/// Composite transparency against a dark matte color.
-	MatteDark,
-}
-
-#[cfg(target_os = "macos")]
-#[derive(Clone, Copy, Debug, PartialEq)]
-/// Scroll-wheel delta routed from the native passive capture host.
-pub enum MacOSNativeCaptureScrollDelta {
-	/// A line-based scroll delta measured in lines along the x/y axes.
-	Line {
-		/// Horizontal line delta.
-		x: f32,
-		/// Vertical line delta.
-		y: f32,
-	},
-	/// A pixel-based scroll delta measured in pixels along the x/y axes.
-	Pixel {
-		/// Horizontal pixel delta.
-		x: f64,
-		/// Vertical pixel delta.
-		y: f64,
-	},
-}
-
-#[cfg(target_os = "macos")]
-#[derive(Clone, Debug, PartialEq)]
-/// Input event routed from the app-owned macOS passive capture host into the overlay core.
-pub enum MacOSNativeCaptureInputEvent {
-	/// Pointer movement over a passive overlay shell.
-	OverlayPointerMoved {
-		/// Monitor whose passive shell observed the pointer movement.
-		monitor: MonitorRect,
-		/// Pointer location in global desktop coordinates.
-		global: GlobalPoint,
-	},
-	/// Mouse-button activity observed by a passive overlay shell.
-	OverlayMouseInput {
-		/// Monitor whose passive shell observed the mouse input.
-		monitor: MonitorRect,
-		/// Pointer location in global desktop coordinates.
-		global: GlobalPoint,
-		/// Mouse button that changed state.
-		button: MouseButton,
-		/// New state for the button.
-		state: ElementState,
-	},
-	/// Pointer movement over a passive toolbar shell.
-	ToolbarPointerMoved {
-		/// Monitor that currently anchors the toolbar shell.
-		monitor: MonitorRect,
-		/// Pointer location in toolbar-local coordinates.
-		local: Pos2,
-		/// Pointer location in global desktop coordinates.
-		global: GlobalPoint,
-		/// Toolbar shell origin in global desktop coordinates.
-		outer_position: GlobalPoint,
-	},
-	/// Pointer exit from the passive toolbar shell.
-	ToolbarPointerLeft,
-	/// Mouse-button activity observed by the passive toolbar shell.
-	ToolbarMouseInput {
-		/// Mouse button that changed state.
-		button: MouseButton,
-		/// New state for the button.
-		state: ElementState,
-	},
-	/// Scroll-wheel input observed by the passive toolbar shell.
-	ToolbarScrollWheel {
-		/// Scroll delta reported by the native host.
-		delta: MacOSNativeCaptureScrollDelta,
-	},
-	/// Keyboard input forwarded from the passive key-focus shell.
-	KeyboardInput {
-		/// Monitor associated with the active key-focus shell, if any.
-		monitor: Option<MonitorRect>,
-		/// Opaque keyboard event payload translated from winit/native state.
-		event: OverlayKeyboardInputEvent,
-	},
-	/// IME input forwarded from the passive key-focus shell.
-	Ime {
-		/// Monitor associated with the active key-focus shell, if any.
-		monitor: Option<MonitorRect>,
-		/// IME payload to apply inside the overlay session.
-		event: Ime,
-	},
-	/// Modifier-key state update forwarded from the native host.
-	ModifiersChanged {
-		/// Current modifier-key state.
-		state: ModifiersState,
-	},
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-/// Single source of truth for live capture entry.
-///
-/// State flow:
-/// `Idle` -> `HoverWindow` -> `PressPending` -> `DraggingSelection` -> `FrozenFromDrag`
-/// `Idle` -> `HoverWindow` -> `PressPending` -> `FrozenFromClick`
-///
-/// Hover and drag visuals are derived from this state instead of being coordinated through
-/// separate button, hover, and drag flags.
-enum LiveCaptureInteraction {
-	#[default]
-	Idle,
-	HoverWindow {
-		monitor: MonitorRect,
-		target: LiveClickCaptureTarget,
-	},
-	PressPending {
-		monitor: MonitorRect,
-		press_global: GlobalPoint,
-		click_target: Option<LiveClickCaptureTarget>,
-		release_global: Option<GlobalPoint>,
-		released: bool,
-	},
-	DraggingSelection {
-		monitor: MonitorRect,
-		press_global: GlobalPoint,
-		current_global: GlobalPoint,
-	},
-	FrozenFromClick {
-		monitor: MonitorRect,
-		target: LiveClickCaptureTarget,
-	},
-	FrozenFromDrag {
-		monitor: MonitorRect,
-		capture_rect: RectPoints,
-	},
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum OverlayEventLoopPhase {
-	Idle,
-	WindowEvent,
-	AboutToWait,
-	RedrawDispatch,
-	HudRedraw,
-	LoupeRedraw,
-	ToolbarRedraw,
-	OverlayRedraw,
-}
-impl OverlayEventLoopPhase {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Idle => "idle",
-			Self::WindowEvent => "window_event",
-			Self::AboutToWait => "about_to_wait",
-			Self::RedrawDispatch => "redraw_dispatch",
-			Self::HudRedraw => "hud_redraw",
-			Self::LoupeRedraw => "loupe_redraw",
-			Self::ToolbarRedraw => "toolbar_redraw",
-			Self::OverlayRedraw => "overlay_window_redraw",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum HudTheme {
-	Dark,
-	Light,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenToolbarTool {
-	Pointer,
-	Pen,
-	Arrow,
-	Text,
-	Mosaic,
-	Spotlight,
-	Undo,
-	Redo,
-	AutoCenter,
-	Scroll,
-	#[cfg(target_os = "macos")]
-	Ocr,
-	Copy,
-	Save,
-}
-impl FrozenToolbarTool {
-	const fn label(self) -> &'static str {
-		match self {
-			Self::Pointer => "Pointer",
-			Self::Pen => "Pen",
-			Self::Arrow => "Arrow",
-			Self::Text => "Text",
-			Self::Mosaic => "Mosaic",
-			Self::Spotlight => "Spotlight",
-			Self::Undo => "Undo",
-			Self::Redo => "Redo",
-			Self::AutoCenter => "Auto-center (C)",
-			Self::Scroll => "Scroll Capture",
-			#[cfg(target_os = "macos")]
-			Self::Ocr => "Recognize Text",
-			Self::Copy => "Copy",
-			Self::Save => "Save",
-		}
-	}
-
-	const fn icon(self) -> &'static str {
-		match self {
-			Self::Pointer => regular::CURSOR,
-			Self::Pen => regular::PENCIL_SIMPLE,
-			Self::Arrow => regular::ARROW_UP_RIGHT,
-			Self::Text => regular::TEXT_T,
-			Self::Mosaic => regular::CHECKERBOARD,
-			Self::Spotlight => regular::FRAME_CORNERS,
-			Self::Undo => regular::ARROW_COUNTER_CLOCKWISE,
-			Self::Redo => regular::ARROW_CLOCKWISE,
-			Self::AutoCenter => regular::ARROWS_IN_CARDINAL,
-			Self::Scroll => regular::ARROWS_DOWN_UP,
-			#[cfg(target_os = "macos")]
-			Self::Ocr => regular::FILE_TEXT,
-			Self::Copy => regular::COPY,
-			Self::Save => regular::FLOPPY_DISK,
-		}
-	}
-
-	const fn is_mode_tool(self) -> bool {
-		matches!(
-			self,
-			Self::Pointer | Self::Pen | Self::Arrow | Self::Text | Self::Mosaic | Self::Spotlight
-		)
-	}
-
-	const fn requires_final_capture(self) -> bool {
-		match self {
-			Self::Pointer
-			| Self::Pen
-			| Self::Arrow
-			| Self::Text
-			| Self::AutoCenter
-			| Self::Spotlight => false,
-			Self::Mosaic | Self::Undo | Self::Redo => true,
-			Self::Scroll | Self::Copy | Self::Save => true,
-			#[cfg(target_os = "macos")]
-			Self::Ocr => true,
-		}
-	}
-
-	fn is_available(self, toolbar_state: &FrozenToolbarState) -> bool {
-		match self {
-			Self::Undo => toolbar_state.undo_available,
-			Self::Redo => toolbar_state.redo_available,
-			_ => true,
-		}
-	}
-
-	fn unavailable_label(self, toolbar_state: &FrozenToolbarState) -> &'static str {
-		if self.requires_final_capture() && !toolbar_state.final_capture_ready {
-			return "Preparing capture...";
-		}
-
-		match self {
-			Self::Undo => "Nothing to undo",
-			Self::Redo => "Nothing to redo",
-			_ => "Preparing capture...",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ScrollCaptureFrameSource {
-	Worker { request_id: u64 },
-	LiveStream { frame_seq: u64 },
-}
-impl ScrollCaptureFrameSource {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Worker { .. } => "worker",
-			Self::LiveStream { .. } => "live_stream",
-		}
-	}
-
-	const fn worker_request_id(self) -> Option<u64> {
-		match self {
-			Self::Worker { request_id } => Some(request_id),
-			Self::LiveStream { .. } => None,
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum PngAction {
-	Copy,
-	Save,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-enum FrozenCaptureSource {
-	#[default]
-	None,
-	DragRegion,
-	Window,
-	FullscreenFallback,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenSelectionCorner {
-	TopLeft,
-	TopRight,
-	BottomLeft,
-	BottomRight,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-enum FrozenSelectionInteractionKind {
-	#[default]
-	Move,
-	Resize(FrozenSelectionCorner),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum DeviceCursorPointSource {
-	DevicePoints,
-	DevicePixelsFallback,
-	EventRecentFallback,
-}
-impl DeviceCursorPointSource {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::DevicePoints => "device_points",
-			Self::DevicePixelsFallback => "device_pixels_fallback",
-			Self::EventRecentFallback => "event_recent_fallback",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SelectionFlowStyle {
-	Band,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum WindowRendererPath {
-	Overlay,
-	LoupeTile,
-}
-impl WindowRendererPath {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Overlay => "overlay",
-			Self::LoupeTile => "loupe_tile",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SurfaceFrameSkipReason {
-	Timeout,
-	Occluded,
-}
-impl SurfaceFrameSkipReason {
-	const fn as_str(self) -> &'static str {
-		match self {
-			Self::Timeout => "timeout",
-			Self::Occluded => "occluded",
-		}
-	}
-
-	const fn should_request_redraw(self) -> bool {
-		matches!(self, Self::Timeout)
-	}
-}
-
-enum AcquiredSurfaceFrame {
-	Ready(SurfaceTexture),
-	Skipped(SurfaceFrameSkipReason),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FrozenEditKind {
-	BrushStroke,
-	MosaicEdit,
-	TextAnnotation,
-	ArrowAnnotation,
-	SpotlightAnnotation,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum FrozenCommittedOverlay<'a> {
-	Brush(&'a FrozenBrushStroke),
-	Text(&'a FrozenTextAnnotation),
-	Arrow(&'a FrozenArrowAnnotation),
 }
 
 pub(super) fn frozen_toolbar_corner_radius_u8(toolbar_height_points: f32) -> u8 {

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -1,5 +1,7 @@
 #[cfg(target_os = "macos")]
 use std::collections::VecDeque;
+#[cfg(all(test, target_os = "macos"))]
+use std::sync::Arc;
 use std::time::Instant;
 
 use color_eyre::Result;
@@ -10,7 +12,8 @@ use crate::live_frame_stream_macos::MacLiveFrameStream;
 use crate::overlay::{
 	FrozenCaptureSource, Key, MonitorRect, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
 	OverlayMode, OverlaySession, PngAction, Pos2, Rect, SCROLL_CAPTURE_INPUT_FRESHNESS,
-	SCROLL_CAPTURE_SAMPLE_INTERVAL, ScrollDirection, ScrollObserveOutcome, Vec2, WindowRenderer,
+	SCROLL_CAPTURE_SAMPLE_INTERVAL, ScrollCaptureHostStartRequest, ScrollDirection,
+	ScrollObserveOutcome, Vec2, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
@@ -298,9 +301,10 @@ impl OverlaySession {
 			overlay_mouse_passthrough_until: None,
 			#[cfg(target_os = "macos")]
 			external_scroll_input_drain_reader: self
-				.scroll_capture
-				.external_scroll_input_drain_reader
-				.clone(),
+				.scroll_capture_host_adapter
+				.as_ref()
+				.map(|adapter| adapter.external_input_drain_reader.clone())
+				.or_else(|| self.scroll_capture.external_scroll_input_drain_reader.clone()),
 			last_external_scroll_input_seq: 0,
 			#[cfg(target_os = "macos")]
 			pixel_delta_residual: MacOSScrollPixelResidual::default(),
@@ -361,6 +365,82 @@ impl OverlaySession {
 		})
 	}
 
+	#[cfg(target_os = "macos")]
+	fn resolve_scroll_capture_host_adapter(
+		&mut self,
+	) -> Option<crate::overlay::ScrollCaptureHostAdapter> {
+		if let Some(host_adapter) = self.scroll_capture_host_adapter.clone() {
+			return Some(host_adapter);
+		}
+
+		#[cfg(test)]
+		{
+			Some(crate::overlay::ScrollCaptureHostAdapter::new(
+				Arc::new(|_| Ok(true)),
+				Arc::new(|| {}),
+				Arc::new(|_, _, _| Ok(())),
+				self.scroll_capture
+					.external_scroll_input_drain_reader
+					.clone()
+					.unwrap_or_else(|| Arc::new(|_, _| Vec::new())),
+			))
+		}
+		#[cfg(not(test))]
+		{
+			self.state.set_error(String::from("Scroll capture capability is unavailable."));
+			self.request_redraw_all();
+
+			None
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn begin_scroll_capture_host_session(
+		&mut self,
+		host_adapter: &crate::overlay::ScrollCaptureHostAdapter,
+		monitor: MonitorRect,
+		capture_rect_points: RectPoints,
+		capture_rect_pixels: RectPoints,
+	) -> bool {
+		#[cfg(test)]
+		if let Some(guard) = self.scroll_capture_start_guard.clone() {
+			match guard() {
+				Ok(true) => {},
+				Ok(false) => return false,
+				Err(err) => {
+					self.state.set_error(format!("{err:#}"));
+					self.request_redraw_all();
+
+					return false;
+				},
+			}
+		}
+		#[cfg(test)]
+		if let Some(hook) = self.scroll_capture_starting_hook.clone()
+			&& let Err(err) = hook()
+		{
+			self.state.set_error(format!("{err:#}"));
+			self.request_redraw_all();
+
+			return false;
+		}
+
+		match (host_adapter.start)(ScrollCaptureHostStartRequest {
+			monitor,
+			capture_rect_points,
+			capture_rect_pixels,
+		}) {
+			Ok(true) => true,
+			Ok(false) => false,
+			Err(err) => {
+				self.state.set_error(format!("{err:#}"));
+				self.request_redraw_all();
+
+				false
+			},
+		}
+	}
+
 	pub(super) fn start_scroll_capture(&mut self) -> OverlayControl {
 		if self.scroll_capture.active {
 			tracing::info!(
@@ -389,25 +469,16 @@ impl OverlaySession {
 			else {
 				return OverlayControl::Continue;
 			};
+			let Some(host_adapter) = self.resolve_scroll_capture_host_adapter() else {
+				return OverlayControl::Continue;
+			};
 
-			if let Some(guard) = self.scroll_capture_start_guard.clone() {
-				match guard() {
-					Ok(true) => {},
-					Ok(false) => return OverlayControl::Continue,
-					Err(err) => {
-						self.state.set_error(format!("{err:#}"));
-						self.request_redraw_all();
-
-						return OverlayControl::Continue;
-					},
-				}
-			}
-			if let Some(hook) = self.scroll_capture_starting_hook.clone()
-				&& let Err(err) = hook()
-			{
-				self.state.set_error(format!("{err:#}"));
-				self.request_redraw_all();
-
+			if !self.begin_scroll_capture_host_session(
+				&host_adapter,
+				monitor,
+				capture_rect_points,
+				capture_rect_pixels,
+			) {
 				return OverlayControl::Continue;
 			}
 
@@ -421,6 +492,8 @@ impl OverlaySession {
 			) {
 				Ok(scroll_capture) => scroll_capture,
 				Err(err) => {
+					(host_adapter.stop)();
+
 					self.state.set_error(format!("{err:#}"));
 					self.request_redraw_all();
 
@@ -428,15 +501,16 @@ impl OverlaySession {
 				},
 			};
 
-			if let Some(hook) = self.scroll_capture_started_hook.clone() {
-				hook();
-			}
 			if let Some(trace_recorder) = self.scroll_capture.trace_recorder.as_ref() {
 				tracing::info!(
 					op = "scroll_capture.trace_recording_enabled",
 					manifest_path = %trace_recorder.manifest_path().display(),
 					"Enabled scroll-capture live trace recording for this session."
 				);
+			}
+			#[cfg(test)]
+			if let Some(hook) = self.scroll_capture_started_hook.clone() {
+				hook();
 			}
 
 			tracing::info!(
@@ -467,18 +541,12 @@ impl OverlaySession {
 				preview.window.set_visible(true);
 				preview.window.request_redraw();
 			}
-			if let (Some(monitor), Some(live_stream)) =
-				(self.scroll_capture.monitor, self.scroll_capture.live_stream.as_ref())
-			{
-				live_stream.prime_monitor_nonblocking(monitor);
-			}
 
 			self.request_redraw_for_monitor(monitor);
 
 			OverlayControl::Continue
 		}
 	}
-
 	pub(super) fn toggle_scroll_capture_paused(&mut self) {
 		if !self.scroll_capture.active {
 			return;

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -12,13 +12,12 @@ use crate::live_frame_stream_macos::MacLiveFrameStream;
 use crate::overlay::{
 	FrozenCaptureSource, Key, MonitorRect, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
 	OverlayMode, OverlaySession, PngAction, Pos2, Rect, SCROLL_CAPTURE_INPUT_FRESHNESS,
-	SCROLL_CAPTURE_SAMPLE_INTERVAL, ScrollCaptureHostStartRequest, ScrollDirection,
-	ScrollObserveOutcome, Vec2, WindowRenderer,
+	SCROLL_CAPTURE_SAMPLE_INTERVAL, ScrollDirection, ScrollObserveOutcome, Vec2, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
-	MacOSScrollPixelResidual, RectPoints, SCROLL_CAPTURE_PREVIEW_WIDTH_PX, ScrollCaptureState,
-	ScrollCaptureTraceRecorder, ScrollSession,
+	MacOSScrollPixelResidual, RectPoints, SCROLL_CAPTURE_PREVIEW_WIDTH_PX,
+	ScrollCaptureHostStartRequest, ScrollCaptureState, ScrollCaptureTraceRecorder, ScrollSession,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
@@ -11,6 +11,8 @@ use crate::live_frame_stream_macos::MacLiveFrameStream;
 use crate::overlay::SCROLL_CAPTURE_DUPLICATE_WORKER_FRAME_RETRY_INTERVAL;
 use crate::overlay::SCROLL_CAPTURE_SAMPLE_INTERVAL;
 #[cfg(target_os = "macos")]
+use crate::overlay::ScrollCaptureHostFrameRequestError;
+#[cfg(target_os = "macos")]
 use crate::overlay::ScrollCaptureTraceInputRecord;
 #[cfg(target_os = "macos")]
 use crate::overlay::session_state::ScrollCaptureLiveFrame;
@@ -23,13 +25,13 @@ use crate::overlay::{
 };
 use crate::overlay::{MonitorRect, RectPoints};
 use crate::overlay::{
-	OverlayControl, OverlaySession, ScrollCaptureFrameSource, ScrollCaptureHostFrameRequestError,
-	ScrollCaptureTraceFrameRecord, ScrollObserveOutcome, ScrollSession,
+	OverlayControl, OverlaySession, ScrollCaptureFrameSource, ScrollCaptureTraceFrameRecord,
+	ScrollObserveOutcome, ScrollSession,
 };
 use crate::scroll_capture::ScrollDirection;
 #[cfg(target_os = "macos")]
 use crate::scroll_capture::{self};
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(any(not(target_os = "macos"), all(test, target_os = "macos")))]
 use crate::worker::WorkerRequestSendError;
 
 impl OverlaySession {
@@ -84,6 +86,47 @@ impl OverlaySession {
 		}
 	}
 
+	#[cfg(any(not(target_os = "macos"), all(test, target_os = "macos")))]
+	fn request_scroll_capture_worker_sample_with_worker(
+		&mut self,
+		now: Instant,
+		monitor: MonitorRect,
+		capture_rect: RectPoints,
+	) {
+		let Some(worker) = self.worker.as_ref() else {
+			self.scroll_capture_set_error("Scroll capture worker is unavailable.");
+
+			return;
+		};
+		let request_id = self.scroll_capture.next_request_id.wrapping_add(1);
+
+		match worker.request_capture_monitor_region(monitor, capture_rect, request_id) {
+			Ok(()) => {
+				self.scroll_capture.next_request_id = request_id;
+				self.scroll_capture.inflight_request_id = Some(request_id);
+				#[cfg(target_os = "macos")]
+				{
+					self.scroll_capture.inflight_request_observation =
+						Some(crate::overlay::session_state::InflightScrollCaptureObservation {
+							was_observable: self
+								.scroll_capture_observation_block_reason_at(now)
+								.is_none(),
+							external_input_seq: self.scroll_capture.last_external_scroll_input_seq,
+							input_direction: self.scroll_capture.input_direction,
+						});
+				}
+				self.scroll_capture.next_sample_at = Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL);
+			},
+			Err(WorkerRequestSendError::Full) => {
+				self.scroll_capture.next_sample_at =
+					Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL.saturating_mul(2));
+			},
+			Err(WorkerRequestSendError::Disconnected) => {
+				self.scroll_capture_set_error("Scroll capture worker disconnected.");
+			},
+		}
+	}
+
 	fn request_scroll_capture_worker_sample_at(&mut self, now: Instant) {
 		if self.scroll_capture.inflight_request_id.is_some() {
 			return;
@@ -112,70 +155,54 @@ impl OverlaySession {
 
 		#[cfg(all(test, target_os = "macos"))]
 		if self.scroll_capture_host_adapter.is_none() {
-			let Some(worker) = self.worker.as_ref() else {
-				self.scroll_capture_set_error("Scroll capture worker is unavailable.");
+			self.request_scroll_capture_worker_sample_with_worker(now, monitor, capture_rect);
+
+			return;
+		}
+
+		#[cfg(not(target_os = "macos"))]
+		{
+			self.request_scroll_capture_worker_sample_with_worker(now, monitor, capture_rect);
+
+			return;
+		}
+
+		#[cfg(target_os = "macos")]
+		{
+			let Some(host_adapter) = self.scroll_capture_host_adapter.as_ref() else {
+				self.scroll_capture_set_error("Scroll capture capability is unavailable.");
 
 				return;
 			};
 			let request_id = self.scroll_capture.next_request_id.wrapping_add(1);
 
-			match worker.request_capture_monitor_region(monitor, capture_rect, request_id) {
+			match (host_adapter.request_frame)(monitor, capture_rect, request_id) {
 				Ok(()) => {
 					self.scroll_capture.next_request_id = request_id;
 					self.scroll_capture.inflight_request_id = Some(request_id);
-					self.scroll_capture.inflight_request_observation =
-						Some(crate::overlay::session_state::InflightScrollCaptureObservation {
-							was_observable: self
-								.scroll_capture_observation_block_reason_at(now)
-								.is_none(),
-							external_input_seq: self.scroll_capture.last_external_scroll_input_seq,
-							input_direction: self.scroll_capture.input_direction,
-						});
+					#[cfg(target_os = "macos")]
+					{
+						self.scroll_capture.inflight_request_observation =
+							Some(crate::overlay::session_state::InflightScrollCaptureObservation {
+								was_observable: self
+									.scroll_capture_observation_block_reason_at(now)
+									.is_none(),
+								external_input_seq: self
+									.scroll_capture
+									.last_external_scroll_input_seq,
+								input_direction: self.scroll_capture.input_direction,
+							});
+					}
 					self.scroll_capture.next_sample_at = Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL);
 				},
-				Err(WorkerRequestSendError::Full) => {
+				Err(ScrollCaptureHostFrameRequestError::Busy) => {
 					self.scroll_capture.next_sample_at =
 						Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL.saturating_mul(2));
 				},
-				Err(WorkerRequestSendError::Disconnected) => {
-					self.scroll_capture_set_error("Scroll capture worker disconnected.");
+				Err(ScrollCaptureHostFrameRequestError::Unavailable(message)) => {
+					self.scroll_capture_set_error(message);
 				},
 			}
-
-			return;
-		}
-
-		let Some(host_adapter) = self.scroll_capture_host_adapter.as_ref() else {
-			self.scroll_capture_set_error("Scroll capture capability is unavailable.");
-
-			return;
-		};
-		let request_id = self.scroll_capture.next_request_id.wrapping_add(1);
-
-		match (host_adapter.request_frame)(monitor, capture_rect, request_id) {
-			Ok(()) => {
-				self.scroll_capture.next_request_id = request_id;
-				self.scroll_capture.inflight_request_id = Some(request_id);
-				#[cfg(target_os = "macos")]
-				{
-					self.scroll_capture.inflight_request_observation =
-						Some(crate::overlay::session_state::InflightScrollCaptureObservation {
-							was_observable: self
-								.scroll_capture_observation_block_reason_at(now)
-								.is_none(),
-							external_input_seq: self.scroll_capture.last_external_scroll_input_seq,
-							input_direction: self.scroll_capture.input_direction,
-						});
-				}
-				self.scroll_capture.next_sample_at = Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL);
-			},
-			Err(ScrollCaptureHostFrameRequestError::Busy) => {
-				self.scroll_capture.next_sample_at =
-					Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL.saturating_mul(2));
-			},
-			Err(ScrollCaptureHostFrameRequestError::Unavailable(message)) => {
-				self.scroll_capture_set_error(message);
-			},
 		}
 	}
 

--- a/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
@@ -23,12 +23,13 @@ use crate::overlay::{
 };
 use crate::overlay::{MonitorRect, RectPoints};
 use crate::overlay::{
-	OverlayControl, OverlaySession, ScrollCaptureFrameSource, ScrollCaptureTraceFrameRecord,
-	ScrollObserveOutcome, ScrollSession,
+	OverlayControl, OverlaySession, ScrollCaptureFrameSource, ScrollCaptureHostFrameRequestError,
+	ScrollCaptureTraceFrameRecord, ScrollObserveOutcome, ScrollSession,
 };
 use crate::scroll_capture::ScrollDirection;
 #[cfg(target_os = "macos")]
 use crate::scroll_capture::{self};
+#[cfg(all(test, target_os = "macos"))]
 use crate::worker::WorkerRequestSendError;
 
 impl OverlaySession {
@@ -108,14 +109,50 @@ impl OverlaySession {
 
 			return;
 		};
-		let Some(worker) = self.worker.as_ref() else {
-			self.scroll_capture_set_error("Scroll capture worker is unavailable.");
+
+		#[cfg(all(test, target_os = "macos"))]
+		if self.scroll_capture_host_adapter.is_none() {
+			let Some(worker) = self.worker.as_ref() else {
+				self.scroll_capture_set_error("Scroll capture worker is unavailable.");
+
+				return;
+			};
+			let request_id = self.scroll_capture.next_request_id.wrapping_add(1);
+
+			match worker.request_capture_monitor_region(monitor, capture_rect, request_id) {
+				Ok(()) => {
+					self.scroll_capture.next_request_id = request_id;
+					self.scroll_capture.inflight_request_id = Some(request_id);
+					self.scroll_capture.inflight_request_observation =
+						Some(crate::overlay::session_state::InflightScrollCaptureObservation {
+							was_observable: self
+								.scroll_capture_observation_block_reason_at(now)
+								.is_none(),
+							external_input_seq: self.scroll_capture.last_external_scroll_input_seq,
+							input_direction: self.scroll_capture.input_direction,
+						});
+					self.scroll_capture.next_sample_at = Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL);
+				},
+				Err(WorkerRequestSendError::Full) => {
+					self.scroll_capture.next_sample_at =
+						Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL.saturating_mul(2));
+				},
+				Err(WorkerRequestSendError::Disconnected) => {
+					self.scroll_capture_set_error("Scroll capture worker disconnected.");
+				},
+			}
+
+			return;
+		}
+
+		let Some(host_adapter) = self.scroll_capture_host_adapter.as_ref() else {
+			self.scroll_capture_set_error("Scroll capture capability is unavailable.");
 
 			return;
 		};
 		let request_id = self.scroll_capture.next_request_id.wrapping_add(1);
 
-		match worker.request_capture_monitor_region(monitor, capture_rect, request_id) {
+		match (host_adapter.request_frame)(monitor, capture_rect, request_id) {
 			Ok(()) => {
 				self.scroll_capture.next_request_id = request_id;
 				self.scroll_capture.inflight_request_id = Some(request_id);
@@ -132,12 +169,12 @@ impl OverlaySession {
 				}
 				self.scroll_capture.next_sample_at = Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL);
 			},
-			Err(WorkerRequestSendError::Full) => {
+			Err(ScrollCaptureHostFrameRequestError::Busy) => {
 				self.scroll_capture.next_sample_at =
 					Some(now + SCROLL_CAPTURE_SAMPLE_INTERVAL.saturating_mul(2));
 			},
-			Err(WorkerRequestSendError::Disconnected) => {
-				self.scroll_capture_set_error("Scroll capture worker disconnected.");
+			Err(ScrollCaptureHostFrameRequestError::Unavailable(message)) => {
+				self.scroll_capture_set_error(message);
 			},
 		}
 	}

--- a/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
@@ -163,8 +163,6 @@ impl OverlaySession {
 		#[cfg(not(target_os = "macos"))]
 		{
 			self.request_scroll_capture_worker_sample_with_worker(now, monitor, capture_rect);
-
-			return;
 		}
 
 		#[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -3230,14 +3230,14 @@ fn scroll_capture_host_busy_request_backs_off_without_error() {
 		Arc::new(|_, _| Vec::new()),
 	));
 
-		let control = session.start_scroll_capture();
+	let control = session.start_scroll_capture();
 
-		assert!(matches!(control, OverlayControl::Continue));
-		assert!(session.scroll_capture.active);
+	assert!(matches!(control, OverlayControl::Continue));
+	assert!(session.scroll_capture.active);
 
-		enable_test_worker_scroll_capture_path(&mut session);
+	enable_test_worker_scroll_capture_path(&mut session);
 
-		let before_retry = Instant::now();
+	let before_retry = Instant::now();
 
 	session.scroll_capture.next_sample_at = Some(before_retry - Duration::from_millis(1));
 

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -79,7 +79,8 @@ use crate::overlay::{
 	LiveStreamStaleGrace, MacOSScrollPixelResidual, OverlayExit,
 	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW, SCROLL_CAPTURE_INPUT_FRESHNESS,
 	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES, SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
-	ScrollCaptureFrameSource, StartupLiveRgbPlan,
+	ScrollCaptureFrameSource, ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
+	StartupLiveRgbPlan,
 };
 use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
 #[cfg(target_os = "macos")]
@@ -3170,6 +3171,28 @@ fn scroll_capture_guard_silent_reject_keeps_frozen_capture_available_without_err
 
 #[cfg(target_os = "macos")]
 #[test]
+fn scroll_capture_host_adapter_silent_reject_keeps_frozen_capture_available_without_error() {
+	let mut session = OverlaySession::new();
+
+	seed_ready_scroll_capture_selection(&mut session);
+
+	session.set_scroll_capture_host_adapter(ScrollCaptureHostAdapter::new(
+		Arc::new(|_| Ok(false)),
+		Arc::new(|| {}),
+		Arc::new(|_, _, _| Ok(())),
+		Arc::new(|_, _| Vec::new()),
+	));
+
+	let control = session.start_scroll_capture();
+
+	assert!(matches!(control, OverlayControl::Continue));
+	assert!(!session.scroll_capture.active);
+	assert!(session.state.frozen_display_image.is_some());
+	assert!(session.state.error_message.is_none());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn scroll_capture_starting_hook_error_keeps_frozen_capture_available() {
 	let mut session = OverlaySession::new();
 
@@ -3190,6 +3213,38 @@ fn scroll_capture_starting_hook_error_keeps_frozen_capture_available() {
 			.as_deref()
 			.is_some_and(|message| message.contains("Observer was not ready."))
 	);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn scroll_capture_host_busy_request_backs_off_without_error() {
+	let mut session = OverlaySession::new();
+
+	seed_ready_scroll_capture_selection(&mut session);
+	enable_test_worker_scroll_capture_path(&mut session);
+
+	session.set_scroll_capture_host_adapter(ScrollCaptureHostAdapter::new(
+		Arc::new(|_| Ok(true)),
+		Arc::new(|| {}),
+		Arc::new(|_, _, _| Err(ScrollCaptureHostFrameRequestError::Busy)),
+		Arc::new(|_, _| Vec::new()),
+	));
+
+	let control = session.start_scroll_capture();
+
+	assert!(matches!(control, OverlayControl::Continue));
+	assert!(session.scroll_capture.active);
+	enable_test_worker_scroll_capture_path(&mut session);
+
+	let before_retry = Instant::now();
+
+	session.scroll_capture.next_sample_at = Some(before_retry - Duration::from_millis(1));
+
+	session.maybe_tick_scroll_capture();
+
+	assert!(session.scroll_capture.inflight_request_id.is_none());
+	assert!(session.state.error_message.is_none());
+	assert!(session.scroll_capture.next_sample_at.is_some_and(|next| next > before_retry));
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -3230,13 +3230,14 @@ fn scroll_capture_host_busy_request_backs_off_without_error() {
 		Arc::new(|_, _| Vec::new()),
 	));
 
-	let control = session.start_scroll_capture();
+		let control = session.start_scroll_capture();
 
-	assert!(matches!(control, OverlayControl::Continue));
-	assert!(session.scroll_capture.active);
-	enable_test_worker_scroll_capture_path(&mut session);
+		assert!(matches!(control, OverlayControl::Continue));
+		assert!(session.scroll_capture.active);
 
-	let before_retry = Instant::now();
+		enable_test_worker_scroll_capture_path(&mut session);
+
+		let before_retry = Instant::now();
 
 	session.scroll_capture.next_sample_at = Some(before_retry - Duration::from_millis(1));
 

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -496,16 +496,18 @@ impl OverlaySession {
 		#[cfg(target_os = "macos")]
 		let scroll_frame_waker = self.scroll_frame_waker.clone();
 		#[cfg(target_os = "macos")]
-		let scroll_capture_start_guard = self.scroll_capture_start_guard.clone();
-		#[cfg(target_os = "macos")]
-		let scroll_capture_starting_hook = self.scroll_capture_starting_hook.clone();
-		#[cfg(target_os = "macos")]
-		let scroll_capture_started_hook = self.scroll_capture_started_hook.clone();
-		#[cfg(target_os = "macos")]
-		let startup_aux_window_waker = self.startup_aux_window_waker.clone();
+		let scroll_capture_host_adapter = self.scroll_capture_host_adapter.clone();
 		#[cfg(target_os = "macos")]
 		let external_scroll_input_drain_reader =
 			self.scroll_capture.external_scroll_input_drain_reader.clone();
+		#[cfg(all(test, target_os = "macos"))]
+		let scroll_capture_start_guard = self.scroll_capture_start_guard.clone();
+		#[cfg(all(test, target_os = "macos"))]
+		let scroll_capture_starting_hook = self.scroll_capture_starting_hook.clone();
+		#[cfg(all(test, target_os = "macos"))]
+		let scroll_capture_started_hook = self.scroll_capture_started_hook.clone();
+		#[cfg(target_os = "macos")]
+		let startup_aux_window_waker = self.startup_aux_window_waker.clone();
 
 		*self = Self::with_config(config);
 
@@ -515,13 +517,17 @@ impl OverlaySession {
 		#[cfg(target_os = "macos")]
 		{
 			self.scroll_frame_waker = scroll_frame_waker;
-			self.scroll_capture_start_guard = scroll_capture_start_guard;
-			self.scroll_capture_starting_hook = scroll_capture_starting_hook;
-			self.scroll_capture_started_hook = scroll_capture_started_hook;
-			self.startup_aux_window_waker = startup_aux_window_waker;
-			self.pending_startup_aux_live_stream_filter_upgrade = false;
+			self.scroll_capture_host_adapter = scroll_capture_host_adapter;
 			self.scroll_capture.external_scroll_input_drain_reader =
 				external_scroll_input_drain_reader;
+			#[cfg(all(test, target_os = "macos"))]
+			{
+				self.scroll_capture_start_guard = scroll_capture_start_guard;
+				self.scroll_capture_starting_hook = scroll_capture_starting_hook;
+				self.scroll_capture_started_hook = scroll_capture_started_hook;
+			}
+			self.startup_aux_window_waker = startup_aux_window_waker;
+			self.pending_startup_aux_live_stream_filter_upgrade = false;
 		}
 	}
 

--- a/packages/rsnap-overlay/src/scroll_capture_capability_macos.rs
+++ b/packages/rsnap-overlay/src/scroll_capture_capability_macos.rs
@@ -118,12 +118,11 @@ impl MacOSScrollCaptureCapability {
 						request_id: resp.request_id,
 					});
 				},
+				}
 			}
-		}
-
-		while let Some(resp) = worker.try_recv() {
-			if let WorkerResponse::Error {
-				source: WorkerErrorSource::CaptureMonitorRegion,
+			while let Some(resp) = worker.try_recv() {
+				if let WorkerResponse::Error {
+					source: WorkerErrorSource::CaptureMonitorRegion,
 				message,
 			} = resp
 			{

--- a/packages/rsnap-overlay/src/scroll_capture_capability_macos.rs
+++ b/packages/rsnap-overlay/src/scroll_capture_capability_macos.rs
@@ -118,11 +118,11 @@ impl MacOSScrollCaptureCapability {
 						request_id: resp.request_id,
 					});
 				},
-				}
 			}
-			while let Some(resp) = worker.try_recv() {
-				if let WorkerResponse::Error {
-					source: WorkerErrorSource::CaptureMonitorRegion,
+		}
+		while let Some(resp) = worker.try_recv() {
+			if let WorkerResponse::Error {
+				source: WorkerErrorSource::CaptureMonitorRegion,
 				message,
 			} = resp
 			{

--- a/packages/rsnap-overlay/src/scroll_capture_capability_macos.rs
+++ b/packages/rsnap-overlay/src/scroll_capture_capability_macos.rs
@@ -1,0 +1,136 @@
+use std::sync::{Arc, Mutex};
+
+use image::RgbaImage;
+
+use crate::backend;
+use crate::overlay::ScrollCaptureHostFrameRequestError;
+use crate::state::{MonitorRect, RectPoints};
+use crate::worker::{
+	CapturedMonitorRegionResult, OverlayWorker, WorkerErrorSource, WorkerRequestSendError,
+	WorkerResponse,
+};
+
+#[derive(Debug)]
+/// Host-owned scroll-capture capability event emitted back into the Rust core.
+pub enum MacOSScrollCaptureCapabilityEvent {
+	/// A fresh region sample became available for scroll-capture observation.
+	Frame {
+		/// Target monitor for the sample.
+		monitor: MonitorRect,
+		/// Sampled monitor-local pixel rect.
+		rect_px: RectPoints,
+		/// Request identifier supplied by the core.
+		request_id: u64,
+		/// Captured RGBA frame.
+		image: RgbaImage,
+	},
+	/// The host completed the request but could not produce a newer frame.
+	NoNewFrame {
+		/// Target monitor for the sample.
+		monitor: MonitorRect,
+		/// Sampled monitor-local pixel rect.
+		rect_px: RectPoints,
+		/// Request identifier supplied by the core.
+		request_id: u64,
+	},
+	/// The host capability failed and the core must fail closed.
+	Failure {
+		/// User-visible failure message.
+		message: String,
+	},
+}
+
+#[derive(Clone)]
+/// App-owned macOS scroll-capture capability runtime for region sampling.
+pub struct MacOSScrollCaptureCapability {
+	worker: Arc<Mutex<OverlayWorker>>,
+}
+impl MacOSScrollCaptureCapability {
+	#[must_use]
+	/// Builds a host-owned capability runtime with the current self-capture exception allowlist.
+	pub fn new(
+		self_capture_exception_window_ids: Vec<u32>,
+		response_waker: Option<Arc<dyn Fn() + Send + Sync>>,
+	) -> Self {
+		Self {
+			worker: Arc::new(Mutex::new(OverlayWorker::new(
+				backend::default_capture_backend_with_self_capture_exception_window_ids(
+					self_capture_exception_window_ids,
+				),
+				response_waker,
+			))),
+		}
+	}
+
+	/// Queues one host-owned region sample request for scroll capture.
+	pub fn request_frame(
+		&self,
+		monitor: MonitorRect,
+		rect_px: RectPoints,
+		request_id: u64,
+	) -> std::result::Result<(), ScrollCaptureHostFrameRequestError> {
+		let worker = self.worker.lock().map_err(|_| {
+			ScrollCaptureHostFrameRequestError::Unavailable(String::from(
+				"Scroll capture capability worker lock was poisoned.",
+			))
+		})?;
+
+		worker.request_capture_monitor_region(monitor, rect_px, request_id).map_err(|err| match err
+		{
+			WorkerRequestSendError::Full => ScrollCaptureHostFrameRequestError::Busy,
+			WorkerRequestSendError::Disconnected => {
+				ScrollCaptureHostFrameRequestError::Unavailable(String::from(
+					"Scroll capture capability is unavailable.",
+				))
+			},
+		})
+	}
+
+	#[must_use]
+	/// Drains every pending host-owned region-sample outcome for the core.
+	pub fn drain_events(&self) -> Vec<MacOSScrollCaptureCapabilityEvent> {
+		let mut events = Vec::new();
+		let worker = match self.worker.lock() {
+			Ok(worker) => worker,
+			Err(poisoned) => {
+				events.push(MacOSScrollCaptureCapabilityEvent::Failure {
+					message: String::from("Scroll capture capability worker lock was poisoned."),
+				});
+
+				poisoned.into_inner()
+			},
+		};
+
+		while let Some(resp) = worker.try_recv_captured_monitor_region() {
+			match resp.result {
+				CapturedMonitorRegionResult::Image(image) => {
+					events.push(MacOSScrollCaptureCapabilityEvent::Frame {
+						monitor: resp.monitor,
+						rect_px: resp.rect_px,
+						request_id: resp.request_id,
+						image,
+					});
+				},
+				CapturedMonitorRegionResult::NoNewFrame => {
+					events.push(MacOSScrollCaptureCapabilityEvent::NoNewFrame {
+						monitor: resp.monitor,
+						rect_px: resp.rect_px,
+						request_id: resp.request_id,
+					});
+				},
+			}
+		}
+
+		while let Some(resp) = worker.try_recv() {
+			if let WorkerResponse::Error {
+				source: WorkerErrorSource::CaptureMonitorRegion,
+				message,
+			} = resp
+			{
+				events.push(MacOSScrollCaptureCapabilityEvent::Failure { message });
+			}
+		}
+
+		events
+	}
+}


### PR DESCRIPTION
## Summary
- move scroll-capture capability acquisition behind an explicit host adapter owned by the app host
- keep stitching and overlap-proof semantics in rsnap-overlay while adding structured host busy/unavailable handling
- add regression coverage for silent permission rejection and busy frame-request backoff, and update host/core docs

## Testing
- cargo make lint
- cargo make test
- cargo make replay-scroll-capture-self-check
- cargo make smoke-self-check-macos

## Notes
- cargo make replay-scroll-capture still requires local traces in ~/Library/Application Support/ink.hack.rsnap/scroll-capture-traces on this machine
- manual live scroll-capture validation was not run in this session