### PR TITLE
XY-290 reshape rsnap workspace facades around host/core split

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ The capture-session contract lives at `docs/spec/capture-session.md`.
 
 ## Workspace Layout
 
-The tracked workspace keeps one app-shell crate in `apps/rsnap/`, one overlay/runtime crate in
-`packages/rsnap-overlay/`, and shared docs/assets/scripts at the repository root.
+The tracked workspace keeps one native-host app crate in `apps/rsnap/`, one Rust-core
+session/rendering crate in `packages/rsnap-overlay/`, and shared docs/assets/scripts at the
+repository root. The app crate exposes runtime and macOS host entry points, while
+`rsnap-overlay` exposes the Rust-core session façade plus explicit transitional host modules.
 Generated or local-only directories such as `target/`, `.worktrees/`, and `.workspaces/` are not
 part of the tracked repository structure. For the authoritative layout and ownership map, read
 `docs/reference/workspace-layout.md`.

--- a/apps/rsnap/src/app.rs
+++ b/apps/rsnap/src/app.rs
@@ -42,12 +42,14 @@ use self::scroll_input_macos::ScrollInputObserverLifecycle;
 #[cfg(target_os = "macos")]
 use self::scroll_input_macos::SharedScrollInputState;
 #[cfg(target_os = "macos")]
+use crate::host_macos::{MacOSCaptureHost, MacOSScrollCaptureCapability};
+#[cfg(target_os = "macos")]
 use crate::permissions_macos;
 use crate::settings::AppSettings;
 use crate::settings_window::{SettingsWindow, SettingsWindowEntry};
-use rsnap_overlay::OverlaySession;
 #[cfg(target_os = "macos")]
-use rsnap_overlay::{FrozenGlobalHotkey, MacOSCaptureHost, MacOSScrollCaptureCapability};
+use rsnap_overlay::session::FrozenGlobalHotkey;
+use rsnap_overlay::session::OverlaySession;
 
 pub(crate) enum UserEvent {
 	TrayIcon,
@@ -411,7 +413,7 @@ mod tests {
 	use crate::app::OverlayHotkeyRegistrationState;
 	use crate::app::{self, SettingsWindowEntry};
 	#[cfg(target_os = "macos")]
-	use rsnap_overlay::FrozenGlobalHotkey;
+	use rsnap_overlay::session::FrozenGlobalHotkey;
 
 	#[test]
 	fn startup_permission_check_uses_permissions_entry() {

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -62,9 +62,12 @@ use crate::permissions_macos;
 use crate::settings;
 #[cfg(target_os = "macos")]
 use rsnap_overlay::session::{
-	DeferredTextRecognitionOutcomeKind, DeferredTextRecognitionRequest, HudAnchor, OutputNaming,
-	OverlayConfig, OverlayControl, OverlayExit, OverlayHostEffectRequest, OverlaySession,
-	ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
+	DeferredTextRecognitionOutcomeKind, DeferredTextRecognitionRequest, ScrollCaptureHostAdapter,
+	ScrollCaptureHostFrameRequestError,
+};
+use rsnap_overlay::session::{
+	HudAnchor, OutputNaming, OverlayConfig, OverlayControl, OverlayExit, OverlayHostEffectRequest,
+	OverlaySession,
 };
 
 #[cfg(target_os = "macos")]

--- a/apps/rsnap/src/app/capture.rs
+++ b/apps/rsnap/src/app/capture.rs
@@ -52,17 +52,19 @@ use crate::app::scroll_input_macos::{
 	self, ScrollInputObserverLifecycle, ScrollInputObserverWaitOutcome, SharedScrollInputState,
 };
 #[cfg(target_os = "macos")]
+use crate::host_macos;
+#[cfg(target_os = "macos")]
+use crate::host_macos::{
+	MacOSCaptureHost, MacOSScrollCaptureCapability, MacOSScrollCaptureCapabilityEvent,
+};
+#[cfg(target_os = "macos")]
 use crate::permissions_macos;
 use crate::settings;
 #[cfg(target_os = "macos")]
-use rsnap_overlay::{
-	DeferredTextRecognitionOutcomeKind, DeferredTextRecognitionRequest, MacOSCaptureHost,
-	MacOSScrollCaptureCapability, MacOSScrollCaptureCapabilityEvent, ScrollCaptureHostAdapter,
-	ScrollCaptureHostFrameRequestError,
-};
-use rsnap_overlay::{
-	HudAnchor, OutputNaming, OverlayConfig, OverlayControl, OverlayExit, OverlayHostEffectRequest,
-	OverlaySession,
+use rsnap_overlay::session::{
+	DeferredTextRecognitionOutcomeKind, DeferredTextRecognitionRequest, HudAnchor, OutputNaming,
+	OverlayConfig, OverlayControl, OverlayExit, OverlayHostEffectRequest, OverlaySession,
+	ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
 };
 
 #[cfg(target_os = "macos")]
@@ -415,10 +417,14 @@ impl App {
 
 	fn map_alt_activation(
 		mode: crate::settings::AltActivationMode,
-	) -> rsnap_overlay::AltActivationMode {
+	) -> rsnap_overlay::session::AltActivationMode {
 		match mode {
-			crate::settings::AltActivationMode::Hold => rsnap_overlay::AltActivationMode::Hold,
-			crate::settings::AltActivationMode::Toggle => rsnap_overlay::AltActivationMode::Toggle,
+			crate::settings::AltActivationMode::Hold => {
+				rsnap_overlay::session::AltActivationMode::Hold
+			},
+			crate::settings::AltActivationMode::Toggle => {
+				rsnap_overlay::session::AltActivationMode::Toggle
+			},
 		}
 	}
 
@@ -955,7 +961,7 @@ impl App {
 			Arc::clone(&latest_deferred_ocr_generation);
 		let pending_deferred_ocr_generation_for_publish =
 			Arc::clone(&pending_deferred_ocr_generation);
-		let outcome = rsnap_overlay::process_deferred_text_recognition_for_latest_capture(
+		let outcome = host_macos::process_deferred_text_recognition_for_latest_capture(
 			request,
 			latest_deferred_ocr_generation,
 			pending_deferred_ocr_generation,
@@ -1551,7 +1557,7 @@ mod tests {
 	#[cfg(target_os = "macos")]
 	use crate::settings::AppSettings;
 	#[cfg(target_os = "macos")]
-	use rsnap_overlay::{
+	use rsnap_overlay::session::{
 		DeferredTextRecognitionRequest, OutputNaming, OverlayConfig, OverlayControl,
 		OverlayHostEffectRequest, OverlaySession,
 	};

--- a/apps/rsnap/src/app/capture_host_macos.rs
+++ b/apps/rsnap/src/app/capture_host_macos.rs
@@ -5,7 +5,8 @@ use std::sync::{
 };
 
 use crate::app::{App, UserEvent};
-use rsnap_overlay::{MacOSCaptureHost, MacOSNativeCaptureInputEvent, OverlayControl, OverlayExit};
+use crate::host_macos::{MacOSCaptureHost, MacOSNativeCaptureInputEvent};
+use rsnap_overlay::session::{OverlayControl, OverlayExit};
 
 #[derive(Clone)]
 pub(super) struct OverlayNativeCaptureInputBuffer {
@@ -167,10 +168,11 @@ mod tests {
 	use crate::app::capture_host_macos::OverlayNativeCaptureInputBuffer;
 	use crate::app::scroll_input_macos::{ScrollInputObserverLifecycle, SharedScrollInputState};
 	use crate::app::{App, OverlayEventProxy, UserEvent};
+	use crate::host_macos::MacOSNativeCaptureInputEvent;
 	use crate::settings::AppSettings;
-	use rsnap_overlay::{
-		GlobalPoint, MacOSNativeCaptureInputEvent, MonitorRect, OverlayConfig, OverlaySession,
-		RectPoints, WindowListSnapshot, WindowRect,
+	use rsnap_overlay::session::{
+		GlobalPoint, MonitorRect, OverlayConfig, OverlaySession, RectPoints, WindowListSnapshot,
+		WindowRect,
 	};
 
 	fn test_monitor() -> MonitorRect {

--- a/apps/rsnap/src/app/runtime.rs
+++ b/apps/rsnap/src/app/runtime.rs
@@ -27,7 +27,7 @@ use crate::app::{App, UserEvent};
 use crate::settings::AppSettings;
 use crate::settings_window::{CaptureHotkeyNotice, SettingsControl, SettingsWindowAction};
 #[cfg(target_os = "macos")]
-use rsnap_overlay::OverlayExit;
+use rsnap_overlay::session::OverlayExit;
 
 impl ApplicationHandler<UserEvent> for App {
 	fn resumed(&mut self, event_loop: &ActiveEventLoop) {

--- a/apps/rsnap/src/app/shell.rs
+++ b/apps/rsnap/src/app/shell.rs
@@ -12,7 +12,7 @@ use winit::event_loop::ActiveEventLoop;
 
 use crate::app::App;
 use crate::icon;
-use rsnap_overlay::OverlayExit;
+use rsnap_overlay::session::OverlayExit;
 
 impl App {
 	#[cfg(target_os = "macos")]

--- a/apps/rsnap/src/host_macos.rs
+++ b/apps/rsnap/src/host_macos.rs
@@ -1,0 +1,9 @@
+//! Public macOS native-host entry points for the desktop app crate.
+
+pub use rsnap_overlay::host_effects_macos::{
+	process_deferred_text_recognition, process_deferred_text_recognition_for_latest_capture,
+};
+pub use rsnap_overlay::host_macos::{
+	MacOSCaptureHost, MacOSCaptureHostSyncState, MacOSNativeCaptureInputEvent,
+	MacOSNativeCaptureScrollDelta, MacOSScrollCaptureCapability, MacOSScrollCaptureCapabilityEvent,
+};

--- a/apps/rsnap/src/lib.rs
+++ b/apps/rsnap/src/lib.rs
@@ -1,7 +1,15 @@
-//! Library surface for `rsnap` benchmark and test support.
+//! Library surface for the `rsnap` native host crate.
 
 #![allow(unused_crate_dependencies)]
 
+#[cfg(target_os = "macos")]
+pub mod host_macos;
+pub mod runtime {
+	//! Public runtime entry points for the desktop host crate.
+
+	pub use crate::app::run;
+	pub use crate::startup::{StartupBuildInfo, init_logging, startup_build_info};
+}
 pub mod settings_window;
 
 mod app;
@@ -11,7 +19,4 @@ mod permissions_macos;
 mod settings;
 mod startup;
 
-pub use self::{
-	app::run,
-	startup::{StartupBuildInfo, init_logging, startup_build_info},
-};
+pub use self::runtime::{StartupBuildInfo, init_logging, run, startup_build_info};

--- a/apps/rsnap/src/settings.rs
+++ b/apps/rsnap/src/settings.rs
@@ -7,7 +7,7 @@ use directories::{ProjectDirs, UserDirs};
 use global_hotkey::hotkey::{Code, HotKey, Modifiers};
 use serde::{Deserialize, Serialize};
 
-use rsnap_overlay::{OutputNaming, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode};
+use rsnap_overlay::session::{OutputNaming, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode};
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -370,7 +370,9 @@ mod tests {
 	};
 
 	use crate::settings::{AltActivationMode, AppSettings, LoupeSampleSize};
-	use rsnap_overlay::{OutputNaming, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode};
+	use rsnap_overlay::session::{
+		OutputNaming, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode,
+	};
 
 	#[test]
 	fn toml_roundtrip() {

--- a/apps/rsnap/src/settings_window/bench_support.rs
+++ b/apps/rsnap/src/settings_window/bench_support.rs
@@ -20,7 +20,7 @@ use crate::settings_window::CaptureHotkeyNotice;
 use crate::settings_window::SETTINGS_COMBO_WIDTH;
 use crate::settings_window::hotkey::SettingsUiHotkeyHost;
 use crate::settings_window::sections::{self, SettingsUiHost, SettingsUiSectionDefaults};
-use rsnap_overlay::{OutputNaming, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode};
+use rsnap_overlay::session::{OutputNaming, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// Stable settings-window benchmark scenarios used by Criterion benches.

--- a/apps/rsnap/src/settings_window/chrome.rs
+++ b/apps/rsnap/src/settings_window/chrome.rs
@@ -11,7 +11,7 @@ use crate::settings_window::{
 	SETTINGS_SECTION_GAP, SETTINGS_THEME_ICON_SIZE, SETTINGS_TITLEBAR_HEIGHT, SettingsWindow,
 	platform,
 };
-use rsnap_overlay::ThemeMode;
+use rsnap_overlay::session::ThemeMode;
 
 impl SettingsWindow {
 	pub(super) fn ui(&mut self, root_ui: &mut Ui, settings: &mut AppSettings) -> bool {

--- a/apps/rsnap/src/settings_window/sections.rs
+++ b/apps/rsnap/src/settings_window/sections.rs
@@ -26,7 +26,7 @@ use crate::settings_window::{
 	SETTINGS_SLIDER_RAIL_HEIGHT, SETTINGS_SLIDER_WIDGET_HEIGHT, SETTINGS_VALUE_BOX_WIDTH,
 	SettingsWindow, platform,
 };
-use rsnap_overlay::{OutputNaming, ToolbarPlacement, WindowCaptureAlphaMode};
+use rsnap_overlay::session::{OutputNaming, ToolbarPlacement, WindowCaptureAlphaMode};
 
 pub(super) trait SettingsUiHost: SettingsUiHotkeyHost {
 	fn combo_width(&self) -> f32;

--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -37,8 +37,10 @@ The checked-in repository does not yet fully match the target design.
 
 Today:
 
-- `apps/rsnap/` is still the app shell
-- `packages/rsnap-overlay/` is still a large transitional runtime container
+- `apps/rsnap/` is still the app shell and now exposes the runtime and native-host entry points
+- `packages/rsnap-overlay/` is still a large transitional runtime container, but its public root
+  now centers on session/replay surfaces while remaining macOS host adapters stay behind explicit
+  host modules
 - final-byte export effects now cross the boundary as explicit host-effect requests: the overlay
   prepares authoritative export/OCR payloads, and `apps/rsnap/` owns clipboard, save, and
   deferred OCR publication

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -30,8 +30,8 @@ For the active target architecture and migration direction, read:
 
 | Path | Role |
 | --- | --- |
-| `apps/rsnap/` | Desktop app-shell crate: tray/menubar startup, hotkeys, settings window, permissions, logging, and session handoff into `rsnap-overlay` |
-| `packages/rsnap-overlay/` | Current overlay/runtime crate: capture-session logic, overlay rendering, capture backend integration, worker runtime, and scroll-capture stitching/replay semantics |
+| `apps/rsnap/` | Desktop native-host crate: tray/menubar startup, hotkeys, settings window, permissions, runtime entry points, macOS host facades, and session handoff into `rsnap-overlay::session` |
+| `packages/rsnap-overlay/` | Rust-core session/rendering crate: capture-session logic, overlay rendering, capture backend integration, worker runtime, and scroll-capture stitching/replay semantics, with any remaining macOS host adapters quarantined behind explicit host modules |
 | `docs/` | Agent-facing repository docs split into `spec`, `runbook`, `reference`, and `decisions` |
 | `assets/` | Shared app-icon and tray-icon source plus generated bundle/runtime assets |
 | `scripts/` | Packaging and dedicated macOS smoke helpers |
@@ -62,6 +62,8 @@ It owns:
 
 Key paths:
 
+- `apps/rsnap/src/lib.rs`: public runtime entry points plus the crate-level native-host façade
+- `apps/rsnap/src/host_macos.rs`: public macOS host-owned capture/effect entry points
 - `apps/rsnap/src/app.rs`: app-shell root and event routing
 - `apps/rsnap/src/app/`: focused support modules for capture, hotkeys, runtime, and macOS scroll
   input
@@ -94,8 +96,8 @@ Important:
 
 Key paths:
 
-- `packages/rsnap-overlay/src/lib.rs`: current public session-level surface exported to the app
-  shell
+- `packages/rsnap-overlay/src/lib.rs`: explicit `session` façade plus quarantined
+  `host_macos` / `host_effects_macos` transition modules
 - `packages/rsnap-overlay/src/overlay.rs`: current overlay root plus its focused
   runtime/rendering support modules
 - `packages/rsnap-overlay/src/live_frame_stream_macos.rs`: current macOS live-stream support

--- a/packages/rsnap-overlay/src/lib.rs
+++ b/packages/rsnap-overlay/src/lib.rs
@@ -1,7 +1,7 @@
-//! Public session-level overlay API used by the desktop application crate.
+//! Public Rust-core session API used by the desktop application crate.
 //!
 //! Backend implementations remain internal to this crate and are not part of the
-//! app-shell integration surface.
+//! native-host integration surface exposed from `apps/rsnap`.
 
 #![allow(unused_crate_dependencies)]
 
@@ -20,6 +20,49 @@ pub mod replay_support {
 		RecordedScrollCaptureReplayMode, RecordedScrollCaptureReplayRecordedOutcome,
 		RecordedScrollCaptureReplayStepResult, RecordedScrollCaptureReplaySummary,
 		replay_recorded_scroll_capture_trace, replay_recorded_scroll_capture_trace_with_mode,
+	};
+}
+pub mod session {
+	//! Rust-core session, protocol, and shared state exports consumed by the native app host.
+
+	#[cfg(target_os = "macos")]
+	pub use crate::deferred_text_recognition::{
+		DeferredTextRecognitionOutcome, DeferredTextRecognitionOutcomeKind,
+		DeferredTextRecognitionRequest,
+	};
+	pub use crate::overlay::{
+		AltActivationMode, FrozenGlobalHotkey, HudAnchor, OutputNaming, OverlayConfig,
+		OverlayControl, OverlayExit, OverlayHostEffectRequest, OverlayKeyboardInputEvent,
+		OverlaySession, ThemeMode, ToolbarPlacement, WindowCaptureAlphaMode,
+	};
+	#[cfg(target_os = "macos")]
+	pub use crate::overlay::{
+		ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError, ScrollCaptureHostStartRequest,
+	};
+	pub use crate::state::{
+		GlobalPoint, LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb,
+		WindowHit, WindowListSnapshot, WindowRect,
+	};
+}
+#[cfg(target_os = "macos")]
+pub mod host_effects_macos {
+	//! Host-owned macOS effect helpers executed after the core emits explicit requests.
+
+	pub use crate::deferred_text_recognition::{
+		process_deferred_text_recognition, process_deferred_text_recognition_for_latest_capture,
+	};
+}
+#[cfg(target_os = "macos")]
+pub mod host_macos {
+	//! Transitional macOS host adapters kept explicit so the crate root does not imply
+	//! top-level host ownership.
+
+	pub use crate::overlay::{
+		MacOSCaptureHost, MacOSCaptureHostSyncState, MacOSNativeCaptureInputEvent,
+		MacOSNativeCaptureScrollDelta,
+	};
+	pub use crate::scroll_capture_capability_macos::{
+		MacOSScrollCaptureCapability, MacOSScrollCaptureCapabilityEvent,
 	};
 }
 
@@ -41,32 +84,6 @@ mod state;
 mod system_fonts;
 mod text_rendering;
 mod worker;
-
-#[cfg(target_os = "macos")]
-pub use crate::deferred_text_recognition::{
-	DeferredTextRecognitionOutcome, DeferredTextRecognitionOutcomeKind,
-	DeferredTextRecognitionRequest, process_deferred_text_recognition,
-	process_deferred_text_recognition_for_latest_capture,
-};
-pub use crate::overlay::{
-	AltActivationMode, FrozenGlobalHotkey, HudAnchor, OutputNaming, OverlayConfig, OverlayControl,
-	OverlayExit, OverlayHostEffectRequest, OverlayKeyboardInputEvent, OverlaySession, ThemeMode,
-	ToolbarPlacement, WindowCaptureAlphaMode,
-};
-#[cfg(target_os = "macos")]
-pub use crate::overlay::{
-	MacOSCaptureHost, MacOSCaptureHostSyncState, MacOSNativeCaptureInputEvent,
-	MacOSNativeCaptureScrollDelta, ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
-	ScrollCaptureHostStartRequest,
-};
-#[cfg(target_os = "macos")]
-pub use crate::scroll_capture_capability_macos::{
-	MacOSScrollCaptureCapability, MacOSScrollCaptureCapabilityEvent,
-};
-pub use crate::state::{
-	GlobalPoint, LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb, WindowHit,
-	WindowListSnapshot, WindowRect,
-};
 
 /// Returns the `rsnap-overlay` crate version.
 pub fn overlay_version() -> &'static str {

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -1052,7 +1052,8 @@ impl Default for OverlayConfig {
 	}
 }
 
-/// Stateful overlay controller that drives capture windows and session output.
+/// Transitional Rust-core session controller that owns product state, rendering,
+/// explicit host requests, and host-sync state consumed by the native app host.
 pub struct OverlaySession {
 	config: OverlayConfig,
 	worker: Option<OverlayWorker>,

--- a/packages/rsnap-overlay/src/overlay/frozen_spotlight_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_spotlight_runtime.rs
@@ -2,6 +2,7 @@ use crate::overlay::{
 	FrozenEditKind, FrozenSpotlightAnnotation, FrozenSpotlightDragState, FrozenToolbarTool,
 	GlobalPoint, OverlaySession,
 };
+use crate::state::RectPoints;
 
 impl OverlaySession {
 	pub(super) const fn frozen_spotlight_scrim_alpha() -> u8 {
@@ -16,15 +17,15 @@ impl OverlaySession {
 		((u16::from(channel) * Self::frozen_spotlight_outside_brightness_numerator()) / 255) as u8
 	}
 
-	fn rect_points_right(rect: crate::RectPoints) -> u32 {
+	fn rect_points_right(rect: RectPoints) -> u32 {
 		rect.x.saturating_add(rect.width)
 	}
 
-	fn rect_points_bottom(rect: crate::RectPoints) -> u32 {
+	fn rect_points_bottom(rect: RectPoints) -> u32 {
 		rect.y.saturating_add(rect.height)
 	}
 
-	fn rect_points_contains_rect(outer: crate::RectPoints, inner: crate::RectPoints) -> bool {
+	fn rect_points_contains_rect(outer: RectPoints, inner: RectPoints) -> bool {
 		inner.x >= outer.x
 			&& inner.y >= outer.y
 			&& Self::rect_points_right(inner) <= Self::rect_points_right(outer)
@@ -32,9 +33,9 @@ impl OverlaySession {
 	}
 
 	pub(super) fn clipped_frozen_spotlight_rects(
-		capture_rect: crate::RectPoints,
-		spotlight_rects: impl IntoIterator<Item = crate::RectPoints>,
-	) -> Vec<crate::RectPoints> {
+		capture_rect: RectPoints,
+		spotlight_rects: impl IntoIterator<Item = RectPoints>,
+	) -> Vec<RectPoints> {
 		spotlight_rects
 			.into_iter()
 			.filter_map(|rect| Self::intersect_rect_points(rect, capture_rect))
@@ -43,9 +44,9 @@ impl OverlaySession {
 	}
 
 	pub(super) fn frozen_spotlight_scrim_rects(
-		capture_rect: crate::RectPoints,
-		spotlight_rects: &[crate::RectPoints],
-	) -> Vec<crate::RectPoints> {
+		capture_rect: RectPoints,
+		spotlight_rects: &[RectPoints],
+	) -> Vec<RectPoints> {
 		if capture_rect.is_empty() || spotlight_rects.is_empty() {
 			return Vec::new();
 		}
@@ -81,7 +82,7 @@ impl OverlaySession {
 					continue;
 				}
 
-				let rect = crate::RectPoints::new(
+				let rect = RectPoints::new(
 					left,
 					top,
 					right.saturating_sub(left),
@@ -122,7 +123,7 @@ impl OverlaySession {
 
 		self.frozen_spotlight_drag =
 			FrozenSpotlightDragState { active: true, anchor_x: cursor_x, anchor_y: cursor_y };
-		self.frozen_spotlight_preview_rect = Some(crate::RectPoints::new(cursor_x, cursor_y, 1, 1));
+		self.frozen_spotlight_preview_rect = Some(RectPoints::new(cursor_x, cursor_y, 1, 1));
 
 		self.request_redraw_for_monitor(monitor);
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -11,7 +11,7 @@ use image::RgbaImage;
 use objc::runtime::Object;
 use winit::window::CursorIcon;
 
-use crate::OverlayControl;
+use crate::overlay::OverlayControl;
 #[cfg(target_os = "macos")]
 use crate::overlay::WindowCaptureAlphaMode;
 use crate::overlay::session_state::FrozenAnnotationStyleCapsulePlacement;

--- a/packages/rsnap-overlay/src/overlay/trace_recording.rs
+++ b/packages/rsnap-overlay/src/overlay/trace_recording.rs
@@ -624,7 +624,6 @@ mod tests {
 	use std::process;
 	use std::sync::atomic::{AtomicU64, Ordering};
 
-	use crate::GlobalPoint;
 	use crate::overlay::trace_recording;
 	use crate::overlay::trace_recording::SCROLL_CAPTURE_TRACE_SCHEMA;
 	use crate::overlay::trace_recording::{
@@ -635,6 +634,7 @@ mod tests {
 		env, fs,
 	};
 	use crate::overlay::{OverlaySession, ScrollCaptureFrameSource};
+	use crate::state::GlobalPoint;
 
 	static TRACE_TEST_ROOT_COUNTER: AtomicU64 = AtomicU64::new(0);
 

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -23,7 +23,8 @@ use crate::overlay::{
 use crate::overlay::{MacLiveFrameStream, MainThreadMarker, NSScreen};
 
 impl OverlaySession {
-	/// Starts the overlay session and creates the required capture windows.
+	/// Starts the core session runtime and prepares the render windows and surfaces that the
+	/// native host will present and synchronize for an active capture session.
 	pub fn start(&mut self, event_loop: &ActiveEventLoop) -> Result<(), String> {
 		let startup_started_at = Instant::now();
 
@@ -121,8 +122,8 @@ impl OverlaySession {
 		Ok(())
 	}
 
-	/// Pre-creates the GPU context plus hidden overlay/HUD windows so the first capture can
-	/// reuse them instead of paying the full cold-start cost on demand.
+	/// Pre-creates render resources and hidden session windows so the native host can reuse them
+	/// instead of paying the full cold-start cost on the first capture.
 	pub fn prewarm(&mut self, event_loop: &ActiveEventLoop) -> Result<(), String> {
 		if self.is_active() || self.has_prewarmed_startup_resources() {
 			return Ok(());


### PR DESCRIPTION
## Summary
- reshape the public facades so `apps/rsnap` exposes runtime and macOS native-host entry points while `rsnap-overlay` exposes explicit `session`, `host_macos`, and `host_effects_macos` modules
- retarget app-side imports to the explicit host/core surfaces and tighten overlay docs/comments so the checked-in ownership story matches the host/core split
- update workspace docs to describe the new public shape without reopening already-landed behavior slices

## Validation
- cargo make lint
- cargo make test
- cargo make smoke-self-check-macos

## Intentionally Untouched
- product behavior from XY-291, XY-292, XY-293, XY-294, XY-295, XY-298, and XY-299
