### PR TITLE
Restore macOS selection flow overlay affordance

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -3835,6 +3835,10 @@ impl OverlaySession {
 			&& self.state.live_bg_image.is_some()
 	}
 
+	fn selection_flow_enabled_for_overlay_draw(&self) -> bool {
+		self.config.selection_flow_enabled
+	}
+
 	#[cfg(target_os = "macos")]
 	fn should_refresh_live_surface_bg_for_overlay_monitor(
 		&self,
@@ -3952,9 +3956,8 @@ impl OverlaySession {
 			.allow_frozen_surface_bg_for_overlay_monitor(overlay_monitor, scroll_capture_active);
 		let allow_live_surface_bg =
 			self.should_draw_live_surface_bg_for_overlay_monitor(overlay_monitor);
+		let selection_flow_enabled = self.selection_flow_enabled_for_overlay_draw();
 		let toolbar_state = if draw_toolbar { Some(&mut self.toolbar_state) } else { None };
-		let selection_flow_enabled =
-			self.config.selection_flow_enabled && !cfg!(target_os = "macos");
 
 		{
 			let Some(overlay_window) = self.windows.get_mut(&window_id) else {

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -4033,6 +4033,17 @@ fn live_surface_bg_refresh_disables_during_drag_capture_and_loupe() {
 	assert!(session.should_refresh_live_surface_bg_for_overlay_monitor(monitor));
 }
 
+#[test]
+fn selection_flow_overlay_draw_respects_config() {
+	let mut session = OverlaySession::new();
+
+	assert!(session.selection_flow_enabled_for_overlay_draw());
+
+	session.config.selection_flow_enabled = false;
+
+	assert!(!session.selection_flow_enabled_for_overlay_draw());
+}
+
 #[cfg(not(target_os = "macos"))]
 #[test]
 fn handle_capture_redraw_does_not_rearm_inflight_freeze_capture() {

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -3430,6 +3430,40 @@ fn render_live_capture_affordances_keep_hover_scrim_when_flow_disabled() {
 }
 
 #[test]
+fn render_live_capture_affordances_draw_hover_flow_when_enabled() {
+	let ctx = tests::test_egui_context();
+	let layer = LayerId::new(Order::Foreground, Id::new("live-hover-flow-enabled"));
+	let painter = ctx.layer_painter(layer);
+	let monitor = tests::test_monitor();
+	let screen_rect =
+		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
+	let mut selection_dashed_border_cache = SelectionDashedBorderCache::default();
+	let mut state = OverlayState::new();
+	let mut selection_flow_geometry_cache = SelectionFlowGeometryCache::default();
+
+	state.mode = OverlayMode::Live;
+	state.hovered_window_rect = Some(MonitorRectPoints {
+		monitor_id: monitor.id,
+		rect: RectPoints::new(100, 120, 240, 320),
+	});
+
+	assert!(WindowRenderer::render_live_capture_affordances(
+		&ctx,
+		&painter,
+		&state,
+		monitor,
+		screen_rect,
+		HudTheme::Light,
+		true,
+		1.0,
+		&mut selection_flow_geometry_cache,
+		&mut selection_dashed_border_cache,
+	));
+	assert!(!selection_flow_geometry_cache.is_empty());
+	assert_eq!(selection_dashed_border_cache.key, None);
+}
+
+#[test]
 fn render_live_capture_affordances_draw_drag_border_when_flow_disabled() {
 	let ctx = tests::test_egui_context();
 	let layer = LayerId::new(Order::Foreground, Id::new("live-drag-flow-disabled"));


### PR DESCRIPTION
## Summary
- restore live overlay selection flow drawing on macOS instead of forcing it off before overlay redraw
- add a regression test for the overlay draw gate and a rendering behavior test that exercises hover flow geometry
- keep the change scoped to the selection-flow path only

## Testing
- cargo make lint-rust
- cargo make test-rust
- cargo run -r