### PR TITLE
XY-287 fix native macOS cursor ownership during overlay capture

### DIFF
--- a/apps/rsnap/src/app/capture_host_macos.rs
+++ b/apps/rsnap/src/app/capture_host_macos.rs
@@ -136,7 +136,15 @@ impl App {
 	pub(super) fn sync_overlay_capture_host(&mut self) {
 		let sync_result = match (self.overlay_session.as_mut(), self.overlay_capture_host.as_mut())
 		{
-			(Some(session), Some(host)) => host.sync(session.take_macos_capture_host_sync_state()),
+			(Some(session), Some(host)) => {
+				let sync_result = host.sync(session.take_macos_capture_host_sync_state());
+
+				if sync_result.is_ok() {
+					session.refresh_macos_cursor_after_host_sync();
+				}
+
+				sync_result
+			},
 			_ => return,
 		};
 

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -2820,7 +2820,9 @@ impl OverlaySession {
 		self.skip_toolbar_focus_on_next_show = true;
 		#[cfg(target_os = "macos")]
 		{
-			self.preserve_frontmost_on_next_toolbar_show = true;
+			// Keep rsnap active for the entire overlay session so AppKit continues to honor native
+			// crosshair / grab / resize cursors. The pre-capture frontmost app is restored on exit.
+			self.preserve_frontmost_on_next_toolbar_show = false;
 		}
 
 		tracing::debug!(
@@ -4478,6 +4480,33 @@ impl MacOSOverlayCursorRectSupport {
 
 		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
 	}
+
+	fn apply_cursor_for_current_pointer(&self) {
+		tracing::trace!(
+			op = "overlay.macos_overlay_cursor_rect_support_apply_current_pointer",
+			view_key = self.view_key,
+			"Applying macOS overlay cursor rect authority for current pointer."
+		);
+
+		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
+	}
+
+	fn apply_cursor_for_current_pointer_or_fallback(&self, fallback_icon: CursorIcon) {
+		if macos_overlay_view_cursor_rect_entries(self.view_key).is_none() {
+			tracing::trace!(
+				op = "overlay.macos_overlay_cursor_rect_support_apply_fallback",
+				view_key = self.view_key,
+				icon = ?fallback_icon,
+				"Fell back to the session cursor icon because the render cursor rects are not ready yet."
+			);
+
+			macos_set_cursor_icon(fallback_icon);
+
+			return;
+		}
+
+		self.apply_cursor_for_current_pointer();
+	}
 }
 
 #[cfg(target_os = "macos")]
@@ -5035,8 +5064,22 @@ fn macos_set_cursor_icon(icon: CursorIcon) {
 	let cursor = macos_cursor_object_for_icon(icon);
 
 	if cursor.is_null() {
+		tracing::trace!(
+			op = "overlay.macos_set_cursor_icon",
+			icon = ?icon,
+			cursor_available = false,
+			"Skipped macOS cursor update because no cursor object was available."
+		);
+
 		return;
 	}
+
+	tracing::trace!(
+		op = "overlay.macos_set_cursor_icon",
+		icon = ?icon,
+		cursor_available = true,
+		"Setting macOS cursor icon."
+	);
 
 	unsafe {
 		let _: () = objc::msg_send![cursor, set];
@@ -5238,8 +5281,28 @@ fn macos_apply_overlay_cursor_for_current_pointer(overlay_view_key: usize) {
 	let Some(icon) =
 		macos_cursor_icon_for_current_pointer(entries.as_deref(), local_point, overlay_bounds)
 	else {
+		tracing::trace!(
+			op = "overlay.macos_apply_overlay_cursor_for_current_pointer",
+			view_key = overlay_view_key,
+			entry_count = entries.as_ref().map_or(0, Vec::len),
+			local_point = ?local_point,
+			overlay_bounds = ?overlay_bounds,
+			icon = ?"none",
+			"Skipped macOS overlay cursor apply because the pointer is not within an active cursor rect."
+		);
+
 		return;
 	};
+
+	tracing::trace!(
+		op = "overlay.macos_apply_overlay_cursor_for_current_pointer",
+		view_key = overlay_view_key,
+		entry_count = entries.as_ref().map_or(0, Vec::len),
+		local_point = ?local_point,
+		overlay_bounds = ?overlay_bounds,
+		icon = ?icon,
+		"Resolved macOS overlay cursor icon for current pointer."
+	);
 
 	macos_set_cursor_icon(icon);
 }

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -51,11 +51,9 @@ impl OverlaySession {
 			return;
 		};
 
-		overlay_window
-			.cursor_rects
-			.apply_cursor_for_current_pointer_or_fallback(
-				self.overlay_cursor_icon_for_monitor(overlay_window.monitor),
-			);
+		overlay_window.cursor_rects.apply_cursor_for_current_pointer_or_fallback(
+			self.overlay_cursor_icon_for_monitor(overlay_window.monitor),
+		);
 	}
 
 	fn live_capture_interaction_hovered_window_rect(

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -13,7 +13,64 @@ use crate::overlay::{
 	FROZEN_SELECTION_RESIZE_HANDLE_INTERIOR_REACH_MAX_POINTS, OverlayCursorRect, Rect, Vec2,
 };
 
+#[cfg(target_os = "macos")]
+pub(super) const fn macos_overlay_cursor_uses_render_rects(
+	mode: OverlayMode,
+	_host_live_pointer_input: bool,
+) -> bool {
+	// Keep native cursor rects active in live mode as well. The passive input shell still owns
+	// pointer dispatch, but the render window must continue advertising a native cursor shape so
+	// AppKit does not fall back to an empty-rect arrow during live/frozen handoff.
+	match mode {
+		OverlayMode::Live | OverlayMode::Frozen => true,
+	}
+}
+
 impl OverlaySession {
+	#[cfg(target_os = "macos")]
+	pub(super) fn apply_macos_cursor_authority(&self) {
+		let render_cursor_rects = macos_overlay_cursor_uses_render_rects(
+			self.state.mode,
+			self.should_host_live_pointer_input_in_native_shell(),
+		);
+
+		tracing::trace!(
+			op = "overlay.apply_macos_cursor_authority",
+			mode = ?self.state.mode,
+			render_cursor_rects,
+			cursor = ?self.state.cursor,
+			monitor_id = self.monitor_for_mode().or(self.state.monitor).map(|monitor| monitor.id),
+			"Applied macOS cursor authority."
+		);
+
+		if !render_cursor_rects {
+			if self.session_active
+				&& !self.capture_windows_hidden
+				&& matches!(self.state.mode, OverlayMode::Live)
+				&& !self.windows.is_empty()
+			{
+				super::macos_set_cursor_icon(CursorIcon::Crosshair);
+			}
+
+			return;
+		}
+
+		let Some(current_monitor) = self.monitor_for_mode().or(self.state.monitor) else {
+			return;
+		};
+		let Some(overlay_window) =
+			self.windows.values().find(|overlay_window| overlay_window.monitor == current_monitor)
+		else {
+			return;
+		};
+
+		overlay_window
+			.cursor_rects
+			.apply_cursor_for_current_pointer_or_fallback(
+				self.overlay_cursor_icon_for_monitor(overlay_window.monitor),
+			);
+	}
+
 	fn live_capture_interaction_hovered_window_rect(
 		interaction: LiveCaptureInteraction,
 	) -> Option<MonitorRectPoints> {
@@ -700,6 +757,13 @@ impl OverlaySession {
 
 	pub(super) fn sync_overlay_cursor_icons(&self) {
 		let current_monitor = self.monitor_for_mode().or(self.state.monitor);
+		#[cfg(target_os = "macos")]
+		let render_cursor_rects = macos_overlay_cursor_uses_render_rects(
+			self.state.mode,
+			self.should_host_live_pointer_input_in_native_shell(),
+		);
+		#[cfg(not(target_os = "macos"))]
+		let render_cursor_rects = false;
 
 		for overlay_window in self.windows.values() {
 			let icon = self.overlay_cursor_icon_for_monitor(overlay_window.monitor);
@@ -711,24 +775,29 @@ impl OverlaySession {
 				icon = ?icon,
 				active_monitor_id = ?current_monitor.map(|monitor| monitor.id),
 				cursor = ?self.state.cursor,
+				render_cursor_rects,
 				"Synced overlay cursor icons."
 			);
 
+			#[cfg(not(target_os = "macos"))]
 			overlay_window.window.set_cursor(icon);
 			#[cfg(target_os = "macos")]
 			{
-				overlay_window.cursor_rects.sync_cursor_rects(
-					overlay_window.window.as_ref(),
-					&self.frozen_selection_cursor_rects_for_monitor(overlay_window.monitor),
-				);
+				overlay_window.window.set_cursor(icon);
 
-				if current_monitor == Some(overlay_window.monitor) {
-					super::macos_set_cursor_icon(
-						self.overlay_cursor_icon_for_monitor(overlay_window.monitor),
-					);
-				}
+				let rects = if render_cursor_rects {
+					self.frozen_selection_cursor_rects_for_monitor(overlay_window.monitor)
+				} else {
+					Vec::new()
+				};
+				overlay_window
+					.cursor_rects
+					.sync_cursor_rects(overlay_window.window.as_ref(), &rects);
 			}
 		}
+
+		#[cfg(target_os = "macos")]
+		self.apply_macos_cursor_authority();
 	}
 
 	pub(super) fn frozen_selection_drag_hides_auxiliary_windows(&self) -> bool {

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -13,19 +13,6 @@ use crate::overlay::{
 	FROZEN_SELECTION_RESIZE_HANDLE_INTERIOR_REACH_MAX_POINTS, OverlayCursorRect, Rect, Vec2,
 };
 
-#[cfg(target_os = "macos")]
-pub(super) const fn macos_overlay_cursor_uses_render_rects(
-	mode: OverlayMode,
-	_host_live_pointer_input: bool,
-) -> bool {
-	// Keep native cursor rects active in live mode as well. The passive input shell still owns
-	// pointer dispatch, but the render window must continue advertising a native cursor shape so
-	// AppKit does not fall back to an empty-rect arrow during live/frozen handoff.
-	match mode {
-		OverlayMode::Live | OverlayMode::Frozen => true,
-	}
-}
-
 impl OverlaySession {
 	#[cfg(target_os = "macos")]
 	pub(super) fn apply_macos_cursor_authority(&self) {
@@ -781,6 +768,7 @@ impl OverlaySession {
 
 			#[cfg(not(target_os = "macos"))]
 			overlay_window.window.set_cursor(icon);
+
 			#[cfg(target_os = "macos")]
 			{
 				overlay_window.window.set_cursor(icon);
@@ -790,6 +778,7 @@ impl OverlaySession {
 				} else {
 					Vec::new()
 				};
+
 				overlay_window
 					.cursor_rects
 					.sync_cursor_rects(overlay_window.window.as_ref(), &rects);
@@ -1371,5 +1360,18 @@ impl OverlaySession {
 		(pixel[0] as f32 - mean[0]).abs().round() as u32
 			+ (pixel[1] as f32 - mean[1]).abs().round() as u32
 			+ (pixel[2] as f32 - mean[2]).abs().round() as u32
+	}
+}
+
+#[cfg(target_os = "macos")]
+pub(super) const fn macos_overlay_cursor_uses_render_rects(
+	mode: OverlayMode,
+	_host_live_pointer_input: bool,
+) -> bool {
+	// Keep native cursor rects active in live mode as well. The passive input shell still owns
+	// pointer dispatch, but the render window must continue advertising a native cursor shape so
+	// AppKit does not fall back to an empty-rect arrow during live/frozen handoff.
+	match mode {
+		OverlayMode::Live | OverlayMode::Frozen => true,
 	}
 }

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -385,7 +385,6 @@ impl MacOSCaptureHost {
 			"Attempted to restore the pre-capture frontmost application."
 		);
 	}
-
 }
 
 struct MacOSCaptureHostOverlayShell {
@@ -1292,7 +1291,6 @@ extern "C" fn macos_passive_shell_view_draw_rect(this: &Object, _cmd: Sel, dirty
 				objc::msg_send![objc::class!(NSBezierPath), fillRect: NSRect::from(dirty_rect)];
 		}
 	}
-
 }
 
 extern "C" fn macos_passive_shell_view_reset_cursor_rects(this: &Object, _cmd: Sel) {

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -796,6 +796,7 @@ impl OverlaySession {
 				placement,
 			}
 		});
+
 		if self.toolbar_window_visible && self.preserve_frontmost_on_next_toolbar_show {
 			self.preserve_frontmost_on_next_toolbar_show = false;
 		}

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use egui::FontId;
@@ -62,8 +61,6 @@ impl MacOSNativeCaptureShells {
 			window_count = windows.len(),
 			"Synced passive overlay shells."
 		);
-
-		macos_set_system_cursor_hidden(visible);
 
 		for overlay_window in windows {
 			if let Some(shell) = self.overlay_shells.get(&overlay_window.monitor.id) {
@@ -169,7 +166,6 @@ pub struct MacOSCaptureHostSyncState {
 	toolbar_pointer_shell_visible: bool,
 	key_focus_target: Option<MacOSCaptureHostKeyFocusTarget>,
 	frozen_mode_active: bool,
-	preserve_frontmost_on_toolbar_show: bool,
 }
 
 /// App-owned macOS capture host adapter that owns native shell lifecycle,
@@ -195,6 +191,10 @@ impl MacOSCaptureHost {
 	pub fn begin_session(&mut self) {
 		self.frontmost_application_before_start = super::macos_frontmost_application();
 		self.last_synced_frozen_mode = false;
+
+		// AppKit only keeps native cursor ownership stable while rsnap is the active app. Capture
+		// the prior frontmost app for teardown restore, then activate rsnap for the overlay session.
+		super::macos_activate_app();
 
 		tracing::info!(
 			op = "overlay.frontmost_app_captured",
@@ -337,8 +337,6 @@ impl MacOSCaptureHost {
 	}
 
 	fn destroy_native_capture_shells(&mut self, session: &OverlaySession) {
-		macos_set_system_cursor_hidden(false);
-
 		for overlay_window in session.windows.values() {
 			super::macos_set_capture_window_mouse_passthrough(
 				overlay_window.window.as_ref(),
@@ -361,19 +359,11 @@ impl MacOSCaptureHost {
 		self.restore_frontmost_application_after_exit(target);
 	}
 
-	fn maybe_preserve_frontmost_application(&mut self, state: &MacOSCaptureHostSyncState) {
-		let transitioned_into_frozen = state.frozen_mode_active && !self.last_synced_frozen_mode;
-
-		if transitioned_into_frozen {
-			self.restore_recorded_frontmost_application_for_focus_preservation(
-				"begin_frozen_capture",
-			);
-		}
-		if state.preserve_frontmost_on_toolbar_show {
-			self.restore_recorded_frontmost_application_for_focus_preservation(
-				"toolbar_first_show",
-			);
-		}
+	fn maybe_preserve_frontmost_application(&mut self, _state: &MacOSCaptureHostSyncState) {
+		// Do not hand focus back during an active overlay session. Live crosshair and frozen hover
+		// cursors are native AppKit cursors; restoring the previous frontmost app during capture
+		// hands visible cursor ownership back to that app and leaves rsnap showing an arrow until
+		// the next direct interaction. The original app is restored when the session exits.
 	}
 
 	fn restore_frontmost_application_after_exit(&self, target: Option<MacOSFrontmostApplication>) {
@@ -396,20 +386,6 @@ impl MacOSCaptureHost {
 		);
 	}
 
-	fn restore_recorded_frontmost_application_for_focus_preservation(&self, reason: &'static str) {
-		let Some(target) = self.frontmost_application_before_start else {
-			return;
-		};
-		let restored = super::macos_restore_frontmost_application(target);
-
-		tracing::info!(
-			op = "overlay.frontmost_app_focus_preservation_attempted",
-			target_process_id = target.process_id,
-			reason,
-			restored,
-			"Attempted to preserve the pre-capture frontmost application during overlay interaction."
-		);
-	}
 }
 
 struct MacOSCaptureHostOverlayShell {
@@ -780,6 +756,12 @@ impl OverlaySession {
 		host.destroy_native_capture_shells(self);
 	}
 
+	/// Re-applies cursor authority after the host has switched native shell visibility or
+	/// passthrough ownership.
+	pub fn refresh_macos_cursor_after_host_sync(&self) {
+		self.apply_macos_cursor_authority();
+	}
+
 	/// Builds the explicit macOS host sync state for the current overlay session.
 	pub fn take_macos_capture_host_sync_state(&mut self) -> MacOSCaptureHostSyncState {
 		let overlay_shells = self
@@ -814,10 +796,7 @@ impl OverlaySession {
 				placement,
 			}
 		});
-		let preserve_frontmost_on_toolbar_show =
-			self.toolbar_window_visible && self.preserve_frontmost_on_next_toolbar_show;
-
-		if preserve_frontmost_on_toolbar_show {
+		if self.toolbar_window_visible && self.preserve_frontmost_on_next_toolbar_show {
 			self.preserve_frontmost_on_next_toolbar_show = false;
 		}
 
@@ -827,7 +806,6 @@ impl OverlaySession {
 			toolbar_shell,
 			toolbar_pointer_shell_visible: self.should_host_toolbar_pointer_input_in_native_shell(),
 			frozen_mode_active: matches!(self.state.mode, OverlayMode::Frozen),
-			preserve_frontmost_on_toolbar_show,
 			key_focus_target: self.native_key_focus_shell_target(),
 		}
 	}
@@ -1314,11 +1292,6 @@ extern "C" fn macos_passive_shell_view_draw_rect(this: &Object, _cmd: Sel, dirty
 		}
 	}
 
-	let Some(point) = macos_passive_shell_cursor_point(this as *const Object as usize) else {
-		return;
-	};
-
-	macos_draw_passive_shell_crosshair(point);
 }
 
 extern "C" fn macos_passive_shell_view_reset_cursor_rects(this: &Object, _cmd: Sel) {
@@ -1974,15 +1947,6 @@ fn macos_passive_shell_cursor_points() -> &'static Mutex<HashMap<usize, Option<N
 	POINTS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn macos_passive_shell_cursor_point(view_key: usize) -> Option<NSPoint> {
-	let points = macos_passive_shell_cursor_points();
-
-	match points.lock() {
-		Ok(guard) => guard.get(&view_key).copied().flatten(),
-		Err(poisoned) => poisoned.into_inner().get(&view_key).copied().flatten(),
-	}
-}
-
 fn macos_clear_passive_shell_cursor_point(view_key: usize) {
 	let points = macos_passive_shell_cursor_points();
 
@@ -2083,81 +2047,6 @@ fn macos_seed_passive_shell_cursor_point(
 			&& local_point.y <= bounds.origin.y + bounds.size.height;
 
 		contains.then_some(local_point)
-	}
-}
-
-fn macos_draw_passive_shell_crosshair(point: NSPoint) {
-	let outline_color: *mut Object = unsafe {
-		objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 0.0 alpha: 0.95]
-	};
-	let fill_color: *mut Object = unsafe {
-		objc::msg_send![objc::class!(NSColor), colorWithCalibratedWhite: 1.0 alpha: 0.95]
-	};
-
-	macos_fill_passive_shell_crosshair_segments(outline_color, point, 3.0);
-	macos_fill_passive_shell_crosshair_segments(fill_color, point, 1.0);
-}
-
-fn macos_fill_passive_shell_crosshair_segments(color: *mut Object, point: NSPoint, thickness: f64) {
-	if color.is_null() {
-		return;
-	}
-
-	const EXTENT: f64 = 11.0;
-	const GAP: f64 = 3.0;
-
-	let rects = [
-		NSRect::new(
-			NSPoint::new(point.x - EXTENT, point.y - thickness * 0.5),
-			NSSize::new(EXTENT - GAP, thickness),
-		),
-		NSRect::new(
-			NSPoint::new(point.x + GAP, point.y - thickness * 0.5),
-			NSSize::new(EXTENT - GAP, thickness),
-		),
-		NSRect::new(
-			NSPoint::new(point.x - thickness * 0.5, point.y - EXTENT),
-			NSSize::new(thickness, EXTENT - GAP),
-		),
-		NSRect::new(
-			NSPoint::new(point.x - thickness * 0.5, point.y + GAP),
-			NSSize::new(thickness, EXTENT - GAP),
-		),
-	];
-
-	unsafe {
-		let _: () = objc::msg_send![color, setFill];
-
-		for rect in rects {
-			let _: () = objc::msg_send![objc::class!(NSBezierPath), fillRect: rect];
-		}
-	}
-}
-
-#[link(name = "CoreGraphics", kind = "framework")]
-unsafe extern "C" {
-	fn CGMainDisplayID() -> u32;
-	fn CGDisplayHideCursor(display: u32) -> i32;
-	fn CGDisplayShowCursor(display: u32) -> i32;
-}
-
-fn macos_set_system_cursor_hidden(hidden: bool) {
-	static CURSOR_HIDDEN: AtomicBool = AtomicBool::new(false);
-
-	let previous = CURSOR_HIDDEN.swap(hidden, Ordering::SeqCst);
-
-	if previous == hidden {
-		return;
-	}
-
-	unsafe {
-		if hidden {
-			let _ = CGDisplayHideCursor(CGMainDisplayID());
-			let _: () = objc::msg_send![objc::class!(NSCursor), hide];
-		} else {
-			let _: () = objc::msg_send![objc::class!(NSCursor), unhide];
-			let _ = CGDisplayShowCursor(CGMainDisplayID());
-		}
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -33,6 +33,7 @@ use crate::overlay::{
 #[cfg(target_os = "macos")]
 use crate::state::MonitorImageSnapshot;
 use crate::worker::{WorkerErrorSource, WorkerResponse};
+#[cfg(target_os = "macos")]
 use crate::overlay::frozen_selection_runtime;
 
 fn test_mosaic_source_image() -> RgbaImage {

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -785,7 +785,7 @@ fn entering_frozen_capture_skips_initial_toolbar_focus_restore() {
 	assert!(session.skip_toolbar_focus_on_next_show);
 	assert!(!session.should_focus_frozen_toolbar_window_on_show());
 	#[cfg(target_os = "macos")]
-	assert!(session.preserve_frontmost_on_next_toolbar_show);
+	assert!(!session.preserve_frontmost_on_next_toolbar_show);
 }
 
 #[cfg(target_os = "macos")]
@@ -2017,6 +2017,23 @@ fn live_cursor_rects_cover_overlay_with_crosshair() {
 	assert_eq!(rects[0].icon, CursorIcon::Crosshair);
 	assert_eq!(rects[0].rect.min, Pos2::ZERO);
 	assert_eq!(rects[0].rect.max, Pos2::new(monitor.width as f32, monitor.height as f32));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_live_cursor_sync_keeps_render_rects_active_during_native_shell_input() {
+	assert!(super::super::frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
+		OverlayMode::Live,
+		true,
+	));
+	assert!(super::super::frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
+		OverlayMode::Live,
+		false,
+	));
+	assert!(super::super::frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
+		OverlayMode::Frozen,
+		true,
+	));
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -33,6 +33,7 @@ use crate::overlay::{
 #[cfg(target_os = "macos")]
 use crate::state::MonitorImageSnapshot;
 use crate::worker::{WorkerErrorSource, WorkerResponse};
+use crate::overlay::frozen_selection_runtime;
 
 fn test_mosaic_source_image() -> RgbaImage {
 	RgbaImage::from_fn(8, 8, |x, y| {
@@ -2022,15 +2023,15 @@ fn live_cursor_rects_cover_overlay_with_crosshair() {
 #[cfg(target_os = "macos")]
 #[test]
 fn macos_live_cursor_sync_keeps_render_rects_active_during_native_shell_input() {
-	assert!(super::super::frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
+	assert!(frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
 		OverlayMode::Live,
 		true,
 	));
-	assert!(super::super::frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
+	assert!(frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
 		OverlayMode::Live,
 		false,
 	));
-	assert!(super::super::frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
+	assert!(frozen_selection_runtime::macos_overlay_cursor_uses_render_rects(
 		OverlayMode::Frozen,
 		true,
 	));

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -14,6 +14,8 @@ use winit::window::CursorIcon;
 use crate::overlay::OverlayControl;
 #[cfg(target_os = "macos")]
 use crate::overlay::WindowCaptureAlphaMode;
+#[cfg(target_os = "macos")]
+use crate::overlay::frozen_selection_runtime;
 use crate::overlay::session_state::FrozenAnnotationStyleCapsulePlacement;
 use crate::overlay::tests::{
 	self, Duration, ElementState, FrozenCaptureSource, FrozenSelectionDragState,
@@ -33,8 +35,6 @@ use crate::overlay::{
 #[cfg(target_os = "macos")]
 use crate::state::MonitorImageSnapshot;
 use crate::worker::{WorkerErrorSource, WorkerResponse};
-#[cfg(target_os = "macos")]
-use crate::overlay::frozen_selection_runtime;
 
 fn test_mosaic_source_image() -> RgbaImage {
 	RgbaImage::from_fn(8, 8, |x, y| {


### PR DESCRIPTION
## Summary
- keep rsnap frontmost during overlay capture so AppKit native cursor ownership stays with the overlay session
- keep macOS render cursor rects active through live and frozen handoff, with a fallback native icon before cursor rects are ready
- refresh cursor authority after host sync and add regression coverage for native cursor behavior

## Verification
- cargo test -p rsnap-overlay entering_frozen_capture_skips_initial_toolbar_focus_restore --lib
- cargo test -p rsnap-overlay macos_live_cursor_sync_keeps_render_rects_active_during_native_shell_input --lib
- cargo test -p rsnap-overlay frozen_selection_cursor_rects_use_native_handle_hover_and_full_window_resize_drag --lib
- cargo test -p rsnap host_buffered_native_text_input_reaches_frozen_text_edit_through_app_dispatch
- cargo make lint-rust
- cargo make test-rust
