### PR TITLE
Dedupe smoke and perf validation ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,65 +114,25 @@ cargo make lint
 cargo make test
 ```
 
-Scroll-capture verification now starts with deterministic replay instead of the old GUI smoke:
+Smoke/perf entrypoints:
 
 ```sh
 scripts/smoke/replay-scroll-capture.sh
 scripts/smoke/replay-scroll-capture-self-check.sh
-```
-
-For semantic trace analysis (first bad frame, under-consumption, overshoot), use:
-
-```sh
 scripts/smoke/analyze-scroll-capture-trace.sh
-```
-
-The remaining macOS GUI smoke harnesses are still available for live-loupe and
-desktop-session checks:
-
-```sh
+scripts/smoke/live-loupe-perf-macos.sh
+scripts/smoke/live-loupe-perf-self-check-macos.sh
 scripts/smoke/self-check-macos.sh
 scripts/smoke/macos.sh
-```
-
-`scripts/smoke/replay-scroll-capture.sh` and
-`scripts/smoke/analyze-scroll-capture-trace.sh` now force the latest recorded
-live trace through the same worker-pairwise commit path that current macOS
-production scroll capture uses. They are trace-driven rather than
-scenario-driven, so they expect at least one recorded trace under
-`~/Library/Application Support/ink.hack.rsnap/scroll-capture-traces/` unless
-you pass `--trace <manifest-path>` directly to the example. Use the direct
-example without `--force-worker-pairwise` only when you intentionally want to
-compare the legacy recorded-source replay mode.
-`scripts/smoke/replay-scroll-capture-self-check.sh` is the repo-local fallback
-when you want to verify the replay harness itself without relying on a
-user-recorded trace. `scripts/smoke/self-check-macos.sh` and
-`scripts/smoke/macos.sh` still drive the logged-in macOS live-loupe smoke path
-and require the expected Screen Recording / automation permissions.
-
-For `XY-185` style downward scroll-capture work, treat the verification order as:
-
-1. deterministic tests and `cargo make checks`
-2. `scripts/smoke/replay-scroll-capture.sh`
-3. `scripts/smoke/analyze-scroll-capture-trace.sh`
-4. one fresh release live touchpad run with a newly recorded trace
-
-Repo-native performance entrypoints are available for deterministic benches and
-dedicated smoke:
-
-```sh
 scripts/perf/local.sh
 scripts/perf/self-check-macos.sh
 scripts/perf/macos.sh
 ```
 
-Use `scripts/perf/local.sh` for component-render and scroll-capture regressions
-that should stay comparable on a normal development machine.
-`scripts/perf/self-check-macos.sh` validates the dedicated macOS smoke
-environment, and `scripts/perf/macos.sh` is the end-to-end GUI performance
-entrypoint for a logged-in desktop session. The durable runbook for command
-selection and baseline comparison lives at
-`docs/runbook/performance-validation.md`.
+For durable command selection, verification order, baseline workflow, and asset ownership:
+
+- `docs/runbook/performance-validation.md`
+- `docs/reference/smoke-perf-validation-surface.md`
 
 The capture-session contract lives at `docs/spec/capture-session.md`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ The active split below is by question type, not by human-versus-agent audience.
   `docs/runbook/architecture-reset-implementation.md`
 - Need the active architecture-reset target and migration posture ->
   `docs/reference/host-core-reset.md`
+- Need the current smoke/perf ownership map before pruning validation assets ->
+  `docs/reference/smoke-perf-validation-surface.md`
 - Need current repository layout or crate ownership notes ->
   `docs/reference/workspace-layout.md`
 - Need durable rationale for the architecture reset ->

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -45,6 +45,8 @@ Then keep the body descriptive:
 
 - `docs/reference/host-core-reset.md` for the active target architecture and migration posture of
   the host/core reset
+- `docs/reference/smoke-perf-validation-surface.md` for the current smoke/perf asset ownership
+  map across scripts, replay, benches, runtime tests, and session tests
 - `docs/reference/workspace-layout.md` for workspace layout, crate boundaries, and local-only
   directories
 - `docs/reference/live-sampling.md` for the stream-first live RGB and loupe sampling path

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -1,0 +1,60 @@
+# Smoke/Perf Validation Surface Reference
+
+Purpose: Describe the current smoke/perf validation surface by ownership layer so cleanup work can
+distinguish authoritative behavior coverage from thin entrypoint wrappers.
+
+Read this when: You are deciding whether a smoke/perf asset is redundant, choosing where a new
+validation case belongs, or auditing whether a script, benchmark, replay test, or runtime test is
+the owner for a behavior.
+
+Sources: `scripts/smoke/`; `scripts/perf/`; `packages/rsnap-overlay/src/scroll_capture/tests.rs`;
+`packages/rsnap-overlay/src/overlay/tests/worker_tick_runtime.rs`;
+`packages/rsnap-overlay/src/overlay/tests/worker_observation_runtime.rs`;
+`packages/rsnap-overlay/src/overlay/replay_support.rs`; `apps/rsnap/benches/settings_window.rs`;
+`packages/rsnap-overlay/benches/scroll_capture.rs`
+
+Depends on: `docs/runbook/performance-validation.md`; `docs/spec/performance.md`
+
+Covers: The current layer map for smoke/perf entrypoints, deterministic replay/bench surfaces,
+overlay runtime integration tests, and scroll-capture session semantics tests.
+
+## Layer definitions
+
+| Layer | Owns | Typical artifact |
+| --- | --- | --- |
+| Script entrypoint | Human/agent command routing and stable command names | `scripts/smoke/*.sh`, `scripts/perf/*.sh` |
+| Deterministic replay / bench | Recorded-trace replay and repeatable benchmark evidence | replay example/tests, Criterion benches |
+| Overlay runtime integration | Worker scheduling, retries, stale-input handling, request issuance | `overlay/tests/worker_*_runtime.rs` |
+| Scroll-capture session semantics | Stitching, overlap, pairwise commit/no-change semantics | `scroll_capture/tests.rs` |
+
+## Coverage matrix
+
+| Asset | Layer | Primary owner | What it should prove |
+| --- | --- | --- | --- |
+| `scripts/smoke/replay-scroll-capture.sh` | Script entrypoint | deterministic replay | Runs the latest recorded trace through worker-pairwise replay. |
+| `scripts/smoke/replay-scroll-capture-self-check.sh` | Script entrypoint | deterministic replay | Runs the worker-pairwise replay self-check without a user trace. |
+| `scripts/smoke/analyze-scroll-capture-trace.sh` | Script entrypoint | deterministic replay | Emits summary-only replay analysis for semantic drift triage. |
+| `scripts/smoke/live-loupe-perf-macos.sh` | Script entrypoint | live macOS smoke | Drives the remaining live-loupe desktop smoke path. |
+| `scripts/smoke/live-loupe-perf-self-check-macos.sh` | Script entrypoint | smoke readiness | Runs the live-loupe macOS environment/tooling self-check directly. |
+| `scripts/smoke/self-check-macos.sh` | Script entrypoint | smoke readiness | Verifies macOS smoke tooling and replay self-check without the real GUI run. |
+| `scripts/smoke/macos.sh` | Script entrypoint | smoke aggregation | Runs the macOS live-loupe smoke plus recorded-trace replay. |
+| `scripts/perf/local.sh` | Script entrypoint | deterministic benches | Runs the committed Criterion smoke-sized benchmark sweep. |
+| `scripts/perf/self-check-macos.sh` | Script entrypoint | perf aggregation | Runs local deterministic benches plus macOS smoke readiness. |
+| `scripts/perf/macos.sh` | Script entrypoint | perf aggregation | Runs local deterministic benches plus the real macOS smoke path. |
+| `packages/rsnap-overlay/src/overlay/replay_support.rs` tests | Deterministic replay / bench | replay harness | Trace round-trip, replay mode selection, and summary classification. |
+| `apps/rsnap/benches/settings_window.rs` | Deterministic replay / bench | component perf | Stable settings-window layout/frame baselines. |
+| `packages/rsnap-overlay/benches/scroll_capture.rs` | Deterministic replay / bench | hot-path perf | Stable fingerprint, overlap-match, and one-step session commit baselines. |
+| `packages/rsnap-overlay/src/overlay/tests/worker_tick_runtime.rs` | Overlay runtime integration | overlay runtime | Request issuance, retry timing, backoff, and fresh-input worker scheduling. |
+| `packages/rsnap-overlay/src/overlay/tests/worker_observation_runtime.rs` | Overlay runtime integration | overlay runtime | Latched, stale, and superseded worker observation context handling. |
+| `packages/rsnap-overlay/src/scroll_capture/tests.rs` | Scroll-capture session semantics | scroll session | Downward stitching, overlap resolution, and worker-pairwise session semantics. |
+
+## Cleanup rules
+
+- Prefer deleting or merging a script only when another remaining script still provides the same
+  stable entrypoint value.
+- Prefer deleting or merging a runtime test only when its remaining assertions are already owned by
+  `scroll_capture/tests.rs` and it no longer proves runtime state-machine behavior.
+- Prefer extracting shared fixtures when two layers intentionally cover different behavior with the
+  same synthetic frame families.
+- Keep replay self-check aligned with the worker-pairwise production path; treat recorded-source
+  replay as a secondary internal comparison surface.

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -9,7 +9,8 @@ refreshing local benchmark baselines, or deciding whether a change needs determi
 deterministic benches, dedicated desktop smoke, or some combination of those surfaces.
 
 Inputs: `scripts/smoke/`; `scripts/perf/`; `docs/spec/performance.md`;
-`docs/runbook/scroll-capture-benchmarks.md`
+`docs/runbook/scroll-capture-benchmarks.md`;
+`docs/reference/smoke-perf-validation-surface.md`
 
 Depends on: `docs/spec/performance.md`
 
@@ -40,10 +41,9 @@ Use the smallest command that matches the regression surface:
 `scripts/smoke/replay-scroll-capture.sh` and
 `scripts/smoke/analyze-scroll-capture-trace.sh` force
 `scroll_capture_replay --force-worker-pairwise`, so the repo-native non-live
-entrypoints exercise the same worker screenshot + pairwise registration commit
-path that current macOS production uses. Invoke the example directly without
-that flag only when you intentionally want to compare the legacy
-recorded-source replay mode.
+entrypoints exercise the same replay mode that current macOS production uses.
+Use `scripts/smoke/replay-scroll-capture-self-check.sh` for the matching
+worker-pairwise self-check path when no recorded user trace is available.
 
 ## What each high-level task does
 
@@ -70,18 +70,8 @@ For the downward scroll-capture rebuild, the expected verification sequence is:
 4. any targeted deterministic `cargo test -p rsnap-overlay ...`
 5. one fresh release live touchpad run with a newly recorded trace
 
-The low-level deterministic and smoke tasks remain available:
-
-- `scripts/smoke/replay-scroll-capture.sh`
-- `scripts/smoke/replay-scroll-capture-self-check.sh`
-- `scripts/smoke/analyze-scroll-capture-trace.sh`
-- `scripts/smoke/live-loupe-perf-macos.sh`
-- `scripts/smoke/live-loupe-perf-self-check-macos.sh`
-- `scripts/smoke/self-check-macos.sh`
-- `scripts/smoke/macos.sh`
-
-Use them when you need to isolate deterministic scroll-capture replay or the live-loupe smoke
-harness instead of the high-level performance entrypoint.
+For the current ownership map of those scripts versus replay, runtime, and
+session tests, read `docs/reference/smoke-perf-validation-surface.md`.
 
 ## Baseline workflow for local benchmarks
 
@@ -140,6 +130,8 @@ Dedicated macOS smoke:
 
 ## Related docs
 
+- `docs/reference/smoke-perf-validation-surface.md` for the smoke/perf ownership map and cleanup
+  boundaries.
 - `docs/runbook/scroll-capture-benchmarks.md` for the scroll-capture fixture contract and
   per-target baseline commands.
 - `docs/reference/live-sampling.md` for the stream-first live cursor and loupe path that

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -14,26 +14,9 @@ Depends on: `docs/spec/performance.md`
 Outputs: A repeatable local benchmark run, an optional saved Criterion baseline, and a clear
 understanding of what the synthetic fixture is intended to cover.
 
-If you are debugging correctness rather than hot-path speed, start with:
-
-```bash
-scripts/smoke/replay-scroll-capture.sh
-scripts/smoke/replay-scroll-capture-self-check.sh
-```
-
-That replay runner exercises shipping overlay and session logic against the latest recorded live
-trace and should be treated as the primary non-live correctness surface. The repo-native replay
-tasks force the worker-pairwise mode so they match current macOS production scroll-capture
-authority. It requires a recorded manifest under `~/Library/Application Support/ink.hack.rsnap/scroll-capture-traces/`
-unless you invoke the example with `--trace <manifest-path>`. Use the direct example without
-`--force-worker-pairwise` only when you intentionally want to compare the legacy recorded-source
-replay path. `scripts/smoke/replay-scroll-capture-self-check.sh` is the deterministic fallback
-when you want to validate the replay harness without depending on a user-recorded trace. For
-semantic analysis (first bad frame, under-consumption, overshoot), use:
-
-```bash
-scripts/smoke/analyze-scroll-capture-trace.sh
-```
+If you are debugging correctness rather than hot-path speed, route through
+`docs/runbook/performance-validation.md` first. That runbook owns replay,
+self-check, semantic analysis, and macOS smoke command selection.
 
 Use the benchmark target below only when you specifically need performance numbers. A clean
 benchmark run does not replace replay, trace analysis, or the final fresh live touchpad

--- a/packages/rsnap-overlay/examples/scroll_capture_replay.rs
+++ b/packages/rsnap-overlay/examples/scroll_capture_replay.rs
@@ -1,4 +1,4 @@
-//! Deterministic scroll-capture replay runner used by cargo-make verification tasks.
+//! Deterministic scroll-capture replay runner used by the repo smoke/perf scripts.
 
 #![allow(unused_crate_dependencies)]
 

--- a/packages/rsnap-overlay/src/overlay/replay_support.rs
+++ b/packages/rsnap-overlay/src/overlay/replay_support.rs
@@ -1178,7 +1178,7 @@ mod tests {
 
 	#[cfg(target_os = "macos")]
 	#[test]
-	fn replay_recorded_live_trace_round_trips_one_commit() {
+	fn replay_recorded_live_trace_round_trips_one_commit_in_recorded_source_mode() {
 		let rows = [
 			[10, 0, 0, 255],
 			[20, 0, 0, 255],
@@ -1291,7 +1291,7 @@ mod tests {
 	}
 
 	#[test]
-	fn replay_recorded_live_trace_round_trips_one_commit_forces_worker_pairwise() {
+	fn replay_recorded_live_trace_round_trips_one_commit_in_worker_pairwise_mode() {
 		let base_frame = make_sparse_textlike_window(256, 120, 0);
 		let next_frame = make_sparse_textlike_window(256, 120, 9);
 		let mut session = OverlaySession::new();

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -109,10 +109,12 @@ fn make_scroll_capture_window(
 	)
 }
 
+#[cfg(target_os = "macos")]
 fn make_sparse_worker_capture_window(width: u32, height: u32, start_row: u32) -> image::RgbaImage {
 	scroll_capture_runtime_support::make_sparse_worker_capture_window(width, height, start_row)
 }
 
+#[cfg(target_os = "macos")]
 fn make_browser_like_worker_capture_window(
 	width: u32,
 	height: u32,

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -1,13 +1,12 @@
 mod live_runtime;
 mod rendering_behaviors;
+mod scroll_capture_runtime_support;
 mod scroll_input_runtime;
 mod self_capture_runtime;
 mod stream_refresh_runtime;
 mod worker_observation_runtime;
 mod worker_tick_runtime;
 
-#[cfg(target_os = "macos")]
-use std::collections::VecDeque;
 use std::path::PathBuf;
 #[cfg(target_os = "macos")]
 use std::sync::Arc;
@@ -17,8 +16,6 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 #[cfg(target_os = "macos")]
 use std::sync::atomic::Ordering;
-#[cfg(target_os = "macos")]
-use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -42,8 +39,6 @@ use winit::window::WindowId;
 
 #[cfg(target_os = "macos")]
 use crate::backend;
-#[cfg(target_os = "macos")]
-use crate::backend::CaptureBackend;
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::MacLiveFrameStream;
 use crate::overlay::FrozenCaptureSource;
@@ -96,52 +91,74 @@ use crate::worker::OverlayWorker;
 #[cfg(target_os = "macos")]
 use crate::worker::{WorkerErrorSource, WorkerRequestSendError, WorkerResponse};
 
-#[cfg(target_os = "macos")]
-struct SequenceScrollCaptureBackend {
-	frames: VecDeque<Option<image::RgbaImage>>,
-}
-#[cfg(target_os = "macos")]
-impl SequenceScrollCaptureBackend {
-	fn new(frames: impl IntoIterator<Item = Option<image::RgbaImage>>) -> Self {
-		Self { frames: frames.into_iter().collect() }
-	}
+fn make_scroll_capture_test_image(width: u32, rows: &[[u8; 4]]) -> image::RgbaImage {
+	scroll_capture_runtime_support::make_scroll_capture_test_image(width, rows)
 }
 
+fn make_scroll_capture_window(
+	document: &[[u8; 4]],
+	width: u32,
+	start_row: usize,
+	window_rows: usize,
+) -> image::RgbaImage {
+	scroll_capture_runtime_support::make_scroll_capture_window(
+		document,
+		width,
+		start_row,
+		window_rows,
+	)
+}
+
+fn make_sparse_worker_capture_window(width: u32, height: u32, start_row: u32) -> image::RgbaImage {
+	scroll_capture_runtime_support::make_sparse_worker_capture_window(width, height, start_row)
+}
+
+fn make_browser_like_worker_capture_window(
+	width: u32,
+	height: u32,
+	start_row: u32,
+) -> image::RgbaImage {
+	scroll_capture_runtime_support::make_browser_like_worker_capture_window(
+		width, height, start_row,
+	)
+}
+
+fn set_scroll_capture_input(session: &mut OverlaySession, direction: ScrollDirection) {
+	scroll_capture_runtime_support::set_scroll_capture_input(session, direction);
+}
+
 #[cfg(target_os = "macos")]
-impl CaptureBackend for SequenceScrollCaptureBackend {
-	fn capture_monitor(&mut self, _monitor: MonitorRect) -> Result<image::RgbaImage> {
-		Err(eyre::eyre!("unused in this test"))
-	}
+fn enable_test_worker_scroll_capture_path(session: &mut OverlaySession) {
+	scroll_capture_runtime_support::enable_test_worker_scroll_capture_path(session);
+}
 
-	fn capture_monitor_region_for_scroll_capture(
-		&mut self,
-		_monitor: MonitorRect,
-		_rect_px: RectPoints,
-	) -> Result<Option<image::RgbaImage>> {
-		Ok(self.frames.pop_front().unwrap_or(None))
-	}
+#[cfg(target_os = "macos")]
+fn seed_worker_scroll_capture_session(
+	session: &mut OverlaySession,
+	monitor: MonitorRect,
+	rect: RectPoints,
+	base: image::RgbaImage,
+	frames: impl IntoIterator<Item = Option<image::RgbaImage>>,
+) {
+	scroll_capture_runtime_support::seed_worker_scroll_capture_session(
+		session, monitor, rect, base, frames,
+	);
+}
 
-	fn pixel_rgb_in_monitor(
-		&mut self,
-		_monitor: MonitorRect,
-		_point: GlobalPoint,
-	) -> Result<Option<Rgb>> {
-		Ok(None)
-	}
+#[cfg(target_os = "macos")]
+fn drain_scroll_capture_worker_until_idle(session: &mut OverlaySession) {
+	scroll_capture_runtime_support::drain_scroll_capture_worker_until_idle(session);
+}
 
-	fn rgba_patch_in_monitor(
-		&mut self,
-		_monitor: MonitorRect,
-		_point: GlobalPoint,
-		_width_px: u32,
-		_height_px: u32,
-	) -> Result<Option<image::RgbaImage>> {
-		Ok(None)
-	}
+fn observe_scroll_capture_frame(
+	session: &mut OverlaySession,
+	frame: image::RgbaImage,
+) -> Option<ScrollObserveOutcome> {
+	scroll_capture_runtime_support::observe_scroll_capture_frame(session, frame)
+}
 
-	fn refresh_window_cache(&mut self) -> Result<Arc<WindowListSnapshot>> {
-		Err(eyre::eyre!("unused in this test"))
-	}
+fn scroll_capture_export_height(session: &OverlaySession) -> u32 {
+	scroll_capture_runtime_support::scroll_capture_export_height(session)
 }
 
 fn session_pending_freeze_capture(session: &OverlaySession) -> Option<MonitorRect> {
@@ -434,151 +451,6 @@ fn commit_frozen_display_preview_state(
 				.or_else(|| session_inflight_window_freeze_capture(session)),
 		},
 	};
-}
-
-fn make_scroll_capture_test_image(width: u32, rows: &[[u8; 4]]) -> image::RgbaImage {
-	let mut image = image::RgbaImage::new(width, rows.len() as u32);
-
-	for (y, row) in rows.iter().enumerate() {
-		for x in 0..width {
-			image.put_pixel(x, y as u32, Rgba(*row));
-		}
-	}
-
-	image
-}
-
-fn make_scroll_capture_window(
-	document: &[[u8; 4]],
-	width: u32,
-	start_row: usize,
-	window_rows: usize,
-) -> image::RgbaImage {
-	make_scroll_capture_test_image(width, &document[start_row..start_row + window_rows])
-}
-
-#[cfg(target_os = "macos")]
-fn make_sparse_worker_capture_window(width: u32, height: u32, start_row: u32) -> image::RgbaImage {
-	let stripe_x = 104_u32;
-	let mut image = image::RgbaImage::from_pixel(width, height, Rgba([255, 255, 255, 255]));
-
-	for y in 0..height {
-		let document_row = start_row.saturating_add(y);
-		let shade = ((document_row.saturating_mul(17)) % 180) as u8;
-
-		for x in stripe_x..stripe_x.saturating_add(6) {
-			image.put_pixel(x, y, Rgba([shade, shade, shade, 255]));
-		}
-		for x in stripe_x.saturating_add(10)..stripe_x.saturating_add(13) {
-			if document_row % 19 < 9 {
-				image.put_pixel(x, y, Rgba([40, 40, 40, 255]));
-			}
-		}
-	}
-
-	image
-}
-
-#[cfg(target_os = "macos")]
-fn make_browser_like_worker_capture_window(
-	width: u32,
-	height: u32,
-	start_row: u32,
-) -> image::RgbaImage {
-	let scrollbar_left = width.saturating_sub(18);
-	let content_left = 56_u32;
-	let content_right = width.saturating_sub(48);
-	let heading_width = 220_u32;
-	let paragraph_width = content_right.saturating_sub(content_left);
-	let mut image = make_sparse_worker_capture_window(width, height, start_row);
-
-	for y in 0..height {
-		let document_row = start_row.saturating_add(y);
-
-		if document_row % 420 < 18 {
-			for x in content_left..content_left.saturating_add(heading_width) {
-				image.put_pixel(x, y, Rgba([26, 26, 26, 255]));
-			}
-		} else if document_row % 420 >= 54 && document_row % 420 < 220 {
-			if document_row % 24 < 3 {
-				let trim = ((document_row / 24) % 5) * 18;
-
-				for x in
-					content_left..content_left.saturating_add(paragraph_width.saturating_sub(trim))
-				{
-					image.put_pixel(x, y, Rgba([72, 72, 72, 255]));
-				}
-			}
-		} else if document_row % 420 >= 270 && document_row % 420 < 360 && document_row % 20 < 2 {
-			for x in content_left.saturating_add(20)
-				..content_left.saturating_add(paragraph_width.saturating_sub(70))
-			{
-				image.put_pixel(x, y, Rgba([98, 98, 98, 255]));
-			}
-		}
-
-		for x in scrollbar_left..width {
-			image.put_pixel(x, y, Rgba([232, 232, 232, 255]));
-		}
-	}
-
-	let thumb_height = (height / 5).max(16);
-	let thumb_top = (start_row / 3) % height.max(thumb_height + 1);
-	let thumb_top = thumb_top.min(height.saturating_sub(thumb_height));
-
-	for y in thumb_top..thumb_top.saturating_add(thumb_height) {
-		for x in scrollbar_left.saturating_add(3)..width.saturating_sub(4) {
-			image.put_pixel(x, y, Rgba([96, 96, 96, 255]));
-		}
-	}
-
-	image
-}
-
-fn set_scroll_capture_input(session: &mut OverlaySession, direction: ScrollDirection) {
-	session.scroll_capture.input_direction = Some(direction);
-	session.scroll_capture.input_direction_at = Some(Instant::now());
-	session.scroll_capture.input_gesture_active = true;
-}
-
-#[cfg(target_os = "macos")]
-fn enable_test_worker_scroll_capture_path(session: &mut OverlaySession) {
-	session.scroll_capture.force_worker_sampling_in_tests = true;
-}
-
-#[cfg(target_os = "macos")]
-fn drain_scroll_capture_worker_until_idle(session: &mut OverlaySession) {
-	for _ in 0..64 {
-		let _ = session.drain_worker_responses();
-
-		if session.scroll_capture.inflight_request_id.is_none() {
-			return;
-		}
-
-		thread::sleep(Duration::from_millis(5));
-	}
-
-	panic!(
-		"timed out waiting for worker scroll-capture response; inflight_request_id={:?}",
-		session.scroll_capture.inflight_request_id
-	);
-}
-
-fn observe_scroll_capture_frame(
-	session: &mut OverlaySession,
-	frame: image::RgbaImage,
-) -> Option<ScrollObserveOutcome> {
-	match session.observe_scroll_capture_frame(frame).transpose() {
-		Ok(outcome) => outcome,
-		Err(err) => panic!("observe_scroll_capture_frame failed: {err:#}"),
-	}
-}
-
-fn scroll_capture_export_height(session: &OverlaySession) -> u32 {
-	match session.scroll_capture.session.as_ref() {
-		Some(scroll_session) => scroll_session.export_image().height(),
-		None => panic!("scroll_capture_export_height requires an active scroll session"),
-	}
 }
 
 fn test_monitor() -> MonitorRect {

--- a/packages/rsnap-overlay/src/overlay/tests/scroll_capture_runtime_support.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/scroll_capture_runtime_support.rs
@@ -1,48 +1,40 @@
-use super::{
-	GlobalPoint, Instant, MonitorRect, OverlaySession, RectPoints, Rgb, ScrollDirection,
-	ScrollObserveOutcome,
-};
-pub(super) use crate::scroll_capture::test_support::{
-	make_browser_like_window as make_browser_like_worker_capture_window,
-	make_sparse_textlike_window as make_sparse_worker_capture_window,
-	make_test_image as make_scroll_capture_test_image, make_window as make_scroll_capture_window,
-};
-
 #[cfg(target_os = "macos")]
 use std::collections::VecDeque;
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use std::thread;
 
 #[cfg(target_os = "macos")]
 use color_eyre::eyre;
+use image::RgbaImage;
 
-#[cfg(target_os = "macos")]
-use super::{Duration, OverlayWorker, Result};
 #[cfg(target_os = "macos")]
 use crate::backend::CaptureBackend;
 #[cfg(target_os = "macos")]
+use crate::overlay::tests::{
+	Duration, GlobalPoint, MonitorRect, OverlayWorker, RectPoints, Result, Rgb,
+};
+use crate::overlay::tests::{Instant, OverlaySession, ScrollDirection, ScrollObserveOutcome};
+#[cfg(target_os = "macos")]
 use crate::scroll_capture::ScrollSession;
-
-pub(super) fn set_scroll_capture_input(session: &mut OverlaySession, direction: ScrollDirection) {
-	session.scroll_capture.input_direction = Some(direction);
-	session.scroll_capture.input_direction_at = Some(Instant::now());
-	session.scroll_capture.input_gesture_active = true;
-}
+use crate::scroll_capture::test_support;
+#[cfg(target_os = "macos")]
+use crate::state::WindowListSnapshot;
 
 #[cfg(target_os = "macos")]
 pub(super) struct SequenceScrollCaptureBackend {
-	frames: VecDeque<Option<image::RgbaImage>>,
+	frames: VecDeque<Option<RgbaImage>>,
 }
 #[cfg(target_os = "macos")]
 impl SequenceScrollCaptureBackend {
-	pub(super) fn new(frames: impl IntoIterator<Item = Option<image::RgbaImage>>) -> Self {
+	pub(super) fn new(frames: impl IntoIterator<Item = Option<RgbaImage>>) -> Self {
 		Self { frames: frames.into_iter().collect() }
 	}
 }
-
 #[cfg(target_os = "macos")]
 impl CaptureBackend for SequenceScrollCaptureBackend {
-	fn capture_monitor(&mut self, _monitor: MonitorRect) -> Result<image::RgbaImage> {
+	fn capture_monitor(&mut self, _monitor: MonitorRect) -> Result<RgbaImage> {
 		Err(eyre::eyre!("unused in this test"))
 	}
 
@@ -50,7 +42,7 @@ impl CaptureBackend for SequenceScrollCaptureBackend {
 		&mut self,
 		_monitor: MonitorRect,
 		_rect_px: RectPoints,
-	) -> Result<Option<image::RgbaImage>> {
+	) -> Result<Option<RgbaImage>> {
 		Ok(self.frames.pop_front().unwrap_or(None))
 	}
 
@@ -68,13 +60,50 @@ impl CaptureBackend for SequenceScrollCaptureBackend {
 		_point: GlobalPoint,
 		_width_px: u32,
 		_height_px: u32,
-	) -> Result<Option<image::RgbaImage>> {
+	) -> Result<Option<RgbaImage>> {
 		Ok(None)
 	}
 
-	fn refresh_window_cache(&mut self) -> Result<std::sync::Arc<crate::state::WindowListSnapshot>> {
+	fn refresh_window_cache(&mut self) -> Result<Arc<WindowListSnapshot>> {
 		Err(eyre::eyre!("unused in this test"))
 	}
+}
+
+pub(super) fn make_scroll_capture_test_image(width: u32, rows: &[[u8; 4]]) -> RgbaImage {
+	test_support::make_test_image(width, rows)
+}
+
+pub(super) fn make_scroll_capture_window(
+	document: &[[u8; 4]],
+	width: u32,
+	start_row: usize,
+	window_rows: usize,
+) -> RgbaImage {
+	test_support::make_window(document, width, start_row, window_rows)
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn make_sparse_worker_capture_window(
+	width: u32,
+	height: u32,
+	start_row: u32,
+) -> RgbaImage {
+	test_support::make_sparse_textlike_window(width, height, start_row)
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn make_browser_like_worker_capture_window(
+	width: u32,
+	height: u32,
+	start_row: u32,
+) -> RgbaImage {
+	test_support::make_browser_like_window(width, height, start_row)
+}
+
+pub(super) fn set_scroll_capture_input(session: &mut OverlaySession, direction: ScrollDirection) {
+	session.scroll_capture.input_direction = Some(direction);
+	session.scroll_capture.input_direction_at = Some(Instant::now());
+	session.scroll_capture.input_gesture_active = true;
 }
 
 #[cfg(target_os = "macos")]
@@ -87,8 +116,8 @@ pub(super) fn seed_worker_scroll_capture_session(
 	session: &mut OverlaySession,
 	monitor: MonitorRect,
 	rect: RectPoints,
-	base: image::RgbaImage,
-	frames: impl IntoIterator<Item = Option<image::RgbaImage>>,
+	base: RgbaImage,
+	frames: impl IntoIterator<Item = Option<RgbaImage>>,
 ) {
 	session.worker =
 		Some(OverlayWorker::new(Box::new(SequenceScrollCaptureBackend::new(frames)), None));
@@ -96,6 +125,7 @@ pub(super) fn seed_worker_scroll_capture_session(
 	session.scroll_capture.monitor = Some(monitor);
 	session.scroll_capture.capture_rect_pixels = Some(rect);
 	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
+
 	enable_test_worker_scroll_capture_path(session);
 }
 
@@ -119,7 +149,7 @@ pub(super) fn drain_scroll_capture_worker_until_idle(session: &mut OverlaySessio
 
 pub(super) fn observe_scroll_capture_frame(
 	session: &mut OverlaySession,
-	frame: image::RgbaImage,
+	frame: RgbaImage,
 ) -> Option<ScrollObserveOutcome> {
 	match session.observe_scroll_capture_frame(frame).transpose() {
 		Ok(outcome) => outcome,

--- a/packages/rsnap-overlay/src/overlay/tests/scroll_capture_runtime_support.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/scroll_capture_runtime_support.rs
@@ -1,0 +1,135 @@
+use super::{
+	GlobalPoint, Instant, MonitorRect, OverlaySession, RectPoints, Rgb, ScrollDirection,
+	ScrollObserveOutcome,
+};
+pub(super) use crate::scroll_capture::test_support::{
+	make_browser_like_window as make_browser_like_worker_capture_window,
+	make_sparse_textlike_window as make_sparse_worker_capture_window,
+	make_test_image as make_scroll_capture_test_image, make_window as make_scroll_capture_window,
+};
+
+#[cfg(target_os = "macos")]
+use std::collections::VecDeque;
+#[cfg(target_os = "macos")]
+use std::thread;
+
+#[cfg(target_os = "macos")]
+use color_eyre::eyre;
+
+#[cfg(target_os = "macos")]
+use super::{Duration, OverlayWorker, Result};
+#[cfg(target_os = "macos")]
+use crate::backend::CaptureBackend;
+#[cfg(target_os = "macos")]
+use crate::scroll_capture::ScrollSession;
+
+pub(super) fn set_scroll_capture_input(session: &mut OverlaySession, direction: ScrollDirection) {
+	session.scroll_capture.input_direction = Some(direction);
+	session.scroll_capture.input_direction_at = Some(Instant::now());
+	session.scroll_capture.input_gesture_active = true;
+}
+
+#[cfg(target_os = "macos")]
+pub(super) struct SequenceScrollCaptureBackend {
+	frames: VecDeque<Option<image::RgbaImage>>,
+}
+#[cfg(target_os = "macos")]
+impl SequenceScrollCaptureBackend {
+	pub(super) fn new(frames: impl IntoIterator<Item = Option<image::RgbaImage>>) -> Self {
+		Self { frames: frames.into_iter().collect() }
+	}
+}
+
+#[cfg(target_os = "macos")]
+impl CaptureBackend for SequenceScrollCaptureBackend {
+	fn capture_monitor(&mut self, _monitor: MonitorRect) -> Result<image::RgbaImage> {
+		Err(eyre::eyre!("unused in this test"))
+	}
+
+	fn capture_monitor_region_for_scroll_capture(
+		&mut self,
+		_monitor: MonitorRect,
+		_rect_px: RectPoints,
+	) -> Result<Option<image::RgbaImage>> {
+		Ok(self.frames.pop_front().unwrap_or(None))
+	}
+
+	fn pixel_rgb_in_monitor(
+		&mut self,
+		_monitor: MonitorRect,
+		_point: GlobalPoint,
+	) -> Result<Option<Rgb>> {
+		Ok(None)
+	}
+
+	fn rgba_patch_in_monitor(
+		&mut self,
+		_monitor: MonitorRect,
+		_point: GlobalPoint,
+		_width_px: u32,
+		_height_px: u32,
+	) -> Result<Option<image::RgbaImage>> {
+		Ok(None)
+	}
+
+	fn refresh_window_cache(&mut self) -> Result<std::sync::Arc<crate::state::WindowListSnapshot>> {
+		Err(eyre::eyre!("unused in this test"))
+	}
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn enable_test_worker_scroll_capture_path(session: &mut OverlaySession) {
+	session.scroll_capture.force_worker_sampling_in_tests = true;
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn seed_worker_scroll_capture_session(
+	session: &mut OverlaySession,
+	monitor: MonitorRect,
+	rect: RectPoints,
+	base: image::RgbaImage,
+	frames: impl IntoIterator<Item = Option<image::RgbaImage>>,
+) {
+	session.worker =
+		Some(OverlayWorker::new(Box::new(SequenceScrollCaptureBackend::new(frames)), None));
+	session.scroll_capture.active = true;
+	session.scroll_capture.monitor = Some(monitor);
+	session.scroll_capture.capture_rect_pixels = Some(rect);
+	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
+	enable_test_worker_scroll_capture_path(session);
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn drain_scroll_capture_worker_until_idle(session: &mut OverlaySession) {
+	for _ in 0..64 {
+		let _ = session.drain_worker_responses();
+
+		if session.scroll_capture.inflight_request_id.is_none() {
+			return;
+		}
+
+		thread::sleep(Duration::from_millis(5));
+	}
+
+	panic!(
+		"timed out waiting for worker scroll-capture response; inflight_request_id={:?}",
+		session.scroll_capture.inflight_request_id
+	);
+}
+
+pub(super) fn observe_scroll_capture_frame(
+	session: &mut OverlaySession,
+	frame: image::RgbaImage,
+) -> Option<ScrollObserveOutcome> {
+	match session.observe_scroll_capture_frame(frame).transpose() {
+		Ok(outcome) => outcome,
+		Err(err) => panic!("observe_scroll_capture_frame failed: {err:#}"),
+	}
+}
+
+pub(super) fn scroll_capture_export_height(session: &OverlaySession) -> u32 {
+	match session.scroll_capture.session.as_ref() {
+		Some(scroll_session) => scroll_session.export_image().height(),
+		None => panic!("scroll_capture_export_height requires an active scroll session"),
+	}
+}

--- a/packages/rsnap-overlay/src/overlay/tests/worker_tick_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/worker_tick_runtime.rs
@@ -1,8 +1,7 @@
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::{
-	self, Arc, GlobalPoint, Instant, MacLiveFrameStream, MonitorRect, OverlaySession,
-	OverlayWorker, RectPoints, ScrollDirection, ScrollObserveOutcome, ScrollSession,
-	SequenceScrollCaptureBackend,
+	self, Arc, GlobalPoint, Instant, MacLiveFrameStream, MonitorRect, OverlaySession, RectPoints,
+	ScrollDirection, ScrollObserveOutcome, ScrollSession,
 };
 use crate::overlay::tests::{Duration, SCROLL_CAPTURE_SAMPLE_INTERVAL};
 
@@ -209,16 +208,13 @@ fn maybe_tick_scroll_capture_worker_path_recovers_after_blocked_overshot_frame()
 	let followup = tests::make_browser_like_worker_capture_window(512, 640, 844);
 	let mut session = OverlaySession::new();
 
-	session.worker = Some(OverlayWorker::new(
-		Box::new(SequenceScrollCaptureBackend::new([Some(blocked), Some(followup)])),
-		None,
-	));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
+	tests::seed_worker_scroll_capture_session(
+		&mut session,
+		monitor,
+		rect,
+		base,
+		[Some(blocked), Some(followup)],
+	);
 	tests::set_scroll_capture_input(&mut session, ScrollDirection::Down);
 
 	session.scroll_capture.next_sample_at = Some(Instant::now() - Duration::from_millis(1));
@@ -257,16 +253,13 @@ fn maybe_tick_scroll_capture_worker_path_retries_immediately_after_blocked_overs
 	let followup = tests::make_browser_like_worker_capture_window(512, 640, 844);
 	let mut session = OverlaySession::new();
 
-	session.worker = Some(OverlayWorker::new(
-		Box::new(SequenceScrollCaptureBackend::new([Some(blocked), Some(followup)])),
-		None,
-	));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
+	tests::seed_worker_scroll_capture_session(
+		&mut session,
+		monitor,
+		rect,
+		base,
+		[Some(blocked), Some(followup)],
+	);
 	tests::set_scroll_capture_input(&mut session, ScrollDirection::Down);
 
 	session.scroll_capture.last_external_scroll_input_seq = 1;
@@ -306,26 +299,20 @@ fn maybe_tick_scroll_capture_worker_path_recovers_across_interleaved_no_frame_an
 	let rect = RectPoints::new(100, 120, 512, 640);
 	let mut session = OverlaySession::new();
 
-	session.worker = Some(OverlayWorker::new(
-		Box::new(SequenceScrollCaptureBackend::new([
+	tests::seed_worker_scroll_capture_session(
+		&mut session,
+		monitor,
+		rect,
+		tests::make_browser_like_worker_capture_window(512, 640, 0),
+		[
 			None,
 			Some(tests::make_browser_like_worker_capture_window(512, 640, 84)),
 			Some(tests::make_browser_like_worker_capture_window(512, 640, 700)),
 			Some(tests::make_browser_like_worker_capture_window(512, 640, 784)),
 			None,
 			Some(tests::make_browser_like_worker_capture_window(512, 640, 868)),
-		])),
-		None,
-	));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(
-		ScrollSession::new(tests::make_browser_like_worker_capture_window(512, 640, 0), 320)
-			.unwrap(),
+		],
 	);
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
 
 	for expected_top_y in [84_i32, 168, 252] {
 		let mut attempts = 0_u8;
@@ -376,14 +363,7 @@ fn maybe_tick_scroll_capture_worker_path_keeps_same_direction_superseded_respons
 	let moved = tests::make_sparse_worker_capture_window(512, 640, 180);
 	let mut session = OverlaySession::new();
 
-	session.worker =
-		Some(OverlayWorker::new(Box::new(SequenceScrollCaptureBackend::new([Some(moved)])), None));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
+	tests::seed_worker_scroll_capture_session(&mut session, monitor, rect, base, [Some(moved)]);
 	tests::set_scroll_capture_input(&mut session, ScrollDirection::Down);
 
 	session.scroll_capture.last_external_scroll_input_seq = 1;
@@ -410,23 +390,17 @@ fn maybe_tick_scroll_capture_worker_path_commits_successive_browser_like_frames_
 	let rect = RectPoints::new(100, 120, 512, 640);
 	let mut session = OverlaySession::new();
 
-	session.worker = Some(OverlayWorker::new(
-		Box::new(SequenceScrollCaptureBackend::new([
+	tests::seed_worker_scroll_capture_session(
+		&mut session,
+		monitor,
+		rect,
+		tests::make_browser_like_worker_capture_window(512, 640, 0),
+		[
 			Some(tests::make_browser_like_worker_capture_window(512, 640, 84)),
 			Some(tests::make_browser_like_worker_capture_window(512, 640, 168)),
 			Some(tests::make_browser_like_worker_capture_window(512, 640, 252)),
-		])),
-		None,
-	));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(
-		ScrollSession::new(tests::make_browser_like_worker_capture_window(512, 640, 0), 320)
-			.unwrap(),
+		],
 	);
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
 
 	for (step, expected_top_y) in [84_i32, 168, 252].into_iter().enumerate() {
 		tests::set_scroll_capture_input(&mut session, ScrollDirection::Down);
@@ -464,14 +438,7 @@ fn maybe_tick_scroll_capture_worker_path_drops_opposite_direction_superseded_res
 	let moved = tests::make_sparse_worker_capture_window(512, 640, 180);
 	let mut session = OverlaySession::new();
 
-	session.worker =
-		Some(OverlayWorker::new(Box::new(SequenceScrollCaptureBackend::new([Some(moved)])), None));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
+	tests::seed_worker_scroll_capture_session(&mut session, monitor, rect, base, [Some(moved)]);
 	tests::set_scroll_capture_input(&mut session, ScrollDirection::Down);
 
 	session.scroll_capture.last_external_scroll_input_seq = 1;
@@ -500,16 +467,13 @@ fn maybe_tick_scroll_capture_worker_path_retries_immediately_after_no_new_frame_
 	let moved = tests::make_browser_like_worker_capture_window(512, 640, 84);
 	let mut session = OverlaySession::new();
 
-	session.worker = Some(OverlayWorker::new(
-		Box::new(SequenceScrollCaptureBackend::new([None, Some(moved)])),
-		None,
-	));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
+	tests::seed_worker_scroll_capture_session(
+		&mut session,
+		monitor,
+		rect,
+		base,
+		[None, Some(moved)],
+	);
 	tests::set_scroll_capture_input(&mut session, ScrollDirection::Down);
 
 	session.scroll_capture.last_external_scroll_input_seq = 1;
@@ -560,20 +524,13 @@ fn maybe_tick_scroll_capture_worker_path_backs_off_after_duplicate_committed_fra
 	let step_two = tests::make_browser_like_worker_capture_window(512, 640, 168);
 	let mut session = OverlaySession::new();
 
-	session.worker = Some(OverlayWorker::new(
-		Box::new(SequenceScrollCaptureBackend::new([
-			Some(step_one.clone()),
-			Some(step_one),
-			Some(step_two),
-		])),
-		None,
-	));
-	session.scroll_capture.active = true;
-	session.scroll_capture.monitor = Some(monitor);
-	session.scroll_capture.capture_rect_pixels = Some(rect);
-	session.scroll_capture.session = Some(ScrollSession::new(base, 320).unwrap());
-
-	tests::enable_test_worker_scroll_capture_path(&mut session);
+	tests::seed_worker_scroll_capture_session(
+		&mut session,
+		monitor,
+		rect,
+		base,
+		[Some(step_one.clone()), Some(step_one), Some(step_two)],
+	);
 	tests::set_scroll_capture_input(&mut session, ScrollDirection::Down);
 
 	session.scroll_capture.last_external_scroll_input_seq = 1;

--- a/packages/rsnap-overlay/src/scroll_capture.rs
+++ b/packages/rsnap-overlay/src/scroll_capture.rs
@@ -3298,4 +3298,7 @@ enum DownwardViewportResolution {
 }
 
 #[cfg(test)]
+pub(crate) mod test_support;
+
+#[cfg(test)]
 mod tests;

--- a/packages/rsnap-overlay/src/scroll_capture/test_support.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/test_support.rs
@@ -1,0 +1,128 @@
+use image::Rgba;
+
+pub(crate) fn make_test_image(width: u32, rows: &[[u8; 4]]) -> image::RgbaImage {
+	let mut image = image::RgbaImage::new(width, rows.len() as u32);
+
+	for (y, row) in rows.iter().enumerate() {
+		for x in 0..width {
+			image.put_pixel(x, y as u32, Rgba(*row));
+		}
+	}
+
+	image
+}
+
+pub(crate) fn make_window(
+	document: &[[u8; 4]],
+	width: u32,
+	start_row: usize,
+	window_rows: usize,
+) -> image::RgbaImage {
+	make_test_image(width, &document[start_row..start_row + window_rows])
+}
+
+pub(crate) fn make_sparse_textlike_window(
+	width: u32,
+	height: u32,
+	start_row: u32,
+) -> image::RgbaImage {
+	let stripe_x = 104_u32;
+	let mut image = image::RgbaImage::from_pixel(width, height, Rgba([255, 255, 255, 255]));
+
+	for y in 0..height {
+		let document_row = start_row.saturating_add(y);
+		let shade = ((document_row.saturating_mul(17)) % 180) as u8;
+
+		for x in stripe_x..stripe_x.saturating_add(6) {
+			image.put_pixel(x, y, Rgba([shade, shade, shade, 255]));
+		}
+		for x in stripe_x.saturating_add(10)..stripe_x.saturating_add(13) {
+			if document_row % 19 < 9 {
+				image.put_pixel(x, y, Rgba([40, 40, 40, 255]));
+			}
+		}
+	}
+
+	image
+}
+
+pub(crate) fn make_sparse_textlike_window_with_moving_edge_scrollbar(
+	width: u32,
+	height: u32,
+	start_row: u32,
+	thumb_top: u32,
+) -> image::RgbaImage {
+	let track_left = width.saturating_sub(18);
+	let thumb_height = (height / 4).max(12).min(height.max(1));
+	let thumb_top = thumb_top.min(height.saturating_sub(thumb_height));
+	let thumb_right = width.saturating_sub(3).max(track_left.saturating_add(4));
+	let mut image = make_sparse_textlike_window(width, height, start_row);
+
+	for y in 0..height {
+		for x in track_left..width {
+			image.put_pixel(x, y, Rgba([224, 224, 224, 255]));
+		}
+	}
+	for y in thumb_top..thumb_top.saturating_add(thumb_height) {
+		for x in track_left.saturating_add(3)..thumb_right {
+			image.put_pixel(x, y, Rgba([28, 28, 28, 255]));
+		}
+	}
+
+	image
+}
+
+pub(crate) fn make_browser_like_window(
+	width: u32,
+	height: u32,
+	start_row: u32,
+) -> image::RgbaImage {
+	let scrollbar_left = width.saturating_sub(18);
+	let content_left = 56_u32;
+	let content_right = width.saturating_sub(48);
+	let heading_width = 220_u32;
+	let paragraph_width = content_right.saturating_sub(content_left);
+	let mut image = make_sparse_textlike_window(width, height, start_row);
+
+	for y in 0..height {
+		let document_row = start_row.saturating_add(y);
+
+		if document_row % 420 < 18 {
+			for x in content_left..content_left.saturating_add(heading_width) {
+				image.put_pixel(x, y, Rgba([26, 26, 26, 255]));
+			}
+		} else if document_row % 420 >= 54 && document_row % 420 < 220 {
+			if document_row % 24 < 3 {
+				let trim = ((document_row / 24) % 5) * 18;
+
+				for x in
+					content_left..content_left.saturating_add(paragraph_width.saturating_sub(trim))
+				{
+					image.put_pixel(x, y, Rgba([72, 72, 72, 255]));
+				}
+			}
+		} else if document_row % 420 >= 270 && document_row % 420 < 360 && document_row % 20 < 2 {
+			for x in content_left.saturating_add(20)
+				..content_left.saturating_add(paragraph_width.saturating_sub(70))
+			{
+				image.put_pixel(x, y, Rgba([98, 98, 98, 255]));
+			}
+		}
+
+		for x in scrollbar_left..width {
+			image.put_pixel(x, y, Rgba([232, 232, 232, 255]));
+		}
+	}
+
+	let thumb_height = (height / 5).max(16);
+	let thumb_top = (start_row / 3) % height.max(thumb_height + 1);
+	let thumb_top = thumb_top.min(height.saturating_sub(thumb_height));
+
+	for y in thumb_top..thumb_top.saturating_add(thumb_height) {
+		for x in scrollbar_left.saturating_add(3)..width.saturating_sub(4) {
+			image.put_pixel(x, y, Rgba([96, 96, 96, 255]));
+		}
+	}
+
+	image
+}

--- a/packages/rsnap-overlay/src/scroll_capture/tests.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/tests.rs
@@ -1,23 +1,14 @@
 use image::Rgba;
 
-use crate::scroll_capture::support;
 use crate::scroll_capture::{
 	self, DirectionMatch, DownwardRegistration, DownwardViewportCandidate,
 	DownwardViewportCandidateSource, DownwardViewportResolution, MotionObservation,
 	OverlapSearchConfig, PreviewOnlyDownwardLocalSample, ScrollDirection, ScrollFrameFingerprint,
-	ScrollObserveOutcome, ScrollSession,
+	ScrollObserveOutcome, ScrollSession, support, test_support,
 };
 
 fn make_test_image(width: u32, rows: &[[u8; 4]]) -> image::RgbaImage {
-	let mut image = image::RgbaImage::new(width, rows.len() as u32);
-
-	for (y, row) in rows.iter().enumerate() {
-		for x in 0..width {
-			image.put_pixel(x, y as u32, Rgba(*row));
-		}
-	}
-
-	image
+	test_support::make_test_image(width, rows)
 }
 
 fn make_window(
@@ -26,28 +17,11 @@ fn make_window(
 	start_row: usize,
 	window_rows: usize,
 ) -> image::RgbaImage {
-	make_test_image(width, &document[start_row..start_row + window_rows])
+	test_support::make_window(document, width, start_row, window_rows)
 }
 
 fn make_sparse_textlike_window(width: u32, height: u32, start_row: u32) -> image::RgbaImage {
-	let stripe_x = 104_u32;
-	let mut image = image::RgbaImage::from_pixel(width, height, Rgba([255, 255, 255, 255]));
-
-	for y in 0..height {
-		let document_row = start_row.saturating_add(y);
-		let shade = ((document_row.saturating_mul(17)) % 180) as u8;
-
-		for x in stripe_x..stripe_x.saturating_add(6) {
-			image.put_pixel(x, y, Rgba([shade, shade, shade, 255]));
-		}
-		for x in stripe_x.saturating_add(10)..stripe_x.saturating_add(13) {
-			if document_row % 19 < 9 {
-				image.put_pixel(x, y, Rgba([40, 40, 40, 255]));
-			}
-		}
-	}
-
-	image
+	test_support::make_sparse_textlike_window(width, height, start_row)
 }
 
 fn make_sparse_textlike_window_with_moving_edge_scrollbar(
@@ -56,75 +30,129 @@ fn make_sparse_textlike_window_with_moving_edge_scrollbar(
 	start_row: u32,
 	thumb_top: u32,
 ) -> image::RgbaImage {
-	let track_left = width.saturating_sub(18);
-	let thumb_height = (height / 4).max(12).min(height.max(1));
-	let thumb_top = thumb_top.min(height.saturating_sub(thumb_height));
-	let thumb_right = width.saturating_sub(3).max(track_left.saturating_add(4));
-	let mut image = make_sparse_textlike_window(width, height, start_row);
-
-	for y in 0..height {
-		for x in track_left..width {
-			image.put_pixel(x, y, Rgba([224, 224, 224, 255]));
-		}
-	}
-	for y in thumb_top..thumb_top.saturating_add(thumb_height) {
-		for x in track_left.saturating_add(3)..thumb_right {
-			image.put_pixel(x, y, Rgba([28, 28, 28, 255]));
-		}
-	}
-
-	image
+	test_support::make_sparse_textlike_window_with_moving_edge_scrollbar(
+		width, height, start_row, thumb_top,
+	)
 }
 
 fn make_browser_like_window(width: u32, height: u32, start_row: u32) -> image::RgbaImage {
-	let scrollbar_left = width.saturating_sub(18);
-	let content_left = 56_u32;
-	let content_right = width.saturating_sub(48);
-	let heading_width = 220_u32;
-	let paragraph_width = content_right.saturating_sub(content_left);
-	let mut image = make_sparse_textlike_window(width, height, start_row);
+	test_support::make_browser_like_window(width, height, start_row)
+}
 
-	for y in 0..height {
-		let document_row = start_row.saturating_add(y);
+#[cfg(target_os = "macos")]
+fn build_worker_pairwise_session(frame: image::RgbaImage) -> ScrollSession {
+	ScrollSession::new(frame, 320).expect("worker pairwise test session should initialize")
+}
 
-		if document_row % 420 < 18 {
-			for x in content_left..content_left.saturating_add(heading_width) {
-				image.put_pixel(x, y, Rgba([26, 26, 26, 255]));
-			}
-		} else if document_row % 420 >= 54 && document_row % 420 < 220 {
-			if document_row % 24 < 3 {
-				let trim = ((document_row / 24) % 5) * 18;
+#[cfg(target_os = "macos")]
+fn growth_rows_i32(growth_rows: u32) -> i32 {
+	i32::try_from(growth_rows).expect("worker pairwise growth rows should fit in i32")
+}
 
-				for x in
-					content_left..content_left.saturating_add(paragraph_width.saturating_sub(trim))
-				{
-					image.put_pixel(x, y, Rgba([72, 72, 72, 255]));
-				}
-			}
-		} else if document_row % 420 >= 270 && document_row % 420 < 360 && document_row % 20 < 2 {
-			for x in content_left.saturating_add(20)
-				..content_left.saturating_add(paragraph_width.saturating_sub(70))
-			{
-				image.put_pixel(x, y, Rgba([98, 98, 98, 255]));
-			}
-		}
+#[cfg(target_os = "macos")]
+fn worker_pairwise_growth_rows(
+	previous: &image::RgbaImage,
+	next: &image::RgbaImage,
+	reason: &str,
+) -> u32 {
+	match support::classify_vision_downward_sample_motion_against(previous, next) {
+		Some(matched) => matched.motion_rows,
+		None => panic!("{reason}"),
+	}
+}
 
-		for x in scrollbar_left..width {
-			image.put_pixel(x, y, Rgba([232, 232, 232, 255]));
-		}
+#[cfg(target_os = "macos")]
+fn assert_worker_pairwise_commit(
+	session: &mut ScrollSession,
+	previous: &image::RgbaImage,
+	next: image::RgbaImage,
+	reason: &str,
+) -> u32 {
+	let growth_rows = worker_pairwise_growth_rows(previous, &next, reason);
+	let outcome = match session.observe_worker_pairwise_vision_frame(next) {
+		Ok(outcome) => outcome,
+		Err(err) => panic!("{reason}: {err:#}"),
+	};
+
+	assert_eq!(
+		outcome,
+		ScrollObserveOutcome::Committed { direction: ScrollDirection::Down, growth_rows }
+	);
+
+	growth_rows
+}
+
+#[cfg(target_os = "macos")]
+fn assert_worker_pairwise_successive_growth(frames: Vec<image::RgbaImage>, reason: &str) {
+	let base_height = frames[0].height();
+	let mut session = build_worker_pairwise_session(frames[0].clone());
+	let mut expected_export_height = base_height;
+	let mut expected_viewport_top_y = 0_i32;
+
+	for window in frames.windows(2) {
+		let growth_rows =
+			assert_worker_pairwise_commit(&mut session, &window[0], window[1].clone(), reason);
+
+		expected_export_height = expected_export_height.saturating_add(growth_rows);
+		expected_viewport_top_y += growth_rows_i32(growth_rows);
 	}
 
-	let thumb_height = (height / 5).max(16);
-	let thumb_top = (start_row / 3) % height.max(thumb_height + 1);
-	let thumb_top = thumb_top.min(height.saturating_sub(thumb_height));
+	assert_eq!(session.export_image().height(), expected_export_height);
+	assert_eq!(session.current_viewport_top_y(), expected_viewport_top_y);
+}
 
-	for y in thumb_top..thumb_top.saturating_add(thumb_height) {
-		for x in scrollbar_left.saturating_add(3)..width.saturating_sub(4) {
-			image.put_pixel(x, y, Rgba([96, 96, 96, 255]));
-		}
-	}
+#[cfg(target_os = "macos")]
+fn assert_worker_pairwise_repeat_between_steps(
+	base: image::RgbaImage,
+	step_one: image::RgbaImage,
+	step_two: image::RgbaImage,
+	first_reason: &str,
+	followup_reason: &str,
+) {
+	let mut session = build_worker_pairwise_session(base.clone());
+	let step_one_reference = step_one.clone();
+	let first_growth =
+		assert_worker_pairwise_commit(&mut session, &base, step_one.clone(), first_reason);
+	let no_change_outcome = match session.observe_worker_pairwise_vision_frame(step_one) {
+		Ok(outcome) => outcome,
+		Err(err) => panic!("{first_reason}: {err:#}"),
+	};
 
-	image
+	assert_eq!(no_change_outcome, ScrollObserveOutcome::NoChange);
+
+	let followup_growth = assert_worker_pairwise_commit(
+		&mut session,
+		&step_one_reference,
+		step_two.clone(),
+		followup_reason,
+	);
+
+	assert_eq!(session.export_image().height(), base.height() + first_growth + followup_growth);
+	assert_eq!(session.current_viewport_top_y(), growth_rows_i32(first_growth + followup_growth));
+}
+
+#[cfg(target_os = "macos")]
+fn assert_worker_pairwise_blocked_recovery(
+	base: image::RgbaImage,
+	blocked: image::RgbaImage,
+	followup: image::RgbaImage,
+	reason: &str,
+) {
+	let mut session = build_worker_pairwise_session(base.clone());
+	let no_change_outcome = match session.observe_worker_pairwise_vision_frame(blocked.clone()) {
+		Ok(outcome) => outcome,
+		Err(err) => panic!("{reason}: {err:#}"),
+	};
+
+	assert_eq!(no_change_outcome, ScrollObserveOutcome::NoChange);
+	assert_eq!(session.export_image().height(), base.height());
+	assert_eq!(session.current_viewport_top_y(), 0);
+
+	let growth_rows =
+		assert_worker_pairwise_commit(&mut session, &blocked, followup.clone(), reason);
+
+	assert_eq!(session.export_image().height(), base.height() + growth_rows);
+	assert_eq!(session.current_viewport_top_y(), growth_rows_i32(growth_rows));
 }
 
 #[test]
@@ -250,102 +278,37 @@ fn pairwise_downward_shift_estimate_tracks_successive_browser_like_steps() {
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_uses_latest_committed_live_frame_for_followup_growth() {
-	let base = make_sparse_textlike_window(512, 640, 0);
-	let step_one = make_sparse_textlike_window(512, 640, 180);
-	let step_two = make_sparse_textlike_window(512, 640, 360);
-	let first_match = support::classify_vision_downward_sample_motion_against(&base, &step_one)
-		.expect("first pairwise registration should detect downward motion");
-	let followup_match =
-		support::classify_vision_downward_sample_motion_against(&step_one, &step_two)
-			.expect("followup pairwise registration should detect downward motion");
-	let mut session = ScrollSession::new(base, 320).unwrap();
-
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_one).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: first_match.motion_rows,
-		}
-	);
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_two).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: followup_match.motion_rows,
-		}
-	);
-	assert_eq!(
-		session.export_image().height(),
-		640 + first_match.motion_rows + followup_match.motion_rows
-	);
-	assert_eq!(
-		session.current_viewport_top_y(),
-		i32::try_from(first_match.motion_rows + followup_match.motion_rows).unwrap()
+	assert_worker_pairwise_successive_growth(
+		vec![
+			make_sparse_textlike_window(512, 640, 0),
+			make_sparse_textlike_window(512, 640, 180),
+			make_sparse_textlike_window(512, 640, 360),
+		],
+		"pairwise registration should detect each successive sparse-textlike step",
 	);
 }
 
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_handles_repeated_frame_between_growth_steps() {
-	let base = make_sparse_textlike_window(512, 640, 0);
-	let step_one = make_sparse_textlike_window(512, 640, 180);
-	let step_two = make_sparse_textlike_window(512, 640, 360);
-	let first_match = support::classify_vision_downward_sample_motion_against(&base, &step_one)
-		.expect("first pairwise registration should detect downward motion");
-	let followup_match =
-		support::classify_vision_downward_sample_motion_against(&step_one, &step_two)
-			.expect("followup pairwise registration should detect downward motion");
-	let mut session = ScrollSession::new(base, 320).unwrap();
-
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_one.clone()).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: first_match.motion_rows,
-		}
-	);
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_one).unwrap(),
-		ScrollObserveOutcome::NoChange
-	);
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_two).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: followup_match.motion_rows,
-		}
-	);
-	assert_eq!(
-		session.export_image().height(),
-		640 + first_match.motion_rows + followup_match.motion_rows
+	assert_worker_pairwise_repeat_between_steps(
+		make_sparse_textlike_window(512, 640, 0),
+		make_sparse_textlike_window(512, 640, 180),
+		make_sparse_textlike_window(512, 640, 360),
+		"first pairwise registration should detect downward motion",
+		"followup pairwise registration should detect downward motion",
 	);
 }
 
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_recovers_after_blocked_overshot_frame() {
-	let base = make_browser_like_window(512, 640, 0);
-	let blocked = make_browser_like_window(512, 640, 760);
-	let followup = make_browser_like_window(512, 640, 844);
-	let matched = support::classify_vision_downward_sample_motion_against(&blocked, &followup)
-		.expect("pairwise registration should detect the followup step after the blocked overshot");
-	let mut session = ScrollSession::new(base, 320).unwrap();
-
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(blocked).unwrap(),
-		ScrollObserveOutcome::NoChange
+	assert_worker_pairwise_blocked_recovery(
+		make_browser_like_window(512, 640, 0),
+		make_browser_like_window(512, 640, 760),
+		make_browser_like_window(512, 640, 844),
+		"pairwise registration should detect the followup step after the blocked overshot",
 	);
-	assert_eq!(session.export_image().height(), 640);
-	assert_eq!(session.current_viewport_top_y(), 0);
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(followup).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: matched.motion_rows,
-		}
-	);
-	assert_eq!(session.export_image().height(), 640 + matched.motion_rows);
-	assert_eq!(session.current_viewport_top_y(), i32::try_from(matched.motion_rows).unwrap());
 }
 
 #[cfg(target_os = "macos")]
@@ -425,34 +388,13 @@ fn worker_pairwise_vision_clears_preview_local_followup_carryover_on_commit() {
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_commits_successive_slowdown_steps() {
-	let frames = [0_u32, 180, 300, 380, 420]
-		.into_iter()
-		.map(|start_row| make_sparse_textlike_window(512, 640, start_row))
-		.collect::<Vec<_>>();
-	let mut session = ScrollSession::new(frames[0].clone(), 320).unwrap();
-	let mut expected_export_height = 640_u32;
-	let mut expected_viewport_top_y = 0_i32;
-
-	for window in frames.windows(2) {
-		let previous = &window[0];
-		let next = window[1].clone();
-		let matched = support::classify_vision_downward_sample_motion_against(previous, &next)
-			.expect("pairwise registration should detect each slowdown step");
-
-		assert_eq!(
-			session.observe_worker_pairwise_vision_frame(next).unwrap(),
-			ScrollObserveOutcome::Committed {
-				direction: ScrollDirection::Down,
-				growth_rows: matched.motion_rows,
-			}
-		);
-
-		expected_export_height = expected_export_height.saturating_add(matched.motion_rows);
-		expected_viewport_top_y += i32::try_from(matched.motion_rows).unwrap();
-	}
-
-	assert_eq!(session.export_image().height(), expected_export_height);
-	assert_eq!(session.current_viewport_top_y(), expected_viewport_top_y);
+	assert_worker_pairwise_successive_growth(
+		[0_u32, 180, 300, 380, 420]
+			.into_iter()
+			.map(|start_row| make_sparse_textlike_window(512, 640, start_row))
+			.collect(),
+		"pairwise registration should detect each slowdown step",
+	);
 }
 
 #[cfg(target_os = "macos")]
@@ -479,98 +421,36 @@ fn worker_pairwise_vision_commits_browser_like_growth_above_legacy_cap() {
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_commits_successive_browser_like_steps() {
-	let frames = [0_u32, 180, 360, 540, 720]
-		.into_iter()
-		.map(|start_row| make_browser_like_window(512, 640, start_row))
-		.collect::<Vec<_>>();
-	let mut session = ScrollSession::new(frames[0].clone(), 320).unwrap();
-	let mut expected_export_height = 640_u32;
-	let mut expected_viewport_top_y = 0_i32;
-
-	for window in frames.windows(2) {
-		let previous = &window[0];
-		let next = window[1].clone();
-		let matched = support::classify_vision_downward_sample_motion_against(previous, &next)
-			.expect("pairwise registration should detect each browser-like step");
-
-		assert_eq!(
-			session.observe_worker_pairwise_vision_frame(next).unwrap(),
-			ScrollObserveOutcome::Committed {
-				direction: ScrollDirection::Down,
-				growth_rows: matched.motion_rows,
-			}
-		);
-
-		expected_export_height = expected_export_height.saturating_add(matched.motion_rows);
-		expected_viewport_top_y += i32::try_from(matched.motion_rows).unwrap();
-	}
-
-	assert_eq!(session.export_image().height(), expected_export_height);
-	assert_eq!(session.current_viewport_top_y(), expected_viewport_top_y);
+	assert_worker_pairwise_successive_growth(
+		[0_u32, 180, 360, 540, 720]
+			.into_iter()
+			.map(|start_row| make_browser_like_window(512, 640, start_row))
+			.collect(),
+		"pairwise registration should detect each browser-like step",
+	);
 }
 
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_handles_repeated_browser_like_frame_between_growth_steps() {
-	let base = make_browser_like_window(512, 640, 0);
-	let step_one = make_browser_like_window(512, 640, 180);
-	let step_two = make_browser_like_window(512, 640, 360);
-	let first_match = support::classify_vision_downward_sample_motion_against(&base, &step_one)
-		.expect("first browser-like step should register downward motion");
-	let followup_match =
-		support::classify_vision_downward_sample_motion_against(&step_one, &step_two)
-			.expect("followup browser-like step should register downward motion");
-	let mut session = ScrollSession::new(base, 320).unwrap();
-
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_one.clone()).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: first_match.motion_rows,
-		}
-	);
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_one).unwrap(),
-		ScrollObserveOutcome::NoChange
-	);
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(step_two).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: followup_match.motion_rows,
-		}
-	);
-	assert_eq!(
-		session.export_image().height(),
-		640 + first_match.motion_rows + followup_match.motion_rows
+	assert_worker_pairwise_repeat_between_steps(
+		make_browser_like_window(512, 640, 0),
+		make_browser_like_window(512, 640, 180),
+		make_browser_like_window(512, 640, 360),
+		"first browser-like step should register downward motion",
+		"followup browser-like step should register downward motion",
 	);
 }
 
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_browser_like_followup_uses_adjacent_worker_frame() {
-	let base = make_browser_like_window(512, 640, 0);
-	let blocked = make_browser_like_window(512, 640, 700);
-	let followup = make_browser_like_window(512, 640, 784);
-	let matched = support::classify_vision_downward_sample_motion_against(&blocked, &followup)
-		.expect(
-			"browser-like pairwise registration should use the immediately previous worker frame",
-		);
-	let mut session = ScrollSession::new(base, 320).unwrap();
-
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(blocked).unwrap(),
-		ScrollObserveOutcome::NoChange
+	assert_worker_pairwise_blocked_recovery(
+		make_browser_like_window(512, 640, 0),
+		make_browser_like_window(512, 640, 700),
+		make_browser_like_window(512, 640, 784),
+		"browser-like pairwise registration should use the immediately previous worker frame",
 	);
-	assert_eq!(
-		session.observe_worker_pairwise_vision_frame(followup).unwrap(),
-		ScrollObserveOutcome::Committed {
-			direction: ScrollDirection::Down,
-			growth_rows: matched.motion_rows,
-		}
-	);
-	assert_eq!(session.export_image().height(), 640 + matched.motion_rows);
-	assert_eq!(session.current_viewport_top_y(), i32::try_from(matched.motion_rows).unwrap());
 }
 
 #[test]

--- a/scripts/smoke/analyze-scroll-capture-trace.sh
+++ b/scripts/smoke/analyze-scroll-capture-trace.sh
@@ -1,27 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/smoke/lib/replay-scroll-capture.sh
+source "$SCRIPT_DIR/lib/replay-scroll-capture.sh"
 
-usage() {
-  cat <<'EOF'
-Usage: analyze-scroll-capture-trace.sh [replay-args]
-
-Runs the recorded live-trace replay example in summary-only JSON analysis mode.
-
-Common replay args:
-  --trace <manifest-path>   analyze a specific trace manifest
-  --list                    list the available traces
-  --self-check              run the example's internal self-check mode
-EOF
-}
-
-case "${1:-}" in
-  --help|-h)
-    usage
-    exit 0
-    ;;
-esac
-
-cd "$ROOT_DIR"
-exec cargo run -p rsnap-overlay --example scroll_capture_replay -- --force-worker-pairwise --json --summary-only "$@"
+replay_scroll_capture_run analyze "$@"

--- a/scripts/smoke/lib/replay-scroll-capture.sh
+++ b/scripts/smoke/lib/replay-scroll-capture.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+replay_scroll_capture_smoke_dir() {
+  cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+replay_scroll_capture_repo_root() {
+  cd -- "$(replay_scroll_capture_smoke_dir)/../.." && pwd
+}
+
+replay_scroll_capture_usage() {
+  local mode="$1"
+
+  case "$mode" in
+    replay)
+      cat <<'EOF'
+Usage: replay-scroll-capture.sh [replay-args]
+
+Runs the recorded live-trace replay example in worker-pairwise mode.
+
+Common replay args:
+  --trace <manifest-path>   replay a specific trace manifest
+  --list                    list the available traces
+  --self-check              delegate to replay-scroll-capture-self-check.sh
+EOF
+      ;;
+    analyze)
+      cat <<'EOF'
+Usage: analyze-scroll-capture-trace.sh [replay-args]
+
+Runs the recorded live-trace replay example in summary-only JSON analysis mode.
+
+Common replay args:
+  --trace <manifest-path>   analyze a specific trace manifest
+  --list                    list the available traces
+  --self-check              delegate to replay-scroll-capture-self-check.sh
+EOF
+      ;;
+    *)
+      printf 'unknown replay-scroll-capture mode: %s\n' "$mode" >&2
+      return 2
+      ;;
+  esac
+}
+
+replay_scroll_capture_has_flag() {
+  local needle="$1"
+  shift
+
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "$needle" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+replay_scroll_capture_assert_self_check_only() {
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" != "--self-check" ]]; then
+      printf '%s\n' \
+        '--self-check cannot be combined with replay args; use replay-scroll-capture-self-check.sh directly for extra test flags.' >&2
+      return 2
+    fi
+  done
+
+  return 0
+}
+
+replay_scroll_capture_run() {
+  local mode="$1"
+  shift
+
+  if replay_scroll_capture_has_flag "--help" "$@" || replay_scroll_capture_has_flag "-h" "$@"; then
+    replay_scroll_capture_usage "$mode"
+    return 0
+  fi
+
+  if replay_scroll_capture_has_flag "--self-check" "$@"; then
+    replay_scroll_capture_assert_self_check_only "$@" || return $?
+    exec "$(replay_scroll_capture_smoke_dir)/replay-scroll-capture-self-check.sh"
+  fi
+
+  local extra_args=()
+  case "$mode" in
+    replay)
+      ;;
+    analyze)
+      extra_args=(--json --summary-only)
+      ;;
+    *)
+      printf 'unknown replay-scroll-capture mode: %s\n' "$mode" >&2
+      return 2
+      ;;
+  esac
+
+  cd "$(replay_scroll_capture_repo_root)"
+  exec cargo run -p rsnap-overlay --example scroll_capture_replay -- \
+    --force-worker-pairwise \
+    "${extra_args[@]}" \
+    "$@"
+}

--- a/scripts/smoke/replay-scroll-capture-self-check.sh
+++ b/scripts/smoke/replay-scroll-capture-self-check.sh
@@ -7,7 +7,7 @@ usage() {
   cat <<'EOF'
 Usage: replay-scroll-capture-self-check.sh
 
-Runs the deterministic replay self-check test without requiring a recorded user trace.
+Runs the deterministic worker-pairwise replay self-check without requiring a recorded user trace.
 EOF
 }
 
@@ -19,4 +19,4 @@ case "${1:-}" in
 esac
 
 cd "$ROOT_DIR"
-exec cargo test -p rsnap-overlay replay_recorded_live_trace_round_trips_one_commit --lib "$@"
+exec cargo test -p rsnap-overlay replay_recorded_live_trace_round_trips_one_commit_in_worker_pairwise_mode --lib "$@"

--- a/scripts/smoke/replay-scroll-capture.sh
+++ b/scripts/smoke/replay-scroll-capture.sh
@@ -1,27 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/smoke/lib/replay-scroll-capture.sh
+source "$SCRIPT_DIR/lib/replay-scroll-capture.sh"
 
-usage() {
-  cat <<'EOF'
-Usage: replay-scroll-capture.sh [replay-args]
-
-Runs the recorded live-trace replay example in worker-pairwise mode.
-
-Common replay args:
-  --trace <manifest-path>   replay a specific trace manifest
-  --list                    list the available traces
-  --self-check              run the example's internal self-check mode
-EOF
-}
-
-case "${1:-}" in
-  --help|-h)
-    usage
-    exit 0
-    ;;
-esac
-
-cd "$ROOT_DIR"
-exec cargo run -p rsnap-overlay --example scroll_capture_replay -- --force-worker-pairwise "$@"
+replay_scroll_capture_run replay "$@"


### PR DESCRIPTION
## Summary
- dedupe smoke/perf replay and runtime fixture ownership with shared test support modules
- align replay/analyze smoke wrappers and self-check routing around worker-pairwise replay
- tighten smoke/perf docs so the runbook owns command selection and the new reference map owns coverage boundaries

## Validation
- `bash -n scripts/smoke/*.sh scripts/perf/*.sh scripts/smoke/lib/replay-scroll-capture.sh`
- `scripts/smoke/replay-scroll-capture.sh --help`
- `scripts/smoke/replay-scroll-capture.sh --list`
- `scripts/smoke/replay-scroll-capture.sh --self-check`
- `scripts/smoke/analyze-scroll-capture-trace.sh --help`
- `scripts/smoke/analyze-scroll-capture-trace.sh --list`
- `scripts/smoke/analyze-scroll-capture-trace.sh --self-check`
- `scripts/smoke/replay-scroll-capture-self-check.sh`
- `scripts/smoke/live-loupe-perf-macos.sh --help`
- `scripts/smoke/live-loupe-perf-self-check-macos.sh --help`
- `cargo test -p rsnap-overlay replay_recorded_live_trace_round_trips_one_commit --lib`
- `cargo test -p rsnap-overlay scroll_capture::tests --lib`
- `cargo test -p rsnap-overlay worker_tick_runtime --lib`
- `cargo test -p rsnap-overlay worker_observation_runtime --lib`
- `cargo bench -p rsnap --bench settings_window -- --list`
- `cargo bench -p rsnap-overlay --bench scroll_capture -- --list`
- `cargo make checks`
