### PR TITLE
Enforce fixed 120Hz cadence contract

### DIFF
--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -22,7 +22,7 @@ Defines:
 - the active render cadence contract for rsnap UI and overlay paths
 - the tracked performance scenarios and their primary metrics
 - the distinction between target cadence, diagnostic thresholds, and coarse smoke gates
-- the currently known gap between the agreed cadence contract and the live implementation
+- the current cadence implementation status and any known gap against the agreed contract
 
 ## Scope
 
@@ -42,25 +42,22 @@ or animation.
 
 For actively rendered rsnap UI and overlay paths, target cadence is:
 
-`min(120 Hz, active display refresh ceiling)`
+`120 Hz`
 
 Practical meaning:
 
-- If the active display refresh rate is `<= 120 Hz`, rsnap should not run below that display
-  refresh rate during the relevant active interaction path.
-- If the active display refresh rate is `> 120 Hz`, the current contract caps the target at
-  `120 Hz`.
+- The target frame budget is always `8.33 ms` for the relevant active interaction path.
+- rsnap MUST NOT lower this target by reading the active display refresh rate, deriving a
+  per-monitor display refresh ceiling, or treating an unknown display refresh rate as a separate
+  acceptance class.
+- Passing the cadence contract requires achieving the fixed `120 Hz` target. A lower display
+  refresh rate is not an alternate target and does not relax the requirement.
 
-Derived target frame budgets:
+Target frame budget:
 
-| Active display refresh ceiling | Target cadence | Target frame budget |
-| --- | --- | --- |
-| `60 Hz` | `60 Hz` | `16.67 ms` |
-| `75 Hz` | `75 Hz` | `13.33 ms` |
-| `90 Hz` | `90 Hz` | `11.11 ms` |
-| `120 Hz` | `120 Hz` | `8.33 ms` |
-| `144 Hz` | `120 Hz` | `8.33 ms` |
-| `240 Hz` | `120 Hz` | `8.33 ms` |
+| Target cadence | Target frame budget |
+| --- | --- |
+| `120 Hz` | `8.33 ms` |
 
 This cadence contract is normative even when current logs or smoke harnesses use coarser warning
 thresholds.
@@ -70,7 +67,7 @@ thresholds.
 The performance contract distinguishes three layers:
 
 1. Target cadence
-   - The per-surface target frame interval derived from the active render cadence contract.
+   - The per-surface target frame interval defined by the active render cadence contract.
    - This is the standard that implementation and benchmark work should aim to satisfy.
 2. Diagnostic thresholds
    - Structured timing or warning thresholds emitted by the runtime.
@@ -92,7 +89,7 @@ Surface:
 - live cursor sample apply path
 
 Primary metrics:
-- effective active redraw cadence against the target frame budget for the active display
+- effective active redraw cadence against the fixed `120 Hz` target frame budget
 - phase timings for redraw-related work
 - live sample apply latency
 
@@ -157,29 +154,43 @@ Passing one environment class does not automatically satisfy the other.
 
 The current overlay runtime already exposes several useful diagnostic thresholds:
 
-- `LIVE_PRESENT_INTERVAL_MIN = 8.33 ms` for the 120 Hz floor-derived present interval.
+- `LIVE_PRESENT_INTERVAL_MIN = 8.33 ms` for the fixed `120 Hz` target present interval.
 - `SLOW_OP_WARN_RENDER = 24 ms` for coarse render warnings.
 - `OVERLAY_EVENT_LOOP_STALL_THRESHOLD = 250 ms` for severe event-loop stalls.
 - `overlay.live_sample_apply_latency` is logged once latency reaches `12 ms`.
+- Native-host `live_chrome.hud.apply_latency` and `live_chrome.loupe.apply_latency` measure the
+  first successful visible apply for a live input sequence. If the position-only fast path moves
+  the HUD or loupe first, that fast-path apply owns the sample and the later full snapshot refresh
+  must not re-record the same input sequence as a slower apply.
+- Native-host `live_chrome.*.fast_position_latency` and
+  `live_chrome.*.fast_position_duration` are diagnostic signals for the position-only fast path;
+  they do not replace the first-visible-apply latency metric.
+- Native-host `live_chrome.*.fast_position_gap` reports the interval between successful
+  position-only moves. Use it to diagnose cadence jitter when per-move duration and apply latency
+  are low but the HUD or loupe still feels uneven.
+- Native-host `live_chrome.frame_tick_gap` reports the active live-frame clock interval. It should
+  cluster around the fixed `120 Hz` budget (`8.33 ms`) during active live capture.
 
 These values are useful for diagnosis, but they are not the full performance contract:
 
-- `24 ms` render warnings are too coarse to prove compliance with `8.33 ms` or `16.67 ms`
-  target budgets.
+- `24 ms` render warnings are too coarse to prove compliance with the `8.33 ms` target budget.
 - a passing live-loupe smoke run only shows that the path avoided severe regressions under the
   current harness thresholds.
 - direct cadence-aware benchmarks and phase timing are still required for contract compliance.
 
 ## Current cadence implementation status
 
-Overlay repaint interval derivation now applies the cadence contract directly:
+The current contract no longer treats display refresh-rate discovery as part of cadence
+derivation or acceptance. Implementation status should be judged against the fixed target:
 
-- known refresh rates below `120 Hz` use the known display ceiling
-- known refresh rates above `120 Hz` are capped at `120 Hz`
-- unknown refresh rates fall back to the contract cap of `120 Hz`
+- active interaction paths must target `120 Hz` directly
+- cadence derivation must not query or branch on the active display refresh rate
+- any implementation path that still lowers cadence from a known monitor refresh rate remains a
+  contract gap until removed
 
-Remaining performance work should treat cadence derivation as aligned and focus on measurement
-coverage, redraw localization, and benchmark baselines rather than re-arguing the core cap logic.
+Remaining performance work should focus on measurement coverage, redraw localization, benchmark
+baselines, and removing any refresh-rate-derived cadence paths before claiming contract
+compliance.
 
 ## Minimum artifact set for contract compliance
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -333,7 +333,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			frame: screen.frame,
 			widthPixels: max(1, Int((screen.frame.width * scale).rounded())),
 			heightPixels: max(1, Int((screen.frame.height * scale).rounded())),
-			framesPerSecond: NativeHostDisplayRefresh.effectiveFramesPerSecond(for: screen)
+			framesPerSecond: NativeHostDisplayRefresh.targetFramesPerSecond
 		)
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -315,20 +315,53 @@ private final class LiveChromeOverlayWindow: NSWindow {
 	override var canBecomeKey: Bool { false }
 	override var canBecomeMain: Bool { false }
 
-	func update(frame: CGRect, settings: NativeHostSettings) {
-		let roundedFrame = CGRect(
-			x: frame.origin.x.rounded(),
-			y: frame.origin.y.rounded(),
-			width: ceil(frame.width),
-			height: ceil(frame.height)
+	private var presentationScale: CGFloat {
+		max(
+			backingScaleFactor,
+			screen?.backingScaleFactor ?? 0,
+			NSScreen.main?.backingScaleFactor ?? 1,
+			1
 		)
+	}
+
+	private func presentationFrame(from frame: CGRect) -> CGRect {
+		let scale = presentationScale
+		return CGRect(
+			x: (frame.origin.x * scale).rounded() / scale,
+			y: (frame.origin.y * scale).rounded() / scale,
+			width: (frame.width * scale).rounded(.up) / scale,
+			height: (frame.height * scale).rounded(.up) / scale
+		)
+	}
+
+	func prewarmForPresentation(settings: NativeHostSettings) {
+		guard !isPresented else {
+			return
+		}
+
+		let prewarmFrame = CGRect(x: -10_000, y: -10_000, width: 1, height: 1)
+		alphaValue = 0
+		setFrame(prewarmFrame, display: false, animate: false)
+		lastPresentedFrame = prewarmFrame
+		orderFrontRegardless()
+		isPresented = true
+		displayIfNeeded()
+
+		let blurAmount = settings.hudGlassEnabled ? settings.hudBlur : 0
+		MacOSWindowBlurBridge.applyBlur(to: self, amount: blurAmount)
+		lastAppliedBlurAmount = blurAmount
+	}
+
+	func update(frame: CGRect, settings: NativeHostSettings) {
+		let roundedFrame = presentationFrame(from: frame)
+		let tolerance: CGFloat = 0.001
 		if let lastPresentedFrame {
 			let sizeChanged =
-				abs(lastPresentedFrame.width - roundedFrame.width) > 0.5
-				|| abs(lastPresentedFrame.height - roundedFrame.height) > 0.5
+				abs(lastPresentedFrame.width - roundedFrame.width) > tolerance
+				|| abs(lastPresentedFrame.height - roundedFrame.height) > tolerance
 			let originChanged =
-				abs(lastPresentedFrame.minX - roundedFrame.minX) > 0.5
-				|| abs(lastPresentedFrame.minY - roundedFrame.minY) > 0.5
+				abs(lastPresentedFrame.minX - roundedFrame.minX) > tolerance
+				|| abs(lastPresentedFrame.minY - roundedFrame.minY) > tolerance
 			if sizeChanged {
 				setFrame(roundedFrame, display: false, animate: false)
 			} else if originChanged {
@@ -349,27 +382,26 @@ private final class LiveChromeOverlayWindow: NSWindow {
 			orderFrontRegardless()
 			isPresented = true
 		}
+		if alphaValue != 1 {
+			alphaValue = 1
+		}
 	}
 
 	func moveIfPossible(frame: CGRect) -> Bool {
 		guard let lastPresentedFrame else {
 			return false
 		}
-		let roundedFrame = CGRect(
-			x: frame.origin.x.rounded(),
-			y: frame.origin.y.rounded(),
-			width: ceil(frame.width),
-			height: ceil(frame.height)
-		)
+		let roundedFrame = presentationFrame(from: frame)
+		let tolerance: CGFloat = 0.001
 		let sizeMatches =
-			abs(lastPresentedFrame.width - roundedFrame.width) <= 0.5
-			&& abs(lastPresentedFrame.height - roundedFrame.height) <= 0.5
+			abs(lastPresentedFrame.width - roundedFrame.width) <= tolerance
+			&& abs(lastPresentedFrame.height - roundedFrame.height) <= tolerance
 		guard sizeMatches else {
 			return false
 		}
 		let originChanged =
-			abs(lastPresentedFrame.minX - roundedFrame.minX) > 0.5
-			|| abs(lastPresentedFrame.minY - roundedFrame.minY) > 0.5
+			abs(lastPresentedFrame.minX - roundedFrame.minX) > tolerance
+			|| abs(lastPresentedFrame.minY - roundedFrame.minY) > tolerance
 		guard originChanged else {
 			return false
 		}
@@ -385,6 +417,7 @@ private final class LiveChromeOverlayWindow: NSWindow {
 		orderOut(nil)
 		isPresented = false
 		lastPresentedFrame = nil
+		alphaValue = 1
 	}
 }
 
@@ -696,6 +729,10 @@ final class LiveChromeVisualWindowController {
 		"live_chrome.hud.fast_position_duration",
 		category: "LiveChromeTelemetry"
 	)
+	private let hudFastPositionGapMetric = NativeHostTelemetry.distribution(
+		"live_chrome.hud.fast_position_gap",
+		category: "LiveChromeTelemetry"
+	)
 	private let loupeFastPositionLatencyMetric = NativeHostTelemetry.distribution(
 		"live_chrome.loupe.fast_position_latency",
 		category: "LiveChromeTelemetry"
@@ -704,10 +741,21 @@ final class LiveChromeVisualWindowController {
 		"live_chrome.loupe.fast_position_duration",
 		category: "LiveChromeTelemetry"
 	)
+	private let loupeFastPositionGapMetric = NativeHostTelemetry.distribution(
+		"live_chrome.loupe.fast_position_gap",
+		category: "LiveChromeTelemetry"
+	)
 	private var lastHudLatencyInputSequence: UInt64?
 	private var lastLoupeLatencyInputSequence: UInt64?
 	private var lastFastHudLatencyInputSequence: UInt64?
 	private var lastFastLoupeLatencyInputSequence: UInt64?
+	private var lastFastHudPositionUptime: TimeInterval?
+	private var lastFastLoupePositionUptime: TimeInterval?
+
+	func prepareForLivePresentation(settings: NativeHostSettings) {
+		hudWindow.prewarmForPresentation(settings: settings)
+		loupeWindow.prewarmForPresentation(settings: settings)
+	}
 
 	func update(snapshot: LiveChromeVisualSnapshot?, focusedWindowNumber: Int?) {
 		let updateStart = ProcessInfo.processInfo.systemUptime
@@ -769,11 +817,22 @@ final class LiveChromeVisualWindowController {
 			let moveStart = ProcessInfo.processInfo.systemUptime
 			if hudWindow.moveIfPossible(frame: hudFrame) {
 				hudFastPositionDurationMetric.recordMillisecondsSince(moveStart)
+				recordPositionGap(
+					moveStart,
+					lastMoveUptime: &lastFastHudPositionUptime,
+					metric: hudFastPositionGapMetric
+				)
 				recordInputLatency(
 					inputUptime: snapshot.inputUptime,
 					inputSequence: snapshot.inputSequence,
 					lastInputSequence: &lastFastHudLatencyInputSequence,
 					metric: hudFastPositionLatencyMetric
+				)
+				recordInputLatency(
+					inputUptime: snapshot.inputUptime,
+					inputSequence: snapshot.inputSequence,
+					lastInputSequence: &lastHudLatencyInputSequence,
+					metric: hudApplyLatencyMetric
 				)
 			}
 		}
@@ -781,14 +840,43 @@ final class LiveChromeVisualWindowController {
 			let moveStart = ProcessInfo.processInfo.systemUptime
 			if loupeWindow.moveIfPossible(frame: loupeFrame) {
 				loupeFastPositionDurationMetric.recordMillisecondsSince(moveStart)
+				recordPositionGap(
+					moveStart,
+					lastMoveUptime: &lastFastLoupePositionUptime,
+					metric: loupeFastPositionGapMetric
+				)
 				recordInputLatency(
 					inputUptime: snapshot.inputUptime,
 					inputSequence: snapshot.inputSequence,
 					lastInputSequence: &lastFastLoupeLatencyInputSequence,
 					metric: loupeFastPositionLatencyMetric
 				)
+				recordInputLatency(
+					inputUptime: snapshot.inputUptime,
+					inputSequence: snapshot.inputSequence,
+					lastInputSequence: &lastLoupeLatencyInputSequence,
+					metric: loupeApplyLatencyMetric
+				)
 			}
 		}
+	}
+
+	private func recordPositionGap(
+		_ moveUptime: TimeInterval,
+		lastMoveUptime: inout TimeInterval?,
+		metric: NativeHostTelemetry.DistributionMetric
+	) {
+		defer {
+			lastMoveUptime = moveUptime
+		}
+		guard let lastMoveUptime else {
+			return
+		}
+		let gapMilliseconds = (moveUptime - lastMoveUptime) * 1_000
+		guard gapMilliseconds >= 0, gapMilliseconds < 250 else {
+			return
+		}
+		metric.record(gapMilliseconds)
 	}
 
 	private func recordInputLatency(

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1,7 +1,6 @@
 import AppKit
 import CoreGraphics
 import CoreImage
-import CoreVideo
 import Foundation
 import QuartzCore
 import RsnapHostBridge
@@ -166,8 +165,15 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	func start() {
 		stop()
 		let timer = DispatchSource.makeTimerSource(queue: queue)
-		let interval = TimeInterval(1.0 / 60.0)
-		timer.schedule(deadline: .now(), repeating: interval)
+		let intervalNanoseconds = max(
+			1,
+			Int((NativeHostDisplayRefresh.frameInterval * 1_000_000_000.0).rounded())
+		)
+		timer.schedule(
+			deadline: .now(),
+			repeating: .nanoseconds(intervalNanoseconds),
+			leeway: .nanoseconds(0)
+		)
 		timer.setEventHandler { [weak self] in
 			self?.refresh()
 		}
@@ -378,82 +384,73 @@ final class GlassPatchFeed {
 	}
 }
 
-final class LiveDisplayLinkDriver: @unchecked Sendable {
+final class LiveFrameClockDriver: @unchecked Sendable {
 	var onTick: (() -> Void)?
 	private let stateLock = NSLock()
-	private var displayLink: CVDisplayLink?
-	private var currentDisplayID: CGDirectDisplayID?
+	private let tickGapMetric = NativeHostTelemetry.distribution(
+		"live_chrome.frame_tick_gap",
+		category: "LiveChromeTelemetry"
+	)
+	private var timer: DispatchSourceTimer?
 	private var currentTargetFramesPerSecond: Int?
-	private var tickPending = false
+	private var lastTickUptime: TimeInterval?
 
-	func start(displayID: CGDirectDisplayID, targetFramesPerSecond: Int) {
+	func start(targetFramesPerSecond: Int) {
 		let sanitizedTarget = max(1, targetFramesPerSecond)
 		stateLock.lock()
-		let alreadyRunning =
-			displayLink != nil && currentDisplayID == displayID
-			&& currentTargetFramesPerSecond == sanitizedTarget
+		let alreadyRunning = timer != nil && currentTargetFramesPerSecond == sanitizedTarget
 		stateLock.unlock()
 		guard !alreadyRunning else {
 			return
 		}
 
 		stop()
-		var link: CVDisplayLink?
-		guard CVDisplayLinkCreateWithActiveCGDisplays(&link) == kCVReturnSuccess, let link else {
-			return
-		}
-		CVDisplayLinkSetCurrentCGDisplay(link, displayID)
-		CVDisplayLinkSetOutputHandler(link) { [weak self] _, _, _, _, _ in
-			guard let self else {
-				return kCVReturnSuccess
-			}
-			self.stateLock.lock()
-			guard !self.tickPending else {
-				self.stateLock.unlock()
-				return kCVReturnSuccess
-			}
-			self.tickPending = true
-			self.stateLock.unlock()
-			DispatchQueue.main.async {
-				self.stateLock.lock()
-				self.tickPending = false
-				self.stateLock.unlock()
-				self.onTick?()
-			}
-			return kCVReturnSuccess
+		let timer = DispatchSource.makeTimerSource(queue: .main)
+		let intervalNanoseconds = max(
+			1,
+			Int((1_000_000_000.0 / Double(sanitizedTarget)).rounded())
+		)
+		timer.schedule(
+			deadline: .now(),
+			repeating: .nanoseconds(intervalNanoseconds),
+			leeway: .nanoseconds(0)
+		)
+		timer.setEventHandler { [weak self] in
+			self?.tick()
 		}
 		stateLock.lock()
-		displayLink = link
-		currentDisplayID = displayID
+		self.timer = timer
 		currentTargetFramesPerSecond = sanitizedTarget
-		tickPending = false
+		lastTickUptime = nil
 		stateLock.unlock()
-		guard CVDisplayLinkStart(link) == kCVReturnSuccess else {
-			stateLock.lock()
-			displayLink = nil
-			currentDisplayID = nil
-			currentTargetFramesPerSecond = nil
-			tickPending = false
-			stateLock.unlock()
-			return
+		timer.resume()
+	}
+
+	private func tick() {
+		let now = ProcessInfo.processInfo.systemUptime
+		if let lastTickUptime {
+			let gapMilliseconds = (now - lastTickUptime) * 1_000
+			if gapMilliseconds >= 0, gapMilliseconds < 250 {
+				tickGapMetric.record(gapMilliseconds)
+			}
 		}
+		lastTickUptime = now
+		onTick?()
 	}
 
 	func stop() {
 		stateLock.lock()
-		guard let displayLink else {
-			currentDisplayID = nil
+		guard let timer else {
 			currentTargetFramesPerSecond = nil
-			tickPending = false
+			lastTickUptime = nil
 			stateLock.unlock()
 			return
 		}
-		self.displayLink = nil
-		currentDisplayID = nil
+		self.timer = nil
 		currentTargetFramesPerSecond = nil
-		tickPending = false
+		lastTickUptime = nil
 		stateLock.unlock()
-		CVDisplayLinkStop(displayLink)
+		timer.cancel()
 	}
 
 	deinit {
@@ -918,13 +915,13 @@ final class LiveOverlayRenderer {
 	private let loupeStrokeLayer = CAShapeLayer()
 	private let loupePatchLayer = CALayer()
 	private let loupeCenterLayer = CAShapeLayer()
-	private let displayLink = LiveDisplayLinkDriver()
+	private let frameClock = LiveFrameClockDriver()
 	private var snapshotProvider: (() -> LivePreviewSnapshot?)?
 
 	init(hostView: NSView) {
 		self.hostView = hostView
 		configureLayers()
-		displayLink.onTick = { [weak self] in
+		frameClock.onTick = { [weak self] in
 			self?.renderCurrentSnapshot()
 			self?.onTick?()
 		}
@@ -943,15 +940,15 @@ final class LiveOverlayRenderer {
 	}
 
 	func updateDisplayID(_ displayID: CGDirectDisplayID?, targetFramesPerSecond: Int) {
-		guard let displayID else {
+		guard displayID != nil else {
 			stop()
 			return
 		}
-		displayLink.start(displayID: displayID, targetFramesPerSecond: targetFramesPerSecond)
+		frameClock.start(targetFramesPerSecond: targetFramesPerSecond)
 	}
 
 	func stop() {
-		displayLink.stop()
+		frameClock.stop()
 		rootLayer.isHidden = true
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -1126,7 +1126,7 @@ final class CaptureSessionController: NSObject {
 		let frozenFrame = frozenFrameAuthority.snapshot(
 			containing: selectionCenter,
 			after: token,
-			maxWait: frozenFrameLatchWait(for: selectionCenter)
+			maxWait: frozenFrameLatchWait()
 		)
 		guard let frozenFrame else {
 			NSLog("Frozen transition aborted: no fresh authority frame was available")
@@ -1156,12 +1156,8 @@ final class CaptureSessionController: NSObject {
 		try session.send(report: .freezeSnapshotCommitted(selection: selection))
 	}
 
-	private func frozenFrameLatchWait(for point: CGPoint) -> TimeInterval {
-		let frameInterval =
-			screen(containing: point)
-			.map(NativeHostDisplayRefresh.frameInterval(for:))
-			?? (1.0 / 60.0)
-		return min(0.040, max(0.018, frameInterval * 2.5))
+	private func frozenFrameLatchWait() -> TimeInterval {
+		min(0.040, max(0.018, NativeHostDisplayRefresh.frameInterval * 2.5))
 	}
 
 	private func hostOwnedFrozenPresentationScene(for selection: CGRect) -> SceneSnapshot {
@@ -1930,6 +1926,7 @@ final class CaptureOverlayController {
 			}
 		}
 		collapsedForFrozen = false
+		liveChromeWindows.prepareForLivePresentation(settings: settings)
 		liveFrameStream.start(for: NSScreen.screens, prewarmPoint: focusPoint)
 		windowSnapshotFeed.start(
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
@@ -2438,7 +2435,6 @@ final class CaptureHostView: NSView {
 	private lazy var liveRenderer = LiveOverlayRenderer(hostView: self)
 	private var liveRendererInstalled = false
 	private var deferredLiveShutdownWorkItem: DispatchWorkItem?
-	private var loggedLiveDisplayHz: Int?
 	private var loggedLiveTargetHz: Int?
 
 	override var acceptsFirstResponder: Bool { true }
@@ -2487,7 +2483,7 @@ final class CaptureHostView: NSView {
 				liveHoverChromeSuppressed = false
 			}
 			if livePointerPreviewGlobal == nil {
-				seedLivePointerPreview(scene.pointer)
+				seedLivePointerPreview(scene.pointer, recordsInputLatency: false)
 			}
 			if liveHighlightedWindowPreview == nil {
 				liveHighlightedWindowPreview = scene.highlightedWindow
@@ -2553,7 +2549,7 @@ final class CaptureHostView: NSView {
 		frozenFirstDisplayCompletionQueued = false
 		lastLivePreviewSnapshot = nil
 		if scene.mode == .live {
-			seedLivePointerPreview(scene.pointer)
+			seedLivePointerPreview(scene.pointer, recordsInputLatency: false)
 			liveHighlightedWindowPreview = scene.highlightedWindow
 		} else {
 			resetLivePointerPreview()
@@ -2652,7 +2648,7 @@ final class CaptureHostView: NSView {
 	override func mouseMoved(with event: NSEvent) {
 		refreshHoveredToolbarAction(for: event.locationInWindow)
 		let point = globalPoint(from: event)
-		updateLivePointerPreview(to: point)
+		updateLivePointerPreview(to: point, rendersImmediately: false)
 		queuePointerEvent(.moved(point))
 	}
 
@@ -2661,7 +2657,7 @@ final class CaptureHostView: NSView {
 
 		if scene.mode == .live {
 			let point = globalPoint(from: event)
-			updateLivePointerPreview(to: point)
+			updateLivePointerPreview(to: point, rendersImmediately: false)
 			queuePointerEvent(.liveDragged(point))
 		} else {
 			controller?.continueFrozenInteraction(to: globalPoint(from: event))
@@ -2677,7 +2673,7 @@ final class CaptureHostView: NSView {
 			break
 		case .live:
 			suppressLiveHoverChrome()
-			updateLivePointerPreview(to: point)
+			updateLivePointerPreview(to: point, rendersImmediately: true)
 			controller?.beginPrimaryInteraction(at: point)
 		case .frozen:
 			if let action = toolbarAction(at: localPoint) {
@@ -2692,7 +2688,7 @@ final class CaptureHostView: NSView {
 	override func mouseUp(with event: NSEvent) {
 		let point = globalPoint(from: event)
 		if scene.mode == .live {
-			updateLivePointerPreview(to: point)
+			updateLivePointerPreview(to: point, rendersImmediately: true)
 			controller?.completePrimaryInteraction(at: point)
 		} else if scene.mode == .frozen {
 			controller?.completeFrozenInteraction(at: point)
@@ -2941,24 +2937,35 @@ final class CaptureHostView: NSView {
 		return localPoint(from: globalPoint)
 	}
 
-	private func seedLivePointerPreview(_ globalPoint: CGPoint?) {
+	private func seedLivePointerPreview(
+		_ globalPoint: CGPoint?,
+		recordsInputLatency: Bool = true
+	) {
 		guard let globalPoint else {
 			resetLivePointerPreview()
 			return
 		}
 		livePointerPreviewGlobal = globalPoint
-		livePointerPreviewInputUptime = ProcessInfo.processInfo.systemUptime
-		livePointerPreviewInputSequence &+= 1
+		if recordsInputLatency {
+			livePointerPreviewInputUptime = ProcessInfo.processInfo.systemUptime
+			livePointerPreviewInputSequence &+= 1
+		} else {
+			livePointerPreviewInputUptime = nil
+			livePointerPreviewInputSequence = 0
+		}
 	}
 
 	@discardableResult
-	private func setLivePointerPreview(to globalPoint: CGPoint) -> Bool {
+	private func setLivePointerPreview(
+		to globalPoint: CGPoint,
+		recordsInputLatency: Bool = true
+	) -> Bool {
 		if let current = livePointerPreviewGlobal,
 			hypot(current.x - globalPoint.x, current.y - globalPoint.y) < 0.5
 		{
 			return false
 		}
-		seedLivePointerPreview(globalPoint)
+		seedLivePointerPreview(globalPoint, recordsInputLatency: recordsInputLatency)
 		return true
 	}
 
@@ -2968,7 +2975,10 @@ final class CaptureHostView: NSView {
 		livePointerPreviewInputSequence = 0
 	}
 
-	private func updateLivePointerPreview(to globalPoint: CGPoint) {
+	private func updateLivePointerPreview(
+		to globalPoint: CGPoint,
+		rendersImmediately: Bool
+	) {
 		guard scene.mode == .live else {
 			return
 		}
@@ -2979,7 +2989,9 @@ final class CaptureHostView: NSView {
 		liveHighlightedWindowPreview =
 			controller?.previewHighlightedWindow(at: globalPoint) ?? scene.highlightedWindow
 		updateLivePreviewDemands()
-		liveRenderer.renderNow()
+		if rendersImmediately {
+			liveRenderer.renderNow()
+		}
 	}
 
 	private func localFrozenSelectionRect() -> CGRect? {
@@ -3838,16 +3850,10 @@ final class CaptureHostView: NSView {
 		let polledPoint = NSEvent.mouseLocation
 		if let currentPreview = livePointerPreviewGlobal {
 			if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y) >= 0.5 {
-				setLivePointerPreview(to: polledPoint)
-				liveHighlightedWindowPreview =
-					controller?.previewHighlightedWindow(at: polledPoint)
-					?? liveHighlightedWindowPreview
+				applyPolledLivePointerPreview(polledPoint)
 			}
 		} else {
-			setLivePointerPreview(to: polledPoint)
-			liveHighlightedWindowPreview =
-				controller?.previewHighlightedWindow(at: polledPoint)
-				?? liveHighlightedWindowPreview
+			applyPolledLivePointerPreview(polledPoint, recordsInputLatency: false)
 		}
 
 		updateLivePreviewDemands()
@@ -3886,6 +3892,21 @@ final class CaptureHostView: NSView {
 			loupePatch: loupePatch,
 			glassPatches: [:]
 		)
+	}
+
+	private func applyPolledLivePointerPreview(
+		_ globalPoint: CGPoint,
+		recordsInputLatency: Bool = true
+	) {
+		let pointerChanged = setLivePointerPreview(
+			to: globalPoint,
+			recordsInputLatency: recordsInputLatency
+		)
+		if pointerChanged {
+			controller?.updateLiveChromePositions(currentLiveChromePositionSnapshot())
+		}
+		liveHighlightedWindowPreview =
+			controller?.previewHighlightedWindow(at: globalPoint) ?? liveHighlightedWindowPreview
 	}
 
 	private func currentChromeVisualSnapshot() -> LiveChromeVisualSnapshot? {
@@ -4111,22 +4132,17 @@ final class CaptureHostView: NSView {
 		}
 		guard scene.mode == .live || pendingFrozenFirstDisplay else {
 			liveRenderer.suspend()
-			loggedLiveDisplayHz = nil
 			loggedLiveTargetHz = nil
 			return
 		}
 		deferredLiveShutdownWorkItem?.cancel()
 		deferredLiveShutdownWorkItem = nil
-		let displayHz = NativeHostDisplayRefresh.displayFramesPerSecond(for: window?.screen)
-		let targetHz = NativeHostDisplayRefresh.effectiveFramesPerSecond(for: window?.screen)
-		if loggedLiveDisplayHz != displayHz || loggedLiveTargetHz != targetHz {
-			loggedLiveDisplayHz = displayHz
+		let targetHz = NativeHostDisplayRefresh.targetFramesPerSecond
+		if loggedLiveTargetHz != targetHz {
 			loggedLiveTargetHz = targetHz
 			NativeHostTelemetry.liveChromeRefreshTarget(
-				displayHz: displayHz,
 				targetHz: targetHz,
-				frameBudgetMilliseconds: NativeHostDisplayRefresh.frameBudgetMilliseconds(
-					for: window?.screen)
+				frameBudgetMilliseconds: NativeHostDisplayRefresh.frameBudgetMilliseconds
 			)
 		}
 		liveRenderer.updateDisplayID(currentDisplayID(), targetFramesPerSecond: targetHz)
@@ -4453,7 +4469,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func pointerDispatchInterval() -> TimeInterval {
-		NativeHostDisplayRefresh.frameInterval(for: window?.screen)
+		NativeHostDisplayRefresh.frameInterval
 	}
 
 	private func lastPointerDispatchUptime(for event: QueuedPointerEvent) -> TimeInterval {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostDisplayRefresh.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostDisplayRefresh.swift
@@ -1,26 +1,13 @@
-import AppKit
 import Foundation
 
 enum NativeHostDisplayRefresh {
-	static let preferredMaximumFramesPerSecond = 120
-	static let fallbackFramesPerSecond = 60
+	static let targetFramesPerSecond = 120
 
-	static func displayFramesPerSecond(for screen: NSScreen?) -> Int {
-		max(
-			1,
-			screen?.maximumFramesPerSecond ?? NSScreen.main?.maximumFramesPerSecond
-				?? fallbackFramesPerSecond)
+	static var frameInterval: TimeInterval {
+		1.0 / Double(targetFramesPerSecond)
 	}
 
-	static func effectiveFramesPerSecond(for screen: NSScreen?) -> Int {
-		min(displayFramesPerSecond(for: screen), preferredMaximumFramesPerSecond)
-	}
-
-	static func frameInterval(for screen: NSScreen?) -> TimeInterval {
-		1.0 / Double(effectiveFramesPerSecond(for: screen))
-	}
-
-	static func frameBudgetMilliseconds(for screen: NSScreen?) -> Double {
-		frameInterval(for: screen) * 1_000
+	static var frameBudgetMilliseconds: Double {
+		frameInterval * 1_000
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -21,10 +21,10 @@ enum NativeHostTelemetry {
 	}
 
 	static func liveChromeRefreshTarget(
-		displayHz: Int, targetHz: Int, frameBudgetMilliseconds: Double
+		targetHz: Int, frameBudgetMilliseconds: Double
 	) {
 		liveChromeLogger.info(
-			"event=live_chrome.refresh_target displayHz=\(displayHz, privacy: .public) targetHz=\(targetHz, privacy: .public) frameBudgetMs=\(frameBudgetMilliseconds, format: .fixed(precision: 2), privacy: .public)"
+			"event=live_chrome.refresh_target targetHz=\(targetHz, privacy: .public) frameBudgetMs=\(frameBudgetMilliseconds, format: .fixed(precision: 2), privacy: .public)"
 		)
 	}
 

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -50,7 +50,6 @@ use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
 	borrow::Cow,
-	cmp::Ordering,
 	collections::{HashMap, HashSet},
 	path::PathBuf,
 	sync::{Arc, Mutex},
@@ -365,7 +364,7 @@ const SELECTION_FLOW_SPEED: f32 = 0.24;
 const SELECTION_FLOW_CORE_WIDTH_PX: f32 = 2.4;
 const SELECTION_FLOW_CORE_FLOW_WIDTH: f32 = 0.06;
 const SELECTION_FLOW_FLOW_BOOST: f32 = 2.8;
-const INTERACTIVE_REPAINT_FPS_CAP: f32 = 120.0;
+const INTERACTIVE_REPAINT_TARGET_FPS: f32 = 120.0;
 const SELECTION_FLOW_PALETTE: [(u8, u8, u8); 3] =
 	[(196, 226, 255), (228, 198, 255), (176, 244, 224)];
 const SELECTION_FLOW_LIGHT_PALETTE: [(u8, u8, u8); 3] =

--- a/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
@@ -1,7 +1,7 @@
 use crate::overlay::{
 	Duration, FROZEN_TEXT_CARET_REPAINT_INTERVAL, GlobalPoint, HUD_LOUPE_MOVE_INTERVAL_MIN,
-	INTERACTIVE_REPAINT_FPS_CAP, Instant, LOUPE_WINDOW_WARMUP_REDRAWS, LogicalPosition,
-	MonitorRect, MonitorRectPoints, OVERLAY_EVENT_LOOP_STALL_THRESHOLD, Ordering, OverlayControl,
+	INTERACTIVE_REPAINT_TARGET_FPS, Instant, LOUPE_WINDOW_WARMUP_REDRAWS, LogicalPosition,
+	MonitorRect, MonitorRectPoints, OVERLAY_EVENT_LOOP_STALL_THRESHOLD, OverlayControl,
 	OverlayEventLoopPhase, OverlayMode, OverlaySession, SLOW_OP_WARN_INTERVAL,
 	SLOW_OP_WARN_OUTER_POSITION, WindowEvent,
 };
@@ -260,41 +260,12 @@ impl OverlaySession {
 		old_cursor != Some(cursor) || old_monitor != Some(monitor)
 	}
 
-	pub(super) fn repaint_interval_for_monitor(&self, monitor: Option<MonitorRect>) -> Duration {
-		let monitor_fps = monitor
-			.and_then(|target| {
-				self.windows.values().find_map(|window| {
-					(target == window.monitor).then_some(window.refresh_rate_millihertz)
-				})
-			})
-			.flatten()
-			.and_then(|hz| {
-				let fps = (hz as f32) / 1_000.0;
-
-				if fps.is_finite() && fps > 0.0 { Some(fps) } else { None }
-			});
-		let fallback_fps = self
-			.windows
-			.values()
-			.filter_map(|window| window.refresh_rate_millihertz)
-			.filter_map(|hz| {
-				let fps = (hz as f32) / 1_000.0;
-
-				if fps.is_finite() && fps > 0.0 { Some(fps) } else { None }
-			})
-			.max_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-		let fps = Self::interactive_repaint_fps(monitor_fps, fallback_fps);
-
-		Duration::from_secs_f32(1.0 / fps)
+	pub(super) fn repaint_interval_for_monitor(&self, _monitor: Option<MonitorRect>) -> Duration {
+		Duration::from_secs_f32(1.0 / Self::interactive_repaint_fps())
 	}
 
-	pub(super) fn interactive_repaint_fps(
-		monitor_fps: Option<f32>,
-		fallback_fps: Option<f32>,
-	) -> f32 {
-		monitor_fps
-			.or(fallback_fps)
-			.map_or(INTERACTIVE_REPAINT_FPS_CAP, |fps| fps.min(INTERACTIVE_REPAINT_FPS_CAP))
+	pub(super) const fn interactive_repaint_fps() -> f32 {
+		INTERACTIVE_REPAINT_TARGET_FPS
 	}
 
 	pub(super) fn selection_flow_repaint_interval(&self, monitor: Option<MonitorRect>) -> Duration {

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -170,7 +170,6 @@ pub(super) struct OverlayWindow {
 	pub(super) cursor_rects: MacOSOverlayCursorRectSupport,
 	pub(super) window: Arc<Window>,
 	pub(super) renderer: WindowRenderer,
-	pub(super) refresh_rate_millihertz: Option<u32>,
 }
 
 pub(super) struct GpuContext {

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -4027,22 +4027,8 @@ fn frozen_toolbar_clamps_floating_position() {
 }
 
 #[test]
-fn interactive_repaint_fps_uses_known_lower_monitor_refresh() {
-	assert_eq!(OverlaySession::interactive_repaint_fps(Some(60.0), Some(144.0)), 60.0);
-	assert_eq!(OverlaySession::interactive_repaint_fps(Some(75.0), Some(120.0)), 75.0);
-}
-
-#[test]
-fn interactive_repaint_fps_caps_known_higher_refresh_to_contract_limit() {
-	assert_eq!(OverlaySession::interactive_repaint_fps(Some(144.0), Some(60.0)), 120.0);
-	assert_eq!(OverlaySession::interactive_repaint_fps(Some(240.0), None), 120.0);
-}
-
-#[test]
-fn interactive_repaint_fps_falls_back_to_known_or_default_cap() {
-	assert_eq!(OverlaySession::interactive_repaint_fps(None, Some(90.0)), 90.0);
-	assert_eq!(OverlaySession::interactive_repaint_fps(None, Some(144.0)), 120.0);
-	assert_eq!(OverlaySession::interactive_repaint_fps(None, None), 120.0);
+fn interactive_repaint_fps_is_fixed_contract_target() {
+	assert_eq!(OverlaySession::interactive_repaint_fps(), 120.0);
 }
 
 #[test]

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -724,9 +724,6 @@ impl OverlaySession {
 
 			#[cfg(target_os = "macos")]
 			let cursor_rects = overlay::macos_install_overlay_cursor_rect_support(window.as_ref())?;
-			let refresh_rate_millihertz =
-				window.current_monitor().and_then(|monitor| monitor.refresh_rate_millihertz());
-
 			if visible {
 				window.request_redraw();
 				#[cfg(not(target_os = "macos"))]
@@ -749,7 +746,6 @@ impl OverlaySession {
 					cursor_rects,
 					window,
 					renderer,
-					refresh_rate_millihertz,
 				},
 			);
 		}

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -724,6 +724,7 @@ impl OverlaySession {
 
 			#[cfg(target_os = "macos")]
 			let cursor_rects = overlay::macos_install_overlay_cursor_rect_support(window.as_ref())?;
+
 			if visible {
 				window.request_redraw();
 				#[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Summary
- update the performance spec to make 120Hz / 8.33ms the hard active-interaction target
- remove refresh-rate-derived scheduling from the Rust overlay and Swift native host paths
- add native-host live chrome telemetry for first visible apply, fast-position cadence, and frame tick gaps
- prewarm HUD/loupe windows and pixel-align live chrome presentation to reduce startup and Retina stepping artifacts

## Validation
- cargo make fmt-check
- cargo make lint-swift
- cargo make test-macos-native-host
- cargo make lint-rust
- cargo make test-rust
- git diff --check
- signed release launched from target/rsnap-native-host/rsnap.app for local live-mode telemetry

## Notes
- The follow-up direction for moving live HUD/loupe into the overlay CALayer presentation path is intentionally not included here. This PR keeps the current NSWindow-based surface and adds the telemetry needed to evaluate that migration.