### PR TITLE
Move live chrome to overlay CALayers

### DIFF
--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -170,6 +170,14 @@ The current overlay runtime already exposes several useful diagnostic thresholds
   are low but the HUD or loupe still feels uneven.
 - Native-host `live_chrome.frame_tick_gap` reports the active live-frame clock interval. It should
   cluster around the fixed `120 Hz` budget (`8.33 ms`) during active live capture.
+- Native-host `live_chrome.layer_render_duration` reports the in-overlay CALayer presentation path
+  for live/frozen preview rendering when live chrome is not moved as separate windows.
+- Native-host `live_chrome.layer_chrome_render_duration` reports the in-overlay HUD/loupe content
+  refresh path after live chrome movement has been split from full overlay preview rendering.
+- Native-host `live_chrome.layer_position_duration` and `live_chrome.layer_position_gap` report the
+  layer-only live chrome move path used between full preview refreshes. The live chrome follow
+  clock may use a small scheduling headroom below `8.33 ms`, but acceptance is still judged against
+  the fixed `120 Hz` frame budget.
 
 These values are useful for diagnosis, but they are not the full performance contract:
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -89,6 +89,14 @@ struct LiveChromePositionSnapshot {
 	let inputSequence: UInt64
 }
 
+struct LiveChromeBackdropSnapshot {
+	let sourceWindowNumber: Int?
+	let hudFrame: CGRect?
+	let loupeFrame: CGRect?
+	let theme: CaptureChromeTheme
+	let settings: NativeHostSettings
+}
+
 @MainActor
 enum PhosphorToolbarIcons {
 	private final class BundleProbe {}
@@ -418,6 +426,144 @@ private final class LiveChromeOverlayWindow: NSWindow {
 		isPresented = false
 		lastPresentedFrame = nil
 		alphaValue = 1
+	}
+}
+
+private final class LiveChromeBackdropWindow: NSWindow {
+	let renderView: LiveChromeBackdropView
+	private var lastPresentedFrame: CGRect?
+	private var lastAppliedBlurAmount: CGFloat?
+	private var isPresented = false
+
+	init() {
+		self.renderView = LiveChromeBackdropView(frame: .zero)
+		super.init(
+			contentRect: CGRect(x: 0, y: 0, width: 1, height: 1),
+			styleMask: [.borderless],
+			backing: .buffered,
+			defer: false
+		)
+		contentView = renderView
+		backgroundColor = .clear
+		collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+		hasShadow = false
+		ignoresMouseEvents = true
+		isMovable = false
+		animationBehavior = .none
+		isOpaque = false
+		level = NSWindow.Level(rawValue: NSWindow.Level.screenSaver.rawValue - 1)
+		sharingType = .none
+		titleVisibility = .hidden
+		titlebarAppearsTransparent = true
+		orderOut(nil)
+	}
+
+	override var canBecomeKey: Bool { false }
+	override var canBecomeMain: Bool { false }
+
+	private var presentationScale: CGFloat {
+		max(
+			backingScaleFactor,
+			screen?.backingScaleFactor ?? 0,
+			NSScreen.main?.backingScaleFactor ?? 1,
+			1
+		)
+	}
+
+	private func presentationFrame(from frame: CGRect) -> CGRect {
+		let scale = presentationScale
+		return CGRect(
+			x: (frame.origin.x * scale).rounded() / scale,
+			y: (frame.origin.y * scale).rounded() / scale,
+			width: (frame.width * scale).rounded(.up) / scale,
+			height: (frame.height * scale).rounded(.up) / scale
+		)
+	}
+
+	func update(frame: CGRect, theme: CaptureChromeTheme, settings: NativeHostSettings) {
+		let roundedFrame = presentationFrame(from: frame)
+		let tolerance: CGFloat = 0.001
+		if let lastPresentedFrame {
+			let sizeChanged =
+				abs(lastPresentedFrame.width - roundedFrame.width) > tolerance
+				|| abs(lastPresentedFrame.height - roundedFrame.height) > tolerance
+			let originChanged =
+				abs(lastPresentedFrame.minX - roundedFrame.minX) > tolerance
+				|| abs(lastPresentedFrame.minY - roundedFrame.minY) > tolerance
+			if sizeChanged {
+				setFrame(roundedFrame, display: false, animate: false)
+			} else if originChanged {
+				setFrameOrigin(roundedFrame.origin)
+			}
+		} else {
+			setFrame(roundedFrame, display: false, animate: false)
+		}
+		lastPresentedFrame = roundedFrame
+
+		let blurAmount = settings.hudGlassEnabled ? settings.hudBlur : 0
+		if lastAppliedBlurAmount == nil || abs((lastAppliedBlurAmount ?? 0) - blurAmount) > 0.01 {
+			MacOSWindowBlurBridge.applyBlur(to: self, amount: blurAmount)
+			lastAppliedBlurAmount = blurAmount
+		}
+
+		renderView.update(theme: theme, settings: settings)
+		if !isPresented {
+			orderFrontRegardless()
+			isPresented = true
+		}
+		if alphaValue != 1 {
+			alphaValue = 1
+		}
+	}
+
+	func hide() {
+		guard isPresented else {
+			return
+		}
+		orderOut(nil)
+		isPresented = false
+		lastPresentedFrame = nil
+		alphaValue = 1
+	}
+}
+
+private final class LiveChromeBackdropView: NSView {
+	private var theme: CaptureChromeTheme = .dark
+	private var settings = NativeHostSettings.defaults
+
+	override var isOpaque: Bool { false }
+
+	func update(theme: CaptureChromeTheme, settings: NativeHostSettings) {
+		let changed = self.theme != theme || self.settings != settings
+		self.theme = theme
+		self.settings = settings
+		if changed {
+			needsDisplay = true
+		}
+	}
+
+	override func draw(_ dirtyRect: NSRect) {
+		super.draw(dirtyRect)
+		let palette = CaptureChrome.palette(for: theme, settings: settings)
+		let pillPath = NSBezierPath(
+			roundedRect: bounds,
+			xRadius: CaptureChrome.hudCornerRadius,
+			yRadius: CaptureChrome.hudCornerRadius
+		)
+		guard let context = NSGraphicsContext.current?.cgContext else {
+			return
+		}
+		context.saveGState()
+		context.setShadow(offset: .zero, blur: 10, color: palette.shadow.cgColor)
+		context.setFillColor(
+			CaptureChrome.effectiveBodyFill(
+				palette: palette,
+				settings: settings,
+				hasGlass: true
+			).cgColor
+		)
+		pillPath.fill()
+		context.restoreGState()
 	}
 }
 
@@ -899,6 +1045,44 @@ final class LiveChromeVisualWindowController {
 	}
 
 	func hideLiveWindows() {
+		hudWindow.hide()
+		loupeWindow.hide()
+	}
+}
+
+@MainActor
+final class LiveChromeBackdropWindowController {
+	private let hudWindow = LiveChromeBackdropWindow()
+	private let loupeWindow = LiveChromeBackdropWindow()
+
+	func update(snapshot: LiveChromeBackdropSnapshot?, focusedWindowNumber: Int?) {
+		guard let snapshot else {
+			hideAll()
+			return
+		}
+		guard snapshot.sourceWindowNumber == focusedWindowNumber else {
+			return
+		}
+		guard snapshot.settings.hudGlassEnabled, snapshot.settings.hudBlur > 0.01 else {
+			hideAll()
+			return
+		}
+
+		if let hudFrame = snapshot.hudFrame {
+			hudWindow.update(frame: hudFrame, theme: snapshot.theme, settings: snapshot.settings)
+		} else {
+			hudWindow.hide()
+		}
+
+		if let loupeFrame = snapshot.loupeFrame {
+			loupeWindow.update(
+				frame: loupeFrame, theme: snapshot.theme, settings: snapshot.settings)
+		} else {
+			loupeWindow.hide()
+		}
+	}
+
+	func hideAll() {
 		hudWindow.hide()
 		loupeWindow.hide()
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1,6 +1,5 @@
 import AppKit
 import CoreGraphics
-import CoreImage
 import Foundation
 import QuartzCore
 import RsnapHostBridge
@@ -8,14 +7,6 @@ import RsnapHostBridge
 enum LiveGlassSurfaceKind: Hashable {
 	case hud
 	case loupe
-}
-
-struct GlassPatchRequest {
-	let kind: LiveGlassSurfaceKind
-	let globalRect: CGRect
-	let blurAmount: CGFloat
-	let tintAmount: CGFloat
-	let brightnessBias: CGFloat
 }
 
 struct LivePreviewSnapshot {
@@ -249,138 +240,6 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		stateLock.lock()
 		latestSample = sample
 		stateLock.unlock()
-	}
-}
-
-final class GlassPatchFeed {
-	private struct CachedPatch {
-		let request: GlassPatchRequest
-		let capturedAt: TimeInterval
-		let image: CGImage
-	}
-
-	private let queue = DispatchQueue(
-		label: "ink.hack.rsnap.native-host.glass-patch-feed", qos: .utility)
-	private let stateLock = NSLock()
-	private let capturePatch: (CGRect) -> CGImage?
-	private let ciContext = CIContext(options: nil)
-	private var timer: DispatchSourceTimer?
-	private var requests: [LiveGlassSurfaceKind: GlassPatchRequest] = [:]
-	private var cachedPatches: [LiveGlassSurfaceKind: CachedPatch] = [:]
-
-	init(capturePatch: @escaping (CGRect) -> CGImage?) {
-		self.capturePatch = capturePatch
-	}
-
-	func start() {
-		stop()
-		let timer = DispatchSource.makeTimerSource(queue: queue)
-		let interval = TimeInterval(1.0 / 12.0)
-		timer.schedule(deadline: .now() + interval, repeating: interval)
-		timer.setEventHandler { [weak self] in
-			self?.refresh()
-		}
-		self.timer = timer
-		timer.resume()
-	}
-
-	func stop() {
-		timer?.cancel()
-		timer = nil
-		stateLock.lock()
-		requests.removeAll()
-		cachedPatches.removeAll()
-		stateLock.unlock()
-	}
-
-	func updateRequests(_ requests: [GlassPatchRequest]) {
-		let nextRequests = Dictionary(uniqueKeysWithValues: requests.map { ($0.kind, $0) })
-		stateLock.lock()
-		self.requests = nextRequests
-		cachedPatches = cachedPatches.filter { nextRequests[$0.key] != nil }
-		stateLock.unlock()
-	}
-
-	func snapshot() -> [LiveGlassSurfaceKind: CGImage] {
-		stateLock.lock()
-		let result = cachedPatches.mapValues(\.image)
-		stateLock.unlock()
-		return result
-	}
-
-	private func refresh() {
-		stateLock.lock()
-		let requests = self.requests
-		let cachedPatches = self.cachedPatches
-		stateLock.unlock()
-
-		var nextCachedPatches = cachedPatches
-		let now = ProcessInfo.processInfo.systemUptime
-
-		for (kind, request) in requests {
-			if let cachedPatch = cachedPatches[kind] {
-				let cachedCenter = CGPoint(
-					x: cachedPatch.request.globalRect.midX, y: cachedPatch.request.globalRect.midY)
-				let nextCenter = CGPoint(x: request.globalRect.midX, y: request.globalRect.midY)
-				let distance = hypot(cachedCenter.x - nextCenter.x, cachedCenter.y - nextCenter.y)
-				if distance < 24, now - cachedPatch.capturedAt < 0.08 {
-					continue
-				}
-			}
-
-			guard
-				let patch = capturePatch(request.globalRect),
-				let blurred = blurredImage(
-					from: patch,
-					blurAmount: request.blurAmount,
-					tintAmount: request.tintAmount,
-					brightnessBias: request.brightnessBias
-				)
-			else {
-				continue
-			}
-			nextCachedPatches[kind] = CachedPatch(request: request, capturedAt: now, image: blurred)
-		}
-
-		stateLock.lock()
-		self.cachedPatches = nextCachedPatches
-		stateLock.unlock()
-	}
-
-	private func blurredImage(from image: CGImage, blurAmount: CGFloat) -> CGImage? {
-		blurredImage(from: image, blurAmount: blurAmount, tintAmount: 0, brightnessBias: 0)
-	}
-
-	private func blurredImage(
-		from image: CGImage,
-		blurAmount: CGFloat,
-		tintAmount: CGFloat,
-		brightnessBias: CGFloat
-	) -> CGImage? {
-		let ciImage = CIImage(cgImage: image)
-		let clampedImage = ciImage.clampedToExtent()
-		guard let filter = CIFilter(name: "CIGaussianBlur") else {
-			return image
-		}
-		filter.setValue(clampedImage, forKey: kCIInputImageKey)
-		let normalizedBlur = blurAmount.clamped(to: 0...1)
-		let blurRadius = 4 + pow(normalizedBlur, 0.82) * 44
-		filter.setValue(blurRadius, forKey: kCIInputRadiusKey)
-		guard let outputImage = filter.outputImage?.cropped(to: ciImage.extent) else {
-			return image
-		}
-		let tunedImage: CIImage
-		if let colorControls = CIFilter(name: "CIColorControls") {
-			colorControls.setValue(outputImage, forKey: kCIInputImageKey)
-			colorControls.setValue(
-				1.08 + tintAmount.clamped(to: 0...1) * 0.34, forKey: kCIInputSaturationKey)
-			colorControls.setValue(1.03, forKey: kCIInputContrastKey)
-			colorControls.setValue(brightnessBias, forKey: kCIInputBrightnessKey)
-			tunedImage = colorControls.outputImage?.cropped(to: ciImage.extent) ?? outputImage
-		} else {
-			tunedImage = outputImage
-		}
-		return ciContext.createCGImage(tunedImage, from: tunedImage.extent) ?? image
 	}
 }
 
@@ -916,7 +775,24 @@ final class LiveOverlayRenderer {
 	private let loupePatchLayer = CALayer()
 	private let loupeCenterLayer = CAShapeLayer()
 	private let frameClock = LiveFrameClockDriver()
+	private let layerRenderDurationMetric = NativeHostTelemetry.distribution(
+		"live_chrome.layer_render_duration",
+		category: "LiveChromeTelemetry"
+	)
+	private let layerChromeRenderDurationMetric = NativeHostTelemetry.distribution(
+		"live_chrome.layer_chrome_render_duration",
+		category: "LiveChromeTelemetry"
+	)
+	private let layerPositionDurationMetric = NativeHostTelemetry.distribution(
+		"live_chrome.layer_position_duration",
+		category: "LiveChromeTelemetry"
+	)
+	private let layerPositionGapMetric = NativeHostTelemetry.distribution(
+		"live_chrome.layer_position_gap",
+		category: "LiveChromeTelemetry"
+	)
 	private var snapshotProvider: (() -> LivePreviewSnapshot?)?
+	private var lastLayerPositionMoveUptime: TimeInterval?
 
 	init(hostView: NSView) {
 		self.hostView = hostView
@@ -947,6 +823,10 @@ final class LiveOverlayRenderer {
 		frameClock.start(targetFramesPerSecond: targetFramesPerSecond)
 	}
 
+	func stopFrameClock() {
+		frameClock.stop()
+	}
+
 	func stop() {
 		frameClock.stop()
 		rootLayer.isHidden = true
@@ -959,6 +839,35 @@ final class LiveOverlayRenderer {
 	func renderNow() {
 		renderCurrentSnapshot()
 		onTick?()
+	}
+
+	func renderLiveChromeNow() {
+		renderChromeSnapshot()
+		onTick?()
+	}
+
+	func moveLiveChrome(hudFrame: CGRect?, loupeFrame: CGRect?) {
+		let moveStart = ProcessInfo.processInfo.systemUptime
+		var moved = false
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		if let hudFrame, !hudLayer.isHidden, layerFrameNeedsUpdate(hudLayer.frame, hudFrame) {
+			hudLayer.frame = hudFrame
+			moved = true
+		}
+		if let loupeFrame, !loupeLayer.isHidden,
+			layerFrameNeedsUpdate(loupeLayer.frame, loupeFrame)
+		{
+			loupeLayer.frame = loupeFrame
+			moved = true
+		}
+		CATransaction.commit()
+
+		guard moved else {
+			return
+		}
+		layerPositionDurationMetric.recordMillisecondsSince(moveStart)
+		recordLayerPositionGap(moveStart)
 	}
 
 	private func configureLayers() {
@@ -1012,6 +921,10 @@ final class LiveOverlayRenderer {
 			rootLayer.isHidden = true
 			return
 		}
+		let renderStart = ProcessInfo.processInfo.systemUptime
+		defer {
+			layerRenderDurationMetric.recordMillisecondsSince(renderStart)
+		}
 		CATransaction.begin()
 		CATransaction.setDisableActions(true)
 		rootLayer.isHidden = false
@@ -1021,6 +934,45 @@ final class LiveOverlayRenderer {
 		renderHud(snapshot)
 		renderLoupe(snapshot)
 		CATransaction.commit()
+	}
+
+	private func renderChromeSnapshot() {
+		guard let snapshot = snapshotProvider?() else {
+			rootLayer.isHidden = true
+			return
+		}
+		let renderStart = ProcessInfo.processInfo.systemUptime
+		defer {
+			layerChromeRenderDurationMetric.recordMillisecondsSince(renderStart)
+		}
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		rootLayer.isHidden = false
+		rootLayer.frame = snapshot.bounds
+		renderHud(snapshot)
+		renderLoupe(snapshot)
+		CATransaction.commit()
+	}
+
+	private func layerFrameNeedsUpdate(_ current: CGRect, _ next: CGRect) -> Bool {
+		abs(current.minX - next.minX) > 0.001
+			|| abs(current.minY - next.minY) > 0.001
+			|| abs(current.width - next.width) > 0.001
+			|| abs(current.height - next.height) > 0.001
+	}
+
+	private func recordLayerPositionGap(_ moveUptime: TimeInterval) {
+		defer {
+			lastLayerPositionMoveUptime = moveUptime
+		}
+		guard let lastLayerPositionMoveUptime else {
+			return
+		}
+		let gapMilliseconds = (moveUptime - lastLayerPositionMoveUptime) * 1_000
+		guard gapMilliseconds >= 0, gapMilliseconds < 250 else {
+			return
+		}
+		layerPositionGapMetric.record(gapMilliseconds)
 	}
 
 	private func renderFrozenDisplay(_ snapshot: LivePreviewSnapshot) {
@@ -1315,26 +1267,30 @@ final class LiveOverlayRenderer {
 		)
 		let glassEnabled = settings.hudGlassEnabled && settings.hudBlur > 0.01
 		let opacity = CGFloat(settings.hudOpacity.clamped(to: 0...1))
-		let hasGlass = glassEnabled && glassImage != nil
+		let hasInlineGlass = glassEnabled && glassImage != nil
+		let usesExternalGlass = glassEnabled && glassImage == nil
+		let hasGlass = hasInlineGlass || usesExternalGlass
 
 		container.cornerRadius = cornerRadius
 		container.shadowColor = palette.shadow.cgColor
 		container.shadowOffset = .zero
 		container.shadowRadius = 10
-		container.shadowOpacity = Float(max(0.12, opacity * 0.75))
+		container.shadowOpacity = usesExternalGlass ? 0 : Float(max(0.12, opacity * 0.75))
 
 		glassLayer.frame = frame
 		glassLayer.cornerRadius = cornerRadius
 		glassLayer.masksToBounds = true
 		glassLayer.contentsGravity = .resizeAspectFill
 		glassLayer.contents = glassImage
-		glassLayer.opacity = hasGlass ? CaptureChrome.glassOpacity(settings: settings) : 0
-		glassLayer.isHidden = !hasGlass
+		glassLayer.opacity = hasInlineGlass ? CaptureChrome.glassOpacity(settings: settings) : 0
+		glassLayer.isHidden = !hasInlineGlass
 
 		fillLayer.frame = frame
 		fillLayer.cornerRadius = cornerRadius
 		fillLayer.backgroundColor =
-			CaptureChrome.effectiveBodyFill(
+			usesExternalGlass
+			? NSColor.clear.cgColor
+			: CaptureChrome.effectiveBodyFill(
 				palette: palette,
 				settings: settings,
 				hasGlass: hasGlass

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -469,12 +469,8 @@ final class CaptureSessionController: NSObject {
 		)
 	}
 
-	func updateLiveGlassRequests(_ requests: [GlassPatchRequest]) {
-		overlayController?.updateLiveGlassRequests(requests)
-	}
-
-	func liveGlassPatches() -> [LiveGlassSurfaceKind: CGImage] {
-		overlayController?.liveGlassPatches() ?? [:]
+	func updateLiveChromeBackdrops(_ snapshot: LiveChromeBackdropSnapshot?) {
+		overlayController?.updateLiveChromeBackdrops(snapshot)
 	}
 
 	func updateLiveChromeVisuals(_ snapshot: LiveChromeVisualSnapshot?) {
@@ -1877,6 +1873,7 @@ final class CaptureOverlayController {
 	private lazy var windowSnapshotFeed = WindowSnapshotFeed()
 	private lazy var chromeSampleFeed = ChromeSampleFeed(broker: liveFrameStream)
 	private let liveChromeWindows = LiveChromeVisualWindowController()
+	private let liveChromeBackdrops = LiveChromeBackdropWindowController()
 
 	init(controller: CaptureSessionController, liveFrameStream: LiveFrameStreamBroker) {
 		self.controller = controller
@@ -1926,7 +1923,6 @@ final class CaptureOverlayController {
 			}
 		}
 		collapsedForFrozen = false
-		liveChromeWindows.prepareForLivePresentation(settings: settings)
 		liveFrameStream.start(for: NSScreen.screens, prewarmPoint: focusPoint)
 		windowSnapshotFeed.start(
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
@@ -1997,6 +1993,7 @@ final class CaptureOverlayController {
 	func close() {
 		windowSnapshotFeed.stop()
 		chromeSampleFeed.stop()
+		liveChromeBackdrops.hideAll()
 		liveChromeWindows.hideAll()
 		guard !windows.isEmpty else {
 			focusedWindowNumber = nil
@@ -2104,21 +2101,16 @@ final class CaptureOverlayController {
 		return latestSample
 	}
 
-	fileprivate func updateLiveGlassRequests(_ requests: [GlassPatchRequest]) {
-		let _ = requests
-	}
-
-	fileprivate func liveGlassPatches() -> [LiveGlassSurfaceKind: CGImage] {
-		[:]
-	}
-
 	fileprivate func updateLiveChromeVisuals(
 		_ snapshot: LiveChromeVisualSnapshot?
 	) {
-		guard snapshot != nil else {
-			return
-		}
 		liveChromeWindows.update(snapshot: snapshot, focusedWindowNumber: focusedWindowNumber)
+	}
+
+	fileprivate func updateLiveChromeBackdrops(
+		_ snapshot: LiveChromeBackdropSnapshot?
+	) {
+		liveChromeBackdrops.update(snapshot: snapshot, focusedWindowNumber: focusedWindowNumber)
 	}
 
 	fileprivate func updateLiveChromePositions(
@@ -2236,6 +2228,7 @@ final class CaptureOverlayController {
 		}
 		windowSnapshotFeed.stop()
 		chromeSampleFeed.stop()
+		liveChromeBackdrops.hideAll()
 		liveChromeWindows.hideLiveWindows()
 
 		guard windows.count > 1 else {
@@ -2434,6 +2427,7 @@ final class CaptureHostView: NSView {
 	private var glassPatchCache: [GlassSurfaceKind: GlassPatchCache] = [:]
 	private lazy var liveRenderer = LiveOverlayRenderer(hostView: self)
 	private var liveRendererInstalled = false
+	private var liveChromeFollowTimer: DispatchSourceTimer?
 	private var deferredLiveShutdownWorkItem: DispatchWorkItem?
 	private var loggedLiveTargetHz: Int?
 
@@ -2469,6 +2463,9 @@ final class CaptureHostView: NSView {
 		chrome: CaptureChromeState,
 		settings: NativeHostSettings
 	) {
+		let previousScene = self.scene
+		let previousChrome = self.chrome
+		let previousSettings = self.settings
 		let previousMode = self.scene.mode
 		let transitioningToFrozen = previousMode == .live && scene.mode == .frozen
 		if scene.mode != .frozen {
@@ -2506,7 +2503,16 @@ final class CaptureHostView: NSView {
 		updateLiveRendererState()
 		if scene.mode == .live {
 			updateLivePreviewDemands()
-			liveRenderer.renderNow()
+			if shouldRenderFullLiveOverlay(
+				previousScene: previousScene,
+				previousChrome: previousChrome,
+				previousSettings: previousSettings,
+				previousMode: previousMode
+			) {
+				liveRenderer.renderNow()
+			} else {
+				liveRenderer.renderLiveChromeNow()
+			}
 		} else {
 			if transitioningToFrozen {
 				needsDisplay = true
@@ -2520,6 +2526,22 @@ final class CaptureHostView: NSView {
 				controller?.updateLiveChromeVisuals(currentChromeVisualSnapshot())
 			}
 		}
+	}
+
+	private func shouldRenderFullLiveOverlay(
+		previousScene: SceneSnapshot,
+		previousChrome: CaptureChromeState,
+		previousSettings: NativeHostSettings,
+		previousMode: SceneKind
+	) -> Bool {
+		guard scene.mode == .live else {
+			return false
+		}
+		return previousMode != .live
+			|| previousScene.liveSelectionPreview != scene.liveSelectionPreview
+			|| previousScene.highlightedWindow != scene.highlightedWindow
+			|| previousChrome.hostLocalFrozenSelecting != chrome.hostLocalFrozenSelecting
+			|| previousSettings != settings
 	}
 
 	private func completeFrozenFirstDisplayHandoff() {
@@ -2982,14 +3004,15 @@ final class CaptureHostView: NSView {
 		guard scene.mode == .live else {
 			return
 		}
-		let pointerChanged = setLivePointerPreview(to: globalPoint)
-		if pointerChanged {
-			controller?.updateLiveChromePositions(currentLiveChromePositionSnapshot())
-		}
-		liveHighlightedWindowPreview =
+		// The follow clock owns routine layer movement so event bursts cannot create
+		// irregular extra commits between fixed 120Hz ticks.
+		_ = setLivePointerPreview(to: globalPoint)
+		let nextHighlightedWindow =
 			controller?.previewHighlightedWindow(at: globalPoint) ?? scene.highlightedWindow
-		updateLivePreviewDemands()
-		if rendersImmediately {
+		let highlightChanged = liveHighlightedWindowPreview != nextHighlightedWindow
+		liveHighlightedWindowPreview = nextHighlightedWindow
+		if rendersImmediately || highlightChanged {
+			updateLivePreviewDemands()
 			liveRenderer.renderNow()
 		}
 	}
@@ -3871,6 +3894,18 @@ final class CaptureHostView: NSView {
 			: nil
 		let positionDisplay = currentPositionDisplay()
 		let colorDisplay = currentLiveColorDisplay(for: rgbSample)
+		let hudPlacement = liveHoverChromeSuppressed ? nil : currentHudPlacement()
+		let hudFrame = hudPlacement?.frame
+		let loupeFrame =
+			!liveHoverChromeSuppressed && scene.loupeVisible
+			? hudPlacement.flatMap {
+				currentLoupeFrame(
+					hudFrame: $0.frame,
+					patch: chromeSample?.loupePatch,
+					alignTrailing: $0.flippedHorizontally
+				)
+			}
+			: nil
 
 		return LivePreviewSnapshot(
 			bounds: bounds,
@@ -3883,8 +3918,8 @@ final class CaptureHostView: NSView {
 			dragSelectionLocal: dragSelectionLocal,
 			hoverSelectionLocal: hoverSelectionLocal,
 			selectionSizeText: dragSelectionLocal.map(selectionSizeText(for:)),
-			hudFrame: nil,
-			loupeFrame: nil,
+			hudFrame: hudFrame,
+			loupeFrame: loupeFrame,
 			positionDisplay: positionDisplay,
 			colorDisplay: colorDisplay,
 			rgbSample: rgbSample,
@@ -3898,119 +3933,113 @@ final class CaptureHostView: NSView {
 		_ globalPoint: CGPoint,
 		recordsInputLatency: Bool = true
 	) {
-		let pointerChanged = setLivePointerPreview(
+		_ = setLivePointerPreview(
 			to: globalPoint,
 			recordsInputLatency: recordsInputLatency
 		)
-		if pointerChanged {
-			controller?.updateLiveChromePositions(currentLiveChromePositionSnapshot())
-		}
 		liveHighlightedWindowPreview =
 			controller?.previewHighlightedWindow(at: globalPoint) ?? liveHighlightedWindowPreview
+	}
+
+	private func startLiveChromeFollowClock() {
+		guard liveChromeFollowTimer == nil else {
+			return
+		}
+		let timer = DispatchSource.makeTimerSource(queue: .main)
+		let intervalNanoseconds = max(
+			1,
+			Int((NativeHostDisplayRefresh.followClockInterval * 1_000_000_000.0).rounded())
+		)
+		timer.schedule(
+			deadline: .now(),
+			repeating: .nanoseconds(intervalNanoseconds),
+			leeway: .nanoseconds(0)
+		)
+		timer.setEventHandler { [weak self] in
+			self?.pollLiveChromeFollowPosition()
+		}
+		liveChromeFollowTimer = timer
+		timer.resume()
+	}
+
+	private func stopLiveChromeFollowClock() {
+		liveChromeFollowTimer?.cancel()
+		liveChromeFollowTimer = nil
+	}
+
+	private func pollLiveChromeFollowPosition() {
+		guard scene.mode == .live else {
+			stopLiveChromeFollowClock()
+			return
+		}
+		let point = NSEvent.mouseLocation
+		let pointerChanged = setLivePointerPreview(to: point, recordsInputLatency: false)
+		let nextHighlightedWindow =
+			controller?.previewHighlightedWindow(at: point) ?? scene.highlightedWindow
+		let highlightChanged = liveHighlightedWindowPreview != nextHighlightedWindow
+		liveHighlightedWindowPreview = nextHighlightedWindow
+		if highlightChanged {
+			updateLivePreviewDemands()
+			updateLiveChromeBackdrops()
+			liveRenderer.renderNow()
+		} else if pointerChanged {
+			updateLivePreviewDemands()
+			moveLiveChromeLayers()
+		}
+	}
+
+	private func moveLiveChromeLayers() {
+		let frames = currentLiveChromeLayerFrames()
+		updateLiveChromeBackdrops(hudFrame: frames.hud, loupeFrame: frames.loupe)
+		liveRenderer.moveLiveChrome(hudFrame: frames.hud, loupeFrame: frames.loupe)
+	}
+
+	private func updateLiveChromeBackdrops() {
+		let frames = currentLiveChromeLayerFrames()
+		updateLiveChromeBackdrops(hudFrame: frames.hud, loupeFrame: frames.loupe)
+	}
+
+	private func updateLiveChromeBackdrops(hudFrame: CGRect?, loupeFrame: CGRect?) {
+		guard scene.mode == .live, settings.hudGlassEnabled && settings.hudBlur > 0.01 else {
+			controller?.updateLiveChromeBackdrops(nil)
+			return
+		}
+		controller?.updateLiveChromeBackdrops(
+			LiveChromeBackdropSnapshot(
+				sourceWindowNumber: window?.windowNumber,
+				hudFrame: hudFrame.flatMap(globalRect(from:)),
+				loupeFrame: loupeFrame.flatMap(globalRect(from:)),
+				theme: chromeTheme(),
+				settings: settings
+			)
+		)
+	}
+
+	private func currentLiveChromeLayerFrames() -> (hud: CGRect?, loupe: CGRect?) {
+		let hudPlacement = liveHoverChromeSuppressed ? nil : currentHudPlacement()
+		let hudFrame = hudPlacement?.frame
+		let loupeFrame =
+			!liveHoverChromeSuppressed && scene.loupeVisible
+			? hudPlacement.flatMap {
+				currentLoupeFrame(
+					hudFrame: $0.frame,
+					patch: chrome.loupePatch,
+					alignTrailing: $0.flippedHorizontally
+				)
+			}
+			: nil
+		return (hudFrame, loupeFrame)
 	}
 
 	private func currentChromeVisualSnapshot() -> LiveChromeVisualSnapshot? {
 		switch scene.mode {
 		case .live:
-			return currentLiveChromeVisualSnapshot()
+			return nil
 		case .frozen:
 			return currentFrozenChromeVisualSnapshot()
 		case .hidden:
 			return nil
 		}
-	}
-
-	private func currentLiveChromeVisualSnapshot() -> LiveChromeVisualSnapshot? {
-		guard scene.mode == .live, let sourceWindowNumber = window?.windowNumber else {
-			return nil
-		}
-
-		let chromeSample = currentLiveChromeSample()
-		let rgbSample =
-			chromeSample?.rgbSample
-			?? chrome.rgbSample
-			?? scene.rgb
-		let hudPlacement = liveHoverChromeSuppressed ? nil : currentHudPlacement()
-		let hudFrameLocal = hudPlacement?.frame
-		let hudFrame = hudFrameLocal.flatMap(globalRect(from:))
-		let loupeFrame =
-			!liveHoverChromeSuppressed && scene.loupeVisible
-			? hudFrameLocal
-				.flatMap {
-					currentLoupeFrame(
-						hudFrame: $0,
-						patch: chromeSample?.loupePatch,
-						alignTrailing: hudPlacement?.flippedHorizontally ?? false
-					)
-				}
-				.flatMap(globalRect(from:))
-			: nil
-		let theme = chromeTheme()
-		let positionDisplay = currentPositionDisplay()
-		let colorDisplay = currentLiveColorDisplay(for: rgbSample)
-
-		let hudSnapshot = hudFrame.map {
-			LiveHudVisualSnapshot(
-				sourceWindowNumber: sourceWindowNumber,
-				frame: $0,
-				theme: theme,
-				settings: settings,
-				positionDisplay: positionDisplay,
-				colorDisplay: colorDisplay,
-				rgbSample: rgbSample,
-				keycapVisible: settings.showAltHintKeycap,
-				inputUptime: livePointerPreviewInputUptime,
-				inputSequence: livePointerPreviewInputSequence
-			)
-		}
-		let loupeSnapshot: LiveLoupeVisualSnapshot? = {
-			guard let frame = loupeFrame, let patch = chromeSample?.loupePatch else {
-				return nil
-			}
-			return LiveLoupeVisualSnapshot(
-				sourceWindowNumber: sourceWindowNumber,
-				frame: frame,
-				theme: theme,
-				settings: settings,
-				patch: patch,
-				inputUptime: livePointerPreviewInputUptime,
-				inputSequence: livePointerPreviewInputSequence
-			)
-		}()
-
-		return LiveChromeVisualSnapshot(
-			sourceWindowNumber: sourceWindowNumber,
-			hud: hudSnapshot,
-			loupe: loupeSnapshot,
-			toolbar: nil
-		)
-	}
-
-	private func currentLiveChromePositionSnapshot() -> LiveChromePositionSnapshot? {
-		guard scene.mode == .live, let sourceWindowNumber = window?.windowNumber else {
-			return nil
-		}
-		let hudPlacement = liveHoverChromeSuppressed ? nil : currentHudPlacement()
-		let hudFrame = hudPlacement.flatMap { globalRect(from: $0.frame) }
-		let loupeFrame =
-			!liveHoverChromeSuppressed && scene.loupeVisible
-			? hudPlacement
-				.flatMap {
-					currentLoupeFrame(
-						hudFrame: $0.frame,
-						patch: chrome.loupePatch,
-						alignTrailing: $0.flippedHorizontally
-					)
-				}
-				.flatMap(globalRect(from:))
-			: nil
-		return LiveChromePositionSnapshot(
-			sourceWindowNumber: sourceWindowNumber,
-			hudFrame: hudFrame,
-			loupeFrame: loupeFrame,
-			inputUptime: livePointerPreviewInputUptime,
-			inputSequence: livePointerPreviewInputSequence
-		)
 	}
 
 	private func currentFrozenChromeVisualSnapshot() -> LiveChromeVisualSnapshot? {
@@ -4131,6 +4160,7 @@ final class CaptureHostView: NSView {
 			return
 		}
 		guard scene.mode == .live || pendingFrozenFirstDisplay else {
+			stopLiveChromeFollowClock()
 			liveRenderer.suspend()
 			loggedLiveTargetHz = nil
 			return
@@ -4145,6 +4175,12 @@ final class CaptureHostView: NSView {
 				frameBudgetMilliseconds: NativeHostDisplayRefresh.frameBudgetMilliseconds
 			)
 		}
+		if scene.mode == .live {
+			liveRenderer.stopFrameClock()
+			startLiveChromeFollowClock()
+			return
+		}
+		stopLiveChromeFollowClock()
 		liveRenderer.updateDisplayID(currentDisplayID(), targetFramesPerSecond: targetHz)
 	}
 
@@ -4153,6 +4189,7 @@ final class CaptureHostView: NSView {
 		deferredLiveShutdownWorkItem = nil
 		pendingFrozenFirstDisplay = false
 		lastLivePreviewSnapshot = nil
+		stopLiveChromeFollowClock()
 		guard scene.mode != .live else {
 			return
 		}
@@ -4164,6 +4201,7 @@ final class CaptureHostView: NSView {
 		guard scene.mode == .live else {
 			controller?.updateLivePreviewDemand(
 				point: nil, settings: settings, includeLoupePatch: false)
+			controller?.updateLiveChromeBackdrops(nil)
 			return
 		}
 		let point = livePointerPreviewGlobal ?? scene.pointer
@@ -4172,6 +4210,7 @@ final class CaptureHostView: NSView {
 			settings: settings,
 			includeLoupePatch: scene.loupeVisible && !liveHoverChromeSuppressed
 		)
+		updateLiveChromeBackdrops()
 	}
 
 	private func currentDisplayID() -> CGDirectDisplayID? {
@@ -4409,6 +4448,7 @@ final class CaptureHostView: NSView {
 		for materialView in [hudMaterialView, loupeMaterialView] {
 			materialView.isHidden = true
 		}
+		updateLiveChromeBackdrops()
 	}
 
 	private func suppressLiveHoverChrome() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostDisplayRefresh.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostDisplayRefresh.swift
@@ -7,6 +7,10 @@ enum NativeHostDisplayRefresh {
 		1.0 / Double(targetFramesPerSecond)
 	}
 
+	static var followClockInterval: TimeInterval {
+		frameInterval * 0.92
+	}
+
 	static var frameBudgetMilliseconds: Double {
 		frameInterval * 1_000
 	}


### PR DESCRIPTION
Summary:
- Move live HUD and loupe presentation into overlay-managed CALayers.
- Split full preview rendering from lightweight live chrome render and position updates.
- Add live_chrome layer telemetry and document the follow-clock headroom path.

Validation:
- cargo make fmt
- cargo make lint-fix
- cargo make checks
- cargo make test-macos-native-host

Notes:
- Rebases onto main after PR #131 landed, so this PR contains only the CALayer direction.