### PR TITLE
Add live chrome glass mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ macOS-first screenshot prototype in native-host / Rust-core reset.
 - Scroll capture is currently implemented on macOS for dragged-region freezes and uses image-first downward stitching with a live side preview.
 - Upward scrolling may be observed for rewind/reacquire, but it never appends stitched rows.
 - `Esc` cancels capture; during scroll capture, `Esc` / `Back` returns to normal Frozen mode.
-- Glass HUD with configurable blur, tint, and hue controls.
+- Glass HUD with Liquid Glass on supported macOS, plus classic blur/tint controls.
 - Tab-triggered loupe sample and frozen-mode toolbar for quick action access.
 
 ## Status
@@ -98,17 +98,15 @@ cargo run -p rsnap
 
 - The native `Settings…` window currently owns:
   - HUD glass enable/disable
-  - HUD opacity / blur / tint / hue
+  - HUD glass style (`Liquid Glass` / `Classic Blur`)
+  - Liquid Glass style (`Regular` / `Clear`) when supported by macOS
+  - Classic HUD opacity / blur / tint / color
   - HUD `Tab` hint visibility
   - loupe sample size (`small` / `medium` / `large`)
   - output directory
   - filename prefix
   - output naming (`timestamp` / `sequence`)
   - frozen toolbar placement (`bottom` / `top`)
-- Legacy `settings.toml` values for `show_alt_hint_keycap`, `hud_glass_enabled`, `hud_opacity`,
-  `hud_blur`, `hud_tint`, `hud_tint_hue`, `loupe_sample_size`, `output_dir`,
-  `output_filename_prefix`, `output_naming`, and `toolbar_placement` are migrated into the native
-  settings store on first launch.
 
 ### Output (save-to-disk)
 

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -159,25 +159,18 @@ The current overlay runtime already exposes several useful diagnostic thresholds
 - `OVERLAY_EVENT_LOOP_STALL_THRESHOLD = 250 ms` for severe event-loop stalls.
 - `overlay.live_sample_apply_latency` is logged once latency reaches `12 ms`.
 - Native-host `live_chrome.hud.apply_latency` and `live_chrome.loupe.apply_latency` measure the
-  first successful visible apply for a live input sequence. If the position-only fast path moves
-  the HUD or loupe first, that fast-path apply owns the sample and the later full snapshot refresh
-  must not re-record the same input sequence as a slower apply.
-- Native-host `live_chrome.*.fast_position_latency` and
-  `live_chrome.*.fast_position_duration` are diagnostic signals for the position-only fast path;
-  they do not replace the first-visible-apply latency metric.
-- Native-host `live_chrome.*.fast_position_gap` reports the interval between successful
-  position-only moves. Use it to diagnose cadence jitter when per-move duration and apply latency
-  are low but the HUD or loupe still feels uneven.
+  first successful visible apply for a live input sequence.
+- Native-host `live_chrome.hud.window_update_duration`,
+  `live_chrome.loupe.window_update_duration`, and `live_chrome.update_duration` report the external
+  live chrome window update path used by Liquid Glass HUD/loupe presentation.
 - Native-host `live_chrome.frame_tick_gap` reports the active live-frame clock interval. It should
   cluster around the fixed `120 Hz` budget (`8.33 ms`) during active live capture.
 - Native-host `live_chrome.layer_render_duration` reports the in-overlay CALayer presentation path
   for live/frozen preview rendering when live chrome is not moved as separate windows.
 - Native-host `live_chrome.layer_chrome_render_duration` reports the in-overlay HUD/loupe content
   refresh path after live chrome movement has been split from full overlay preview rendering.
-- Native-host `live_chrome.layer_position_duration` and `live_chrome.layer_position_gap` report the
-  layer-only live chrome move path used between full preview refreshes. The live chrome follow
-  clock may use a small scheduling headroom below `8.33 ms`, but acceptance is still judged against
-  the fixed `120 Hz` frame budget.
+- The live chrome follow clock may use a small scheduling headroom below `8.33 ms`, but acceptance
+  is still judged against the fixed `120 Hz` frame budget.
 
 These values are useful for diagnosis, but they are not the full performance contract:
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -373,31 +373,35 @@ private final class LiveChromeLiquidGlassView: NSView {
 	}
 
 	private static func makeGlassRoot(settings: NativeHostSettings) -> AnyView {
-		if #available(macOS 26.0, *) {
-			return makeAvailableGlassRoot(settings: settings)
-		}
+		#if compiler(>=6.2)
+			if #available(macOS 26.0, *) {
+				return makeAvailableGlassRoot(settings: settings)
+			}
+		#endif
 		return AnyView(Color.clear)
 	}
 
-	@available(macOS 26.0, *)
-	private static func makeAvailableGlassRoot(settings: NativeHostSettings) -> AnyView {
-		var glass =
-			switch settings.liquidGlassStyle {
-			case .regular:
-				Glass.regular
-			case .clear:
-				Glass.clear
-			}
-		glass = glass.interactive(false)
-		return AnyView(
-			GlassEffectContainer(spacing: 0) {
-				Color.clear
-					.frame(maxWidth: .infinity, maxHeight: .infinity)
-					.glassEffect(glass, in: .rect(cornerRadius: CaptureChrome.hudCornerRadius))
-			}
-			.allowsHitTesting(false)
-		)
-	}
+	#if compiler(>=6.2)
+		@available(macOS 26.0, *)
+		private static func makeAvailableGlassRoot(settings: NativeHostSettings) -> AnyView {
+			var glass =
+				switch settings.liquidGlassStyle {
+				case .regular:
+					Glass.regular
+				case .clear:
+					Glass.clear
+				}
+			glass = glass.interactive(false)
+			return AnyView(
+				GlassEffectContainer(spacing: 0) {
+					Color.clear
+						.frame(maxWidth: .infinity, maxHeight: .infinity)
+						.glassEffect(glass, in: .rect(cornerRadius: CaptureChrome.hudCornerRadius))
+				}
+				.allowsHitTesting(false)
+			)
+		}
+	#endif
 }
 
 private final class LiveChromeOverlayWindow: NSWindow {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -4,6 +4,7 @@ import CoreText
 import Darwin
 import Foundation
 import RsnapHostBridge
+import SwiftUI
 
 @MainActor
 private enum LiveChromeTypography {
@@ -79,14 +80,6 @@ struct LiveChromeVisualSnapshot {
 	let hud: LiveHudVisualSnapshot?
 	let loupe: LiveLoupeVisualSnapshot?
 	let toolbar: FrozenToolbarVisualSnapshot?
-}
-
-struct LiveChromePositionSnapshot {
-	let sourceWindowNumber: Int?
-	let hudFrame: CGRect?
-	let loupeFrame: CGRect?
-	let inputUptime: TimeInterval?
-	let inputSequence: UInt64
 }
 
 struct LiveChromeBackdropSnapshot {
@@ -251,6 +244,15 @@ private enum ChromeVisualKind {
 	case hud
 	case loupe
 	case toolbar
+
+	func usesLiquidGlassSurface(settings: NativeHostSettings) -> Bool {
+		settings.usesLiquidHudGlass && self != .toolbar
+	}
+
+	func usesClassicWindowGlass(settings: NativeHostSettings) -> Bool {
+		settings.hudGlassEnabled && !usesLiquidGlassSurface(settings: settings)
+			&& settings.hudBlur > 0.01
+	}
 }
 
 @MainActor
@@ -289,9 +291,121 @@ private enum MacOSWindowBlurBridge {
 	}
 }
 
+@MainActor
+private enum LiveChromeLiquidGlassBridge {
+	static func makeGlassView() -> NSView? {
+		guard LiveChromeGlassMaterialSupport.isLiquidGlassAvailable else {
+			return nil
+		}
+		let glassView = LiveChromeLiquidGlassView(frame: .zero)
+		glassView.autoresizingMask = [.width, .height]
+		return glassView
+	}
+
+	static func update(_ glassView: NSView, settings: NativeHostSettings) {
+		guard let glassView = glassView as? LiveChromeLiquidGlassView else {
+			return
+		}
+		glassView.update(settings: settings)
+	}
+
+	static func setContentView(_ contentView: NSView?, on glassView: NSView) {
+		guard let glassView = glassView as? LiveChromeLiquidGlassView else {
+			return
+		}
+		glassView.setContentView(contentView)
+	}
+}
+
+@MainActor
+private final class LiveChromeLiquidGlassView: NSView {
+	private let glassHostView: NSHostingView<AnyView>
+	private let contentContainerView = NSView(frame: .zero)
+	private weak var currentContentView: NSView?
+
+	override var isOpaque: Bool { false }
+
+	override init(frame frameRect: NSRect) {
+		self.glassHostView = NSHostingView(
+			rootView: Self.makeGlassRoot(settings: .defaults))
+		super.init(frame: frameRect)
+
+		wantsLayer = true
+		layer?.backgroundColor = NSColor.clear.cgColor
+		layer?.isOpaque = false
+
+		glassHostView.frame = bounds
+		glassHostView.autoresizingMask = [.width, .height]
+		glassHostView.wantsLayer = true
+		glassHostView.layer?.backgroundColor = NSColor.clear.cgColor
+		glassHostView.layer?.isOpaque = false
+		addSubview(glassHostView)
+
+		contentContainerView.frame = bounds
+		contentContainerView.autoresizingMask = [.width, .height]
+		contentContainerView.wantsLayer = true
+		contentContainerView.layer?.backgroundColor = NSColor.clear.cgColor
+		contentContainerView.layer?.isOpaque = false
+		addSubview(contentContainerView)
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	func update(settings: NativeHostSettings) {
+		glassHostView.rootView = Self.makeGlassRoot(settings: settings)
+	}
+
+	func setContentView(_ contentView: NSView?) {
+		guard currentContentView !== contentView else {
+			return
+		}
+		currentContentView?.removeFromSuperview()
+		currentContentView = contentView
+		guard let contentView else {
+			return
+		}
+		contentView.frame = contentContainerView.bounds
+		contentView.autoresizingMask = [.width, .height]
+		contentContainerView.addSubview(contentView)
+	}
+
+	private static func makeGlassRoot(settings: NativeHostSettings) -> AnyView {
+		if #available(macOS 26.0, *) {
+			return makeAvailableGlassRoot(settings: settings)
+		}
+		return AnyView(Color.clear)
+	}
+
+	@available(macOS 26.0, *)
+	private static func makeAvailableGlassRoot(settings: NativeHostSettings) -> AnyView {
+		var glass =
+			switch settings.liquidGlassStyle {
+			case .regular:
+				Glass.regular
+			case .clear:
+				Glass.clear
+			}
+		glass = glass.interactive(false)
+		return AnyView(
+			GlassEffectContainer(spacing: 0) {
+				Color.clear
+					.frame(maxWidth: .infinity, maxHeight: .infinity)
+					.glassEffect(glass, in: .rect(cornerRadius: CaptureChrome.hudCornerRadius))
+			}
+			.allowsHitTesting(false)
+		)
+	}
+}
+
 private final class LiveChromeOverlayWindow: NSWindow {
 	let kind: ChromeVisualKind
 	let renderView: LiveChromeRenderView
+	private let liquidGlassView: NSView?
+	private var isUsingLiquidGlassContent = false
+	private var lastLiquidGlassStyle: LiquidGlassStylePreference?
 	private var lastPresentedFrame: CGRect?
 	private var lastAppliedBlurAmount: CGFloat?
 	private var isPresented = false
@@ -299,6 +413,7 @@ private final class LiveChromeOverlayWindow: NSWindow {
 	init(kind: ChromeVisualKind) {
 		self.kind = kind
 		self.renderView = LiveChromeRenderView(kind: kind, frame: .zero)
+		self.liquidGlassView = LiveChromeLiquidGlassBridge.makeGlassView()
 		super.init(
 			contentRect: CGRect(x: 0, y: 0, width: 1, height: 1),
 			styleMask: [.borderless],
@@ -306,6 +421,8 @@ private final class LiveChromeOverlayWindow: NSWindow {
 			defer: false
 		)
 		contentView = renderView
+		renderView.autoresizingMask = [.width, .height]
+		liquidGlassView?.autoresizingMask = [.width, .height]
 		backgroundColor = .clear
 		collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
 		hasShadow = false
@@ -347,6 +464,7 @@ private final class LiveChromeOverlayWindow: NSWindow {
 			return
 		}
 
+		configureContentView(settings: settings)
 		let prewarmFrame = CGRect(x: -10_000, y: -10_000, width: 1, height: 1)
 		alphaValue = 0
 		setFrame(prewarmFrame, display: false, animate: false)
@@ -355,12 +473,13 @@ private final class LiveChromeOverlayWindow: NSWindow {
 		isPresented = true
 		displayIfNeeded()
 
-		let blurAmount = settings.hudGlassEnabled ? settings.hudBlur : 0
+		let blurAmount = windowBackgroundBlurAmount(settings: settings)
 		MacOSWindowBlurBridge.applyBlur(to: self, amount: blurAmount)
 		lastAppliedBlurAmount = blurAmount
 	}
 
 	func update(frame: CGRect, settings: NativeHostSettings) {
+		configureContentView(settings: settings)
 		let roundedFrame = presentationFrame(from: frame)
 		let tolerance: CGFloat = 0.001
 		if let lastPresentedFrame {
@@ -380,7 +499,7 @@ private final class LiveChromeOverlayWindow: NSWindow {
 		}
 		lastPresentedFrame = roundedFrame
 
-		let blurAmount = settings.hudGlassEnabled ? settings.hudBlur : 0
+		let blurAmount = windowBackgroundBlurAmount(settings: settings)
 		if lastAppliedBlurAmount == nil || abs((lastAppliedBlurAmount ?? 0) - blurAmount) > 0.01 {
 			MacOSWindowBlurBridge.applyBlur(to: self, amount: blurAmount)
 			lastAppliedBlurAmount = blurAmount
@@ -392,6 +511,38 @@ private final class LiveChromeOverlayWindow: NSWindow {
 		}
 		if alphaValue != 1 {
 			alphaValue = 1
+		}
+	}
+
+	private func windowBackgroundBlurAmount(settings: NativeHostSettings) -> CGFloat {
+		if kind.usesClassicWindowGlass(settings: settings) {
+			return CGFloat(settings.hudBlur)
+		}
+		return 0
+	}
+
+	private func configureContentView(settings: NativeHostSettings) {
+		let shouldUseLiquidGlass = kind.usesLiquidGlassSurface(settings: settings)
+		if shouldUseLiquidGlass, let liquidGlassView {
+			if !isUsingLiquidGlassContent {
+				contentView = liquidGlassView
+				liquidGlassView.frame = contentView?.bounds ?? .zero
+				renderView.frame = liquidGlassView.bounds
+				LiveChromeLiquidGlassBridge.setContentView(renderView, on: liquidGlassView)
+				isUsingLiquidGlassContent = true
+			}
+			if lastLiquidGlassStyle != settings.liquidGlassStyle {
+				LiveChromeLiquidGlassBridge.update(liquidGlassView, settings: settings)
+				lastLiquidGlassStyle = settings.liquidGlassStyle
+			}
+			return
+		}
+
+		if isUsingLiquidGlassContent, let liquidGlassView {
+			LiveChromeLiquidGlassBridge.setContentView(nil, on: liquidGlassView)
+			contentView = renderView
+			isUsingLiquidGlassContent = false
+			lastLiquidGlassStyle = nil
 		}
 	}
 
@@ -500,7 +651,7 @@ private final class LiveChromeBackdropWindow: NSWindow {
 		}
 		lastPresentedFrame = roundedFrame
 
-		let blurAmount = settings.hudGlassEnabled ? settings.hudBlur : 0
+		let blurAmount = settings.usesClassicHudGlass ? settings.hudBlur : 0
 		if lastAppliedBlurAmount == nil || abs((lastAppliedBlurAmount ?? 0) - blurAmount) > 0.01 {
 			MacOSWindowBlurBridge.applyBlur(to: self, amount: blurAmount)
 			lastAppliedBlurAmount = blurAmount
@@ -794,17 +945,22 @@ private final class LiveChromeRenderView: NSView {
 			yRadius: CaptureChrome.hudCornerRadius
 		)
 		context.saveGState()
-		if strongShadow {
-			context.setShadow(offset: .zero, blur: 10, color: palette.shadow.cgColor)
-		}
-		context.setFillColor(
-			CaptureChrome.effectiveBodyFill(
+		let usesLiquidGlass = kind.usesLiquidGlassSurface(settings: settings)
+		if usesLiquidGlass {
+			context.restoreGState()
+			return
+		} else {
+			if strongShadow {
+				context.setShadow(offset: .zero, blur: 10, color: palette.shadow.cgColor)
+			}
+			let fillColor = CaptureChrome.effectiveBodyFill(
 				palette: palette,
 				settings: settings,
-				hasGlass: settings.hudGlassEnabled && settings.hudBlur > 0.01
-			).cgColor
-		)
-		pillPath.fill()
+				hasGlass: kind.usesClassicWindowGlass(settings: settings)
+			)
+			context.setFillColor(fillColor.cgColor)
+			pillPath.fill()
+		}
 		context.restoreGState()
 
 		context.setStrokeColor(palette.outerStroke.cgColor)
@@ -867,36 +1023,8 @@ final class LiveChromeVisualWindowController {
 		"live_chrome.loupe.window_update_duration",
 		category: "LiveChromeTelemetry"
 	)
-	private let hudFastPositionLatencyMetric = NativeHostTelemetry.distribution(
-		"live_chrome.hud.fast_position_latency",
-		category: "LiveChromeTelemetry"
-	)
-	private let hudFastPositionDurationMetric = NativeHostTelemetry.distribution(
-		"live_chrome.hud.fast_position_duration",
-		category: "LiveChromeTelemetry"
-	)
-	private let hudFastPositionGapMetric = NativeHostTelemetry.distribution(
-		"live_chrome.hud.fast_position_gap",
-		category: "LiveChromeTelemetry"
-	)
-	private let loupeFastPositionLatencyMetric = NativeHostTelemetry.distribution(
-		"live_chrome.loupe.fast_position_latency",
-		category: "LiveChromeTelemetry"
-	)
-	private let loupeFastPositionDurationMetric = NativeHostTelemetry.distribution(
-		"live_chrome.loupe.fast_position_duration",
-		category: "LiveChromeTelemetry"
-	)
-	private let loupeFastPositionGapMetric = NativeHostTelemetry.distribution(
-		"live_chrome.loupe.fast_position_gap",
-		category: "LiveChromeTelemetry"
-	)
 	private var lastHudLatencyInputSequence: UInt64?
 	private var lastLoupeLatencyInputSequence: UInt64?
-	private var lastFastHudLatencyInputSequence: UInt64?
-	private var lastFastLoupeLatencyInputSequence: UInt64?
-	private var lastFastHudPositionUptime: TimeInterval?
-	private var lastFastLoupePositionUptime: TimeInterval?
 
 	func prepareForLivePresentation(settings: NativeHostSettings) {
 		hudWindow.prewarmForPresentation(settings: settings)
@@ -955,76 +1083,6 @@ final class LiveChromeVisualWindowController {
 		}
 	}
 
-	func updatePositions(snapshot: LiveChromePositionSnapshot?, focusedWindowNumber: Int?) {
-		guard let snapshot, snapshot.sourceWindowNumber == focusedWindowNumber else {
-			return
-		}
-		if let hudFrame = snapshot.hudFrame {
-			let moveStart = ProcessInfo.processInfo.systemUptime
-			if hudWindow.moveIfPossible(frame: hudFrame) {
-				hudFastPositionDurationMetric.recordMillisecondsSince(moveStart)
-				recordPositionGap(
-					moveStart,
-					lastMoveUptime: &lastFastHudPositionUptime,
-					metric: hudFastPositionGapMetric
-				)
-				recordInputLatency(
-					inputUptime: snapshot.inputUptime,
-					inputSequence: snapshot.inputSequence,
-					lastInputSequence: &lastFastHudLatencyInputSequence,
-					metric: hudFastPositionLatencyMetric
-				)
-				recordInputLatency(
-					inputUptime: snapshot.inputUptime,
-					inputSequence: snapshot.inputSequence,
-					lastInputSequence: &lastHudLatencyInputSequence,
-					metric: hudApplyLatencyMetric
-				)
-			}
-		}
-		if let loupeFrame = snapshot.loupeFrame {
-			let moveStart = ProcessInfo.processInfo.systemUptime
-			if loupeWindow.moveIfPossible(frame: loupeFrame) {
-				loupeFastPositionDurationMetric.recordMillisecondsSince(moveStart)
-				recordPositionGap(
-					moveStart,
-					lastMoveUptime: &lastFastLoupePositionUptime,
-					metric: loupeFastPositionGapMetric
-				)
-				recordInputLatency(
-					inputUptime: snapshot.inputUptime,
-					inputSequence: snapshot.inputSequence,
-					lastInputSequence: &lastFastLoupeLatencyInputSequence,
-					metric: loupeFastPositionLatencyMetric
-				)
-				recordInputLatency(
-					inputUptime: snapshot.inputUptime,
-					inputSequence: snapshot.inputSequence,
-					lastInputSequence: &lastLoupeLatencyInputSequence,
-					metric: loupeApplyLatencyMetric
-				)
-			}
-		}
-	}
-
-	private func recordPositionGap(
-		_ moveUptime: TimeInterval,
-		lastMoveUptime: inout TimeInterval?,
-		metric: NativeHostTelemetry.DistributionMetric
-	) {
-		defer {
-			lastMoveUptime = moveUptime
-		}
-		guard let lastMoveUptime else {
-			return
-		}
-		let gapMilliseconds = (moveUptime - lastMoveUptime) * 1_000
-		guard gapMilliseconds >= 0, gapMilliseconds < 250 else {
-			return
-		}
-		metric.record(gapMilliseconds)
-	}
-
 	private func recordInputLatency(
 		inputUptime: TimeInterval?,
 		inputSequence: UInt64,
@@ -1063,7 +1121,7 @@ final class LiveChromeBackdropWindowController {
 		guard snapshot.sourceWindowNumber == focusedWindowNumber else {
 			return
 		}
-		guard snapshot.settings.hudGlassEnabled, snapshot.settings.hudBlur > 0.01 else {
+		guard snapshot.settings.usesClassicHudGlass else {
 			hideAll()
 			return
 		}

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -783,16 +783,7 @@ final class LiveOverlayRenderer {
 		"live_chrome.layer_chrome_render_duration",
 		category: "LiveChromeTelemetry"
 	)
-	private let layerPositionDurationMetric = NativeHostTelemetry.distribution(
-		"live_chrome.layer_position_duration",
-		category: "LiveChromeTelemetry"
-	)
-	private let layerPositionGapMetric = NativeHostTelemetry.distribution(
-		"live_chrome.layer_position_gap",
-		category: "LiveChromeTelemetry"
-	)
 	private var snapshotProvider: (() -> LivePreviewSnapshot?)?
-	private var lastLayerPositionMoveUptime: TimeInterval?
 
 	init(hostView: NSView) {
 		self.hostView = hostView
@@ -844,30 +835,6 @@ final class LiveOverlayRenderer {
 	func renderLiveChromeNow() {
 		renderChromeSnapshot()
 		onTick?()
-	}
-
-	func moveLiveChrome(hudFrame: CGRect?, loupeFrame: CGRect?) {
-		let moveStart = ProcessInfo.processInfo.systemUptime
-		var moved = false
-		CATransaction.begin()
-		CATransaction.setDisableActions(true)
-		if let hudFrame, !hudLayer.isHidden, layerFrameNeedsUpdate(hudLayer.frame, hudFrame) {
-			hudLayer.frame = hudFrame
-			moved = true
-		}
-		if let loupeFrame, !loupeLayer.isHidden,
-			layerFrameNeedsUpdate(loupeLayer.frame, loupeFrame)
-		{
-			loupeLayer.frame = loupeFrame
-			moved = true
-		}
-		CATransaction.commit()
-
-		guard moved else {
-			return
-		}
-		layerPositionDurationMetric.recordMillisecondsSince(moveStart)
-		recordLayerPositionGap(moveStart)
 	}
 
 	private func configureLayers() {
@@ -952,27 +919,6 @@ final class LiveOverlayRenderer {
 		renderHud(snapshot)
 		renderLoupe(snapshot)
 		CATransaction.commit()
-	}
-
-	private func layerFrameNeedsUpdate(_ current: CGRect, _ next: CGRect) -> Bool {
-		abs(current.minX - next.minX) > 0.001
-			|| abs(current.minY - next.minY) > 0.001
-			|| abs(current.width - next.width) > 0.001
-			|| abs(current.height - next.height) > 0.001
-	}
-
-	private func recordLayerPositionGap(_ moveUptime: TimeInterval) {
-		defer {
-			lastLayerPositionMoveUptime = moveUptime
-		}
-		guard let lastLayerPositionMoveUptime else {
-			return
-		}
-		let gapMilliseconds = (moveUptime - lastLayerPositionMoveUptime) * 1_000
-		guard gapMilliseconds >= 0, gapMilliseconds < 250 else {
-			return
-		}
-		layerPositionGapMetric.record(gapMilliseconds)
 	}
 
 	private func renderFrozenDisplay(_ snapshot: LivePreviewSnapshot) {
@@ -1265,7 +1211,7 @@ final class LiveOverlayRenderer {
 			cornerHeight: cornerRadius,
 			transform: nil
 		)
-		let glassEnabled = settings.hudGlassEnabled && settings.hudBlur > 0.01
+		let glassEnabled = settings.usesClassicHudGlass
 		let opacity = CGFloat(settings.hudOpacity.clamped(to: 0...1))
 		let hasInlineGlass = glassEnabled && glassImage != nil
 		let usesExternalGlass = glassEnabled && glassImage == nil

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -477,10 +477,6 @@ final class CaptureSessionController: NSObject {
 		overlayController?.updateLiveChromeVisuals(snapshot)
 	}
 
-	func updateLiveChromePositions(_ snapshot: LiveChromePositionSnapshot?) {
-		overlayController?.updateLiveChromePositions(snapshot)
-	}
-
 	func previewHighlightedWindow(at point: CGPoint) -> WindowSnapshot? {
 		overlayController?.hoverWindowPreview(at: point)
 	}
@@ -1928,6 +1924,10 @@ final class CaptureOverlayController {
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
 		chromeSampleFeed.start()
 		chromeSampleFeed.prime(point: focusPoint, sidePixels: 1)
+		for window in windows {
+			window.hostView.refreshLivePresentationNow()
+			window.displayIfNeeded()
+		}
 	}
 
 	fileprivate func update(
@@ -1988,6 +1988,10 @@ final class CaptureOverlayController {
 		targetWindow.makeFirstResponder(targetWindow.hostView)
 		focusedWindowNumber = targetWindow.windowNumber
 		(NSApp.delegate as? NativeHostApplicationController)?.window = targetWindow
+		liveChromeBackdrops.hideAll()
+		liveChromeWindows.hideLiveWindows()
+		targetWindow.hostView.refreshLivePresentationNow()
+		targetWindow.displayIfNeeded()
 	}
 
 	func close() {
@@ -2111,13 +2115,6 @@ final class CaptureOverlayController {
 		_ snapshot: LiveChromeBackdropSnapshot?
 	) {
 		liveChromeBackdrops.update(snapshot: snapshot, focusedWindowNumber: focusedWindowNumber)
-	}
-
-	fileprivate func updateLiveChromePositions(
-		_ snapshot: LiveChromePositionSnapshot?
-	) {
-		liveChromeWindows.updatePositions(
-			snapshot: snapshot, focusedWindowNumber: focusedWindowNumber)
 	}
 
 	fileprivate func frozenCaptureJobSource(
@@ -2448,6 +2445,9 @@ final class CaptureHostView: NSView {
 			guard let self else {
 				return
 			}
+			guard !(self.scene.mode == .live && self.settings.usesLiquidHudGlass) else {
+				return
+			}
 			self.controller?.updateLiveChromeVisuals(self.currentChromeVisualSnapshot())
 		}
 		liveRendererInstalled = true
@@ -2580,6 +2580,17 @@ final class CaptureHostView: NSView {
 		lastCursorPresentation = currentCursorPresentation()
 		updateChromeMaterialViews()
 		updateLiveRendererState()
+	}
+
+	fileprivate func refreshLivePresentationNow() {
+		guard scene.mode == .live else {
+			return
+		}
+		updateLivePreviewDemands()
+		liveRenderer.renderNow()
+		if settings.usesLiquidHudGlass {
+			controller?.updateLiveChromeVisuals(currentChromeVisualSnapshot())
+		}
 	}
 
 	fileprivate func installFrozenFirstFrame(
@@ -3870,13 +3881,16 @@ final class CaptureHostView: NSView {
 			return nil
 		}
 
-		let polledPoint = NSEvent.mouseLocation
-		if let currentPreview = livePointerPreviewGlobal {
-			if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y) >= 0.5 {
-				applyPolledLivePointerPreview(polledPoint)
+		if !settings.usesLiquidHudGlass {
+			let polledPoint = NSEvent.mouseLocation
+			if let currentPreview = livePointerPreviewGlobal {
+				if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y) >= 0.5
+				{
+					applyPolledLivePointerPreview(polledPoint)
+				}
+			} else {
+				applyPolledLivePointerPreview(polledPoint, recordsInputLatency: false)
 			}
-		} else {
-			applyPolledLivePointerPreview(polledPoint, recordsInputLatency: false)
 		}
 
 		updateLivePreviewDemands()
@@ -3906,6 +3920,7 @@ final class CaptureHostView: NSView {
 				)
 			}
 			: nil
+		let renderChromeInExternalWindows = settings.usesLiquidHudGlass
 
 		return LivePreviewSnapshot(
 			bounds: bounds,
@@ -3918,8 +3933,8 @@ final class CaptureHostView: NSView {
 			dragSelectionLocal: dragSelectionLocal,
 			hoverSelectionLocal: hoverSelectionLocal,
 			selectionSizeText: dragSelectionLocal.map(selectionSizeText(for:)),
-			hudFrame: hudFrame,
-			loupeFrame: loupeFrame,
+			hudFrame: renderChromeInExternalWindows ? nil : hudFrame,
+			loupeFrame: renderChromeInExternalWindows ? nil : loupeFrame,
 			positionDisplay: positionDisplay,
 			colorDisplay: colorDisplay,
 			rgbSample: rgbSample,
@@ -3972,26 +3987,21 @@ final class CaptureHostView: NSView {
 			stopLiveChromeFollowClock()
 			return
 		}
+		guard settings.usesLiquidHudGlass else {
+			stopLiveChromeFollowClock()
+			return
+		}
 		let point = NSEvent.mouseLocation
-		let pointerChanged = setLivePointerPreview(to: point, recordsInputLatency: false)
+		_ = setLivePointerPreview(to: point, recordsInputLatency: false)
 		let nextHighlightedWindow =
 			controller?.previewHighlightedWindow(at: point) ?? scene.highlightedWindow
 		let highlightChanged = liveHighlightedWindowPreview != nextHighlightedWindow
 		liveHighlightedWindowPreview = nextHighlightedWindow
+		updateLivePreviewDemands()
+		controller?.updateLiveChromeVisuals(currentChromeVisualSnapshot())
 		if highlightChanged {
-			updateLivePreviewDemands()
-			updateLiveChromeBackdrops()
 			liveRenderer.renderNow()
-		} else if pointerChanged {
-			updateLivePreviewDemands()
-			moveLiveChromeLayers()
 		}
-	}
-
-	private func moveLiveChromeLayers() {
-		let frames = currentLiveChromeLayerFrames()
-		updateLiveChromeBackdrops(hudFrame: frames.hud, loupeFrame: frames.loupe)
-		liveRenderer.moveLiveChrome(hudFrame: frames.hud, loupeFrame: frames.loupe)
 	}
 
 	private func updateLiveChromeBackdrops() {
@@ -4000,7 +4010,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func updateLiveChromeBackdrops(hudFrame: CGRect?, loupeFrame: CGRect?) {
-		guard scene.mode == .live, settings.hudGlassEnabled && settings.hudBlur > 0.01 else {
+		guard scene.mode == .live, settings.usesClassicHudGlass else {
 			controller?.updateLiveChromeBackdrops(nil)
 			return
 		}
@@ -4034,12 +4044,80 @@ final class CaptureHostView: NSView {
 	private func currentChromeVisualSnapshot() -> LiveChromeVisualSnapshot? {
 		switch scene.mode {
 		case .live:
-			return nil
+			return currentLiveChromeVisualSnapshot()
 		case .frozen:
 			return currentFrozenChromeVisualSnapshot()
 		case .hidden:
 			return nil
 		}
+	}
+
+	private func currentLiveChromeVisualSnapshot() -> LiveChromeVisualSnapshot? {
+		guard scene.mode == .live, settings.usesLiquidHudGlass, !chrome.hostLocalFrozenSelecting
+		else {
+			return nil
+		}
+		guard let sourceWindowNumber = window?.windowNumber else {
+			return nil
+		}
+
+		let chromeSample = currentLiveChromeSample()
+		let rgbSample =
+			chromeSample?.rgbSample
+			?? chrome.rgbSample
+			?? scene.rgb
+		let positionDisplay = currentPositionDisplay()
+		let colorDisplay = currentLiveColorDisplay(for: rgbSample)
+		let hudPlacement = liveHoverChromeSuppressed ? nil : currentHudPlacement()
+		let hudSnapshot: LiveHudVisualSnapshot? = hudPlacement.flatMap { placement in
+			guard let frame = globalRect(from: placement.frame) else {
+				return nil
+			}
+			return LiveHudVisualSnapshot(
+				sourceWindowNumber: sourceWindowNumber,
+				frame: frame,
+				theme: chromeTheme(),
+				settings: settings,
+				positionDisplay: positionDisplay,
+				colorDisplay: colorDisplay,
+				rgbSample: rgbSample,
+				keycapVisible: settings.showAltHintKeycap,
+				inputUptime: livePointerPreviewInputUptime,
+				inputSequence: livePointerPreviewInputSequence
+			)
+		}
+		let loupeSnapshot: LiveLoupeVisualSnapshot? = {
+			guard
+				!liveHoverChromeSuppressed,
+				scene.loupeVisible,
+				let hudPlacement,
+				let patch = chromeSample?.loupePatch,
+				let localFrame = currentLoupeFrame(
+					hudFrame: hudPlacement.frame,
+					patch: patch,
+					alignTrailing: hudPlacement.flippedHorizontally
+				),
+				let frame = globalRect(from: localFrame)
+			else {
+				return nil
+			}
+			return LiveLoupeVisualSnapshot(
+				sourceWindowNumber: sourceWindowNumber,
+				frame: frame,
+				theme: chromeTheme(),
+				settings: settings,
+				patch: patch,
+				inputUptime: livePointerPreviewInputUptime,
+				inputSequence: livePointerPreviewInputSequence
+			)
+		}()
+
+		return LiveChromeVisualSnapshot(
+			sourceWindowNumber: sourceWindowNumber,
+			hud: hudSnapshot,
+			loupe: loupeSnapshot,
+			toolbar: nil
+		)
 	}
 
 	private func currentFrozenChromeVisualSnapshot() -> LiveChromeVisualSnapshot? {
@@ -4176,8 +4254,12 @@ final class CaptureHostView: NSView {
 			)
 		}
 		if scene.mode == .live {
-			liveRenderer.stopFrameClock()
-			startLiveChromeFollowClock()
+			liveRenderer.updateDisplayID(currentDisplayID(), targetFramesPerSecond: targetHz)
+			if settings.usesLiquidHudGlass {
+				startLiveChromeFollowClock()
+			} else {
+				stopLiveChromeFollowClock()
+			}
 			return
 		}
 		stopLiveChromeFollowClock()
@@ -4295,8 +4377,7 @@ final class CaptureHostView: NSView {
 			yRadius: CaptureChrome.hudCornerRadius
 		)
 		let glassImage =
-			(settings.hudGlassEnabled && settings.hudBlur > 0.01)
-			? glassPatch(for: surfaceKind, frame: frame) : nil
+			settings.usesClassicHudGlass ? glassPatch(for: surfaceKind, frame: frame) : nil
 		let hasGlass = glassImage != nil
 		context.saveGState()
 		if strongShadow {
@@ -4312,13 +4393,16 @@ final class CaptureHostView: NSView {
 			context.draw(glassImage, in: frame)
 			context.restoreGState()
 		}
-		context.setFillColor(
-			CaptureChrome.effectiveBodyFill(
+		let usesLiquidGlass = scene.mode == .live && settings.usesLiquidHudGlass
+		let fillColor =
+			usesLiquidGlass
+			? NSColor.clear
+			: CaptureChrome.effectiveBodyFill(
 				palette: palette,
 				settings: settings,
 				hasGlass: hasGlass
-			).cgColor
-		)
+			)
+		context.setFillColor(fillColor.cgColor)
 		pillPath.fill()
 		context.restoreGState()
 
@@ -5358,26 +5442,20 @@ enum CaptureChrome {
 	{
 		let opacity = CGFloat(settings.hudOpacity.clamped(to: 0...1))
 		let tint = CGFloat(settings.hudTint.clamped(to: 0...1))
-		let hue = CGFloat(settings.hudTintHue.clamped(to: 0...1))
 		let foregrounds = foregroundPalette(for: theme)
 		let bodyAlphaFloor: CGFloat = theme == .dark ? 0.06 : 0.08
 		let fillOpacity: CGFloat =
 			settings.hudGlassEnabled
 			? max(bodyAlphaFloor, opacity * 0.20)
 			: opacity
-		let tintColor = NSColor(
-			calibratedHue: hue,
-			saturation: theme == .dark ? (0.08 + 0.22 * tint) : (0.04 + 0.16 * tint),
-			brightness: theme == .dark ? (0.30 + 0.12 * tint) : (0.93 - 0.06 * tint),
-			alpha: 1
-		)
+		let tintColor = classicTintColor(for: theme, settings: settings)
 
 		switch theme {
 		case .dark:
 			let baseFill = NSColor(srgbRed: 28 / 255, green: 28 / 255, blue: 32 / 255, alpha: 1)
 			let bodyFill =
 				baseFill
-				.mixed(with: tintColor, fraction: tint * 0.55)
+				.mixed(with: tintColor, fraction: tint * 0.72)
 				.withAlphaComponent(fillOpacity)
 			return CaptureChromePalette(
 				foregrounds: foregrounds,
@@ -5400,7 +5478,7 @@ enum CaptureChrome {
 			let baseFill = NSColor(srgbRed: 232 / 255, green: 236 / 255, blue: 243 / 255, alpha: 1)
 			let bodyFill =
 				baseFill
-				.mixed(with: tintColor, fraction: tint * 0.45)
+				.mixed(with: tintColor, fraction: tint * 0.62)
 				.withAlphaComponent(fillOpacity)
 			return CaptureChromePalette(
 				foregrounds: foregrounds,
@@ -5469,9 +5547,21 @@ enum CaptureChrome {
 		let opacity = CGFloat(settings.hudOpacity.clamped(to: 0...1))
 		if hasGlass {
 			return palette.bodyFill.withAlphaComponent(
-				max(palette.bodyFill.alphaComponent, max(0.18, opacity * 0.34)))
+				max(palette.bodyFill.alphaComponent, max(0.22, opacity * 0.42)))
 		}
 		return palette.bodyFill.withAlphaComponent(max(0.42, opacity * 0.82))
+	}
+
+	private static func classicTintColor(
+		for theme: CaptureChromeTheme, settings: NativeHostSettings
+	) -> NSColor {
+		let hue = CGFloat(settings.hudTintHue.clamped(to: 0...1))
+		return NSColor(
+			calibratedHue: hue,
+			saturation: theme == .dark ? 0.48 : 0.34,
+			brightness: theme == .dark ? 0.62 : 0.94,
+			alpha: 1
+		)
 	}
 }
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
@@ -21,7 +21,13 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 	private let showAltHintKeycapButton = NSButton(
 		checkboxWithTitle: "Show Tab hint in HUD", target: nil, action: nil)
 	private let hudGlassEnabledButton = NSButton(
-		checkboxWithTitle: "Glass HUD", target: nil, action: nil)
+		checkboxWithTitle: "Enable glass", target: nil, action: nil)
+	private let hudGlassModeControl = NSSegmentedControl(
+		labels: HudGlassModePreference.allCases.map(\.title), trackingMode: .selectOne,
+		target: nil, action: nil)
+	private let liquidGlassStyleControl = NSSegmentedControl(
+		labels: LiquidGlassStylePreference.allCases.map(\.title), trackingMode: .selectOne,
+		target: nil, action: nil)
 	private let loupeSampleSizeControl = NSSegmentedControl(
 		labels: LoupeSampleSizePreference.allCases.map(\.title), trackingMode: .selectOne,
 		target: nil, action: nil)
@@ -31,18 +37,17 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		value: 50, minValue: 0, maxValue: 100, target: nil, action: nil)
 	private let hudTintSlider = NSSlider(
 		value: 50, minValue: 0, maxValue: 100, target: nil, action: nil)
-	private let hudHueSlider = NSSlider(
-		value: 215, minValue: 0, maxValue: 360, target: nil, action: nil)
 	private let hudTintColorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 44, height: 24))
 	private let hudOpacityValueLabel = NSTextField(labelWithString: "")
 	private let hudBlurValueLabel = NSTextField(labelWithString: "")
 	private let hudTintValueLabel = NSTextField(labelWithString: "")
-	private let hudHueValueLabel = NSTextField(labelWithString: "")
+	private var classicGlassOptionViews: [NSView] = []
+	private var liquidGlassOptionViews: [NSView] = []
 
 	init(settingsStore: NativeHostSettingsStore) {
 		self.settingsStore = settingsStore
 
-		let contentRect = NSRect(x: 0, y: 0, width: 560, height: 580)
+		let contentRect = NSRect(x: 0, y: 0, width: 560, height: 640)
 		let window = NSWindow(
 			contentRect: contentRect,
 			styleMask: [.titled, .closable, .miniaturizable],
@@ -87,17 +92,8 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		stack.addArrangedSubview(makeNamingRow())
 		stack.addArrangedSubview(makeSectionTitle("Overlay"))
 		stack.addArrangedSubview(makeOverlayRow())
+		stack.addArrangedSubview(makeHudGlassModeRow())
 		stack.addArrangedSubview(makeLoupeSampleSizeRow())
-		stack.addArrangedSubview(
-			makeSliderRow(
-				title: "Opacity", slider: hudOpacitySlider, valueLabel: hudOpacityValueLabel))
-		stack.addArrangedSubview(
-			makeSliderRow(title: "Blur", slider: hudBlurSlider, valueLabel: hudBlurValueLabel))
-		stack.addArrangedSubview(
-			makeSliderRow(title: "Tint", slider: hudTintSlider, valueLabel: hudTintValueLabel))
-		stack.addArrangedSubview(makeTintColorRow())
-		stack.addArrangedSubview(
-			makeSliderRow(title: "Hue", slider: hudHueSlider, valueLabel: hudHueValueLabel))
 		stack.addArrangedSubview(makeToolbarPlacementRow())
 		stack.addArrangedSubview(makeFrozenResizeHandleOrientationRow())
 
@@ -230,11 +226,84 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
 		showAltHintKeycapButton.target = self
 		showAltHintKeycapButton.action = #selector(showAltHintKeycapChanged)
-		hudGlassEnabledButton.target = self
-		hudGlassEnabledButton.action = #selector(hudGlassEnabledChanged)
 
 		container.addArrangedSubview(showAltHintKeycapButton)
+		return container
+	}
+
+	private func makeHudGlassModeRow() -> NSView {
+		let container = NSStackView()
+		container.orientation = .vertical
+		container.alignment = .leading
+		container.spacing = 6
+
+		let title = NSTextField(labelWithString: "Glass style")
+		title.font = .systemFont(ofSize: 13, weight: .medium)
+		container.addArrangedSubview(title)
+
+		hudGlassEnabledButton.target = self
+		hudGlassEnabledButton.action = #selector(hudGlassEnabledChanged)
 		container.addArrangedSubview(hudGlassEnabledButton)
+
+		hudGlassModeControl.target = self
+		hudGlassModeControl.action = #selector(hudGlassModeChanged)
+		hudGlassModeControl.segmentStyle = .rounded
+		hudGlassModeControl.widthAnchor.constraint(equalToConstant: 260).isActive = true
+		if let liquidGlassSegment = HudGlassModePreference.allCases.firstIndex(of: .liquidGlass) {
+			hudGlassModeControl.setToolTip(
+				"Requires Liquid Glass support.", forSegment: liquidGlassSegment)
+		}
+		container.addArrangedSubview(hudGlassModeControl)
+
+		let classicRows = [
+			makeGlassSubsectionTitle("Classic blur options"),
+			makeSliderRow(
+				title: "Opacity", slider: hudOpacitySlider, valueLabel: hudOpacityValueLabel,
+				action: #selector(hudOpacityChanged)),
+			makeSliderRow(
+				title: "Blur", slider: hudBlurSlider, valueLabel: hudBlurValueLabel,
+				action: #selector(hudBlurChanged)),
+			makeSliderRow(
+				title: "Tint", slider: hudTintSlider, valueLabel: hudTintValueLabel,
+				action: #selector(hudTintChanged)),
+			makeTintColorRow(),
+		]
+		classicGlassOptionViews = classicRows
+		for row in classicRows {
+			container.addArrangedSubview(row)
+		}
+
+		let liquidRows = [
+			makeGlassSubsectionTitle("Liquid Glass options"),
+			makeLiquidGlassStyleRow(),
+		]
+		liquidGlassOptionViews = liquidRows
+		for row in liquidRows {
+			container.addArrangedSubview(row)
+		}
+		return container
+	}
+
+	private func makeGlassSubsectionTitle(_ title: String) -> NSTextField {
+		let label = NSTextField(labelWithString: title)
+		label.font = .systemFont(ofSize: 12, weight: .medium)
+		label.textColor = .secondaryLabelColor
+		return label
+	}
+
+	private func makeLiquidGlassStyleRow() -> NSView {
+		let container = NSStackView()
+		container.orientation = .vertical
+		container.alignment = .leading
+		container.spacing = 6
+
+		let title = NSTextField(labelWithString: "Style")
+		title.font = .systemFont(ofSize: 13, weight: .medium)
+		container.addArrangedSubview(title)
+
+		liquidGlassStyleControl.target = self
+		liquidGlassStyleControl.action = #selector(liquidGlassStyleChanged)
+		container.addArrangedSubview(liquidGlassStyleControl)
 		return container
 	}
 
@@ -254,7 +323,9 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		return container
 	}
 
-	private func makeSliderRow(title: String, slider: NSSlider, valueLabel: NSTextField) -> NSView {
+	private func makeSliderRow(
+		title: String, slider: NSSlider, valueLabel: NSTextField, action: Selector
+	) -> NSView {
 		let container = NSStackView()
 		container.orientation = .vertical
 		container.alignment = .leading
@@ -265,18 +336,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		container.addArrangedSubview(titleLabel)
 
 		slider.target = self
-		switch title {
-		case "Opacity":
-			slider.action = #selector(hudOpacityChanged)
-		case "Blur":
-			slider.action = #selector(hudBlurChanged)
-		case "Tint":
-			slider.action = #selector(hudTintChanged)
-		case "Hue":
-			slider.action = #selector(hudHueChanged)
-		default:
-			break
-		}
+		slider.action = action
 
 		valueLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
 		valueLabel.textColor = .secondaryLabelColor
@@ -305,8 +365,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		hudTintColorWell.target = self
 		hudTintColorWell.action = #selector(hudTintColorChanged)
 
-		let hint = NSTextField(
-			labelWithString: "Chooses the hue directly; tint strength still uses the Tint slider.")
+		let hint = NSTextField(labelWithString: "Tint strength still uses the Tint slider.")
 		hint.font = .systemFont(ofSize: 12)
 		hint.textColor = .secondaryLabelColor
 
@@ -331,28 +390,45 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 				of: settings.frozenResizeHandleOrientation) ?? 0
 		showAltHintKeycapButton.state = settings.showAltHintKeycap ? .on : .off
 		hudGlassEnabledButton.state = settings.hudGlassEnabled ? .on : .off
+		hudGlassModeControl.selectedSegment =
+			HudGlassModePreference.allCases.firstIndex(of: settings.resolvedHudGlassMode) ?? 0
+		for (index, mode) in HudGlassModePreference.allCases.enumerated() {
+			let supported =
+				mode != .liquidGlass || LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
+			hudGlassModeControl.setEnabled(supported, forSegment: index)
+		}
+		liquidGlassStyleControl.selectedSegment =
+			LiquidGlassStylePreference.allCases.firstIndex(of: settings.liquidGlassStyle) ?? 0
 		loupeSampleSizeControl.selectedSegment =
 			LoupeSampleSizePreference.allCases.firstIndex(of: settings.loupeSampleSize) ?? 0
 		hudOpacitySlider.doubleValue = settings.hudOpacity * 100
 		hudBlurSlider.doubleValue = settings.hudBlur * 100
 		hudTintSlider.doubleValue = settings.hudTint * 100
-		hudHueSlider.doubleValue = settings.hudTintHue * 360
 		hudTintColorWell.color = NSColor(
 			calibratedHue: CGFloat(settings.hudTintHue),
-			saturation: CGFloat(max(0.18, settings.hudTint)),
+			saturation: 0.85,
 			brightness: 1,
 			alpha: 1
 		)
 		hudOpacityValueLabel.stringValue = "\(Int(settings.hudOpacity * 100))"
 		hudBlurValueLabel.stringValue = "\(Int(settings.hudBlur * 100))"
 		hudTintValueLabel.stringValue = "\(Int(settings.hudTint * 100))"
-		hudHueValueLabel.stringValue = "\(Int(settings.hudTintHue * 360))°"
 		let glassEnabled = settings.hudGlassEnabled
+		let glassMode = settings.resolvedHudGlassMode
+		let classicBlurSelected = glassMode == .classicBlur
+		let liquidGlassSelected = glassMode == .liquidGlass
+		hudGlassModeControl.isEnabled = glassEnabled
+		for view in classicGlassOptionViews {
+			view.isHidden = !glassEnabled || !classicBlurSelected
+		}
+		for view in liquidGlassOptionViews {
+			view.isHidden = !glassEnabled || !liquidGlassSelected
+		}
 		hudOpacitySlider.isEnabled = glassEnabled
 		hudBlurSlider.isEnabled = glassEnabled
 		hudTintSlider.isEnabled = glassEnabled
-		hudHueSlider.isEnabled = glassEnabled
 		hudTintColorWell.isEnabled = glassEnabled
+		liquidGlassStyleControl.isEnabled = glassEnabled && liquidGlassSelected
 	}
 
 	@objc
@@ -421,6 +497,34 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 	}
 
 	@objc
+	private func hudGlassModeChanged() {
+		let index = hudGlassModeControl.selectedSegment
+		guard HudGlassModePreference.allCases.indices.contains(index) else {
+			refreshFromSettings()
+			return
+		}
+		let mode = HudGlassModePreference.allCases[index]
+		if mode == .liquidGlass, !LiveChromeGlassMaterialSupport.isLiquidGlassAvailable {
+			refreshFromSettings()
+			return
+		}
+		settingsStore.update { $0.hudGlassMode = mode }
+		refreshFromSettings()
+	}
+
+	@objc
+	private func liquidGlassStyleChanged() {
+		let index = liquidGlassStyleControl.selectedSegment
+		guard LiquidGlassStylePreference.allCases.indices.contains(index) else {
+			return
+		}
+		settingsStore.update {
+			$0.liquidGlassStyle = LiquidGlassStylePreference.allCases[index]
+		}
+		refreshFromSettings()
+	}
+
+	@objc
 	private func loupeSampleSizeChanged() {
 		let index = loupeSampleSizeControl.selectedSegment
 		guard LoupeSampleSizePreference.allCases.indices.contains(index) else {
@@ -449,22 +553,15 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 	}
 
 	@objc
-	private func hudHueChanged() {
-		settingsStore.update { $0.hudTintHue = hudHueSlider.doubleValue / 360.0 }
-		refreshFromSettings()
-	}
-
-	@objc
 	private func hudTintColorChanged() {
 		let converted = hudTintColorWell.color.usingColorSpace(.deviceRGB) ?? hudTintColorWell.color
 		let hue = converted.hueComponent
-		let saturation = converted.saturationComponent
 		settingsStore.update {
 			$0.hudTintHue = Double(hue)
-			$0.hudTint = Double(max($0.hudTint, saturation))
 		}
 		refreshFromSettings()
 	}
+
 }
 
 @MainActor

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -15,12 +15,13 @@ final class NativeHostSettingsStore {
 		static let frozenResizeHandleOrientation = "frozenResizeHandleOrientation"
 		static let showAltHintKeycap = "showAltHintKeycap"
 		static let hudGlassEnabled = "hudGlassEnabled"
+		static let hudGlassMode = "hudGlassMode"
 		static let hudOpacity = "hudOpacity"
 		static let hudBlur = "hudBlur"
 		static let hudTint = "hudTint"
 		static let hudTintHue = "hudTintHue"
+		static let liquidGlassStyle = "liquidGlassStyle"
 		static let loupeSampleSize = "loupeSampleSize"
-		static let migratedLegacyToml = "migratedLegacyToml"
 	}
 
 	private let defaults: UserDefaults
@@ -29,7 +30,10 @@ final class NativeHostSettingsStore {
 	init(defaults: UserDefaults = .standard) {
 		self.defaults = defaults
 		let baseSettings = NativeHostSettings.defaults
-		var settings = NativeHostSettings(
+		let persistedHudGlassMode = HudGlassModePreference(
+			rawValue: defaults.string(forKey: DefaultsKey.hudGlassMode) ?? "")
+		let hudGlassMode = persistedHudGlassMode ?? baseSettings.hudGlassMode
+		let settings = NativeHostSettings(
 			captureHotkey: defaults.string(forKey: DefaultsKey.captureHotkey)
 				?? baseSettings.captureHotkey,
 			outputDirectory: defaults.url(forKey: DefaultsKey.outputDirectory)
@@ -49,6 +53,7 @@ final class NativeHostSettingsStore {
 				?? baseSettings.showAltHintKeycap,
 			hudGlassEnabled: defaults.object(forKey: DefaultsKey.hudGlassEnabled) as? Bool
 				?? baseSettings.hudGlassEnabled,
+			hudGlassMode: hudGlassMode,
 			hudOpacity: defaults.object(forKey: DefaultsKey.hudOpacity) as? Double
 				?? baseSettings.hudOpacity,
 			hudBlur: defaults.object(forKey: DefaultsKey.hudBlur) as? Double
@@ -57,17 +62,13 @@ final class NativeHostSettingsStore {
 				?? baseSettings.hudTint,
 			hudTintHue: defaults.object(forKey: DefaultsKey.hudTintHue) as? Double
 				?? baseSettings.hudTintHue,
+			liquidGlassStyle: LiquidGlassStylePreference(
+				rawValue: defaults.string(forKey: DefaultsKey.liquidGlassStyle) ?? "")
+				?? baseSettings.liquidGlassStyle,
 			loupeSampleSize: LoupeSampleSizePreference(
 				rawValue: defaults.string(forKey: DefaultsKey.loupeSampleSize) ?? "")
 				?? baseSettings.loupeSampleSize
 		)
-		if !defaults.bool(forKey: DefaultsKey.migratedLegacyToml),
-			let migrated = Self.migrateLegacyToml(into: settings)
-		{
-			settings = migrated
-			defaults.set(true, forKey: DefaultsKey.migratedLegacyToml)
-			Self.persist(settings, into: defaults)
-		}
 		self.settings = settings.sanitized()
 		Self.persist(self.settings, into: defaults)
 	}
@@ -82,7 +83,8 @@ final class NativeHostSettingsStore {
 	func update(_ mutate: (inout NativeHostSettings) -> Void) {
 		var next = settings
 		mutate(&next)
-		settings = next.sanitized()
+		let sanitized = next.sanitized()
+		settings = sanitized
 		Self.persist(settings, into: defaults)
 		NotificationCenter.default.post(name: Self.didChangeNotification, object: self)
 	}
@@ -98,105 +100,13 @@ final class NativeHostSettingsStore {
 			forKey: DefaultsKey.frozenResizeHandleOrientation)
 		defaults.set(settings.showAltHintKeycap, forKey: DefaultsKey.showAltHintKeycap)
 		defaults.set(settings.hudGlassEnabled, forKey: DefaultsKey.hudGlassEnabled)
+		defaults.set(settings.hudGlassMode.rawValue, forKey: DefaultsKey.hudGlassMode)
 		defaults.set(settings.hudOpacity, forKey: DefaultsKey.hudOpacity)
 		defaults.set(settings.hudBlur, forKey: DefaultsKey.hudBlur)
 		defaults.set(settings.hudTint, forKey: DefaultsKey.hudTint)
 		defaults.set(settings.hudTintHue, forKey: DefaultsKey.hudTintHue)
+		defaults.set(settings.liquidGlassStyle.rawValue, forKey: DefaultsKey.liquidGlassStyle)
 		defaults.set(settings.loupeSampleSize.rawValue, forKey: DefaultsKey.loupeSampleSize)
-	}
-
-	private static func migrateLegacyToml(into settings: NativeHostSettings) -> NativeHostSettings?
-	{
-		let legacyPath = FileManager.default.homeDirectoryForCurrentUser
-			.appendingPathComponent("Library", isDirectory: true)
-			.appendingPathComponent("Application Support", isDirectory: true)
-			.appendingPathComponent("ink.hack.rsnap", isDirectory: true)
-			.appendingPathComponent("settings.toml", isDirectory: false)
-		guard let contents = try? String(contentsOf: legacyPath) else {
-			return nil
-		}
-
-		var migrated = settings
-		let lines = contents.split(separator: "\n", omittingEmptySubsequences: false)
-		for rawLine in lines {
-			let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-			guard !line.isEmpty, !line.hasPrefix("#"), let separator = line.firstIndex(of: "=")
-			else {
-				continue
-			}
-			let key = line[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
-			let value = line[line.index(after: separator)...].trimmingCharacters(
-				in: .whitespacesAndNewlines)
-			let unquoted = value.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-			switch key {
-			case "capture_hotkey":
-				migrated.captureHotkey = unquoted
-			case "output_dir":
-				let url = URL(fileURLWithPath: unquoted, isDirectory: true)
-				migrated.outputDirectory = url
-			case "output_filename_prefix":
-				migrated.outputFilenamePrefix = unquoted
-			case "output_naming":
-				if let naming = OutputNamingPreference(rawValue: unquoted) {
-					migrated.outputNaming = naming
-				}
-			case "toolbar_placement":
-				if let placement = ToolbarPlacementPreference(rawValue: unquoted) {
-					migrated.toolbarPlacement = placement
-				}
-			case "frozen_resize_handle_orientation":
-				if let orientation = FrozenResizeHandleOrientationPreference(rawValue: unquoted) {
-					migrated.frozenResizeHandleOrientation = orientation
-				}
-			case "show_alt_hint_keycap":
-				if let boolValue = parseTomlBool(unquoted) {
-					migrated.showAltHintKeycap = boolValue
-				}
-			case "hud_glass_enabled":
-				if let boolValue = parseTomlBool(unquoted) {
-					migrated.hudGlassEnabled = boolValue
-				}
-			case "hud_opacity":
-				if let value = parseTomlDouble(unquoted) {
-					migrated.hudOpacity = value
-				}
-			case "hud_blur":
-				if let value = parseTomlDouble(unquoted) {
-					migrated.hudBlur = value
-				}
-			case "hud_tint":
-				if let value = parseTomlDouble(unquoted) {
-					migrated.hudTint = value
-				}
-			case "hud_tint_hue":
-				if let value = parseTomlDouble(unquoted) {
-					migrated.hudTintHue = value
-				}
-			case "loupe_sample_size":
-				if let sampleSize = LoupeSampleSizePreference(rawValue: unquoted) {
-					migrated.loupeSampleSize = sampleSize
-				}
-			default:
-				continue
-			}
-		}
-
-		return migrated
-	}
-
-	private static func parseTomlBool(_ raw: String) -> Bool? {
-		switch raw.lowercased() {
-		case "true":
-			return true
-		case "false":
-			return false
-		default:
-			return nil
-		}
-	}
-
-	private static func parseTomlDouble(_ raw: String) -> Double? {
-		Double(raw)
 	}
 }
 
@@ -209,28 +119,34 @@ struct NativeHostSettings: Equatable {
 	var frozenResizeHandleOrientation: FrozenResizeHandleOrientationPreference
 	var showAltHintKeycap: Bool
 	var hudGlassEnabled: Bool
+	var hudGlassMode: HudGlassModePreference
 	var hudOpacity: Double
 	var hudBlur: Double
 	var hudTint: Double
 	var hudTintHue: Double
+	var liquidGlassStyle: LiquidGlassStylePreference
 	var loupeSampleSize: LoupeSampleSizePreference
 
-	static let defaults = NativeHostSettings(
-		captureHotkey: "alt+KeyX",
-		outputDirectory: FileManager.default.homeDirectoryForCurrentUser
-			.appendingPathComponent("Desktop", isDirectory: true),
-		outputFilenamePrefix: "rsnap",
-		outputNaming: .timestamp,
-		toolbarPlacement: .bottom,
-		frozenResizeHandleOrientation: .inward,
-		showAltHintKeycap: true,
-		hudGlassEnabled: true,
-		hudOpacity: 0.5,
-		hudBlur: 0.5,
-		hudTint: 0.5,
-		hudTintHue: 215.0 / 360.0,
-		loupeSampleSize: .medium
-	)
+	static var defaults: NativeHostSettings {
+		NativeHostSettings(
+			captureHotkey: "alt+KeyX",
+			outputDirectory: FileManager.default.homeDirectoryForCurrentUser
+				.appendingPathComponent("Desktop", isDirectory: true),
+			outputFilenamePrefix: "rsnap",
+			outputNaming: .timestamp,
+			toolbarPlacement: .bottom,
+			frozenResizeHandleOrientation: .inward,
+			showAltHintKeycap: true,
+			hudGlassEnabled: true,
+			hudGlassMode: HudGlassModePreference.defaultForCurrentSystem,
+			hudOpacity: 0.5,
+			hudBlur: 0.5,
+			hudTint: 0.5,
+			hudTintHue: 215.0 / 360.0,
+			liquidGlassStyle: .clear,
+			loupeSampleSize: .medium
+		)
+	}
 
 	func sanitized() -> Self {
 		var copy = self
@@ -309,6 +225,39 @@ enum FrozenResizeHandleOrientationPreference: String, CaseIterable {
 	}
 }
 
+enum HudGlassModePreference: String, CaseIterable {
+	case liquidGlass = "liquid_glass"
+	case classicBlur = "classic_blur"
+
+	static var defaultForCurrentSystem: Self {
+		LiveChromeGlassMaterialSupport.isLiquidGlassAvailable ? .liquidGlass : .classicBlur
+	}
+
+	var title: String {
+		switch self {
+		case .liquidGlass:
+			return "Liquid Glass"
+		case .classicBlur:
+			return "Classic Blur"
+		}
+	}
+}
+
+enum LiquidGlassStylePreference: String, CaseIterable {
+	case regular
+	case clear
+
+	var title: String {
+		switch self {
+		case .regular:
+			return "Regular"
+		case .clear:
+			return "Clear"
+		}
+	}
+
+}
+
 enum LoupeSampleSizePreference: String, CaseIterable {
 	case small
 	case medium
@@ -334,6 +283,34 @@ enum LoupeSampleSizePreference: String, CaseIterable {
 		case .large:
 			return 31
 		}
+	}
+}
+
+enum LiveChromeGlassMaterialSupport {
+	static var isLiquidGlassAvailable: Bool {
+		if #available(macOS 26.0, *) {
+			return true
+		}
+		return false
+	}
+}
+
+extension NativeHostSettings {
+	var resolvedHudGlassMode: HudGlassModePreference {
+		if hudGlassMode == .liquidGlass,
+			!LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
+		{
+			return .classicBlur
+		}
+		return hudGlassMode
+	}
+
+	var usesClassicHudGlass: Bool {
+		hudGlassEnabled && resolvedHudGlassMode == .classicBlur && hudBlur > 0.01
+	}
+
+	var usesLiquidHudGlass: Bool {
+		hudGlassEnabled && resolvedHudGlassMode == .liquidGlass
 	}
 }
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -288,9 +288,11 @@ enum LoupeSampleSizePreference: String, CaseIterable {
 
 enum LiveChromeGlassMaterialSupport {
 	static var isLiquidGlassAvailable: Bool {
-		if #available(macOS 26.0, *) {
-			return true
-		}
+		#if compiler(>=6.2)
+			if #available(macOS 26.0, *) {
+				return true
+			}
+		#endif
 		return false
 	}
 }


### PR DESCRIPTION
## Summary
- add Liquid Glass vs Classic Blur HUD mode selection with platform fallback
- move live HUD/loupe Liquid Glass rendering into external SwiftUI glass windows while preserving classic blur fallback
- restore live selection flow/scrim cadence and clean stale settings/telemetry docs

## Validation
- cargo make fmt-swift
- cargo make lint-swift
- cargo make test-macos-native-host
- git diff --check

## Runtime
- launched release bundle after validation for manual testing