### PR TITLE
Fix HUD glass material controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ cargo run -p rsnap
 
 - The native `Settings…` window currently owns:
   - HUD glass enable/disable
-  - HUD glass style (`Liquid Glass` / `Classic Blur`)
+  - HUD glass style (`Liquid Glass` / `Classic Glass`)
   - Liquid Glass style (`Regular` / `Clear`) when supported by macOS
-  - Classic HUD opacity / blur / tint / color
+  - shared HUD tint / color, plus Classic Glass opacity / blur
   - HUD `Tab` hint visibility
   - loupe sample size (`small` / `medium` / `large`)
   - output directory

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -250,8 +250,7 @@ private enum ChromeVisualKind {
 	}
 
 	func usesClassicWindowGlass(settings: NativeHostSettings) -> Bool {
-		settings.hudGlassEnabled && !usesLiquidGlassSurface(settings: settings)
-			&& settings.hudBlur > 0.01
+		settings.usesClassicHudGlass && !usesLiquidGlassSurface(settings: settings)
 	}
 }
 
@@ -391,7 +390,7 @@ private final class LiveChromeLiquidGlassView: NSView {
 				case .clear:
 					Glass.clear
 				}
-			glass = glass.interactive(false)
+			glass = glass.tint(.clear).interactive(false)
 			return AnyView(
 				GlassEffectContainer(spacing: 0) {
 					Color.clear
@@ -950,21 +949,16 @@ private final class LiveChromeRenderView: NSView {
 		)
 		context.saveGState()
 		let usesLiquidGlass = kind.usesLiquidGlassSurface(settings: settings)
-		if usesLiquidGlass {
-			context.restoreGState()
-			return
-		} else {
-			if strongShadow {
-				context.setShadow(offset: .zero, blur: 10, color: palette.shadow.cgColor)
-			}
-			let fillColor = CaptureChrome.effectiveBodyFill(
-				palette: palette,
-				settings: settings,
-				hasGlass: kind.usesClassicWindowGlass(settings: settings)
-			)
-			context.setFillColor(fillColor.cgColor)
-			pillPath.fill()
+		if strongShadow, !usesLiquidGlass {
+			context.setShadow(offset: .zero, blur: 10, color: palette.shadow.cgColor)
 		}
+		let fillColor = CaptureChrome.effectiveBodyFill(
+			palette: palette,
+			settings: settings,
+			hasGlass: usesLiquidGlass || kind.usesClassicWindowGlass(settings: settings)
+		)
+		context.setFillColor(fillColor.cgColor)
+		pillPath.fill()
 		context.restoreGState()
 
 		context.setStrokeColor(palette.outerStroke.cgColor)

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1331,7 +1331,7 @@ final class LiveOverlayRenderer {
 			transform: nil
 		)
 		let glassEnabled = settings.usesClassicHudGlass
-		let opacity = CGFloat(settings.hudOpacity.clamped(to: 0...1))
+		let opacity = CaptureChrome.effectiveHudOpacity(settings: settings)
 		let hasInlineGlass = glassEnabled && glassImage != nil
 		let usesExternalGlass = glassEnabled && glassImage == nil
 		let hasGlass = hasInlineGlass || usesExternalGlass

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -5234,6 +5234,8 @@ struct CaptureChromeForegroundPalette {
 }
 
 enum CaptureChrome {
+	private static let liquidGlassBodyOpacity: CGFloat = 0.5
+
 	static let hudInnerMarginX: CGFloat = 12
 	static let hudInnerMarginY: CGFloat = 8
 	static let hudCornerRadius: CGFloat = 18
@@ -5568,7 +5570,7 @@ enum CaptureChrome {
 	static func palette(for theme: CaptureChromeTheme, settings: NativeHostSettings)
 		-> CaptureChromePalette
 	{
-		let opacity = CGFloat(settings.hudOpacity.clamped(to: 0...1))
+		let opacity = effectiveHudOpacity(settings: settings)
 		let tint = CGFloat(settings.hudTint.clamped(to: 0...1))
 		let foregrounds = foregroundPalette(for: theme)
 		let bodyAlphaFloor: CGFloat = theme == .dark ? 0.06 : 0.08
@@ -5576,7 +5578,7 @@ enum CaptureChrome {
 			settings.hudGlassEnabled
 			? max(bodyAlphaFloor, opacity * 0.20)
 			: opacity
-		let tintColor = classicTintColor(for: theme, settings: settings)
+		let tintColor = glassTintColor(for: theme, settings: settings)
 
 		switch theme {
 		case .dark:
@@ -5667,12 +5669,19 @@ enum CaptureChrome {
 		Float(0.88 + settings.hudBlur.clamped(to: 0...1) * 0.12)
 	}
 
+	static func effectiveHudOpacity(settings: NativeHostSettings) -> CGFloat {
+		if settings.usesLiquidHudGlass {
+			return liquidGlassBodyOpacity
+		}
+		return CGFloat(settings.hudOpacity.clamped(to: 0...1))
+	}
+
 	static func effectiveBodyFill(
 		palette: CaptureChromePalette,
 		settings: NativeHostSettings,
 		hasGlass: Bool
 	) -> NSColor {
-		let opacity = CGFloat(settings.hudOpacity.clamped(to: 0...1))
+		let opacity = effectiveHudOpacity(settings: settings)
 		if hasGlass {
 			return palette.bodyFill.withAlphaComponent(
 				max(palette.bodyFill.alphaComponent, max(0.22, opacity * 0.42)))
@@ -5680,7 +5689,7 @@ enum CaptureChrome {
 		return palette.bodyFill.withAlphaComponent(max(0.42, opacity * 0.82))
 	}
 
-	private static func classicTintColor(
+	private static func glassTintColor(
 		for theme: CaptureChromeTheme, settings: NativeHostSettings
 	) -> NSColor {
 		let hue = CGFloat(settings.hudTintHue.clamped(to: 0...1))

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
@@ -41,6 +41,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 	private let hudOpacityValueLabel = NSTextField(labelWithString: "")
 	private let hudBlurValueLabel = NSTextField(labelWithString: "")
 	private let hudTintValueLabel = NSTextField(labelWithString: "")
+	private var glassTintOptionViews: [NSView] = []
 	private var classicGlassOptionViews: [NSView] = []
 	private var liquidGlassOptionViews: [NSView] = []
 
@@ -255,18 +256,26 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		}
 		container.addArrangedSubview(hudGlassModeControl)
 
+		let tintRows = [
+			makeGlassSubsectionTitle("Glass tint"),
+			makeSliderRow(
+				title: "Tint", slider: hudTintSlider, valueLabel: hudTintValueLabel,
+				action: #selector(hudTintChanged)),
+			makeTintColorRow(),
+		]
+		glassTintOptionViews = tintRows
+		for row in tintRows {
+			container.addArrangedSubview(row)
+		}
+
 		let classicRows = [
-			makeGlassSubsectionTitle("Classic blur options"),
+			makeGlassSubsectionTitle("Classic Glass options"),
 			makeSliderRow(
 				title: "Opacity", slider: hudOpacitySlider, valueLabel: hudOpacityValueLabel,
 				action: #selector(hudOpacityChanged)),
 			makeSliderRow(
 				title: "Blur", slider: hudBlurSlider, valueLabel: hudBlurValueLabel,
 				action: #selector(hudBlurChanged)),
-			makeSliderRow(
-				title: "Tint", slider: hudTintSlider, valueLabel: hudTintValueLabel,
-				action: #selector(hudTintChanged)),
-			makeTintColorRow(),
 		]
 		classicGlassOptionViews = classicRows
 		for row in classicRows {
@@ -415,17 +424,20 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		hudTintValueLabel.stringValue = "\(Int(settings.hudTint * 100))"
 		let glassEnabled = settings.hudGlassEnabled
 		let glassMode = settings.resolvedHudGlassMode
-		let classicBlurSelected = glassMode == .classicBlur
+		let classicGlassSelected = glassMode == .classicGlass
 		let liquidGlassSelected = glassMode == .liquidGlass
 		hudGlassModeControl.isEnabled = glassEnabled
+		for view in glassTintOptionViews {
+			view.isHidden = !glassEnabled
+		}
 		for view in classicGlassOptionViews {
-			view.isHidden = !glassEnabled || !classicBlurSelected
+			view.isHidden = !glassEnabled || !classicGlassSelected
 		}
 		for view in liquidGlassOptionViews {
 			view.isHidden = !glassEnabled || !liquidGlassSelected
 		}
-		hudOpacitySlider.isEnabled = glassEnabled
-		hudBlurSlider.isEnabled = glassEnabled
+		hudOpacitySlider.isEnabled = glassEnabled && classicGlassSelected
+		hudBlurSlider.isEnabled = glassEnabled && classicGlassSelected
 		hudTintSlider.isEnabled = glassEnabled
 		hudTintColorWell.isEnabled = glassEnabled
 		liquidGlassStyleControl.isEnabled = glassEnabled && liquidGlassSelected

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -227,18 +227,18 @@ enum FrozenResizeHandleOrientationPreference: String, CaseIterable {
 
 enum HudGlassModePreference: String, CaseIterable {
 	case liquidGlass = "liquid_glass"
-	case classicBlur = "classic_blur"
+	case classicGlass = "classic_glass"
 
 	static var defaultForCurrentSystem: Self {
-		LiveChromeGlassMaterialSupport.isLiquidGlassAvailable ? .liquidGlass : .classicBlur
+		LiveChromeGlassMaterialSupport.isLiquidGlassAvailable ? .liquidGlass : .classicGlass
 	}
 
 	var title: String {
 		switch self {
 		case .liquidGlass:
 			return "Liquid Glass"
-		case .classicBlur:
-			return "Classic Blur"
+		case .classicGlass:
+			return "Classic Glass"
 		}
 	}
 }
@@ -302,13 +302,13 @@ extension NativeHostSettings {
 		if hudGlassMode == .liquidGlass,
 			!LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
 		{
-			return .classicBlur
+			return .classicGlass
 		}
 		return hudGlassMode
 	}
 
 	var usesClassicHudGlass: Bool {
-		hudGlassEnabled && resolvedHudGlassMode == .classicBlur && hudBlur > 0.01
+		hudGlassEnabled && resolvedHudGlassMode == .classicGlass && hudBlur > 0.01
 	}
 
 	var usesLiquidHudGlass: Bool {


### PR DESCRIPTION
## Summary
- rename Classic Blur to Classic Glass and persist the new `classic_glass` mode token
- make only HUD tint/color shared between Liquid Glass and Classic Glass settings
- keep opacity/blur Classic Glass-only and stabilize Liquid Glass Regular against adaptive background tint
- preserve the rebased live color sampling work from `origin/main`

## Validation
- `cargo make fmt-swift`
- `cargo make build-swift-strict`
- `cargo make lint-swift`
- `cargo make test-macos-native-host`
- `git diff --check`
- `RSNAP_NATIVE_HOST_FORCE_REBUILD=1 ./scripts/build_and_run.sh verify`
- `codesign --verify --deep --strict /Users/x/code/y/hack-ink/rsnap/target/rsnap-native-host/rsnap.app`

## Notes
- Existing `classic_blur` persisted values are intentionally not migrated; this repo currently only needs the local/user config updated.
