### PR TITLE
Systematize telemetry collection

### DIFF
--- a/apps/rsnap/src/app/scroll_input_macos/tap.rs
+++ b/apps/rsnap/src/app/scroll_input_macos/tap.rs
@@ -63,7 +63,10 @@ fn run_scroll_input_event_tap_thread(
 
 		lifecycle.mark_failed();
 
-		tracing::warn!("Failed to create scroll input event tap.");
+		tracing::warn!(
+			op = "scroll_input.tap_create_failed",
+			"Failed to create scroll input event tap."
+		);
 
 		return;
 	}
@@ -83,7 +86,10 @@ fn run_scroll_input_event_tap_thread(
 
 		lifecycle.mark_failed();
 
-		tracing::warn!("Failed to create run-loop source for scroll input event tap.");
+		tracing::warn!(
+			op = "scroll_input.tap_run_loop_source_create_failed",
+			"Failed to create run-loop source for scroll input event tap."
+		);
 
 		return;
 	}

--- a/apps/rsnap/src/lib.rs
+++ b/apps/rsnap/src/lib.rs
@@ -7,7 +7,9 @@ pub mod runtime {
 
 	#[cfg(target_os = "macos")]
 	pub use crate::native_launcher_macos::run;
-	pub use crate::startup::{StartupBuildInfo, init_logging, startup_build_info};
+	pub use crate::startup::{
+		RUST_TELEMETRY_SCHEMA, StartupBuildInfo, init_logging, startup_build_info, telemetry_run_id,
+	};
 	#[cfg(not(target_os = "macos"))]
 	pub use crate::unsupported_platform::run;
 }
@@ -20,6 +22,8 @@ mod unsupported_platform;
 
 #[cfg(target_os = "macos")]
 pub use self::native_launcher_macos::run;
-pub use self::runtime::{StartupBuildInfo, init_logging, startup_build_info};
+pub use self::runtime::{
+	RUST_TELEMETRY_SCHEMA, StartupBuildInfo, init_logging, startup_build_info, telemetry_run_id,
+};
 #[cfg(not(target_os = "macos"))]
 pub use self::unsupported_platform::run;

--- a/apps/rsnap/src/main.rs
+++ b/apps/rsnap/src/main.rs
@@ -11,6 +11,9 @@ fn main() -> Result<()> {
 	let build_info = rsnap::startup_build_info();
 
 	tracing::info!(
+		schema = rsnap::RUST_TELEMETRY_SCHEMA,
+		run_id = rsnap::telemetry_run_id(),
+		op = "rsnap.starting",
 		version = build_info.version,
 		git_commit = build_info.git_commit,
 		"Starting rsnap."

--- a/apps/rsnap/src/startup.rs
+++ b/apps/rsnap/src/startup.rs
@@ -1,11 +1,17 @@
 use std::fs;
 use std::path::PathBuf;
+use std::process;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use directories::ProjectDirs;
 use serde::Deserialize;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::EnvFilter;
+
+/// Schema marker emitted by Rust-side telemetry events.
+pub const RUST_TELEMETRY_SCHEMA: &str = "rsnap.rust.telemetry/1";
 
 /// Build metadata logged during application startup.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -27,6 +33,18 @@ pub fn startup_build_info() -> StartupBuildInfo {
 		version: env!("CARGO_PKG_VERSION"),
 		git_commit: option_env!("RSNAP_BUILD_GIT_COMMIT").unwrap_or("unknown"),
 	}
+}
+
+/// Returns the process-scoped telemetry run identifier.
+pub fn telemetry_run_id() -> &'static str {
+	static RUN_ID: OnceLock<String> = OnceLock::new();
+
+	RUN_ID.get_or_init(|| {
+		let started_at_milliseconds =
+			SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |duration| duration.as_millis());
+
+		format!("{}-{started_at_milliseconds}", process::id())
+	})
 }
 
 /// Initializes file logging when the settings and filesystem allow it.
@@ -66,7 +84,13 @@ pub fn init_logging() -> Option<WorkerGuard> {
 
 	tracing_subscriber::fmt().with_writer(writer).with_env_filter(filter).with_ansi(false).init();
 
-	tracing::info!(log_dir = %log_dir.display(), "File logging initialized.");
+	tracing::info!(
+		schema = RUST_TELEMETRY_SCHEMA,
+		run_id = telemetry_run_id(),
+		op = "logging.file_initialized",
+		log_dir = %log_dir.display(),
+		"File logging initialized."
+	);
 
 	Some(guard)
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,12 @@ The active split below is by question type, not by human-versus-agent audience.
   `docs/spec/host-core-protocol.md`
 - Need the product-level capture contract independent from implementation history ->
   `docs/spec/capture-session.md`
+- Need telemetry fields, event names, metric names, or log correlation identifiers ->
+  `docs/spec/telemetry.md`
 - Need runbooks, migrations, validation steps, troubleshooting, or operational sequences ->
   `docs/runbook/`
+- Need native-host or Rust telemetry collection and summary steps ->
+  `docs/runbook/telemetry-debugging.md`
 - Need the step-by-step execution sequence for a host/core reset slice ->
   `docs/runbook/architecture-reset-implementation.md`
 - Need the active architecture-reset target and migration posture ->

--- a/docs/runbook/index.md
+++ b/docs/runbook/index.md
@@ -65,6 +65,8 @@ Then structure the body for execution:
   routing through superseded shell-specific assumptions
 - `docs/runbook/performance-validation.md` for repo-native performance and smoke command routing
 - `docs/runbook/scroll-capture-benchmarks.md` for deterministic scroll-capture benchmark usage
+- `docs/runbook/telemetry-debugging.md` for collecting and summarizing native-host OSLog plus
+  Rust rolling logs during runtime debugging
 
 Historical validation material is archived outside the active runbook lane and should not be used
 as the default validation route for reset work.

--- a/docs/runbook/telemetry-debugging.md
+++ b/docs/runbook/telemetry-debugging.md
@@ -1,0 +1,172 @@
+# Telemetry Debugging
+
+Goal: Collect and summarize rsnap native-host and Rust telemetry for screenshot,
+ScreenCaptureKit, live chrome, and capture-output debugging.
+
+Read this when: A local run has a performance, startup, frozen-frame, pasteboard, live
+chrome, or scroll-capture symptom that needs evidence.
+
+Inputs: A local checkout, macOS Unified Logging, and the native host launched through
+`scripts/build_and_run.sh`.
+
+Depends on: `docs/spec/telemetry.md` for the field contract.
+
+Outputs: A telemetry artifact directory containing native OSLog output, Rust rolling logs,
+combined logs, and a compact summary.
+
+## Launch The Current Build
+
+Use the signed release path when testing user-visible native-host behavior:
+
+```sh
+RSNAP_NATIVE_HOST_FORCE_REBUILD=1 ./scripts/build_and_run.sh run
+```
+
+Use the streaming mode when you need live logs while reproducing:
+
+```sh
+./scripts/build_and_run.sh --telemetry
+```
+
+`--telemetry` streams through `scripts/telemetry/native-host.sh`, so it uses the same
+predicate as the collection path below.
+
+## Collect An Artifact
+
+Run:
+
+```sh
+scripts/telemetry/native-host.sh collect
+```
+
+The command prints the artifact directory. By default it writes under:
+
+```text
+target/telemetry/native-host-YYYYMMDD-HHMMSS/
+```
+
+The artifact contains:
+
+- `native-host.oslog`: macOS Unified Logging entries for `ink.hack.rsnap` native-host telemetry
+- `rust/`: filtered Rust rolling log files containing entries inside the selected telemetry window
+- `all.log`: native-host and Rust logs concatenated for quick grep
+- `summary.txt`: latest run/capture identifiers plus counts grouped by `event`, `metric`,
+  `op`, `captureID`, and run id
+
+Use a custom output directory when comparing multiple runs:
+
+```sh
+RSNAP_TELEMETRY_OUT_DIR=target/telemetry/cold-capture-a scripts/telemetry/native-host.sh collect
+```
+
+Use a custom time window when the symptom happened earlier:
+
+```sh
+RSNAP_TELEMETRY_LAST=30m scripts/telemetry/native-host.sh collect
+```
+
+`RSNAP_TELEMETRY_LAST` applies to macOS Unified Logging through `log show --last`.
+For Rust rolling logs, the same value first skips stale rolling files by modification time
+and then filters entries by their leading UTC timestamp, so old process logs do not
+pollute a fresh artifact. The helper supports `s`, `m`, `h`, and `d` suffixes for
+Rust-log filtering; widen the window or set `RSNAP_RUST_LOG_DIR` when you intentionally
+need older Rust logs.
+
+## Show Or Summarize Without Creating An Artifact
+
+Show recent native-host telemetry:
+
+```sh
+RSNAP_TELEMETRY_LAST=5m scripts/telemetry/native-host.sh show
+```
+
+Summarize native-host telemetry plus available Rust logs:
+
+```sh
+RSNAP_TELEMETRY_LAST=5m scripts/telemetry/native-host.sh summary
+```
+
+The summary command uses the same native-host predicate and Rust-log modification window
+as `collect`.
+
+## Interpret Capture Sessions
+
+Start with `summary.txt` and read `latest.nonzero_capture_id`.
+
+Then inspect the chain:
+
+```sh
+grep 'captureID=1' target/telemetry/native-host-*/all.log
+```
+
+Expected capture chain:
+
+1. `capture_timing.live_sampling_warm`
+2. `capture_timing.start_capture`
+3. `capture_timing.freeze_commit` or `capture_timing.freeze_commit_failed`
+4. `capture_timing.frozen_selection_image`
+5. `capture_timing.copy_capture`
+6. `capture.teardown`
+
+If the chain stops before `capture_timing.start_capture`, focus on permissions,
+warm sampling, window snapshots, or overlay show timing.
+
+If the chain stops at `capture_timing.freeze_commit_failed`, inspect
+`FrozenFrameAuthority` entries for ScreenCaptureKit content lookup, stream start, or first
+frame timing.
+
+If `capture_timing.copy_capture` is slow, compare `captureImageMs`, `makeImageMs`, and
+`writePasteboardMs` before changing capture code.
+
+## Interpret Live Chrome
+
+Find:
+
+```sh
+grep 'event=live_chrome.refresh_target' target/telemetry/native-host-*/all.log
+```
+
+The entry records the cadence and rendering path:
+
+- `captureID`
+- `targetHz`
+- `frameBudgetMs`
+- `hudGlassEnabled`
+- `hudGlassMode`
+- `liquidGlassStyle`
+- `liquidGlassAvailable`
+
+When visual performance differs across settings, compare these fields before comparing
+duration metrics.
+
+## Interpret Rust Runtime Logs
+
+Rust logs aggregate by `op`.
+
+Use:
+
+```sh
+grep 'op=' target/telemetry/native-host-*/all.log
+```
+
+Common useful prefixes:
+
+- `overlay.*`
+- `live_frame_stream.*`
+- `scroll_capture.*`
+- `scroll_input.*`
+- `logging.file_initialized`
+- `rsnap.starting`
+
+Rust startup entries include `schema=rsnap.rust.telemetry/1` and `run_id=...`.
+
+## Required Closeout Evidence
+
+For a telemetry-sensitive fix, report:
+
+- The launched native-host PID.
+- The artifact directory or exact `log show` query.
+- The relevant `runID`.
+- The relevant `captureID`, when a capture session was exercised.
+- The commands run from `Makefile.toml`, such as `cargo make lint-swift` or
+  `cargo make lint-rust`.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -66,3 +66,5 @@ Then keep the body explicit:
   the Frozen toolbar style capsule
 - `docs/spec/performance.md` for render cadence, performance scenarios, metrics,
   thresholds, and known performance-contract gaps
+- `docs/spec/telemetry.md` for native-host OSLog and Rust tracing schema fields, event naming,
+  metric naming, categories, and correlation identifiers

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -1,0 +1,140 @@
+# Telemetry Schema
+
+Purpose: Define the required telemetry fields, source boundaries, and naming rules for
+rsnap runtime debugging.
+
+Status: normative
+
+Read this when: Changing logs, adding timing metrics, writing diagnostic scripts, or
+debugging a native-host capture path.
+
+Not this document: Use `docs/runbook/telemetry-debugging.md` for the collection sequence.
+
+Defines: Native-host OSLog fields, Rust tracing fields, category ownership, event names,
+metric names, and correlation identifiers.
+
+## Sources
+
+rsnap has two active telemetry sources.
+
+| Source | Transport | Schema | Primary file |
+| --- | --- | --- | --- |
+| macOS native host | Unified Logging / OSLog | `rsnap.native_host.telemetry/1` | `native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift` |
+| Rust desktop/runtime | `tracing` rolling file logs | `rsnap.rust.telemetry/1` | `apps/rsnap/src/startup.rs` |
+
+Native-host events are the authoritative source for screenshot startup, live sampling,
+Frozen transition, pasteboard write, and native ScreenCaptureKit lifecycle timing.
+
+Rust tracing events are the authoritative source for the older Rust overlay runtime,
+scroll capture, live frame stream internals, and file-log initialization.
+
+## Required Fields
+
+Every native-host telemetry line must include:
+
+- `schema=rsnap.native_host.telemetry/1`
+- `runID=<uuid>`
+- `event=<stable.name>` or `metric=<stable.name>`
+
+Every native-host capture-session event must include:
+
+- `captureID=<integer>`
+- `captureID=0` only for process-level startup or prewarm work outside an active capture.
+
+Every Rust process telemetry line that identifies the process run must include:
+
+- `schema=rsnap.rust.telemetry/1`
+- `run_id=<pid-started_at_ms>`
+- `op=<stable.name>`
+
+Every new Rust tracing event must include:
+
+- `op=<stable.name>`
+- Structured fields for dynamic values such as ids, counts, durations, paths, and errors.
+
+## Native-Host Categories
+
+| Category | Owns |
+| --- | --- |
+| `Lifecycle` | App startup, status item setup, sound loading, process prewarm status |
+| `Capture` | Non-timing capture lifecycle events and failures |
+| `CaptureTiming` | Capture-session phase timings and capture output timings |
+| `FrozenFrameAuthority` | ScreenCaptureKit frozen-frame stream setup, first frame, and stream failures |
+| `LiveChromeTelemetry` | Live HUD/loupe refresh target and batched live chrome metrics |
+
+Do not reintroduce raw `NSLog` for native-host runtime diagnostics. Route new native-host
+diagnostics through `NativeHostTelemetry`.
+
+Collection scripts must default to schema-qualified native-host OSLog entries:
+
+```text
+subsystem == "ink.hack.rsnap" AND composedMessage CONTAINS "schema=rsnap.native_host.telemetry/1"
+```
+
+Use an explicit predicate override only when investigating legacy or non-telemetry OSLog
+noise.
+
+Rust collection helpers must filter rolling log entries to the selected collection window
+using the leading UTC timestamp emitted by `tracing_subscriber::fmt`.
+
+## Event And Metric Names
+
+Use dotted lowercase names:
+
+- `native_host.finish_launching_begin`
+- `capture_timing.start_capture`
+- `capture_timing.freeze_commit`
+- `capture_timing.copy_capture`
+- `frozen_authority.stream_start_failed`
+- `live_chrome.refresh_target`
+- `logging.file_initialized`
+
+Event names describe one observation. Metric names describe one sampled distribution.
+Do not encode values into the event name; emit values as fields.
+
+## Units
+
+- Durations use milliseconds and end in `Ms`.
+- Rates use hertz and end in `Hz`.
+- Boolean values use `true` or `false`.
+- Pixel dimensions use `width` and `height`.
+- OS display identifiers use `displayID`.
+- Rust identifiers use snake_case unless they are mirroring existing platform names.
+
+## Capture Correlation
+
+`CaptureSessionController` owns `captureID` allocation. A single user-visible capture
+session keeps the same `captureID` from startup through teardown.
+
+Expected capture-session chain:
+
+1. `capture_timing.live_sampling_warm`
+2. `capture_timing.start_capture`
+3. `capture_timing.freeze_commit` or `capture_timing.freeze_commit_failed`
+4. `capture_timing.frozen_selection_image`
+5. `capture_timing.copy_capture`
+6. `capture.teardown`
+
+Missing events in the chain are evidence of the next failing phase and should be treated as
+debug signal, not as logging noise.
+
+## Live Chrome Correlation
+
+`live_chrome.refresh_target` must include:
+
+- `captureID`
+- `targetHz`
+- `frameBudgetMs`
+- `hudGlassEnabled`
+- `hudGlassMode`
+- `liquidGlassStyle`
+- `liquidGlassAvailable`
+
+The live chrome refresh-target dedupe key must include the glass fields above, because the
+rendering path can change without `targetHz` changing.
+
+## Privacy
+
+Native-host telemetry can mark diagnostic fields public when they are needed for debugging.
+Do not log captured image contents, OCR text, clipboard contents, or user-entered annotation
+text. Paths may be logged only when they identify app resources or log artifacts.

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -58,6 +58,12 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 	}
 
+	private struct TelemetryContext {
+		let captureID: UInt64
+		let source: String
+		let startedAtUptime: TimeInterval
+	}
+
 	private final class PixelBufferImageBacking {
 		let pixelBuffer: CVPixelBuffer
 		let baseAddress: UnsafeMutableRawPointer
@@ -99,8 +105,13 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	private var displayTargets: [CGDirectDisplayID: DisplayTarget] = [:]
 	private var streams: [CGDirectDisplayID: DisplayStream] = [:]
 	private var latestFrames: [CGDirectDisplayID: FrameRecord] = [:]
+	private var firstFrameStartUptimes: [CGDirectDisplayID: TimeInterval] = [:]
+	private var firstFrameLoggedDisplayIDs: Set<CGDirectDisplayID> = []
+	private var telemetryContext = TelemetryContext(
+		captureID: 0, source: "capture", startedAtUptime: 0)
 
-	func start(for screens: [NSScreen]) {
+	func start(for screens: [NSScreen], captureID: UInt64 = 0, source: String = "capture") {
+		let setupStartedAt = ProcessInfo.processInfo.systemUptime
 		let targets = screens.compactMap(Self.displayTarget(for:))
 		guard !targets.isEmpty else {
 			stop()
@@ -112,7 +123,13 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		stateLock.lock()
 		let unchanged = activeDisplayIDs == targetIDs && displayTargets == nextTargets
 		displayTargets = nextTargets
-		if unchanged, !streams.isEmpty || setupDisplayIDs == targetIDs {
+		if unchanged, !streams.isEmpty {
+			updateTelemetryContextLocked(
+				captureID: captureID,
+				source: source,
+				startedAtUptime: setupStartedAt,
+				targetIDs: targetIDs
+			)
 			stateLock.unlock()
 			return
 		}
@@ -121,6 +138,12 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		activeDisplayIDs = targetIDs
 		setupDisplayIDs = targetIDs
 		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
+		updateTelemetryContextLocked(
+			captureID: captureID,
+			source: source,
+			startedAtUptime: setupStartedAt,
+			targetIDs: targetIDs
+		)
 		let staleStreams = streams.values
 		streams.removeAll()
 		stateLock.unlock()
@@ -134,12 +157,43 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			guard let self else {
 				return
 			}
+			guard self.isCurrentGeneration(requestGeneration) else {
+				return
+			}
 			guard let content else {
-				NSLog("Frozen frame authority content lookup failed: \(String(describing: error))")
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_lookup_failed",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: String(describing: error)
+				)
+				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+					captureID: captureID,
+					source: source,
+					totalMilliseconds: NativeHostTelemetry.milliseconds(since: setupStartedAt),
+					success: false,
+					displayCount: targets.count,
+					windowCount: 0
+				)
 				self.finishSetup(generation: requestGeneration)
 				return
 			}
-			self.configureStreams(content: content, targets: targets, generation: requestGeneration)
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: setupStartedAt),
+				success: true,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+			self.configureStreams(
+				content: content,
+				targets: targets,
+				generation: requestGeneration,
+				captureID: captureID,
+				source: source
+			)
 		}
 	}
 
@@ -150,6 +204,10 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		setupDisplayIDs = nil
 		displayTargets.removeAll()
 		latestFrames.removeAll()
+		firstFrameStartUptimes.removeAll()
+		firstFrameLoggedDisplayIDs.removeAll()
+		telemetryContext = TelemetryContext(
+			captureID: 0, source: "capture", startedAtUptime: 0)
 		let staleStreams = streams.values
 		streams.removeAll()
 		stateLock.unlock()
@@ -226,7 +284,9 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	private func configureStreams(
 		content: SCShareableContent,
 		targets: [DisplayTarget],
-		generation requestGeneration: UInt64
+		generation requestGeneration: UInt64,
+		captureID: UInt64,
+		source: String
 	) {
 		let currentPID = getpid()
 		let excludedApplications = content.applications.filter { $0.processID == currentPID }
@@ -251,9 +311,12 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			}
 
 			let output = FrozenFrameStreamOutput(
-				displayID: target.displayID, displayFrame: target.frame
+				displayID: target.displayID,
+				displayFrame: target.frame
 			) { [weak self] frame in
 				self?.store(frame: frame, generation: requestGeneration)
+			} telemetrySnapshot: { [weak self] in
+				self?.currentTelemetrySnapshot() ?? (captureID: captureID, source: source)
 			}
 			let stream = SCStream(
 				filter: filter, configuration: Self.streamConfiguration(for: target),
@@ -262,8 +325,12 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 				try stream.addStreamOutput(
 					output, type: SCStreamOutputType.screen, sampleHandlerQueue: outputQueue)
 			} catch {
-				NSLog(
-					"Frozen frame authority output install failed display=\(target.displayID): \(error)"
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.output_install_failed",
+					captureID: captureID,
+					source: source,
+					displayID: target.displayID,
+					error: String(describing: error)
 				)
 				continue
 			}
@@ -280,8 +347,12 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 
 			stream.startCapture { error in
 				if let error {
-					NSLog(
-						"Frozen frame authority stream start failed display=\(target.displayID): \(error)"
+					NativeHostTelemetry.frozenAuthorityWarning(
+						"frozen_authority.stream_start_failed",
+						captureID: captureID,
+						source: source,
+						displayID: target.displayID,
+						error: String(describing: error)
 					)
 				}
 			}
@@ -289,13 +360,38 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		finishSetup(generation: requestGeneration)
 	}
 
-	private func store(frame: FrameRecord, generation requestGeneration: UInt64) {
+	private func store(
+		frame: FrameRecord,
+		generation requestGeneration: UInt64
+	) {
+		var firstFrameTelemetry: TelemetryContext?
 		stateLock.lock()
 		if generation == requestGeneration, activeDisplayIDs.contains(frame.displayID) {
+			if !firstFrameLoggedDisplayIDs.contains(frame.displayID) {
+				firstFrameLoggedDisplayIDs.insert(frame.displayID)
+				let startedAt =
+					firstFrameStartUptimes[frame.displayID] ?? telemetryContext.startedAtUptime
+				firstFrameTelemetry = TelemetryContext(
+					captureID: telemetryContext.captureID,
+					source: telemetryContext.source,
+					startedAtUptime: startedAt
+				)
+			}
 			latestFrames[frame.displayID] = frame
 			stateLock.broadcast()
 		}
 		stateLock.unlock()
+		if let firstFrameTelemetry {
+			NativeHostTelemetry.frozenAuthorityFirstFrameTiming(
+				captureID: firstFrameTelemetry.captureID,
+				source: firstFrameTelemetry.source,
+				displayID: frame.displayID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(
+					since: firstFrameTelemetry.startedAtUptime),
+				frameAgeMilliseconds: frame.ageMilliseconds(),
+				sequence: frame.sequence
+			)
+		}
 	}
 
 	private func finishSetup(generation requestGeneration: UInt64) {
@@ -305,6 +401,38 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			stateLock.broadcast()
 		}
 		stateLock.unlock()
+	}
+
+	private func isCurrentGeneration(_ requestGeneration: UInt64) -> Bool {
+		stateLock.lock()
+		let isCurrent = generation == requestGeneration
+		stateLock.unlock()
+		return isCurrent
+	}
+
+	private func updateTelemetryContextLocked(
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		targetIDs: Set<CGDirectDisplayID>
+	) {
+		telemetryContext = TelemetryContext(
+			captureID: captureID,
+			source: source,
+			startedAtUptime: startedAtUptime
+		)
+		firstFrameStartUptimes = firstFrameStartUptimes.filter { targetIDs.contains($0.key) }
+		firstFrameLoggedDisplayIDs.removeAll(keepingCapacity: true)
+		for targetID in targetIDs {
+			firstFrameStartUptimes[targetID] = startedAtUptime
+		}
+	}
+
+	private func currentTelemetrySnapshot() -> (captureID: UInt64, source: String) {
+		stateLock.lock()
+		let snapshot = (captureID: telemetryContext.captureID, source: telemetryContext.source)
+		stateLock.unlock()
+		return snapshot
 	}
 
 	private static func streamConfiguration(for target: DisplayTarget) -> SCStreamConfiguration {
@@ -388,16 +516,19 @@ private final class FrozenFrameStreamOutput: NSObject, SCStreamOutput, SCStreamD
 	private let displayID: CGDirectDisplayID
 	private let displayFrame: CGRect
 	private let onFrame: (FrozenFrameAuthority.FrameRecord) -> Void
+	private let telemetrySnapshot: () -> (captureID: UInt64, source: String)
 	private var sequence: UInt64 = 0
 
 	init(
 		displayID: CGDirectDisplayID,
 		displayFrame: CGRect,
-		onFrame: @escaping (FrozenFrameAuthority.FrameRecord) -> Void
+		onFrame: @escaping (FrozenFrameAuthority.FrameRecord) -> Void,
+		telemetrySnapshot: @escaping () -> (captureID: UInt64, source: String)
 	) {
 		self.displayID = displayID
 		self.displayFrame = displayFrame
 		self.onFrame = onFrame
+		self.telemetrySnapshot = telemetrySnapshot
 	}
 
 	func stream(
@@ -422,7 +553,14 @@ private final class FrozenFrameStreamOutput: NSObject, SCStreamOutput, SCStreamD
 	}
 
 	func stream(_ stream: SCStream, didStopWithError error: Error) {
-		NSLog("Frozen frame authority stream stopped display=\(displayID): \(error)")
+		let snapshot = telemetrySnapshot()
+		NativeHostTelemetry.frozenAuthorityWarning(
+			"frozen_authority.stream_stopped",
+			captureID: snapshot.captureID,
+			source: snapshot.source,
+			displayID: displayID,
+			error: String(describing: error)
+		)
 	}
 
 	private static func isUsableFrame(_ sampleBuffer: CMSampleBuffer) -> Bool {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -4,7 +4,6 @@ import CoreImage
 import CoreText
 import Darwin
 import Foundation
-import OSLog
 import RsnapHostBridge
 import Vision
 
@@ -27,11 +26,15 @@ struct LiveColorSampleSource: Equatable, Sendable {
 	let scaleFactor: CGFloat
 }
 
+private struct LiveChromeRefreshTelemetryKey: Equatable {
+	let targetHz: Int
+	let hudGlassEnabled: Bool
+	let hudGlassMode: String
+	let liquidGlassStyle: String
+	let liquidGlassAvailable: Bool
+}
+
 @MainActor private let frozenEffectCIContext = CIContext(options: nil)
-private let menuBarLogger = Logger(
-	subsystem: Bundle.main.bundleIdentifier ?? "ink.hack.rsnap",
-	category: "MenuBar"
-)
 
 private enum CaptureSuccessSound {
 	private static let candidatePaths = [
@@ -42,14 +45,19 @@ private enum CaptureSuccessSound {
 	static func load() -> NSSound? {
 		for path in candidatePaths {
 			if let sound = NSSound(contentsOfFile: path, byReference: true) {
-				menuBarLogger.info("loaded capture success sound path=\(path, privacy: .public)")
+				NativeHostTelemetry.lifecycleEvent(
+					"native_host.capture_success_sound_loaded",
+					detail: "path=\(path)"
+				)
 				return sound
 			}
 		}
 
-		let candidates = candidatePaths.joined(separator: ", ")
-		menuBarLogger.warning(
-			"failed to load capture success sound candidates=\(candidates, privacy: .public)")
+		let candidates = candidatePaths.joined(separator: ",")
+		NativeHostTelemetry.lifecycleWarning(
+			"native_host.capture_success_sound_load_failed",
+			detail: "candidates=\(candidates)"
+		)
 		return nil
 	}
 
@@ -60,7 +68,8 @@ private enum CaptureSuccessSound {
 		sound.stop()
 		sound.currentTime = 0
 		if !sound.play() {
-			menuBarLogger.warning("failed to play capture success sound")
+			NativeHostTelemetry.lifecycleWarning(
+				"native_host.capture_success_sound_play_failed")
 		}
 	}
 }
@@ -108,7 +117,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 			return
 		}
 		didBootstrap = true
-		menuBarLogger.info("finishLaunching begin")
+		NativeHostTelemetry.lifecycleEvent("native_host.finish_launching_begin")
 		NSApp.setActivationPolicy(.accessory)
 		ProcessInfo.processInfo.disableAutomaticTermination("rsnap menubar host")
 		ProcessInfo.processInfo.disableSuddenTermination()
@@ -128,8 +137,10 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
 		refreshStatusMenuState()
 		scheduleLiveSamplingPrewarm()
-		menuBarLogger.info(
-			"finishLaunching end statusItemPresent=\(self.statusItem != nil, privacy: .public)")
+		NativeHostTelemetry.lifecycleEvent(
+			"native_host.finish_launching_end",
+			detail: "statusItemPresent=\(statusItem != nil)"
+		)
 	}
 
 	public func applicationDidFinishLaunching(_ notification: Notification) {
@@ -172,20 +183,24 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	private func configureStatusItem() {
 		let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
 		item.isVisible = true
-		menuBarLogger.info(
-			"created status item buttonPresent=\(item.button != nil, privacy: .public)")
+		NativeHostTelemetry.lifecycleEvent(
+			"native_host.status_item_created",
+			detail: "buttonPresent=\(item.button != nil)"
+		)
 		if let button = item.button {
 			if let image = Self.statusItemImage() {
 				button.image = image
 				button.imagePosition = .imageOnly
 				button.imageScaling = .scaleProportionallyDown
 				button.title = ""
-				menuBarLogger.info(
-					"configured status item with image size=\(Int(image.size.width), privacy: .public)x\(Int(image.size.height), privacy: .public)"
+				NativeHostTelemetry.lifecycleEvent(
+					"native_host.status_item_image_configured",
+					detail: "width=\(Int(image.size.width)),height=\(Int(image.size.height))"
 				)
 			} else {
 				button.title = "RS"
-				menuBarLogger.info("configured status item with text fallback")
+				NativeHostTelemetry.lifecycleEvent(
+					"native_host.status_item_text_fallback_configured")
 			}
 		}
 
@@ -215,8 +230,9 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		statusItem = item
 		captureMenuItem = captureItem
 		cancelCaptureMenuItem = cancelItem
-		menuBarLogger.info(
-			"status item installed visible=\(item.isVisible, privacy: .public) hasMenu=\(item.menu != nil, privacy: .public)"
+		NativeHostTelemetry.lifecycleEvent(
+			"native_host.status_item_installed",
+			detail: "visible=\(item.isVisible),hasMenu=\(item.menu != nil)"
 		)
 	}
 
@@ -260,9 +276,12 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 			return
 		}
 		let point = NSEvent.mouseLocation
-		let sample = sessionController.warmLiveSamplingIfPossible(at: point)
-		menuBarLogger.debug(
-			"prewarmed live sampling sampleReady=\(sample?.rgbSample != nil, privacy: .public)")
+		let sample = sessionController.warmLiveSamplingIfPossible(
+			at: point, source: "startup_prewarm", captureID: 0)
+		NativeHostTelemetry.lifecycleDebug(
+			"native_host.live_sampling_prewarm",
+			detail: "sampleReady=\(sample?.rgbSample != nil)"
+		)
 	}
 
 	@objc
@@ -327,6 +346,8 @@ final class CaptureSessionController: NSObject {
 	private var frozenFrameLatchToken: FrozenFrameLatchToken?
 	private var frozenSnapshotGeneration: UInt64 = 0
 	private var completedHostEffect: HostEffectKind?
+	private var nextCaptureTelemetryID: UInt64 = 1
+	private var activeCaptureTelemetryID: UInt64?
 	var captureStateDidChange: (() -> Void)?
 	private var scene = SceneSnapshot(
 		mode: .hidden,
@@ -371,36 +392,114 @@ final class CaptureSessionController: NSObject {
 		settingsStore.settings
 	}
 
+	private var currentCaptureTelemetryID: UInt64 {
+		activeCaptureTelemetryID ?? 0
+	}
+
+	var activeTelemetryCaptureID: UInt64 {
+		currentCaptureTelemetryID
+	}
+
+	private func allocateCaptureTelemetryID() -> UInt64 {
+		let captureID = nextCaptureTelemetryID
+		nextCaptureTelemetryID &+= 1
+		if nextCaptureTelemetryID == 0 {
+			nextCaptureTelemetryID = 1
+		}
+		return captureID
+	}
+
 	@discardableResult
-	func warmLiveSamplingIfPossible(at point: CGPoint) -> LiveChromeSample? {
+	func warmLiveSamplingIfPossible(
+		at point: CGPoint,
+		source: String = "capture",
+		captureID: UInt64 = 0
+	) -> LiveChromeSample? {
+		let warmStartedAt = ProcessInfo.processInfo.systemUptime
+		let screenCount = NSScreen.screens.count
 		guard NativePermissions.status(for: .screenRecording) else {
+			NativeHostTelemetry.liveSamplingWarmTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: warmStartedAt),
+				frozenAuthorityStartMilliseconds: 0,
+				liveStreamStartMilliseconds: 0,
+				seedSampleMilliseconds: 0,
+				sampleReady: false,
+				screenCount: screenCount
+			)
 			return nil
 		}
-		frozenFrameAuthority.start(for: NSScreen.screens)
-		liveFrameStream.start(for: NSScreen.screens, prewarmPoint: point)
-		return liveFrameStream.seedSample(at: point, sidePixels: 1)
+		let screens = NSScreen.screens
+		let frozenAuthorityStartedAt = ProcessInfo.processInfo.systemUptime
+		frozenFrameAuthority.start(for: screens, captureID: captureID, source: source)
+		let frozenAuthorityStartMilliseconds =
+			NativeHostTelemetry.milliseconds(since: frozenAuthorityStartedAt)
+		let liveStreamStartedAt = ProcessInfo.processInfo.systemUptime
+		liveFrameStream.start(for: screens, prewarmPoint: point)
+		let liveStreamStartMilliseconds =
+			NativeHostTelemetry.milliseconds(since: liveStreamStartedAt)
+		let seedStartedAt = ProcessInfo.processInfo.systemUptime
+		let sample = liveFrameStream.seedSample(at: point, sidePixels: 1)
+		let seedSampleMilliseconds = NativeHostTelemetry.milliseconds(since: seedStartedAt)
+		NativeHostTelemetry.liveSamplingWarmTiming(
+			captureID: captureID,
+			source: source,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: warmStartedAt),
+			frozenAuthorityStartMilliseconds: frozenAuthorityStartMilliseconds,
+			liveStreamStartMilliseconds: liveStreamStartMilliseconds,
+			seedSampleMilliseconds: seedSampleMilliseconds,
+			sampleReady: sample?.rgbSample != nil,
+			screenCount: screenCount
+		)
+		return sample
 	}
 
 	func startCapture() {
 		if session != nil {
+			NativeHostTelemetry.captureEvent(
+				"capture.focus_existing",
+				captureID: currentCaptureTelemetryID
+			)
 			overlayController?.focusWindow(at: NSEvent.mouseLocation)
 			return
 		}
+		let captureID = allocateCaptureTelemetryID()
+		activeCaptureTelemetryID = captureID
+		let captureStartedAt = ProcessInfo.processInfo.systemUptime
 		guard ensureCapturePermissions() else {
-			NSLog("RsnapNativeHost startCapture blocked by screen recording permission")
+			NativeHostTelemetry.captureWarning(
+				"capture.start_blocked",
+				captureID: captureID,
+				stage: "screen_recording_permission",
+				error: "permission_denied"
+			)
+			NativeHostTelemetry.captureStartFailureTiming(
+				captureID: captureID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+				failureStage: "screen_recording_permission"
+			)
+			activeCaptureTelemetryID = nil
 			captureStateDidChange?()
 			return
 		}
 
 		do {
 			let startPoint = NSEvent.mouseLocation
-			let initialSample = warmLiveSamplingIfPossible(at: startPoint)
+			let warmStartedAt = ProcessInfo.processInfo.systemUptime
+			let initialSample = warmLiveSamplingIfPossible(
+				at: startPoint, source: "start_capture", captureID: captureID)
+			let warmMilliseconds = NativeHostTelemetry.milliseconds(since: warmStartedAt)
 			frozenFrameLatchToken = nil
 			let desktopFrame = CaptureOverlayController.desktopFrame
+			let windowSnapshotStartedAt = ProcessInfo.processInfo.systemUptime
 			let initialWindowSnapshots = WindowSnapshotFeed.snapshots(desktopFrame: desktopFrame)
+			let windowSnapshotMilliseconds =
+				NativeHostTelemetry.milliseconds(since: windowSnapshotStartedAt)
 			let initialHighlightedWindow = WindowSnapshotFeed.window(
 				at: startPoint, in: initialWindowSnapshots)
 			chromeState.rgbSample = initialSample?.rgbSample
+			let sessionSetupStartedAt = ProcessInfo.processInfo.systemUptime
 			let session = try RsnapHostSession(configuration: settingsStore.sessionConfiguration)
 			self.session = session
 
@@ -415,12 +514,15 @@ final class CaptureSessionController: NSObject {
 			)
 			let initialScene = try session.currentScene()
 			self.scene = initialScene
+			let sessionSetupMilliseconds =
+				NativeHostTelemetry.milliseconds(since: sessionSetupStartedAt)
 
 			let overlayController = CaptureOverlayController(
 				controller: self,
 				liveFrameStream: liveFrameStream
 			)
 			self.overlayController = overlayController
+			let overlayShowStartedAt = ProcessInfo.processInfo.systemUptime
 			overlayController.show(
 				initialScene: initialScene,
 				chrome: chromeState,
@@ -428,13 +530,36 @@ final class CaptureSessionController: NSObject {
 				focusPoint: startPoint,
 				initialWindowSnapshots: initialWindowSnapshots
 			)
+			let overlayShowMilliseconds =
+				NativeHostTelemetry.milliseconds(since: overlayShowStartedAt)
 			(NSApp.delegate as? NativeHostApplicationController)?.window =
 				overlayController.primaryWindow
 			sceneDidChange?(initialScene)
 
 			captureStateDidChange?()
+			NativeHostTelemetry.captureStartTiming(
+				captureID: captureID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+				warmMilliseconds: warmMilliseconds,
+				windowSnapshotMilliseconds: windowSnapshotMilliseconds,
+				sessionSetupMilliseconds: sessionSetupMilliseconds,
+				overlayShowMilliseconds: overlayShowMilliseconds,
+				initialSampleReady: initialSample?.rgbSample != nil,
+				screenCount: NSScreen.screens.count,
+				windowCount: initialWindowSnapshots.count
+			)
 		} catch {
-			NSLog("Failed to start native rsnap host: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.start_failed",
+				captureID: captureID,
+				stage: "exception",
+				error: String(describing: error)
+			)
+			NativeHostTelemetry.captureStartFailureTiming(
+				captureID: captureID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+				failureStage: "exception"
+			)
 			tearDownCapture()
 		}
 	}
@@ -496,7 +621,12 @@ final class CaptureSessionController: NSObject {
 			try session?.send(event: .cancelRequested)
 			try syncCore()
 		} catch {
-			NSLog("Failed to cancel capture: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.cancel_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 			tearDownCapture()
 		}
 	}
@@ -514,7 +644,12 @@ final class CaptureSessionController: NSObject {
 			)
 			try syncCore()
 		} catch {
-			NSLog("Failed to send pointer update: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.pointer_update_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -546,7 +681,12 @@ final class CaptureSessionController: NSObject {
 			)
 			try syncCore()
 		} catch {
-			NSLog("Failed to begin primary interaction: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.primary_interaction_begin_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -580,7 +720,12 @@ final class CaptureSessionController: NSObject {
 			)
 			try syncCore()
 		} catch {
-			NSLog("Failed to update primary interaction: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.primary_interaction_update_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -614,7 +759,12 @@ final class CaptureSessionController: NSObject {
 			)
 			try syncCore()
 		} catch {
-			NSLog("Failed to freeze selection: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.primary_interaction_complete_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -639,7 +789,12 @@ final class CaptureSessionController: NSObject {
 			try sendHostStatusMessage("Scroll capture is not available in the native host yet.")
 			try syncCore()
 		} catch {
-			NSLog("Failed to report unavailable scroll capture: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.scroll_unavailable_report_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -776,6 +931,7 @@ final class CaptureSessionController: NSObject {
 
 		frozenSnapshotGeneration &+= 1
 		let generation = frozenSnapshotGeneration
+		let captureID = currentCaptureTelemetryID
 		chromeState.frozenBaseImage = nil
 		chromeState.frozenMosaicImage = nil
 		ensureFrozenBaseImageFromDisplayIfNeeded(for: nextSelection)
@@ -791,7 +947,12 @@ final class CaptureSessionController: NSObject {
 				try self.session?.send(report: .freezeSnapshotCommitted(selection: nextSelection))
 				try self.syncCore()
 			} catch {
-				NSLog("Failed to commit frozen selection transform: \(error)")
+				NativeHostTelemetry.captureWarning(
+					"capture.frozen_selection_transform_commit_failed",
+					captureID: captureID,
+					stage: "send_or_sync",
+					error: String(describing: error)
+				)
 				self.chromeState.frozenSelectionSnapshot = self.scene.frozenSelection
 				self.refreshOverlay()
 			}
@@ -943,7 +1104,12 @@ final class CaptureSessionController: NSObject {
 			try session?.send(report: .freezeSnapshotCommitted(selection: nextSelection))
 			try syncCore()
 		} catch {
-			NSLog("Failed to auto-center frozen selection: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.frozen_auto_center_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -989,7 +1155,12 @@ final class CaptureSessionController: NSObject {
 			try session?.send(event: .toggleLoupe)
 			try syncCore()
 		} catch {
-			NSLog("Failed to toggle loupe: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.toggle_loupe_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -1004,7 +1175,12 @@ final class CaptureSessionController: NSObject {
 				tearDownCapture()
 			}
 		} catch {
-			NSLog("Failed to send frozen action: \(error)")
+			NativeHostTelemetry.captureWarning(
+				"capture.frozen_action_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "send_or_sync",
+				error: String(describing: error)
+			)
 		}
 	}
 
@@ -1121,17 +1297,34 @@ final class CaptureSessionController: NSObject {
 		guard let session else {
 			return
 		}
+		let captureID = currentCaptureTelemetryID
+		let commitStartedAt = ProcessInfo.processInfo.systemUptime
 		frozenSnapshotGeneration &+= 1
 		let selectionCenter = CGPoint(x: selection.midX, y: selection.midY)
+		let hadLatchToken = frozenFrameLatchToken != nil
 		let token =
 			frozenFrameLatchToken ?? frozenFrameAuthority.latchToken(containing: selectionCenter)
+		let snapshotStartedAt = ProcessInfo.processInfo.systemUptime
 		let frozenFrame = frozenFrameAuthority.snapshot(
 			containing: selectionCenter,
 			after: token,
 			maxWait: frozenFrameLatchWait()
 		)
+		let snapshotWaitMilliseconds =
+			NativeHostTelemetry.milliseconds(since: snapshotStartedAt)
 		guard let frozenFrame else {
-			NSLog("Frozen transition aborted: no fresh authority frame was available")
+			NativeHostTelemetry.captureWarning(
+				"capture.freeze_commit_failed",
+				captureID: captureID,
+				stage: "authority_snapshot",
+				error: "no_fresh_frame"
+			)
+			NativeHostTelemetry.freezeCommitFailureTiming(
+				captureID: captureID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: commitStartedAt),
+				snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+				hadLatchToken: hadLatchToken
+			)
 			try sendHostStatusMessage("Could not freeze the current frame.")
 			return
 		}
@@ -1142,18 +1335,29 @@ final class CaptureSessionController: NSObject {
 		chromeState.frozenSelectionInteraction = nil
 		chromeState.frozenDisplayFrame = frozenFrame.displayFrame
 		chromeState.frozenDisplayImage = frozenFrame.image
+		let baseImageStartedAt = ProcessInfo.processInfo.systemUptime
 		chromeState.frozenBaseImage = frozenBaseImageFromDisplay(for: selection)
-		NSLog(
-			"Frozen authority frame display=%u seq=%llu age=%.1fms",
-			frozenFrame.displayID,
-			frozenFrame.sequence,
-			frozenFrame.ageMilliseconds()
-		)
+		let baseImageMilliseconds =
+			NativeHostTelemetry.milliseconds(since: baseImageStartedAt)
 		let hostOwnedFrozenScene = hostOwnedFrozenPresentationScene(for: selection)
+		let presentStartedAt = ProcessInfo.processInfo.systemUptime
 		overlayController?.presentFrozenFirstFrame(
 			scene: hostOwnedFrozenScene,
 			chrome: chromeState,
 			settings: settingsStore.settings
+		)
+		let presentMilliseconds = NativeHostTelemetry.milliseconds(since: presentStartedAt)
+		NativeHostTelemetry.freezeCommitTiming(
+			captureID: captureID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: commitStartedAt),
+			snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+			baseImageMilliseconds: baseImageMilliseconds,
+			presentMilliseconds: presentMilliseconds,
+			frameAgeMilliseconds: frozenFrame.ageMilliseconds(),
+			displayID: frozenFrame.displayID,
+			sequence: frozenFrame.sequence,
+			hadLatchToken: hadLatchToken,
+			baseReady: chromeState.frozenBaseImage != nil
 		)
 		try session.send(report: .freezeSnapshotCommitted(selection: selection))
 	}
@@ -1206,18 +1410,68 @@ final class CaptureSessionController: NSObject {
 		guard let session else {
 			return
 		}
+		let copyStartedAt = ProcessInfo.processInfo.systemUptime
+		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
 		guard let cgImage = try captureFrozenSelectionImage() else {
+			NativeHostTelemetry.copyCaptureTiming(
+				captureID: currentCaptureTelemetryID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
+				captureImageMilliseconds: NativeHostTelemetry.milliseconds(
+					since: captureImageStartedAt),
+				clearPasteboardMilliseconds: 0,
+				makeImageMilliseconds: 0,
+				writePasteboardMilliseconds: 0,
+				success: false,
+				failureStage: "capture_image",
+				width: 0,
+				height: 0
+			)
 			try sendHostStatusMessage("Could not capture the frozen selection.")
 			return
 		}
+		let captureImageMilliseconds =
+			NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
 
 		let pasteboard = NSPasteboard.general
+		let clearPasteboardStartedAt = ProcessInfo.processInfo.systemUptime
 		pasteboard.clearContents()
+		let clearPasteboardMilliseconds =
+			NativeHostTelemetry.milliseconds(since: clearPasteboardStartedAt)
+		let makeImageStartedAt = ProcessInfo.processInfo.systemUptime
 		let image = NSImage(cgImage: cgImage, size: .zero)
-		guard pasteboard.writeObjects([image]) else {
+		let makeImageMilliseconds = NativeHostTelemetry.milliseconds(since: makeImageStartedAt)
+		let writePasteboardStartedAt = ProcessInfo.processInfo.systemUptime
+		let didWritePasteboard = pasteboard.writeObjects([image])
+		let writePasteboardMilliseconds =
+			NativeHostTelemetry.milliseconds(since: writePasteboardStartedAt)
+		guard didWritePasteboard else {
+			NativeHostTelemetry.copyCaptureTiming(
+				captureID: currentCaptureTelemetryID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
+				captureImageMilliseconds: captureImageMilliseconds,
+				clearPasteboardMilliseconds: clearPasteboardMilliseconds,
+				makeImageMilliseconds: makeImageMilliseconds,
+				writePasteboardMilliseconds: writePasteboardMilliseconds,
+				success: false,
+				failureStage: "pasteboard_write",
+				width: cgImage.width,
+				height: cgImage.height
+			)
 			try sendHostStatusMessage("Could not copy the captured image.")
 			return
 		}
+		NativeHostTelemetry.copyCaptureTiming(
+			captureID: currentCaptureTelemetryID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
+			captureImageMilliseconds: captureImageMilliseconds,
+			clearPasteboardMilliseconds: clearPasteboardMilliseconds,
+			makeImageMilliseconds: makeImageMilliseconds,
+			writePasteboardMilliseconds: writePasteboardMilliseconds,
+			success: true,
+			failureStage: "none",
+			width: cgImage.width,
+			height: cgImage.height
+		)
 
 		CaptureSuccessSound.play(captureSuccessSound)
 
@@ -1281,19 +1535,81 @@ final class CaptureSessionController: NSObject {
 	}
 
 	private func captureFrozenSelectionImage() throws -> CGImage? {
+		let captureStartedAt = ProcessInfo.processInfo.systemUptime
 		guard let selection = try session?.currentScene().frozenSelection else {
+			NativeHostTelemetry.frozenSelectionImageTiming(
+				captureID: currentCaptureTelemetryID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+				ensureMilliseconds: 0,
+				refreshMilliseconds: 0,
+				compositeMilliseconds: 0,
+				source: "no_selection",
+				success: false,
+				width: 0,
+				height: 0,
+				hasOverlayEdits: false
+			)
 			return nil
 		}
 
+		let snapshotMatchedBefore = chromeState.frozenSelectionSnapshot == selection
+		let hadBaseImageBefore = chromeState.frozenBaseImage != nil
+		let hadFrozenDisplayImageBefore = chromeState.frozenDisplayImage != nil
+		let hasOverlayEdits =
+			chromeState.frozenOverlay.canUndo || chromeState.frozenOverlay.activeInteraction != nil
+		let ensureStartedAt = ProcessInfo.processInfo.systemUptime
 		ensureFrozenBaseImageFromDisplayIfNeeded(for: selection)
+		let ensureMilliseconds = NativeHostTelemetry.milliseconds(since: ensureStartedAt)
+		var refreshedFromBelowOverlay = false
+		var refreshMilliseconds = 0.0
 		if chromeState.frozenSelectionSnapshot != selection || chromeState.frozenBaseImage == nil {
+			let refreshStartedAt = ProcessInfo.processInfo.systemUptime
 			refreshFrozenCaptureSnapshot(for: selection)
+			refreshMilliseconds = NativeHostTelemetry.milliseconds(since: refreshStartedAt)
+			refreshedFromBelowOverlay = true
 		}
 		guard let baseImage = chromeState.frozenBaseImage else {
+			NativeHostTelemetry.frozenSelectionImageTiming(
+				captureID: currentCaptureTelemetryID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+				ensureMilliseconds: ensureMilliseconds,
+				refreshMilliseconds: refreshMilliseconds,
+				compositeMilliseconds: 0,
+				source: "missing_base",
+				success: false,
+				width: 0,
+				height: 0,
+				hasOverlayEdits: hasOverlayEdits
+			)
 			return nil
 		}
 
-		return compositeFrozenOverlay(on: baseImage, selection: selection) ?? baseImage
+		let compositeStartedAt = ProcessInfo.processInfo.systemUptime
+		let result = compositeFrozenOverlay(on: baseImage, selection: selection) ?? baseImage
+		let compositeMilliseconds = NativeHostTelemetry.milliseconds(since: compositeStartedAt)
+		let imageSource: String
+		if refreshedFromBelowOverlay {
+			imageSource = "below_overlay_refresh"
+		} else if snapshotMatchedBefore, hadBaseImageBefore {
+			imageSource = "cached_base"
+		} else if hadFrozenDisplayImageBefore {
+			imageSource = "frozen_display_crop"
+		} else {
+			imageSource = "unknown_base"
+		}
+		NativeHostTelemetry.frozenSelectionImageTiming(
+			captureID: currentCaptureTelemetryID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+			ensureMilliseconds: ensureMilliseconds,
+			refreshMilliseconds: refreshMilliseconds,
+			compositeMilliseconds: compositeMilliseconds,
+			source: imageSource,
+			success: true,
+			width: result.width,
+			height: result.height,
+			hasOverlayEdits: hasOverlayEdits
+		)
+		return result
 	}
 
 	private func refreshFrozenCaptureSnapshot(for selection: CGRect) {
@@ -1575,6 +1891,7 @@ final class CaptureSessionController: NSObject {
 	}
 
 	private func tearDownCapture() {
+		let captureID = currentCaptureTelemetryID
 		liveFrameStream.stop()
 		frozenFrameLatchToken = nil
 		frozenSnapshotGeneration &+= 1
@@ -1601,6 +1918,10 @@ final class CaptureSessionController: NSObject {
 		)
 		sceneDidChange?(scene)
 		captureStateDidChange?()
+		if captureID != 0 {
+			NativeHostTelemetry.captureEvent("capture.teardown", captureID: captureID)
+		}
+		activeCaptureTelemetryID = nil
 	}
 
 	@objc
@@ -2541,7 +2862,7 @@ final class CaptureHostView: NSView {
 	private var liveRendererInstalled = false
 	private var liveChromeFollowTimer: DispatchSourceTimer?
 	private var deferredLiveShutdownWorkItem: DispatchWorkItem?
-	private var loggedLiveTargetHz: Int?
+	private var loggedLiveRefreshTarget: LiveChromeRefreshTelemetryKey?
 
 	override var acceptsFirstResponder: Bool { true }
 
@@ -4352,17 +4673,29 @@ final class CaptureHostView: NSView {
 		guard scene.mode == .live || pendingFrozenFirstDisplay else {
 			stopLiveChromeFollowClock()
 			liveRenderer.suspend()
-			loggedLiveTargetHz = nil
+			loggedLiveRefreshTarget = nil
 			return
 		}
 		deferredLiveShutdownWorkItem?.cancel()
 		deferredLiveShutdownWorkItem = nil
 		let targetHz = NativeHostDisplayRefresh.targetFramesPerSecond
-		if loggedLiveTargetHz != targetHz {
-			loggedLiveTargetHz = targetHz
+		let refreshTarget = LiveChromeRefreshTelemetryKey(
+			targetHz: targetHz,
+			hudGlassEnabled: settings.hudGlassEnabled,
+			hudGlassMode: settings.resolvedHudGlassMode.rawValue,
+			liquidGlassStyle: settings.liquidGlassStyle.rawValue,
+			liquidGlassAvailable: LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
+		)
+		if loggedLiveRefreshTarget != refreshTarget {
+			loggedLiveRefreshTarget = refreshTarget
 			NativeHostTelemetry.liveChromeRefreshTarget(
+				captureID: controller?.activeTelemetryCaptureID ?? 0,
 				targetHz: targetHz,
-				frameBudgetMilliseconds: NativeHostDisplayRefresh.frameBudgetMilliseconds
+				frameBudgetMilliseconds: NativeHostDisplayRefresh.frameBudgetMilliseconds,
+				hudGlassEnabled: refreshTarget.hudGlassEnabled,
+				hudGlassMode: refreshTarget.hudGlassMode,
+				liquidGlassStyle: refreshTarget.liquidGlassStyle,
+				liquidGlassAvailable: refreshTarget.liquidGlassAvailable
 			)
 		}
 		if scene.mode == .live {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -3,8 +3,86 @@ import OSLog
 
 enum NativeHostTelemetry {
 	static let subsystem = Bundle.main.bundleIdentifier ?? "ink.hack.rsnap"
+	static let schema = "rsnap.native_host.telemetry/1"
+	static let runID = UUID().uuidString
+	private static let lifecycleLogger = Logger(
+		subsystem: subsystem, category: "Lifecycle")
+	private static let captureLogger = Logger(
+		subsystem: subsystem, category: "Capture")
+	private static let captureTimingLogger = Logger(
+		subsystem: subsystem, category: "CaptureTiming")
+	private static let frozenAuthorityLogger = Logger(
+		subsystem: subsystem, category: "FrozenFrameAuthority")
 	private static let liveChromeLogger = Logger(
 		subsystem: subsystem, category: "LiveChromeTelemetry")
+
+	static func milliseconds(since startUptime: TimeInterval) -> Double {
+		max(0, ProcessInfo.processInfo.systemUptime - startUptime) * 1_000
+	}
+
+	static func lifecycleEvent(
+		_ event: String,
+		outcome: String = "success",
+		detail: String = "none"
+	) {
+		lifecycleLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) event=\(event, privacy: .public) outcome=\(outcome, privacy: .public) detail=\(detail, privacy: .public)"
+		)
+	}
+
+	static func lifecycleWarning(
+		_ event: String,
+		outcome: String = "failure",
+		detail: String = "none"
+	) {
+		lifecycleLogger.warning(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) event=\(event, privacy: .public) outcome=\(outcome, privacy: .public) detail=\(detail, privacy: .public)"
+		)
+	}
+
+	static func lifecycleDebug(
+		_ event: String,
+		outcome: String = "success",
+		detail: String = "none"
+	) {
+		lifecycleLogger.debug(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) event=\(event, privacy: .public) outcome=\(outcome, privacy: .public) detail=\(detail, privacy: .public)"
+		)
+	}
+
+	static func captureEvent(
+		_ event: String,
+		captureID: UInt64,
+		outcome: String = "success",
+		detail: String = "none"
+	) {
+		captureLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=\(event, privacy: .public) outcome=\(outcome, privacy: .public) detail=\(detail, privacy: .public)"
+		)
+	}
+
+	static func captureWarning(
+		_ event: String,
+		captureID: UInt64,
+		stage: String,
+		error: String
+	) {
+		captureLogger.warning(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=\(event, privacy: .public) stage=\(stage, privacy: .public) error=\(error, privacy: .public)"
+		)
+	}
+
+	static func frozenAuthorityWarning(
+		_ event: String,
+		captureID: UInt64,
+		source: String,
+		displayID: UInt32,
+		error: String
+	) {
+		frozenAuthorityLogger.warning(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) source=\(source, privacy: .public) event=\(event, privacy: .public) displayID=\(displayID, privacy: .public) error=\(error, privacy: .public)"
+		)
+	}
 
 	static func distribution(
 		_ name: String,
@@ -21,10 +99,145 @@ enum NativeHostTelemetry {
 	}
 
 	static func liveChromeRefreshTarget(
-		targetHz: Int, frameBudgetMilliseconds: Double
+		captureID: UInt64,
+		targetHz: Int,
+		frameBudgetMilliseconds: Double,
+		hudGlassEnabled: Bool,
+		hudGlassMode: String,
+		liquidGlassStyle: String,
+		liquidGlassAvailable: Bool
 	) {
 		liveChromeLogger.info(
-			"event=live_chrome.refresh_target targetHz=\(targetHz, privacy: .public) frameBudgetMs=\(frameBudgetMilliseconds, format: .fixed(precision: 2), privacy: .public)"
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=live_chrome.refresh_target targetHz=\(targetHz, privacy: .public) frameBudgetMs=\(frameBudgetMilliseconds, format: .fixed(precision: 2), privacy: .public) hudGlassEnabled=\(hudGlassEnabled, privacy: .public) hudGlassMode=\(hudGlassMode, privacy: .public) liquidGlassStyle=\(liquidGlassStyle, privacy: .public) liquidGlassAvailable=\(liquidGlassAvailable, privacy: .public)"
+		)
+	}
+
+	static func liveSamplingWarmTiming(
+		captureID: UInt64,
+		source: String,
+		totalMilliseconds: Double,
+		frozenAuthorityStartMilliseconds: Double,
+		liveStreamStartMilliseconds: Double,
+		seedSampleMilliseconds: Double,
+		sampleReady: Bool,
+		screenCount: Int
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.live_sampling_warm source=\(source, privacy: .public) totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) frozenAuthorityStartMs=\(frozenAuthorityStartMilliseconds, format: .fixed(precision: 2), privacy: .public) liveStreamStartMs=\(liveStreamStartMilliseconds, format: .fixed(precision: 2), privacy: .public) seedSampleMs=\(seedSampleMilliseconds, format: .fixed(precision: 2), privacy: .public) sampleReady=\(sampleReady, privacy: .public) screenCount=\(screenCount, privacy: .public)"
+		)
+	}
+
+	static func captureStartTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		warmMilliseconds: Double,
+		windowSnapshotMilliseconds: Double,
+		sessionSetupMilliseconds: Double,
+		overlayShowMilliseconds: Double,
+		initialSampleReady: Bool,
+		screenCount: Int,
+		windowCount: Int
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.start_capture totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) warmMs=\(warmMilliseconds, format: .fixed(precision: 2), privacy: .public) windowSnapshotMs=\(windowSnapshotMilliseconds, format: .fixed(precision: 2), privacy: .public) sessionSetupMs=\(sessionSetupMilliseconds, format: .fixed(precision: 2), privacy: .public) overlayShowMs=\(overlayShowMilliseconds, format: .fixed(precision: 2), privacy: .public) initialSampleReady=\(initialSampleReady, privacy: .public) screenCount=\(screenCount, privacy: .public) windowCount=\(windowCount, privacy: .public)"
+		)
+	}
+
+	static func captureStartFailureTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		failureStage: String
+	) {
+		captureTimingLogger.warning(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.start_capture_failed totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) failureStage=\(failureStage, privacy: .public)"
+		)
+	}
+
+	static func frozenAuthorityContentLookupTiming(
+		captureID: UInt64,
+		source: String,
+		totalMilliseconds: Double,
+		success: Bool,
+		displayCount: Int,
+		windowCount: Int
+	) {
+		frozenAuthorityLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) source=\(source, privacy: .public) event=capture_timing.frozen_authority_content_lookup totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) success=\(success, privacy: .public) displayCount=\(displayCount, privacy: .public) windowCount=\(windowCount, privacy: .public)"
+		)
+	}
+
+	static func frozenAuthorityFirstFrameTiming(
+		captureID: UInt64,
+		source: String,
+		displayID: UInt32,
+		totalMilliseconds: Double,
+		frameAgeMilliseconds: Double,
+		sequence: UInt64
+	) {
+		frozenAuthorityLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) source=\(source, privacy: .public) event=capture_timing.frozen_authority_first_frame displayID=\(displayID, privacy: .public) totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) sequence=\(sequence, privacy: .public)"
+		)
+	}
+
+	static func freezeCommitTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		snapshotWaitMilliseconds: Double,
+		baseImageMilliseconds: Double,
+		presentMilliseconds: Double,
+		frameAgeMilliseconds: Double,
+		displayID: UInt32,
+		sequence: UInt64,
+		hadLatchToken: Bool,
+		baseReady: Bool
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.freeze_commit totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) snapshotWaitMs=\(snapshotWaitMilliseconds, format: .fixed(precision: 2), privacy: .public) baseImageMs=\(baseImageMilliseconds, format: .fixed(precision: 2), privacy: .public) presentMs=\(presentMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) displayID=\(displayID, privacy: .public) sequence=\(sequence, privacy: .public) hadLatchToken=\(hadLatchToken, privacy: .public) baseReady=\(baseReady, privacy: .public)"
+		)
+	}
+
+	static func freezeCommitFailureTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		snapshotWaitMilliseconds: Double,
+		hadLatchToken: Bool
+	) {
+		captureTimingLogger.warning(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.freeze_commit_failed totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) snapshotWaitMs=\(snapshotWaitMilliseconds, format: .fixed(precision: 2), privacy: .public) hadLatchToken=\(hadLatchToken, privacy: .public)"
+		)
+	}
+
+	static func frozenSelectionImageTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		ensureMilliseconds: Double,
+		refreshMilliseconds: Double,
+		compositeMilliseconds: Double,
+		source: String,
+		success: Bool,
+		width: Int,
+		height: Int,
+		hasOverlayEdits: Bool
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.frozen_selection_image totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) ensureMs=\(ensureMilliseconds, format: .fixed(precision: 2), privacy: .public) refreshMs=\(refreshMilliseconds, format: .fixed(precision: 2), privacy: .public) compositeMs=\(compositeMilliseconds, format: .fixed(precision: 2), privacy: .public) source=\(source, privacy: .public) success=\(success, privacy: .public) width=\(width, privacy: .public) height=\(height, privacy: .public) hasOverlayEdits=\(hasOverlayEdits, privacy: .public)"
+		)
+	}
+
+	static func copyCaptureTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		captureImageMilliseconds: Double,
+		clearPasteboardMilliseconds: Double,
+		makeImageMilliseconds: Double,
+		writePasteboardMilliseconds: Double,
+		success: Bool,
+		failureStage: String,
+		width: Int,
+		height: Int
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.copy_capture totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) captureImageMs=\(captureImageMilliseconds, format: .fixed(precision: 2), privacy: .public) clearPasteboardMs=\(clearPasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) makeImageMs=\(makeImageMilliseconds, format: .fixed(precision: 2), privacy: .public) writePasteboardMs=\(writePasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) success=\(success, privacy: .public) failureStage=\(failureStage, privacy: .public) width=\(width, privacy: .public) height=\(height, privacy: .public)"
 		)
 	}
 
@@ -83,7 +296,7 @@ enum NativeHostTelemetry {
 			let p50 = percentile(sorted, 0.50)
 			let p95 = percentile(sorted, 0.95)
 			logger.info(
-				"metric=\(self.name, privacy: .public) unit=\(self.unit, privacy: .public) samples=\(sorted.count, privacy: .public) p50=\(p50, format: .fixed(precision: 2), privacy: .public) p95=\(p95, format: .fixed(precision: 2), privacy: .public) max=\(maxValue, format: .fixed(precision: 2), privacy: .public)"
+				"schema=\(NativeHostTelemetry.schema, privacy: .public) runID=\(NativeHostTelemetry.runID, privacy: .public) metric=\(self.name, privacy: .public) unit=\(self.unit, privacy: .public) samples=\(sorted.count, privacy: .public) p50=\(p50, format: .fixed(precision: 2), privacy: .public) p95=\(p95, format: .fixed(precision: 2), privacy: .public) max=\(maxValue, format: .fixed(precision: 2), privacy: .public)"
 			)
 		}
 

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -435,7 +435,9 @@ case "$MODE" in
 		;;
 	--telemetry|telemetry)
 		open_app
-		/usr/bin/log stream --info --style compact --predicate "subsystem == \"$BUNDLE_ID\""
+		RSNAP_TELEMETRY_BUNDLE_ID="$BUNDLE_ID" \
+			RSNAP_TELEMETRY_PROCESS="$EXECUTABLE_NAME" \
+			"$ROOT_DIR/scripts/telemetry/native-host.sh" stream
 		;;
 	--verify|verify)
 		open_app

--- a/scripts/telemetry/native-host.sh
+++ b/scripts/telemetry/native-host.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-show}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUNDLE_ID="${RSNAP_TELEMETRY_BUNDLE_ID:-ink.hack.rsnap}"
+EXECUTABLE_NAME="${RSNAP_TELEMETRY_PROCESS:-RsnapNativeHost}"
+LAST="${RSNAP_TELEMETRY_LAST:-10m}"
+RUST_LOG_DIR="${RSNAP_RUST_LOG_DIR:-$HOME/Library/Application Support/ink.hack.rsnap/logs}"
+OUT_DIR="${RSNAP_TELEMETRY_OUT_DIR:-$ROOT_DIR/target/telemetry/native-host-$(date +%Y%m%d-%H%M%S)}"
+NATIVE_PREDICATE="${RSNAP_TELEMETRY_PREDICATE:-subsystem == \"$BUNDLE_ID\" AND composedMessage CONTAINS \"schema=rsnap.native_host.telemetry/1\"}"
+
+usage() {
+	cat <<USAGE
+usage: $0 [show|stream|collect|summary]
+
+Environment:
+  RSNAP_TELEMETRY_LAST       log show window, default: 10m
+  RSNAP_TELEMETRY_OUT_DIR    collect output directory
+  RSNAP_TELEMETRY_PREDICATE  macOS log predicate override
+  RSNAP_RUST_LOG_DIR         Rust rolling log directory
+USAGE
+}
+
+write_native_log() {
+	local destination="$1"
+	/usr/bin/log show --info --style compact --last "$LAST" --predicate "$NATIVE_PREDICATE" \
+		>"$destination"
+}
+
+last_window_seconds() {
+	local value="$LAST"
+
+	if [[ "$value" =~ ^([0-9]+)([smhd])$ ]]; then
+		local number="${BASH_REMATCH[1]}"
+		local suffix="${BASH_REMATCH[2]}"
+		case "$suffix" in
+			s)
+				printf '%s\n' "$((10#$number))"
+				;;
+			m)
+				printf '%s\n' "$((10#$number * 60))"
+				;;
+			h)
+				printf '%s\n' "$((10#$number * 3600))"
+				;;
+			d)
+				printf '%s\n' "$((10#$number * 86400))"
+				;;
+		esac
+		return
+	fi
+
+	if [[ "$value" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$((10#$value))"
+		return
+	fi
+
+	printf '%s\n' 600
+}
+
+RUST_LOG_CUTOFF_EPOCH="$(($(date +%s) - $(last_window_seconds)))"
+
+epoch_to_utc_second() {
+	local epoch="$1"
+
+	if date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null; then
+		return
+	fi
+	date -u -d "@$epoch" '+%Y-%m-%dT%H:%M:%S'
+}
+
+RUST_LOG_CUTOFF_STAMP="$(epoch_to_utc_second "$RUST_LOG_CUTOFF_EPOCH")"
+
+rust_log_modified_epoch() {
+	local path="$1"
+
+	if stat -f %m "$path" 2>/dev/null; then
+		return
+	fi
+	if stat -c %Y "$path" 2>/dev/null; then
+		return
+	fi
+	printf '%s\n' 0
+}
+
+rust_log_is_recent() {
+	local rust_log="$1"
+	local modified_epoch
+
+	modified_epoch="$(rust_log_modified_epoch "$rust_log")"
+	if [[ ! "$modified_epoch" =~ ^[0-9]+$ ]]; then
+		modified_epoch=0
+	fi
+
+	[[ "$modified_epoch" -ge "$RUST_LOG_CUTOFF_EPOCH" ]]
+}
+
+filter_rust_log() {
+	local rust_log="$1"
+	awk -v cutoff="$RUST_LOG_CUTOFF_STAMP" '
+		function has_rust_timestamp(value) {
+			return length(value) >= 20 \
+				&& substr(value, 5, 1) == "-" \
+				&& substr(value, 8, 1) == "-" \
+				&& substr(value, 11, 1) == "T" \
+				&& substr(value, 14, 1) == ":" \
+				&& substr(value, 17, 1) == ":"
+		}
+		has_rust_timestamp($1) && substr($1, 1, 19) >= cutoff {
+			print
+		}
+	' "$rust_log"
+}
+
+copy_recent_rust_logs() {
+	local destination_dir="$1"
+	mkdir -p "$destination_dir"
+	if [[ ! -d "$RUST_LOG_DIR" ]]; then
+		return
+	fi
+	while IFS= read -r -d '' rust_log; do
+		if ! rust_log_is_recent "$rust_log"; then
+			continue
+		fi
+		local destination="$destination_dir/$(basename "$rust_log")"
+		local filtered_destination="$destination.tmp"
+		filter_rust_log "$rust_log" >"$filtered_destination"
+		if [[ -s "$filtered_destination" ]]; then
+			mv "$filtered_destination" "$destination"
+		else
+			rm -f "$filtered_destination"
+		fi
+	done < <(find "$RUST_LOG_DIR" -maxdepth 1 -type f -name 'rsnap*.log*' -print0)
+}
+
+print_rust_logs_in_dir() {
+	local source_dir="$1"
+	if [[ ! -d "$source_dir" ]]; then
+		return
+	fi
+	while IFS= read -r -d '' rust_log; do
+		cat "$rust_log"
+	done < <(find "$source_dir" -maxdepth 1 -type f -name 'rsnap*.log*' -print0)
+}
+
+append_recent_rust_logs() {
+	local destination="$1"
+	if [[ ! -d "$RUST_LOG_DIR" ]]; then
+		return
+	fi
+	while IFS= read -r -d '' rust_log; do
+		if ! rust_log_is_recent "$rust_log"; then
+			continue
+		fi
+		filter_rust_log "$rust_log" >>"$destination"
+	done < <(find "$RUST_LOG_DIR" -maxdepth 1 -type f -name 'rsnap*.log*' -print0)
+}
+
+summarize_file() {
+	local source="$1"
+	awk '
+		function field_value(prefix, value) {
+			sub("^" prefix, "", value)
+			gsub(/^"/, "", value)
+			gsub(/"$/, "", value)
+			return value
+		}
+		{
+			for (i = 1; i <= NF; i++) {
+				if ($i ~ /^event=/) {
+					events[field_value("event=", $i)]++
+				} else if ($i ~ /^metric=/) {
+					metrics[field_value("metric=", $i)]++
+				} else if ($i ~ /^op=/) {
+					ops[field_value("op=", $i)]++
+				} else if ($i ~ /^captureID=/) {
+					value = field_value("captureID=", $i)
+					captures[value]++
+					if (value != "0") {
+						latest_capture_id = value
+					}
+				} else if ($i ~ /^runID=/) {
+					value = field_value("runID=", $i)
+					runs[value]++
+					latest_run_id = value
+				} else if ($i ~ /^run_id=/) {
+					value = field_value("run_id=", $i)
+					runs[value]++
+					latest_run_id = value
+				}
+			}
+		}
+		function print_group(title, values, key) {
+			print title
+			for (key in values) {
+				print "  " key " " values[key]
+			}
+		}
+		END {
+			print "latest"
+			print "  nonzero_capture_id " (latest_capture_id == "" ? "none" : latest_capture_id)
+			print "  run_id " (latest_run_id == "" ? "none" : latest_run_id)
+			print_group("events", events)
+			print_group("metrics", metrics)
+			print_group("ops", ops)
+			print_group("capture_ids", captures)
+			print_group("run_ids", runs)
+		}
+	' "$source"
+}
+
+case "$MODE" in
+	show)
+		/usr/bin/log show --info --style compact --last "$LAST" --predicate "$NATIVE_PREDICATE"
+		;;
+	stream)
+		/usr/bin/log stream --info --style compact --predicate "$NATIVE_PREDICATE"
+		;;
+	collect)
+		mkdir -p "$OUT_DIR/rust"
+		write_native_log "$OUT_DIR/native-host.oslog"
+		copy_recent_rust_logs "$OUT_DIR/rust"
+		{
+			cat "$OUT_DIR/native-host.oslog"
+			print_rust_logs_in_dir "$OUT_DIR/rust"
+		} >"$OUT_DIR/all.log"
+		summarize_file "$OUT_DIR/all.log" >"$OUT_DIR/summary.txt"
+		printf '%s\n' "$OUT_DIR"
+		;;
+	summary)
+		tmp_file="$(mktemp)"
+		trap 'rm -f "$tmp_file"' EXIT
+		write_native_log "$tmp_file"
+		append_recent_rust_logs "$tmp_file"
+		summarize_file "$tmp_file"
+		;;
+	--help|-h|help)
+		usage
+		;;
+	*)
+		usage >&2
+		exit 2
+		;;
+esac


### PR DESCRIPTION
## Summary
- centralize native-host telemetry schema, run IDs, capture IDs, and capture timing events
- add telemetry collection tooling with schema-scoped OSLog predicates, Rust rolling-log window filtering, and summary latest IDs
- document telemetry schema and debugging runbook, and route `build_and_run.sh --telemetry` through the shared helper

## Validation
- `bash -n scripts/telemetry/native-host.sh scripts/build_and_run.sh`
- telemetry fixture collect: Rust log time-window filtering and `latest.nonzero_capture_id`
- `cargo make fmt-swift && cargo make fmt-rust && cargo make lint`
- release run from latest `origin/main` (`64bd465`), PID `24291`, binary mtime `2026-04-27 17:36:54`
- two capture smoke artifact: `target/telemetry/pr-two-captures-main-64bd465`, runID `2FB1AF28-B295-4361-952A-BB12BD1C2205`, latest captureID `2`
