### PR TITLE
Modernize settings and stabilize live sampling

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -262,14 +262,19 @@ swift run --package-path native/macos-host RsnapHostBridgeProbe
 [tasks.test-macos-native-host-stage]
 workspace = false
 script = '''
-RSNAP_NATIVE_HOST_SKIP_SIGN=1 ./scripts/build_and_run.sh stage
+./scripts/build_and_run.sh stage
 COMMON_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
 APP_PATH="${RSNAP_NATIVE_HOST_STAGE_DIR:-$COMMON_ROOT/target/rsnap-native-host}/rsnap.app"
+codesign --verify --deep --strict "$APP_PATH"
+codesign -dv --verbose=4 "$APP_PATH" 2>&1 | grep -q '^TeamIdentifier='
 test -x "$APP_PATH/Contents/MacOS/RsnapNativeHost"
 test -f "$APP_PATH/Contents/Info.plist"
 test -f "$APP_PATH/Contents/Resources/AppIcon.icns"
 plutil -extract CFBundleIdentifier raw "$APP_PATH/Contents/Info.plist" | grep -qx 'ink.hack.rsnap'
-plutil -extract LSUIElement raw "$APP_PATH/Contents/Info.plist" | grep -qx 'true'
+if plutil -extract LSUIElement raw "$APP_PATH/Contents/Info.plist" >/dev/null 2>&1; then
+  echo "LSUIElement must stay unset so Settings is a normal foreground window" >&2
+  exit 1
+fi
 '''
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ The active split below is by question type, not by human-versus-agent audience.
   `docs/spec/host-core-protocol.md`
 - Need the product-level capture contract independent from implementation history ->
   `docs/spec/capture-session.md`
+- Need Settings, status-menu shortcut display, permission placement, Dock behavior, or Settings
+  window semantics -> `docs/spec/settings.md`
 - Need telemetry fields, event names, metric names, or log correlation identifiers ->
   `docs/spec/telemetry.md`
 - Need runbooks, migrations, validation steps, troubleshooting, or operational sequences ->

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -36,16 +36,24 @@ product level rather than binding itself to a particular window toolkit or shell
 
 ## Required behavior
 
-1. Menubar-only app (no Dock icon) on macOS.
+1. Background app shell on macOS: no Dock icon while Settings is closed and no other ordinary app
+   window is visible. Opening Settings may temporarily use a normal app/window activation policy;
+   closing Settings must return rsnap to the background menubar shell.
 2. Global hotkey starts capture session (default `Alt+X`, macOS: Option+X) and can be customized
    from Settings.
-3. When the capture session UI is visible, underlying desktop content MUST NOT be interactive.
-4. The visible capture UI should be transparent and non-dimming by default.
-5. On macOS, rsnap overlay, HUD, loupe, frozen toolbar, and scroll preview surfaces MUST remain
+3. The status menu's New Capture item must use the configured capture shortcut. Shortcut display
+   strings must use platform-native names such as `Option-X`, not raw event names such as
+   `alt+KeyX`.
+4. The status menu must not expose Cancel Capture or Permissions entries. Capture cancellation is
+   owned by in-session input such as `Esc` and secondary click; permission recovery is owned by
+   Settings.
+5. When the capture session UI is visible, underlying desktop content MUST NOT be interactive.
+6. The visible capture UI should be transparent and non-dimming by default.
+7. On macOS, rsnap overlay, HUD, loupe, frozen toolbar, and scroll preview surfaces MUST remain
    externally capturable by system screenshot and screen-recording tools. Internal self-capture
    correctness comes from rsnap's own capture filters and handoff logic, not window content
    protection.
-6. The product contract does not require any specific platform window implementation. Focus,
+8. The product contract does not require any specific platform window implementation. Focus,
    cursor, keyboard, and IME correctness are mandatory outcomes, regardless of how the native host
    achieves them.
 
@@ -55,14 +63,18 @@ product level rather than binding itself to a particular window toolkit or shell
 - Live mode shows a HUD near the cursor with:
   - global cursor coordinates `x,y`
   - pixel color `rgb(r,g,b)` under the cursor
+- During fast pointer movement, the live HUD and loupe must remain visually coherent; they MUST
+  NOT flash through a solid white, blank, or material-only intermediate state.
 - Hovering over a window in live mode shows an obvious targeting outline that follows the current
-  target.
+  target, remains legible in light and dark themes, and does not require moving away to another
+  window before the current target becomes active.
 - Left click + drag freezes a cropped region on the cursor monitor.
 - Live drag preview begins as soon as the pointer moves away from the press point; thin captures
   down to `1x1` pixels are valid frozen selections.
 - Left click without drag hit-tests the window under the cursor on the same monitor and freezes
   that window bounds.
 - If no window is hit, the click path falls back to freezing the current monitor fullscreen.
+- Secondary click cancels capture from live mode.
 - Capture scope is single-monitor only for now. Cross-monitor region selection and cross-monitor
   window capture remain out of scope.
 
@@ -81,7 +93,7 @@ product level rather than binding itself to a particular window toolkit or shell
 
 ## Frozen mode
 
-- `Esc` cancels capture.
+- `Esc` and secondary click cancel capture.
 - `Space` copies the frozen PNG of the selected region/window/fullscreen to the system clipboard,
   then exits.
 - Cmd+S (macOS) / Ctrl+S saves the frozen PNG to disk, then exits.
@@ -103,6 +115,8 @@ product level rather than binding itself to a particular window toolkit or shell
 
 - On macOS, Frozen entry is display-first: entering Frozen mode MUST commit a display image in a
   single visible handoff instead of waiting on a later visible capture swap.
+- The live-to-Frozen handoff MUST NOT flash through a blank surface, a mask/scrim-only state, or
+  any other intermediate mode-switch artifact.
 - Frozen-mode display readiness and export readiness are separate:
   - pointer drag/reposition, pen, arrow, text, spotlight, and toolbar visibility are
     display-driven
@@ -157,7 +171,7 @@ Default settings:
 - Tint amount: `50` (stored `0.5`)
 - Hue: `215` (stored `215.0 / 360.0`)
 - Loupe activation: `Hold` (`Tab`)
-- Loupe sample size: `Medium (21x21)`
+- Loupe sample size: `Small (15x15)`
 - Toolbar placement: `Bottom`
 
 Slider semantics:

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -56,6 +56,8 @@ Then keep the body explicit:
 
 - `docs/spec/capture-session.md` for the product-level capture-flow, Frozen-mode, and
   scroll-capture contract
+- `docs/spec/settings.md` for Settings, status-menu, shortcut, permission, Dock, and Settings
+  window behavior
 - `docs/spec/platform-host-boundary.md` for the normative ownership boundary between native hosts
   and the Rust core
 - `docs/spec/host-core-protocol.md` for the canonical reset crates and semantic host/core protocol

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -1,0 +1,76 @@
+# Settings and App Shell Contract
+
+Purpose: Define the normative Settings, status-menu, shortcut, permission, and macOS app-shell
+behavior for rsnap.
+
+Status: normative
+
+Read this when: You are implementing, reviewing, or validating Settings, status-menu commands,
+shortcut presentation, permission recovery, Dock activation policy, or Settings window behavior.
+
+Not this document: Detailed visual styling, implementation-specific AppKit/SwiftUI structure, or
+capture-session behavior once capture has started. Use `docs/spec/capture-session.md` for
+capture-flow behavior and `docs/spec/platform-host-boundary.md` for host/core ownership.
+
+Defines:
+- Settings window and app-shell behavior
+- status-menu command placement
+- shortcut configuration and presentation rules
+- permission recovery placement
+- Settings interaction and default-size usability invariants
+
+## App Shell
+
+- rsnap is a background menubar app while Settings is closed: it must not keep a Dock icon visible
+  in the idle menubar state.
+- Opening Settings may temporarily promote rsnap to an ordinary app-window activation state so the
+  Settings window participates in normal macOS focus, keyboard, and window management.
+- Closing Settings must return rsnap to the background menubar state when no other ordinary app
+  window is visible.
+- Capture sessions must not require visible Dock activation artifacts to begin, complete, cancel,
+  copy, save, or restore focus.
+
+## Status Menu
+
+- The status menu must expose New Capture, Settings, and Quit.
+- The status menu must not expose Cancel Capture. Capture cancellation is handled in-session by
+  `Esc` and secondary click in both live and Frozen modes.
+- The status menu must not expose Permissions as a separate menu item. Permission status and
+  recovery live in Settings.
+- New Capture must use the same configured shortcut as the global capture hotkey.
+
+## Settings Window
+
+- Settings must be an ordinary top-level platform window, not only an overlay surface.
+- Settings must be selectable by system screenshot/window-picking tools and by rsnap's own window
+  selector so normal selection effects can apply to it.
+- Settings must support standard macOS shortcuts: `Command-W` closes the Settings window and
+  `Command-Q` quits rsnap.
+- The Settings window background must not globally hijack drag gestures. Draggable controls and
+  component hit testing must receive their own pointer gestures.
+
+## Shortcut Settings
+
+- The capture shortcut configuration must be present in Settings.
+- Shortcut display strings must use canonical platform names such as `Option-X`.
+- Raw event spellings such as `alt+KeyX` must not appear in user-facing shortcut fields,
+  summaries, or menu shortcut labels.
+- The default capture shortcut is `Option-X`.
+
+## Permission Settings
+
+- Settings must include a Permissions section.
+- Screen Recording permission is required for the current native macOS capture host.
+- Accessibility and Input Monitoring may be displayed as diagnostic permissions, but they must not
+  be presented as required when the current native host does not need them.
+- Permission recovery should provide a drag-the-app affordance for adding rsnap to System Settings
+  where macOS allows that workflow, plus an Open System Settings fallback.
+- Permission status refresh must be available without restarting rsnap.
+
+## Default-Size Usability
+
+- At the default Settings window size, primary setting labels, selected option labels, and current
+  value summaries must not be truncated.
+- Segmented controls and pill-like options must make the full visible option area clickable, not
+  only the text glyphs.
+- Settings must remain usable and legible in both light and dark macOS appearances.

--- a/native/macos-host/Sources/RsnapNativeHostKit/GlobalHotKeyCenter.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/GlobalHotKeyCenter.swift
@@ -132,11 +132,7 @@ final class GlobalHotKeyCenter {
 	)
 
 	private static func parseCaptureHotKey(_ raw: String) -> HotKeyDefinition? {
-		let tokens =
-			raw
-			.split(separator: "+")
-			.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-			.filter { !$0.isEmpty }
+		let tokens = NativeHostSettings.captureHotKeyTokens(from: raw)
 		guard !tokens.isEmpty else {
 			return nil
 		}

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
@@ -12,6 +12,8 @@ final class LiveFrameStreamBroker {
 	}
 
 	private static let primeThrottleInterval: TimeInterval = 1.0 / 120.0
+	private static let seedSampleMaxAttempts = 4
+	private static let seedSampleRetryInterval: TimeInterval = 1.0 / 120.0
 
 	private let stateLock = NSLock()
 	private var sampler: RsnapLiveSampler?
@@ -106,16 +108,19 @@ final class LiveFrameStreamBroker {
 	}
 
 	func region(in rect: CGRect) -> CGImage? {
+		guard let monitor = monitor(containing: CGPoint(x: rect.midX, y: rect.midY)) else {
+			return nil
+		}
 		stateLock.lock()
 		let sampler = self.sampler
+		let mainDisplayHeight = self.mainDisplayHeight
+		let encodedMonitor = samplerMonitorSnapshot(for: monitor)
 		stateLock.unlock()
-		guard
-			let sampler,
-			let monitor = monitor(containing: CGPoint(x: rect.midX, y: rect.midY)),
-			let snapshot = try? sampler.peekRegion(
-				monitor: samplerMonitorSnapshot(for: monitor),
-				rect: rect
-			)
+		guard let sampler else {
+			return nil
+		}
+		let quartzRect = Self.appKitRectToQuartz(rect, mainDisplayHeight: mainDisplayHeight)
+		guard let snapshot = try? sampler.peekRegion(monitor: encodedMonitor, rect: quartzRect)
 		else {
 			return nil
 		}
@@ -162,7 +167,22 @@ final class LiveFrameStreamBroker {
 		at point: CGPoint,
 		sidePixels: Int
 	) -> LiveChromeSample? {
-		return sample(at: point, sidePixels: sidePixels)
+		var latestSample: LiveChromeSample?
+		for attempt in 0..<Self.seedSampleMaxAttempts {
+			let sample = sample(at: point, sidePixels: sidePixels)
+			if sample?.rgbSample != nil {
+				return sample
+			}
+			if sample != nil {
+				latestSample = sample
+			}
+			guard attempt + 1 < Self.seedSampleMaxAttempts else {
+				break
+			}
+			prime(at: point)
+			Thread.sleep(forTimeInterval: Self.seedSampleRetryInterval)
+		}
+		return latestSample
 	}
 
 	private func monitor(containing point: CGPoint) -> SamplerMonitor? {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -92,7 +92,7 @@ final class WindowSnapshotFeed {
 		for info in candidateWindows {
 			let isOnScreen = (info[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? false
 			let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value ?? -1
-			if !isOnScreen || ownerPID == ownPID {
+			if !isOnScreen {
 				continue
 			}
 			let alpha = (info[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1
@@ -101,6 +101,9 @@ final class WindowSnapshotFeed {
 			}
 			let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
 			if layer < 0 || layer > maxWindowLayerForTargeting {
+				continue
+			}
+			if ownerPID == ownPID && !Self.isTargetableOwnWindow(info, layer: layer) {
 				continue
 			}
 			guard let boundsDictionary = info[kCGWindowBounds as String] as? NSDictionary else {
@@ -125,6 +128,14 @@ final class WindowSnapshotFeed {
 		return snapshots
 	}
 
+	private static func isTargetableOwnWindow(_ info: [String: Any], layer: Int) -> Bool {
+		guard layer == 0 else {
+			return false
+		}
+		let name = (info[kCGWindowName as String] as? String) ?? ""
+		return name == "Settings"
+	}
+
 	static func window(at point: CGPoint, in snapshots: [WindowSnapshot]) -> WindowSnapshot? {
 		snapshots.first(where: { $0.frame.contains(point) })
 	}
@@ -142,9 +153,11 @@ final class WindowSnapshotFeed {
 
 final class ChromeSampleFeed: @unchecked Sendable {
 	typealias BackgroundSampler = @Sendable (CGPoint, LiveColorSampleSource) -> RGBSample?
+	typealias SampleUpdated = () -> Void
 
 	private let broker: LiveFrameStreamBroker
 	private let backgroundSampler: BackgroundSampler
+	private let sampleUpdated: SampleUpdated
 	private let queue = DispatchQueue(
 		label: "ink.hack.rsnap.native-host.chrome-sample-feed", qos: .userInteractive)
 	private let backgroundQueue = DispatchQueue(
@@ -166,6 +179,10 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		batchSize: 20
 	)
 	private static let backgroundProbeMinimumInterval: TimeInterval = 0.25
+	private static let backgroundProbeIdleDelay: TimeInterval = 0.08
+	private static let sampleUpdatedNotificationIdleDelay =
+		NativeHostDisplayRefresh.frameInterval(
+			forTargetFramesPerSecond: NativeHostDisplayRefresh.fallbackFramesPerSecond)
 	private var timer: DispatchSourceTimer?
 	private var refreshQueued = false
 	private var backgroundRefreshQueued = false
@@ -179,13 +196,16 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private var latestSample: LiveChromeSample?
 	private var latestSamplePoint: CGPoint?
 	private var lastRefreshUptime: TimeInterval?
+	private var lastPointChangeUptime = ProcessInfo.processInfo.systemUptime
 
 	init(
 		broker: LiveFrameStreamBroker,
-		backgroundSampler: @escaping BackgroundSampler
+		backgroundSampler: @escaping BackgroundSampler,
+		sampleUpdated: @escaping SampleUpdated = {}
 	) {
 		self.broker = broker
 		self.backgroundSampler = backgroundSampler
+		self.sampleUpdated = sampleUpdated
 	}
 
 	func start(targetFramesPerSecond: Int = NativeHostDisplayRefresh.targetFramesPerSecond) {
@@ -226,6 +246,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		whiteStreamRunHasProbed = false
 		lastBackgroundProbeUptime = 0
 		lastRefreshUptime = nil
+		lastPointChangeUptime = ProcessInfo.processInfo.systemUptime
 		stateLock.unlock()
 	}
 
@@ -252,6 +273,11 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			latestSample = latestSample.map {
 				LiveChromeSample(rgbSample: $0.rgbSample, loupePatch: nil)
 			}
+		}
+		if pointChanged || sourceChanged {
+			backgroundCorrectionMode = false
+			whiteStreamRunHasProbed = false
+			lastPointChangeUptime = ProcessInfo.processInfo.systemUptime
 		}
 		desiredPoint = point
 		desiredSidePixels = nextSidePixels
@@ -297,6 +323,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		let previousSample = latestSample
 		let previousPoint = latestSamplePoint
 		let lastRefreshUptime = self.lastRefreshUptime
+		let pointIdleDuration = now - lastPointChangeUptime
 		self.lastRefreshUptime = now
 		stateLock.unlock()
 		if let lastRefreshUptime {
@@ -325,7 +352,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			enqueueBackgroundSampleIfNeeded(
 				point: point,
 				source: source,
-				streamRgbSample: streamRgbSample
+				streamRgbSample: streamRgbSample,
+				pointIdleDuration: pointIdleDuration
 			)
 		}
 		let patchSample =
@@ -352,10 +380,22 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		previousPoint: CGPoint?,
 		point: CGPoint
 	) -> RGBSample? {
+		reusableRgbSample(
+			rgbSample: previousSample?.rgbSample,
+			previousPoint: previousPoint,
+			point: point
+		)
+	}
+
+	private static func reusableRgbSample(
+		rgbSample: RGBSample?,
+		previousPoint: CGPoint?,
+		point: CGPoint
+	) -> RGBSample? {
 		guard let previousPoint, pointsEquivalent(previousPoint, point) else {
 			return nil
 		}
-		return previousSample?.rgbSample
+		return rgbSample
 	}
 
 	private static func reusablePatchSample(
@@ -377,8 +417,12 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private func enqueueBackgroundSampleIfNeeded(
 		point: CGPoint,
 		source: LiveColorSampleSource,
-		streamRgbSample: RGBSample?
+		streamRgbSample: RGBSample?,
+		pointIdleDuration: TimeInterval
 	) {
+		guard pointIdleDuration >= Self.backgroundProbeIdleDelay else {
+			return
+		}
 		let now = ProcessInfo.processInfo.systemUptime
 		let shouldProbe: Bool
 		stateLock.lock()
@@ -430,27 +474,40 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		let startedAt = ProcessInfo.processInfo.systemUptime
 		let rgbSample = backgroundSampler(point, source)
 		backgroundSampleDurationMetric.recordMillisecondsSince(startedAt)
+		let shouldNotify: Bool
 		stateLock.lock()
 		backgroundRefreshQueued = false
-		defer {
-			stateLock.unlock()
-		}
-		guard
-			let desiredPoint,
+		if let desiredPoint,
 			let rgbSample,
 			desiredSource == source,
 			Self.pointsEquivalent(desiredPoint, point)
-		else {
-			return
+		{
+			if shouldProbeForCorrection {
+				backgroundCorrectionMode = !Self.isLikelyOverlayWhite(rgbSample)
+			}
+			latestSample = LiveChromeSample(
+				rgbSample: rgbSample,
+				loupePatch: latestSample?.loupePatch
+			)
+			latestSamplePoint = point
+			shouldNotify = Self.shouldNotifySampleUpdated(
+				now: ProcessInfo.processInfo.systemUptime,
+				lastPointChangeUptime: lastPointChangeUptime
+			)
+		} else {
+			shouldNotify = false
 		}
-		if shouldProbeForCorrection {
-			backgroundCorrectionMode = !Self.isLikelyOverlayWhite(rgbSample)
+		stateLock.unlock()
+		if shouldNotify {
+			sampleUpdated()
 		}
-		latestSample = LiveChromeSample(
-			rgbSample: rgbSample,
-			loupePatch: latestSample?.loupePatch
-		)
-		latestSamplePoint = point
+	}
+
+	private static func shouldNotifySampleUpdated(
+		now: TimeInterval,
+		lastPointChangeUptime: TimeInterval
+	) -> Bool {
+		now - lastPointChangeUptime >= sampleUpdatedNotificationIdleDelay
 	}
 
 	private static func isLikelyOverlayWhite(_ sample: RGBSample) -> Bool {
@@ -543,59 +600,94 @@ final class LiveFrameClockDriver: @unchecked Sendable {
 }
 
 private final class SelectionFlowBandLayer: CALayer {
-	private struct SamplePoint {
-		let point: CGPoint
-		let progress: CGFloat
+	private enum Edge: CaseIterable {
+		case top
+		case right
+		case bottom
+		case left
+
+		var isHorizontal: Bool {
+			self == .top || self == .bottom
+		}
+
+		var animationKeyPath: String {
+			isHorizontal ? "transform.translation.x" : "transform.translation.y"
+		}
+
+		var flowDirection: CGFloat {
+			switch self {
+			case .top, .right:
+				return 1
+			case .bottom, .left:
+				return -1
+			}
+		}
+
+		var startPoint: CGPoint {
+			isHorizontal ? CGPoint(x: 0, y: 0.5) : CGPoint(x: 0.5, y: 0)
+		}
+
+		var endPoint: CGPoint {
+			isHorizontal ? CGPoint(x: 1, y: 0.5) : CGPoint(x: 0.5, y: 1)
+		}
 	}
 
-	private struct Geometry {
-		let focusRect: CGRect
-		let samples: [SamplePoint]
-		let normals: [CGVector]
+	private final class EdgeFlowLayers {
+		let edge: Edge
+		let clipLayer = CALayer()
+		let glowLayer = CAGradientLayer()
+		let lineLayer = CAGradientLayer()
+
+		init(edge: Edge) {
+			self.edge = edge
+		}
 	}
 
-	private static let cornerRadius: CGFloat = 9.0
-	private static let minSegments = 64
-	private static let maxSegments = 256
-	private static let sampleStep: CGFloat = 12.0
-	private static let speed: CGFloat = 0.24
-	private static let bandWidth: CGFloat = 0.06
-	private static let flowBoost: CGFloat = 2.8
-	private static let phaseMultiplier: CGFloat = 1.28
-	private static let phaseOffset: CGFloat = 0.72
-	private static let darkPalette: [(CGFloat, CGFloat, CGFloat)] = [
-		(196.0 / 255.0, 226.0 / 255.0, 1.0),
-		(228.0 / 255.0, 198.0 / 255.0, 1.0),
-		(176.0 / 255.0, 244.0 / 255.0, 224.0 / 255.0),
+	private static let pathOutset: CGFloat = 1.0
+	private static let darkLineWidth: CGFloat = 1.8
+	private static let lightLineWidth: CGFloat = 1.9
+	private static let darkGlowLineWidth: CGFloat = 5.0
+	private static let lightGlowLineWidth: CGFloat = 5.25
+	private static let flowAnimationKey = "rsnap.selection-flow.edge-translation"
+	private static let flowAnimationDuration: CFTimeInterval = 2.45
+	private static let gradientPeriod: CGFloat = 260
+	private static let darkPalette: [(CGFloat, CGFloat, CGFloat, CGFloat)] = [
+		(112.0 / 255.0, 215.0 / 255.0, 1.0, 0.98),
+		(176.0 / 255.0, 154.0 / 255.0, 1.0, 0.94),
+		(110.0 / 255.0, 245.0 / 255.0, 215.0 / 255.0, 0.90),
+		(65.0 / 255.0, 150.0 / 255.0, 1.0, 0.96),
 	]
-	private static let lightPalette: [(CGFloat, CGFloat, CGFloat)] = [
-		(0.0 / 255.0, 104.0 / 255.0, 226.0 / 255.0),
-		(124.0 / 255.0, 54.0 / 255.0, 214.0 / 255.0),
-		(0.0 / 255.0, 128.0 / 255.0, 104.0 / 255.0),
-	]
-	private static let passes: [(width: CGFloat, alphaScale: CGFloat)] = [
-		(2.4, 0.52)
+	private static let lightPalette: [(CGFloat, CGFloat, CGFloat, CGFloat)] = [
+		(0.0 / 255.0, 76.0 / 255.0, 196.0 / 255.0, 1.0),
+		(83.0 / 255.0, 44.0 / 255.0, 194.0 / 255.0, 0.98),
+		(0.0 / 255.0, 113.0 / 255.0, 98.0 / 255.0, 0.98),
+		(196.0 / 255.0, 82.0 / 255.0, 0.0 / 255.0, 0.96),
 	]
 
+	private let edgeLayers: [EdgeFlowLayers]
 	private var focusRect: CGRect = .null
 	private var theme: CaptureChromeTheme = .dark
-	private var phase: CGFloat = 0
-	private var cachedGeometry: Geometry?
+	private var flowAnimating = false
 
 	override init() {
+		edgeLayers = Edge.allCases.map { EdgeFlowLayers(edge: $0) }
 		super.init()
 		contentsScale = NSScreen.main?.backingScaleFactor ?? 2
 		isOpaque = false
-		needsDisplayOnBoundsChange = true
+		allowsEdgeAntialiasing = true
+		masksToBounds = false
+		configureLayers()
 	}
 
 	override init(layer: Any) {
+		edgeLayers = Edge.allCases.map { EdgeFlowLayers(edge: $0) }
 		super.init(layer: layer)
 		if let layer = layer as? SelectionFlowBandLayer {
 			focusRect = layer.focusRect
 			theme = layer.theme
-			phase = layer.phase
+			flowAnimating = layer.flowAnimating
 		}
+		configureLayers()
 	}
 
 	@available(*, unavailable)
@@ -609,402 +701,261 @@ private final class SelectionFlowBandLayer: CALayer {
 		}
 		isHidden = true
 		focusRect = .null
-		cachedGeometry = nil
+		flowAnimating = false
+		removeFlowAnimation()
 	}
 
 	func update(
 		frame: CGRect,
 		focusRect: CGRect,
 		theme: CaptureChromeTheme,
-		timestamp: CFTimeInterval,
-		contentsScale: CGFloat
+		timestamp _: CFTimeInterval,
+		contentsScale: CGFloat,
+		animates: Bool
 	) {
+		let focusChanged = self.focusRect != focusRect
+		let themeChanged = self.theme != theme
+		let frameChanged = self.frame != frame
+		let scaleChanged = self.contentsScale != contentsScale
+		let animationChanged = flowAnimating != animates
+		let wasHidden = isHidden
 		self.frame = frame
 		self.contentsScale = contentsScale
-		rasterizationScale = contentsScale
-		if self.focusRect != focusRect {
-			cachedGeometry = nil
-		}
 		self.focusRect = focusRect
 		self.theme = theme
-		phase = CGFloat(timestamp) * Self.speed * Self.phaseMultiplier + Self.phaseOffset
-		isHidden = false
-		setNeedsDisplay()
-	}
-
-	override func draw(in ctx: CGContext) {
-		guard !focusRect.isNull else {
-			return
+		flowAnimating = animates
+		if wasHidden || focusChanged || themeChanged || frameChanged || scaleChanged {
+			updateAppearance()
 		}
-		let geometry = selectionFlowGeometry()
-		let samples = geometry.samples
-		let normals = geometry.normals
-		guard samples.count > 1, normals.count == samples.count else {
-			return
-		}
-		ctx.setAllowsAntialiasing(true)
-		ctx.setShouldAntialias(true)
-		for pass in Self.passes {
-			let half = max(pass.width * 0.5, 0.1)
-			for index in samples.indices {
-				let current = samples[index]
-				let next = samples[(index + 1) % samples.count]
-				let currentMovement = selectionFlowBand(
-					progress: current.progress,
-					phase: phase,
-					bandWidth: Self.bandWidth
-				)
-				let nextMovement = selectionFlowBand(
-					progress: next.progress,
-					phase: phase,
-					bandWidth: Self.bandWidth
-				)
-				let currentIntensity = Self.flowBoost * currentMovement
-				let nextIntensity = Self.flowBoost * nextMovement
-				guard max(currentIntensity, nextIntensity) > 0.002 else {
-					continue
-				}
-				let currentColor = selectionFlowColorComponents(
-					progress: current.progress + phase,
-					alphaScale: pass.alphaScale,
-					intensity: currentIntensity
-				)
-				let nextColor = selectionFlowColorComponents(
-					progress: next.progress + phase,
-					alphaScale: pass.alphaScale,
-					intensity: nextIntensity
-				)
-				let color = averagedColorComponents(currentColor, nextColor)
-				if color.alpha <= 0.002 {
-					continue
-				}
-				let currentNormal = scaledVector(normals[index], by: half)
-				let nextNormal = scaledVector(normals[(index + 1) % normals.count], by: half)
-				ctx.setFillColor(
-					red: color.red,
-					green: color.green,
-					blue: color.blue,
-					alpha: color.alpha
-				)
-				ctx.beginPath()
-				ctx.move(to: offset(current.point, by: currentNormal))
-				ctx.addLine(to: offset(next.point, by: nextNormal))
-				ctx.addLine(to: offset(next.point, by: scaledVector(nextNormal, by: -1)))
-				ctx.addLine(to: offset(current.point, by: scaledVector(currentNormal, by: -1)))
-				ctx.closePath()
-				ctx.fillPath()
-			}
-		}
-	}
-
-	private func selectionFlowCornerRadius(for rect: CGRect) -> CGFloat {
-		max(
-			0,
-			min(
-				Self.cornerRadius,
-				min(rect.width / 2 - 0.25, rect.height / 2 - 0.25)
-			)
-		)
-	}
-
-	private func selectionFlowSampleCount(for perimeter: CGFloat) -> Int {
-		guard perimeter > 0, perimeter.isFinite else {
-			return Self.minSegments
-		}
-		let byStep = Int(ceil(perimeter / Self.sampleStep))
-		return min(max(byStep, Self.minSegments), Self.maxSegments)
-	}
-
-	private func selectionFlowGeometry() -> Geometry {
-		if let cachedGeometry, cachedGeometry.focusRect == focusRect {
-			return cachedGeometry
-		}
-		let cornerRadius = selectionFlowCornerRadius(for: focusRect)
-		let perimeter = selectionFlowPerimeter(for: focusRect, cornerRadius: cornerRadius)
-		let sampleCount = selectionFlowSampleCount(for: perimeter)
-		let seamOffset: CGFloat
-		if focusRect.width > cornerRadius * 2 {
-			seamOffset = (focusRect.width - cornerRadius * 2) * 0.5
+		if animates {
+			isHidden = false
+			installFlowAnimation(restartsAnimation: wasHidden || animationChanged)
 		} else {
-			seamOffset = 0
+			isHidden = true
+			removeFlowAnimation()
 		}
-		let samples = selectionFlowSamples(
-			for: focusRect,
-			cornerRadius: cornerRadius,
-			sampleCount: sampleCount,
-			startOffset: seamOffset
-		)
-		let geometry = Geometry(
-			focusRect: focusRect,
-			samples: samples,
-			normals: selectionFlowNormals(for: samples)
-		)
-		cachedGeometry = geometry
-		return geometry
 	}
 
-	private func selectionFlowBand(
-		progress: CGFloat,
-		phase: CGFloat,
-		bandWidth: CGFloat
-	) -> CGFloat {
-		let width = min(max(bandWidth, 0.001), 0.5)
-		let wrapped = (progress - phase).truncatingRemainder(dividingBy: 1)
-		let distance = wrapped >= 0 ? wrapped : wrapped + 1
-		let shortest = min(distance, 1 - distance)
-		let normalized = min(shortest / width, 1)
-		return pow(1 - normalized, 2)
+	private func configureLayers() {
+		for edgeLayer in edgeLayers {
+			edgeLayer.clipLayer.masksToBounds = true
+			edgeLayer.clipLayer.allowsEdgeAntialiasing = true
+			addSublayer(edgeLayer.clipLayer)
+
+			for gradientLayer in [edgeLayer.glowLayer, edgeLayer.lineLayer] {
+				gradientLayer.type = .axial
+				gradientLayer.startPoint = edgeLayer.edge.startPoint
+				gradientLayer.endPoint = edgeLayer.edge.endPoint
+				gradientLayer.allowsEdgeAntialiasing = true
+				edgeLayer.clipLayer.addSublayer(gradientLayer)
+			}
+			edgeLayer.glowLayer.opacity = selectionFlowGlowOpacity()
+		}
 	}
 
-	private func selectionFlowColorComponents(
-		progress: CGFloat,
-		alphaScale: CGFloat,
-		intensity: CGFloat
-	) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+	private func updateAppearance() {
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		let strokeRect = focusRect.insetBy(dx: -Self.pathOutset, dy: -Self.pathOutset)
+		for edgeLayer in edgeLayers {
+			update(edgeLayer, strokeRect: strokeRect)
+		}
+		CATransaction.commit()
+	}
+
+	private func installFlowAnimation(restartsAnimation: Bool) {
+		let hasAnimations = edgeLayers.allSatisfy {
+			$0.lineLayer.animation(forKey: Self.flowAnimationKey) != nil
+				&& $0.glowLayer.animation(forKey: Self.flowAnimationKey) != nil
+		}
+		if !restartsAnimation, hasAnimations {
+			return
+		}
+		removeFlowAnimation()
+		for edgeLayer in edgeLayers {
+			installFlowAnimation(on: edgeLayer.lineLayer, edge: edgeLayer.edge)
+			installFlowAnimation(on: edgeLayer.glowLayer, edge: edgeLayer.edge)
+		}
+	}
+
+	private func installFlowAnimation(on layer: CALayer, edge: Edge) {
+		let keyPath = edge.animationKeyPath
+		let currentOffset = (layer.presentation()?.value(forKeyPath: keyPath) as? CGFloat) ?? 0
+		let travel = edge.flowDirection * Self.gradientPeriod
+		let animation = CABasicAnimation(keyPath: keyPath)
+		animation.fromValue = currentOffset
+		animation.toValue = currentOffset + travel
+		animation.duration = Self.flowAnimationDuration
+		animation.repeatCount = .infinity
+		animation.timingFunction = CAMediaTimingFunction(name: .linear)
+		layer.add(animation, forKey: Self.flowAnimationKey)
+	}
+
+	private func removeFlowAnimation() {
+		for edgeLayer in edgeLayers {
+			edgeLayer.lineLayer.removeAnimation(forKey: Self.flowAnimationKey)
+			edgeLayer.glowLayer.removeAnimation(forKey: Self.flowAnimationKey)
+		}
+	}
+
+	private func update(_ edgeLayer: EdgeFlowLayers, strokeRect: CGRect) {
+		let lineWidth = selectionFlowLineWidth()
+		let glowWidth = selectionFlowGlowLineWidth()
+		let frame = edgeFrame(for: edgeLayer.edge, strokeRect: strokeRect, glowWidth: glowWidth)
+		edgeLayer.clipLayer.frame = pixelAligned(frame)
+		edgeLayer.clipLayer.isHidden = frame.width <= 0 || frame.height <= 0
+		edgeLayer.glowLayer.opacity = selectionFlowGlowOpacity()
+		updateGradients(edgeLayer, lineWidth: lineWidth, glowWidth: glowWidth)
+	}
+
+	private func updateGradients(
+		_ edgeLayer: EdgeFlowLayers,
+		lineWidth: CGFloat,
+		glowWidth: CGFloat
+	) {
+		let clipBounds = edgeLayer.clipLayer.bounds
+		let gradientLength =
+			(edgeLayer.edge.isHorizontal ? clipBounds.width : clipBounds.height)
+			+ Self.gradientPeriod * 2
+		let gradientFrame: CGRect
+		let lineFrame: CGRect
+		if edgeLayer.edge.isHorizontal {
+			gradientFrame = CGRect(
+				x: -Self.gradientPeriod,
+				y: 0,
+				width: gradientLength,
+				height: glowWidth
+			)
+			lineFrame = CGRect(
+				x: -Self.gradientPeriod,
+				y: (glowWidth - lineWidth) / 2,
+				width: gradientLength,
+				height: lineWidth
+			)
+		} else {
+			gradientFrame = CGRect(
+				x: 0,
+				y: -Self.gradientPeriod,
+				width: glowWidth,
+				height: gradientLength
+			)
+			lineFrame = CGRect(
+				x: (glowWidth - lineWidth) / 2,
+				y: -Self.gradientPeriod,
+				width: lineWidth,
+				height: gradientLength
+			)
+		}
+		edgeLayer.glowLayer.frame = pixelAligned(gradientFrame)
+		edgeLayer.lineLayer.frame = pixelAligned(lineFrame)
+		configureGradient(edgeLayer.glowLayer, length: gradientLength, alphaScale: 0.24)
+		configureGradient(edgeLayer.lineLayer, length: gradientLength, alphaScale: 1.0)
+	}
+
+	private func configureGradient(
+		_ gradientLayer: CAGradientLayer,
+		length: CGFloat,
+		alphaScale: CGFloat
+	) {
+		let stops = gradientStops(length: length, alphaScale: alphaScale)
+		gradientLayer.colors = stops.colors
+		gradientLayer.locations = stops.locations
+	}
+
+	private func gradientStops(
+		length: CGFloat,
+		alphaScale: CGFloat
+	) -> (colors: [CGColor], locations: [NSNumber]) {
 		let palette = theme == .dark ? Self.darkPalette : Self.lightPalette
-		let normalized =
-			progress.truncatingRemainder(dividingBy: 1) >= 0
-			? progress.truncatingRemainder(dividingBy: 1)
-			: progress.truncatingRemainder(dividingBy: 1) + 1
-		let bandPosition = normalized * CGFloat(palette.count)
-		let bandIndex = Int(floor(bandPosition)) % palette.count
-		let local = bandPosition - CGFloat(bandIndex)
-		let current = palette[bandIndex]
-		let next = palette[(bandIndex + 1) % palette.count]
-		let blend = { (lhs: CGFloat, rhs: CGFloat) in lhs + (rhs - lhs) * local }
-		let alpha = min(max(alphaScale * intensity, 0), 1)
-		return (
-			red: blend(current.0, next.0),
-			green: blend(current.1, next.1),
-			blue: blend(current.2, next.2),
-			alpha: alpha
+		let step = Self.gradientPeriod / CGFloat(palette.count)
+		let safeLength = max(length, 1)
+		var colors: [CGColor] = []
+		var locations: [NSNumber] = []
+		var distance: CGFloat = 0
+		var index = 0
+		while distance < safeLength {
+			let color = palette[index % palette.count]
+			colors.append(cgColor(from: color, alphaScale: alphaScale))
+			locations.append(NSNumber(value: Double(distance / safeLength)))
+			distance += step
+			index += 1
+		}
+		let color = palette[index % palette.count]
+		colors.append(cgColor(from: color, alphaScale: alphaScale))
+		locations.append(1)
+		return (colors, locations)
+	}
+
+	private func cgColor(
+		from color: (CGFloat, CGFloat, CGFloat, CGFloat),
+		alphaScale: CGFloat
+	) -> CGColor {
+		NSColor(
+			calibratedRed: color.0,
+			green: color.1,
+			blue: color.2,
+			alpha: min(max(color.3 * alphaScale, 0), 1)
+		).cgColor
+	}
+
+	private func edgeFrame(
+		for edge: Edge,
+		strokeRect: CGRect,
+		glowWidth: CGFloat
+	) -> CGRect {
+		let half = glowWidth / 2
+		switch edge {
+		case .top:
+			return CGRect(
+				x: strokeRect.minX - half,
+				y: strokeRect.minY - half,
+				width: strokeRect.width + glowWidth,
+				height: glowWidth
+			)
+		case .right:
+			return CGRect(
+				x: strokeRect.maxX - half,
+				y: strokeRect.minY - half,
+				width: glowWidth,
+				height: strokeRect.height + glowWidth
+			)
+		case .bottom:
+			return CGRect(
+				x: strokeRect.minX - half,
+				y: strokeRect.maxY - half,
+				width: strokeRect.width + glowWidth,
+				height: glowWidth
+			)
+		case .left:
+			return CGRect(
+				x: strokeRect.minX - half,
+				y: strokeRect.minY - half,
+				width: glowWidth,
+				height: strokeRect.height + glowWidth
+			)
+		}
+	}
+
+	private func pixelAligned(_ rect: CGRect) -> CGRect {
+		let scale = max(contentsScale, 1)
+		return CGRect(
+			x: floor(rect.minX * scale) / scale,
+			y: floor(rect.minY * scale) / scale,
+			width: ceil(rect.width * scale) / scale,
+			height: ceil(rect.height * scale) / scale
 		)
 	}
 
-	private func selectionFlowSamples(
-		for rect: CGRect,
-		cornerRadius: CGFloat,
-		sampleCount: Int,
-		startOffset: CGFloat
-	) -> [SamplePoint] {
-		let perimeter = selectionFlowPerimeter(for: rect, cornerRadius: cornerRadius)
-		guard perimeter > 0 else {
-			return []
-		}
-		let start = (startOffset / perimeter).truncatingRemainder(dividingBy: 1)
-		return (0..<sampleCount).map { index in
-			let t = (CGFloat(index) + 0.5) / CGFloat(sampleCount)
-			let progress = (t + start).truncatingRemainder(dividingBy: 1)
-			return SamplePoint(
-				point: selectionFlowPoint(
-					for: rect,
-					cornerRadius: cornerRadius,
-					distance: perimeter * progress
-				),
-				progress: t
-			)
-		}
+	private func selectionFlowLineWidth() -> CGFloat {
+		theme == .dark ? Self.darkLineWidth : Self.lightLineWidth
 	}
 
-	private func selectionFlowNormals(for samples: [SamplePoint]) -> [CGVector] {
-		let count = samples.count
-		guard count > 0 else {
-			return []
-		}
-		var normals = Array(repeating: CGVector(dx: 0, dy: 0), count: count)
-		var firstNonZero: Int?
-		for index in 0..<count {
-			let current = samples[index].point
-			let previous = samples[(index + count - 1) % count].point
-			let next = samples[(index + 1) % count].point
-			let previousTangent = CGVector(dx: current.x - previous.x, dy: current.y - previous.y)
-			let nextTangent = CGVector(dx: next.x - current.x, dy: next.y - current.y)
-			var normal = CGVector(dx: 0, dy: 0)
-			if lengthSquared(previousTangent) > CGFloat.ulpOfOne {
-				let previousLength = length(previousTangent)
-				normal.dx += -previousTangent.dy / previousLength
-				normal.dy += previousTangent.dx / previousLength
-			}
-			if lengthSquared(nextTangent) > CGFloat.ulpOfOne {
-				let nextLength = length(nextTangent)
-				normal.dx += -nextTangent.dy / nextLength
-				normal.dy += nextTangent.dx / nextLength
-			}
-			if lengthSquared(normal) <= CGFloat.ulpOfOne {
-				if lengthSquared(nextTangent) > CGFloat.ulpOfOne {
-					let nextLength = length(nextTangent)
-					normal = CGVector(
-						dx: -nextTangent.dy / nextLength, dy: nextTangent.dx / nextLength)
-				} else if lengthSquared(previousTangent) > CGFloat.ulpOfOne {
-					let previousLength = length(previousTangent)
-					normal = CGVector(
-						dx: -previousTangent.dy / previousLength,
-						dy: previousTangent.dx / previousLength)
-				}
-			}
-			if lengthSquared(normal) > CGFloat.ulpOfOne {
-				let normalized = scaledVector(normal, by: 1 / length(normal))
-				if firstNonZero == nil {
-					firstNonZero = index
-				}
-				normals[index] = normalized
-			}
-		}
-		if let firstNonZero {
-			var previous = normals[firstNonZero]
-			if lengthSquared(previous) > CGFloat.ulpOfOne {
-				for index in (firstNonZero + 1)..<count {
-					if lengthSquared(normals[index]) > CGFloat.ulpOfOne,
-						dot(normals[index], previous) < 0
-					{
-						normals[index] = scaledVector(normals[index], by: -1)
-					}
-					if lengthSquared(normals[index]) > CGFloat.ulpOfOne {
-						previous = normals[index]
-					}
-				}
-				if firstNonZero > 0 {
-					for index in stride(from: firstNonZero - 1, through: 0, by: -1) {
-						if lengthSquared(normals[index]) > CGFloat.ulpOfOne,
-							dot(normals[index], previous) < 0
-						{
-							normals[index] = scaledVector(normals[index], by: -1)
-						}
-						if lengthSquared(normals[index]) > CGFloat.ulpOfOne {
-							previous = normals[index]
-						}
-					}
-				}
-			}
-		}
-		return normals
+	private func selectionFlowGlowLineWidth() -> CGFloat {
+		theme == .dark ? Self.darkGlowLineWidth : Self.lightGlowLineWidth
 	}
 
-	private func selectionFlowPerimeter(for rect: CGRect, cornerRadius: CGFloat) -> CGFloat {
-		let edgeTop = max(rect.width - cornerRadius * 2, 0)
-		let edgeRight = max(rect.height - cornerRadius * 2, 0)
-		let cornerLength = (.pi / 2) * cornerRadius
-		return 2 * (edgeTop + edgeRight) + 4 * cornerLength
-	}
-
-	private func selectionFlowPoint(
-		for rect: CGRect,
-		cornerRadius: CGFloat,
-		distance: CGFloat
-	) -> CGPoint {
-		if cornerRadius <= .ulpOfOne {
-			let perimeter = selectionFlowPerimeter(for: rect, cornerRadius: 0)
-			let keep = distance.truncatingRemainder(dividingBy: perimeter)
-			let edgeTop = rect.width
-			let edgeRight = rect.height
-			if keep < edgeTop {
-				return CGPoint(x: rect.minX + keep, y: rect.minY)
-			}
-			if keep < edgeTop + edgeRight {
-				return CGPoint(x: rect.maxX, y: rect.minY + (keep - edgeTop))
-			}
-			if keep < edgeTop * 2 + edgeRight {
-				return CGPoint(x: rect.maxX - (keep - edgeTop - edgeRight), y: rect.maxY)
-			}
-			return CGPoint(
-				x: rect.minX,
-				y: rect.maxY - (keep - edgeTop * 2 - edgeRight)
-			)
-		}
-
-		let x0 = rect.minX
-		let x1 = rect.maxX
-		let y0 = rect.minY
-		let y1 = rect.maxY
-		let perimeter = selectionFlowPerimeter(for: rect, cornerRadius: cornerRadius)
-		var remain = distance.truncatingRemainder(dividingBy: perimeter)
-		if remain < 0 {
-			remain += perimeter
-		}
-		let edgeTop = max(rect.width - cornerRadius * 2, 0)
-		let edgeRight = max(rect.height - cornerRadius * 2, 0)
-		let cornerLength = (.pi / 2) * cornerRadius
-
-		if remain < edgeTop {
-			return CGPoint(x: x0 + cornerRadius + remain, y: y0)
-		}
-		remain -= edgeTop
-		if remain < cornerLength {
-			let angle = -(.pi / 2) + remain / cornerRadius
-			return CGPoint(
-				x: x1 - cornerRadius + cornerRadius * cos(angle),
-				y: y0 + cornerRadius + cornerRadius * sin(angle)
-			)
-		}
-		remain -= cornerLength
-		if remain < edgeRight {
-			return CGPoint(x: x1, y: y0 + cornerRadius + remain)
-		}
-		remain -= edgeRight
-		if remain < cornerLength {
-			let angle = remain / cornerRadius
-			return CGPoint(
-				x: x1 - cornerRadius + cornerRadius * cos(angle),
-				y: y1 - cornerRadius + cornerRadius * sin(angle)
-			)
-		}
-		remain -= cornerLength
-		if remain < edgeTop {
-			return CGPoint(x: x1 - cornerRadius - remain, y: y1)
-		}
-		remain -= edgeTop
-		if remain < cornerLength {
-			let angle = (.pi / 2) + remain / cornerRadius
-			return CGPoint(
-				x: x0 + cornerRadius + cornerRadius * cos(angle),
-				y: y1 - cornerRadius + cornerRadius * sin(angle)
-			)
-		}
-		remain -= cornerLength
-		if remain < edgeRight {
-			return CGPoint(x: x0, y: y1 - cornerRadius - remain)
-		}
-		remain -= edgeRight
-		if remain < cornerLength {
-			let angle = .pi + remain / cornerRadius
-			return CGPoint(
-				x: x0 + cornerRadius + cornerRadius * cos(angle),
-				y: y0 + cornerRadius + cornerRadius * sin(angle)
-			)
-		}
-		return CGPoint(x: x0 + cornerRadius, y: y0)
-	}
-
-	private func averagedColorComponents(
-		_ lhs: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat),
-		_ rhs: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
-	) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
-		(
-			red: (lhs.red + rhs.red) * 0.5,
-			green: (lhs.green + rhs.green) * 0.5,
-			blue: (lhs.blue + rhs.blue) * 0.5,
-			alpha: (lhs.alpha + rhs.alpha) * 0.5
-		)
-	}
-
-	private func offset(_ point: CGPoint, by vector: CGVector) -> CGPoint {
-		CGPoint(x: point.x + vector.dx, y: point.y + vector.dy)
-	}
-
-	private func scaledVector(_ vector: CGVector, by scalar: CGFloat) -> CGVector {
-		CGVector(dx: vector.dx * scalar, dy: vector.dy * scalar)
-	}
-
-	private func dot(_ lhs: CGVector, _ rhs: CGVector) -> CGFloat {
-		lhs.dx * rhs.dx + lhs.dy * rhs.dy
-	}
-
-	private func lengthSquared(_ vector: CGVector) -> CGFloat {
-		vector.dx * vector.dx + vector.dy * vector.dy
-	}
-
-	private func length(_ vector: CGVector) -> CGFloat {
-		sqrt(lengthSquared(vector))
+	private func selectionFlowGlowOpacity() -> Float {
+		theme == .dark ? 0.30 : 0.34
 	}
 }
 
@@ -1046,6 +997,10 @@ final class LiveOverlayRenderer {
 		"live_chrome.layer_chrome_render_duration",
 		category: "LiveChromeTelemetry"
 	)
+	private let snapshotDurationMetric = NativeHostTelemetry.distribution(
+		"live_chrome.snapshot_duration",
+		category: "LiveChromeTelemetry"
+	)
 	private let layerChromeRenderGapMetric = NativeHostTelemetry.distribution(
 		"live_chrome.layer_chrome_render_gap",
 		category: "LiveChromeTelemetry"
@@ -1055,8 +1010,17 @@ final class LiveOverlayRenderer {
 		category: "LiveChromeTelemetry"
 	)
 	private static let activeInputWindow: TimeInterval = 0.25
+	private enum LayerZ {
+		static let frozenDisplay: CGFloat = 0
+		static let scrim: CGFloat = 10
+		static let selectionChrome: CGFloat = 30
+		static let selectionSize: CGFloat = 40
+		static let hudChrome: CGFloat = 1000
+	}
+
 	private var snapshotProvider: (() -> LivePreviewSnapshot?)?
 	private var lastRenderedFocusRect: CGRect?
+	private var lastRenderedFocusFlowAnimates = false
 	private var lastChromeRenderUptime: TimeInterval?
 	private var lastActiveChromeRenderUptime: TimeInterval?
 
@@ -1088,23 +1052,13 @@ final class LiveOverlayRenderer {
 		frameClock.start(targetFramesPerSecond: targetFramesPerSecond)
 	}
 
-	func stopFrameClock() {
-		frameClock.stop()
-	}
-
 	func stop() {
 		frameClock.stop()
-		rootLayer.isHidden = true
-		lastRenderedFocusRect = nil
-		lastChromeRenderUptime = nil
-		lastActiveChromeRenderUptime = nil
+		hideRootAndResetRenderState()
 	}
 
 	func suspend() {
-		rootLayer.isHidden = true
-		lastRenderedFocusRect = nil
-		lastChromeRenderUptime = nil
-		lastActiveChromeRenderUptime = nil
+		hideRootAndResetRenderState()
 	}
 
 	func renderNow() {
@@ -1115,36 +1069,56 @@ final class LiveOverlayRenderer {
 		renderChromeSnapshot()
 	}
 
+	func moveLiveChrome(hudFrame: CGRect?, loupeFrame: CGRect?) {
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		if let hudFrame, !hudLayer.isHidden, layerFrameNeedsUpdate(hudLayer.frame, hudFrame) {
+			hudLayer.frame = hudFrame
+		}
+		if let loupeFrame, !loupeLayer.isHidden,
+			layerFrameNeedsUpdate(loupeLayer.frame, loupeFrame)
+		{
+			loupeLayer.frame = loupeFrame
+		}
+		CATransaction.commit()
+	}
+
 	private func configureLayers() {
 		rootLayer.zPosition = 100
 		rootLayer.masksToBounds = false
 		frozenDisplayLayer.isHidden = true
+		frozenDisplayLayer.zPosition = LayerZ.frozenDisplay
 		rootLayer.addSublayer(frozenDisplayLayer)
 		for scrimLayer in [topScrimLayer, leftScrimLayer, rightScrimLayer, bottomScrimLayer] {
 			rootLayer.addSublayer(scrimLayer)
 			scrimLayer.isHidden = true
+			scrimLayer.zPosition = LayerZ.scrim
 		}
 		hoverGlowLayer.fillColor = NSColor.clear.cgColor
 		hoverGlowLayer.lineWidth = 2.25
 		hoverGlowLayer.shadowOffset = .zero
 		hoverGlowLayer.shadowRadius = 12
+		hoverGlowLayer.zPosition = LayerZ.selectionChrome
 		rootLayer.addSublayer(hoverGlowLayer)
 
-		hoverFlowLayer.shouldRasterize = true
-		hoverFlowLayer.rasterizationScale = hostView?.window?.screen?.backingScaleFactor ?? 2
+		hoverFlowLayer.zPosition = LayerZ.selectionChrome
 		rootLayer.addSublayer(hoverFlowLayer)
 
 		dragBorderOutlineLayer.fillColor = NSColor.clear.cgColor
+		dragBorderOutlineLayer.zPosition = LayerZ.selectionChrome
 		rootLayer.addSublayer(dragBorderOutlineLayer)
 
 		dragBorderLayer.fillColor = NSColor.clear.cgColor
+		dragBorderLayer.zPosition = LayerZ.selectionChrome
 		rootLayer.addSublayer(dragBorderLayer)
 
 		selectionSizeLayer.contentsScale = 2
+		selectionSizeLayer.zPosition = LayerZ.selectionSize
 		rootLayer.addSublayer(selectionSizeLayer)
 
 		for chromeLayer in [hudLayer, loupeLayer] {
 			chromeLayer.masksToBounds = false
+			chromeLayer.zPosition = LayerZ.hudChrome
 			rootLayer.addSublayer(chromeLayer)
 		}
 		for hudSublayer in [
@@ -1164,25 +1138,23 @@ final class LiveOverlayRenderer {
 	}
 
 	private func renderCurrentSnapshot() {
-		guard let snapshot = snapshotProvider?() else {
-			rootLayer.isHidden = true
-			lastRenderedFocusRect = nil
-			lastChromeRenderUptime = nil
+		guard let snapshot = currentSnapshot() else {
+			hideRootAndResetRenderState()
 			return
 		}
 		renderFullSnapshot(snapshot)
 	}
 
 	private func renderFrameTick() {
-		guard let snapshot = snapshotProvider?() else {
-			rootLayer.isHidden = true
-			lastRenderedFocusRect = nil
-			lastChromeRenderUptime = nil
+		guard let snapshot = currentSnapshot() else {
+			hideRootAndResetRenderState()
 			return
 		}
 		let focusRect = snapshot.dragSelectionLocal ?? snapshot.hoverSelectionLocal
+		let focusFlowAnimates = shouldAnimateSelectionFlow(snapshot)
 		if snapshot.frozenPending || snapshot.dragSelectionLocal != nil
 			|| focusRect != lastRenderedFocusRect
+			|| focusFlowAnimates != lastRenderedFocusFlowAnimates
 		{
 			renderFullSnapshot(snapshot)
 		} else {
@@ -1203,19 +1175,35 @@ final class LiveOverlayRenderer {
 		renderFrozenDisplay(snapshot)
 		renderFocus(snapshot)
 		lastRenderedFocusRect = snapshot.dragSelectionLocal ?? snapshot.hoverSelectionLocal
+		lastRenderedFocusFlowAnimates = shouldAnimateSelectionFlow(snapshot)
 		renderHud(snapshot)
 		renderLoupe(snapshot)
 		CATransaction.commit()
 	}
 
 	private func renderChromeSnapshot() {
-		guard let snapshot = snapshotProvider?() else {
-			rootLayer.isHidden = true
-			lastRenderedFocusRect = nil
-			lastChromeRenderUptime = nil
+		guard let snapshot = currentSnapshot() else {
+			hideRootAndResetRenderState()
 			return
 		}
 		renderChromeSnapshot(snapshot)
+	}
+
+	private func hideRootAndResetRenderState() {
+		rootLayer.isHidden = true
+		lastRenderedFocusRect = nil
+		lastRenderedFocusFlowAnimates = false
+		lastChromeRenderUptime = nil
+		lastActiveChromeRenderUptime = nil
+		hoverFlowLayer.hide()
+	}
+
+	private func currentSnapshot() -> LivePreviewSnapshot? {
+		let snapshotStart = ProcessInfo.processInfo.systemUptime
+		defer {
+			snapshotDurationMetric.recordMillisecondsSince(snapshotStart)
+		}
+		return snapshotProvider?()
 	}
 
 	private func renderChromeSnapshot(_ snapshot: LivePreviewSnapshot) {
@@ -1231,6 +1219,13 @@ final class LiveOverlayRenderer {
 		renderHud(snapshot)
 		renderLoupe(snapshot)
 		CATransaction.commit()
+	}
+
+	private func layerFrameNeedsUpdate(_ current: CGRect, _ next: CGRect) -> Bool {
+		abs(current.minX - next.minX) > 0.001
+			|| abs(current.minY - next.minY) > 0.001
+			|| abs(current.width - next.width) > 0.001
+			|| abs(current.height - next.height) > 0.001
 	}
 
 	private func recordChromeRenderGap(at now: TimeInterval, snapshot: LivePreviewSnapshot) {
@@ -1397,12 +1392,37 @@ final class LiveOverlayRenderer {
 		).cgPath
 		hoverGlowLayer.path = hoverPath
 		hoverGlowLayer.isHidden = true
+		let contentsScale = hostView?.window?.screen?.backingScaleFactor ?? 2
+		let animatesFlow = shouldAnimateSelectionFlow(snapshot)
+		let flowFrame = flowLayerFrame(for: focusRect, scale: contentsScale)
 		hoverFlowLayer.update(
-			frame: snapshot.bounds,
-			focusRect: focusRect,
+			frame: flowFrame,
+			focusRect: focusRect.offsetBy(dx: -flowFrame.minX, dy: -flowFrame.minY),
 			theme: snapshot.theme,
 			timestamp: CACurrentMediaTime(),
-			contentsScale: hostView?.window?.screen?.backingScaleFactor ?? 2
+			contentsScale: contentsScale,
+			animates: animatesFlow
+		)
+	}
+
+	private func shouldAnimateSelectionFlow(_ snapshot: LivePreviewSnapshot) -> Bool {
+		guard snapshot.dragSelectionLocal == nil, snapshot.hoverSelectionLocal != nil,
+			!snapshot.frozenPending
+		else {
+			return false
+		}
+		return true
+	}
+
+	private func flowLayerFrame(for focusRect: CGRect, scale: CGFloat) -> CGRect {
+		let outset: CGFloat = 24
+		let expanded = focusRect.insetBy(dx: -outset, dy: -outset)
+		let safeScale = max(scale, 1)
+		return CGRect(
+			x: floor(expanded.minX * safeScale) / safeScale,
+			y: floor(expanded.minY * safeScale) / safeScale,
+			width: ceil(expanded.width * safeScale) / safeScale,
+			height: ceil(expanded.height * safeScale) / safeScale
 		)
 	}
 
@@ -1549,14 +1569,14 @@ final class LiveOverlayRenderer {
 		let glassEnabled = settings.usesClassicHudGlass
 		let opacity = CaptureChrome.effectiveHudOpacity(settings: settings)
 		let hasInlineGlass = glassEnabled && glassImage != nil
-		let usesExternalGlass = glassEnabled && glassImage == nil
-		let hasGlass = hasInlineGlass || usesExternalGlass
+		let hasGlass = hasInlineGlass || glassEnabled
 
 		container.cornerRadius = cornerRadius
 		container.shadowColor = palette.shadow.cgColor
 		container.shadowOffset = .zero
 		container.shadowRadius = 10
-		container.shadowOpacity = usesExternalGlass ? 0 : Float(max(0.12, opacity * 0.75))
+		container.shadowOpacity = Float(max(0.12, opacity * 0.75))
+		container.shadowPath = boundsPath
 
 		glassLayer.frame = frame
 		glassLayer.cornerRadius = cornerRadius
@@ -1569,9 +1589,7 @@ final class LiveOverlayRenderer {
 		fillLayer.frame = frame
 		fillLayer.cornerRadius = cornerRadius
 		fillLayer.backgroundColor =
-			usesExternalGlass || settings.usesLiquidHudGlass
-			? NSColor.clear.cgColor
-			: CaptureChrome.effectiveBodyFill(
+			CaptureChrome.effectiveBodyFill(
 				palette: palette,
 				settings: settings,
 				hasGlass: hasGlass

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -104,10 +104,11 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	}()
 	private var statusItem: NSStatusItem?
 	private weak var captureMenuItem: NSMenuItem?
-	private weak var cancelCaptureMenuItem: NSMenuItem?
 	private lazy var settingsWindowController = SettingsWindowController(
-		settingsStore: settingsStore)
-	private lazy var permissionsWindowController = PermissionsWindowController()
+		settingsStore: settingsStore,
+		onClose: { [weak self] in
+			self?.settingsWindowDidClose()
+		})
 
 	public func finishLaunching() {
 		guard !didBootstrap else {
@@ -148,6 +149,14 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		false
 	}
 
+	public func applicationShouldHandleReopen(
+		_ sender: NSApplication,
+		hasVisibleWindows flag: Bool
+	) -> Bool {
+		openSettings(nil)
+		return false
+	}
+
 	deinit {
 		NotificationCenter.default.removeObserver(self)
 	}
@@ -167,9 +176,15 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		settingsWindowController.present()
 	}
 
-	@objc
-	private func openPermissions(_ sender: Any?) {
-		permissionsWindowController.present()
+	private func settingsWindowDidClose() {
+		DispatchQueue.main.async { [weak self] in
+			guard let self,
+				self.settingsWindowController.window?.isVisible != true
+			else {
+				return
+			}
+			NSApp.setActivationPolicy(.accessory)
+		}
 	}
 
 	@objc
@@ -203,20 +218,13 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 
 		let menu = NSMenu(title: "Rsnap Native Host")
 		let captureItem = menu.addItem(
-			withTitle: "Capture",
+			withTitle: "New Capture",
 			action: #selector(startCapture(_:)),
-			keyEquivalent: "n"
-		)
-		let cancelItem = menu.addItem(
-			withTitle: "Cancel Capture",
-			action: #selector(cancelCapture(_:)),
-			keyEquivalent: "\u{1b}"
+			keyEquivalent: ""
 		)
 		menu.addItem(.separator())
 		menu.addItem(
 			withTitle: "Settings…", action: #selector(openSettings(_:)), keyEquivalent: ",")
-		menu.addItem(
-			withTitle: "Permissions…", action: #selector(openPermissions(_:)), keyEquivalent: "")
 		menu.addItem(.separator())
 		menu.addItem(withTitle: "Quit", action: #selector(quit(_:)), keyEquivalent: "q")
 		for menuItem in menu.items {
@@ -226,7 +234,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		item.menu = menu
 		statusItem = item
 		captureMenuItem = captureItem
-		cancelCaptureMenuItem = cancelItem
+		updateCaptureMenuShortcut()
 		NativeHostTelemetry.lifecycleEvent(
 			"native_host.status_item_installed",
 			detail: "visible=\(item.isVisible),hasMenu=\(item.menu != nil)"
@@ -248,7 +256,16 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	fileprivate func refreshStatusMenuState() {
 		let isCaptureActive = sessionController.isCaptureActive
 		captureMenuItem?.isEnabled = !isCaptureActive
-		cancelCaptureMenuItem?.isEnabled = isCaptureActive
+	}
+
+	private func updateCaptureMenuShortcut() {
+		guard let captureMenuItem else {
+			return
+		}
+		let shortcut = NativeHostSettings.captureHotKeyPresentation(
+			for: settingsStore.settings.captureHotkey)
+		captureMenuItem.keyEquivalent = shortcut.keyEquivalent
+		captureMenuItem.keyEquivalentModifierMask = shortcut.modifierMask
 	}
 
 	private func refreshHotKeyBindings(for mode: SceneKind) {
@@ -284,6 +301,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	@objc
 	private func settingsDidChange() {
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
+		updateCaptureMenuShortcut()
 	}
 
 	private static func statusItemImage() -> NSImage? {
@@ -343,6 +361,7 @@ final class CaptureSessionController: NSObject {
 	private var frozenFrameLatchToken: FrozenFrameLatchToken?
 	private var frozenSnapshotGeneration: UInt64 = 0
 	private var completedHostEffect: HostEffectKind?
+	private var liveStreamPrimedByStartupPrewarm = false
 	private var nextCaptureTelemetryID: UInt64 = 1
 	private var activeCaptureTelemetryID: UInt64?
 	var captureStateDidChange: (() -> Void)?
@@ -434,6 +453,7 @@ final class CaptureSessionController: NSObject {
 			NativeHostTelemetry.milliseconds(since: frozenAuthorityStartedAt)
 		let liveStreamStartedAt = ProcessInfo.processInfo.systemUptime
 		liveFrameStream.start(for: screens, prewarmPoint: point)
+		liveStreamPrimedByStartupPrewarm = source == "startup_prewarm"
 		let liveStreamStartMilliseconds =
 			NativeHostTelemetry.milliseconds(since: liveStreamStartedAt)
 		let seedStartedAt = ProcessInfo.processInfo.systemUptime
@@ -483,6 +503,7 @@ final class CaptureSessionController: NSObject {
 
 		do {
 			let startPoint = NSEvent.mouseLocation
+			prepareLiveSamplingForCaptureStart()
 			let warmStartedAt = ProcessInfo.processInfo.systemUptime
 			let initialSample = warmLiveSamplingIfPossible(
 				at: startPoint, source: "start_capture", captureID: captureID)
@@ -559,6 +580,14 @@ final class CaptureSessionController: NSObject {
 			)
 			tearDownCapture()
 		}
+	}
+
+	private func prepareLiveSamplingForCaptureStart() {
+		guard liveStreamPrimedByStartupPrewarm else {
+			return
+		}
+		liveFrameStream.stop()
+		liveStreamPrimedByStartupPrewarm = false
 	}
 
 	private func ensureCapturePermissions() -> Bool {
@@ -1878,6 +1907,7 @@ final class CaptureSessionController: NSObject {
 	private func tearDownCapture() {
 		let captureID = currentCaptureTelemetryID
 		liveFrameStream.stop()
+		liveStreamPrimedByStartupPrewarm = false
 		frozenFrameLatchToken = nil
 		frozenSnapshotGeneration &+= 1
 		completedHostEffect = nil
@@ -2185,7 +2215,13 @@ final class CaptureOverlayController {
 	private lazy var windowSnapshotFeed = WindowSnapshotFeed()
 	private lazy var chromeSampleFeed = ChromeSampleFeed(
 		broker: liveFrameStream,
-		backgroundSampler: Self.rgbSampleAtDisplayPoint
+		backgroundSampler: Self.rgbSampleAtDisplayPoint,
+		sampleUpdated: { [weak self] in
+			DispatchQueue.main.async { [weak self] in
+				(self?.primaryWindow as? CaptureOverlayWindow)?.hostView
+					.refreshSampleUpdatedLiveChromeNow()
+			}
+		}
 	)
 	private let liveChromeBackdrops = LiveChromeBackdropWindowController()
 
@@ -2926,8 +2962,10 @@ final class CaptureHostView: NSView {
 	private let loupeMaterialView = PassthroughVisualEffectView(frame: .zero)
 	private var hudLiquidGlassView: NSView?
 	private var loupeLiquidGlassView: NSView?
+	private var lastLiveLiquidGlassUpdateUptime: TimeInterval = 0
 	private var toolbarLiquidGlassView: NSView?
 	private var toolbarLiquidGlassContentView: FrozenToolbarRenderView?
+	private var frozenToolbarLiquidGlassVisible = false
 	private var trackingAreaRef: NSTrackingArea?
 	private var hoveredToolbarAction: ToolbarItemKind?
 	private var lastCursorPresentation: CursorPresentation?
@@ -2941,6 +2979,7 @@ final class CaptureHostView: NSView {
 	private var lastLivePointerEventUptime: TimeInterval?
 	private var liveHighlightedWindowPreview: WindowSnapshot?
 	private var liveHoverChromeSuppressed = false
+	private var sampleUpdatedLiveChromeRenderInProgress = false
 	private var pendingFrozenFirstDisplay = false
 	private var frozenFirstDisplayCompletionQueued = false
 	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
@@ -2959,6 +2998,7 @@ final class CaptureHostView: NSView {
 	private var didEmitLiveChromeInputSummary = false
 
 	override var acceptsFirstResponder: Bool { true }
+	override var isOpaque: Bool { false }
 
 	override init(frame frameRect: NSRect) {
 		super.init(frame: frameRect)
@@ -2995,11 +3035,16 @@ final class CaptureHostView: NSView {
 		self.scene = scene
 		self.chrome = chrome
 		self.settings = settings
+		if previousMode != scene.mode {
+			window?.acceptsMouseMovedEvents = true
+			updateTrackingAreas()
+		}
 		if scene.mode == .live {
 			pendingFrozenFirstDisplay = false
 			if previousMode != .live {
 				liveHoverChromeSuppressed = false
 				resetLiveChromeInputTelemetry()
+				seedLiveChromeSampleCache(from: chrome)
 			}
 			if livePointerPreviewGlobal == nil {
 				seedLivePointerPreview(scene.pointer, recordsInputLatency: false)
@@ -3102,6 +3147,9 @@ final class CaptureHostView: NSView {
 		lastCursorPresentation = currentCursorPresentation()
 		updateChromeMaterialViews()
 		updateLiveRendererState()
+		if scene.mode == .live {
+			seedLiveChromeSampleCache(from: chrome)
+		}
 	}
 
 	fileprivate func refreshLivePresentationNow() {
@@ -3110,6 +3158,26 @@ final class CaptureHostView: NSView {
 		}
 		updateLivePreviewDemands()
 		liveRenderer.renderNow()
+	}
+
+	fileprivate func refreshLiveChromeNow() {
+		guard scene.mode == .live else {
+			return
+		}
+		updateLivePreviewSampleDemand()
+		liveRenderer.renderLiveChromeNow()
+	}
+
+	fileprivate func refreshSampleUpdatedLiveChromeNow() {
+		guard scene.mode == .live else {
+			return
+		}
+		sampleUpdatedLiveChromeRenderInProgress = true
+		defer {
+			sampleUpdatedLiveChromeRenderInProgress = false
+		}
+		updateLivePreviewSampleDemand()
+		liveRenderer.renderLiveChromeNow()
 	}
 
 	fileprivate func installFrozenFirstFrame(
@@ -3172,11 +3240,12 @@ final class CaptureHostView: NSView {
 			removeTrackingArea(trackingAreaRef)
 		}
 
+		let options: NSTrackingArea.Options = [
+			.activeAlways, .cursorUpdate, .inVisibleRect, .mouseMoved, .enabledDuringMouseDrag,
+		]
 		let trackingAreaRef = NSTrackingArea(
 			rect: bounds,
-			options: [
-				.activeAlways, .cursorUpdate, .inVisibleRect, .mouseMoved, .enabledDuringMouseDrag,
-			],
+			options: options,
 			owner: self,
 			userInfo: nil
 		)
@@ -3200,6 +3269,8 @@ final class CaptureHostView: NSView {
 		let point = globalPoint(from: event)
 		if scene.mode == .live {
 			liveChromeMouseEventCount += 1
+			updateLivePointerPreview(to: point, rendersImmediately: true)
+			return
 		}
 		updateLivePointerPreview(to: point, rendersImmediately: false)
 		queuePointerEvent(.moved(point))
@@ -3238,6 +3309,10 @@ final class CaptureHostView: NSView {
 			controller?.beginFrozenInteraction(at: point)
 			syncVisibleCursor()
 		}
+	}
+
+	override func rightMouseDown(with event: NSEvent) {
+		controller?.cancelCapture()
 	}
 
 	override func mouseUp(with event: NSEvent) {
@@ -3319,6 +3394,7 @@ final class CaptureHostView: NSView {
 		guard let context = NSGraphicsContext.current?.cgContext else {
 			return
 		}
+		context.clear(bounds)
 
 		switch scene.mode {
 		case .hidden:
@@ -3331,7 +3407,7 @@ final class CaptureHostView: NSView {
 				return
 			}
 			drawFrozenDisplaySurface(in: context)
-			if let selection = localFrozenSelectionRect() {
+			if let selection = localFrozenSelectionRect().map(pixelAlignedSelectionRect) {
 				drawSelectionScrim(
 					for: selection, in: context, alpha: CaptureChrome.frozenScrimAlpha)
 				drawDashedSelectionBorder(
@@ -3349,6 +3425,20 @@ final class CaptureHostView: NSView {
 			scheduleFrozenFirstFrameInstallCompletionIfNeeded()
 		}
 
+	}
+
+	private func pixelAlignedSelectionRect(_ rect: CGRect) -> CGRect {
+		let scale = max(window?.screen?.backingScaleFactor ?? 1, 1)
+		let minX = floor(rect.minX * scale) / scale
+		let minY = floor(rect.minY * scale) / scale
+		let maxX = ceil(rect.maxX * scale) / scale
+		let maxY = ceil(rect.maxY * scale) / scale
+		return CGRect(
+			x: minX,
+			y: minY,
+			width: max(0, maxX - minX),
+			height: max(0, maxY - minY)
+		)
 	}
 
 	private func scheduleFrozenFirstFrameInstallCompletionIfNeeded() {
@@ -3545,7 +3635,8 @@ final class CaptureHostView: NSView {
 		recordLivePointerEventGap()
 		let pointerChanged = setLivePointerPreview(to: globalPoint)
 		if pointerChanged || rendersImmediately {
-			updateLivePreviewDemands()
+			updateLivePreviewSampleDemand()
+			moveLiveChromeLayers()
 			liveRenderer.renderLiveChromeNow()
 		}
 	}
@@ -3574,14 +3665,18 @@ final class CaptureHostView: NSView {
 		guard !didEmitLiveChromeInputSummary else {
 			return
 		}
-		guard liveChromeMouseEventCount > 0 else {
+		let observedMouseEvents = max(
+			liveChromeMouseEventCount,
+			Int(min(livePointerPreviewInputSequence, UInt64(Int.max)))
+		)
+		guard observedMouseEvents > 0 else {
 			return
 		}
 		didEmitLiveChromeInputSummary = true
 		NativeHostTelemetry.liveChromeInputSummary(
 			captureID: controller?.activeTelemetryCaptureID ?? 0,
 			reason: reason,
-			mouseEvents: liveChromeMouseEventCount,
+			mouseEvents: observedMouseEvents,
 			followTicks: 0,
 			fastMoveAttempts: 0,
 			fastMoveSuccesses: 0,
@@ -3806,24 +3901,21 @@ final class CaptureHostView: NSView {
 
 	private func drawSelectionScrim(for focusRect: CGRect, in context: CGContext, alpha: CGFloat) {
 		let scrimColor = NSColor(calibratedWhite: 0, alpha: alpha)
-		context.setFillColor(scrimColor.cgColor)
-
-		for rect in [
-			CGRect(
-				x: bounds.minX, y: bounds.minY, width: bounds.width,
-				height: max(0, focusRect.minY - bounds.minY)),
-			CGRect(
-				x: bounds.minX, y: focusRect.minY, width: max(0, focusRect.minX - bounds.minX),
-				height: focusRect.height),
-			CGRect(
-				x: focusRect.maxX, y: focusRect.minY, width: max(0, bounds.maxX - focusRect.maxX),
-				height: focusRect.height),
-			CGRect(
-				x: bounds.minX, y: focusRect.maxY, width: bounds.width,
-				height: max(0, bounds.maxY - focusRect.maxY)),
-		] where rect.width > 0 && rect.height > 0 {
-			context.fill(rect)
+		let visibleFocusRect = focusRect.intersection(bounds)
+		if visibleFocusRect.isNull || visibleFocusRect.width <= 0 || visibleFocusRect.height <= 0 {
+			context.setFillColor(scrimColor.cgColor)
+			context.fill(bounds)
+			return
 		}
+
+		let path = CGMutablePath()
+		path.addRect(bounds)
+		path.addRect(visibleFocusRect)
+		context.saveGState()
+		context.setFillColor(scrimColor.cgColor)
+		context.addPath(path)
+		context.drawPath(using: .eoFill)
+		context.restoreGState()
 	}
 
 	private func drawLiveSelectionGlow(around rect: CGRect, in context: CGContext) {
@@ -4285,7 +4377,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func drawFrozenToolbar(for selection: CGRect, in context: CGContext) {
-		guard !settings.usesLiquidHudGlass else {
+		guard !settings.usesLiquidHudGlass || !frozenToolbarLiquidGlassVisible else {
 			return
 		}
 		guard let layout = toolbarLayout(for: selection) else {
@@ -4298,7 +4390,8 @@ final class CaptureHostView: NSView {
 			context: context,
 			theme: theme,
 			strongShadow: false,
-			surfaceKind: .toolbar
+			surfaceKind: .toolbar,
+			allowsLiquidGlassClearFill: false
 		)
 
 		for item in layout.items {
@@ -4549,6 +4642,7 @@ final class CaptureHostView: NSView {
 				)
 			}
 			: nil
+		hideClassicGlassMaterialViews()
 		updateLiveLiquidGlassViews(hudFrame: hudFrame, loupeFrame: loupeFrame)
 
 		return LivePreviewSnapshot(
@@ -4568,7 +4662,8 @@ final class CaptureHostView: NSView {
 			colorDisplay: colorDisplay,
 			rgbSample: rgbSample,
 			keycapVisible: settings.showAltHintKeycap,
-			inputUptime: livePointerPreviewInputUptime,
+			inputUptime: sampleUpdatedLiveChromeRenderInProgress
+				? nil : livePointerPreviewInputUptime,
 			loupePatch: loupePatch,
 			glassPatches: [:]
 		)
@@ -4598,19 +4693,15 @@ final class CaptureHostView: NSView {
 	}
 
 	private func updateLiveChromeBackdrops(hudFrame: CGRect?, loupeFrame: CGRect?) {
-		guard scene.mode == .live, settings.usesClassicHudGlass else {
-			controller?.updateLiveChromeBackdrops(nil)
-			return
-		}
-		controller?.updateLiveChromeBackdrops(
-			LiveChromeBackdropSnapshot(
-				sourceWindowNumber: window?.windowNumber,
-				hudFrame: hudFrame.flatMap(globalRect(from:)),
-				loupeFrame: loupeFrame.flatMap(globalRect(from:)),
-				theme: chromeTheme(),
-				settings: settings
-			)
-		)
+		controller?.updateLiveChromeBackdrops(nil)
+		hideClassicGlassMaterialViews()
+	}
+
+	private func moveLiveChromeLayers() {
+		let frames = currentLiveChromeLayerFrames()
+		hideClassicGlassMaterialViews()
+		hideLiveLiquidGlassViews()
+		liveRenderer.moveLiveChrome(hudFrame: frames.hud, loupeFrame: frames.loupe)
 	}
 
 	private func currentLiveChromeLayerFrames() -> (hud: CGRect?, loupe: CGRect?) {
@@ -4803,6 +4894,10 @@ final class CaptureHostView: NSView {
 			}
 			return sample
 		}
+		if chrome.rgbSample != nil || chrome.loupePatch != nil {
+			seedLiveChromeSampleCache(from: chrome)
+			return latestLiveChromeSample
+		}
 		return latestLiveChromeSample
 	}
 
@@ -4811,7 +4906,24 @@ final class CaptureHostView: NSView {
 			latestLiveRgbSample = rgbSample
 			return rgbSample
 		}
+		if let rgbSample = chrome.rgbSample {
+			latestLiveRgbSample = rgbSample
+			return rgbSample
+		}
 		return latestLiveRgbSample
+	}
+
+	private func seedLiveChromeSampleCache(from chrome: CaptureChromeState) {
+		guard chrome.rgbSample != nil || chrome.loupePatch != nil else {
+			return
+		}
+		latestLiveChromeSample = LiveChromeSample(
+			rgbSample: chrome.rgbSample,
+			loupePatch: chrome.loupePatch
+		)
+		if let rgbSample = chrome.rgbSample {
+			latestLiveRgbSample = rgbSample
+		}
 	}
 
 	private func selectionSizeText(for rect: CGRect) -> String {
@@ -4874,7 +4986,8 @@ final class CaptureHostView: NSView {
 		context: CGContext,
 		theme: CaptureChromeTheme,
 		strongShadow: Bool,
-		surfaceKind: GlassSurfaceKind
+		surfaceKind: GlassSurfaceKind,
+		allowsLiquidGlassClearFill: Bool = true
 	) {
 		let palette = CaptureChrome.palette(for: theme, settings: settings)
 		let pillPath = NSBezierPath(
@@ -4899,7 +5012,7 @@ final class CaptureHostView: NSView {
 			context.draw(glassImage, in: frame)
 			context.restoreGState()
 		}
-		let usesLiquidGlass = settings.usesLiquidHudGlass
+		let usesLiquidGlass = allowsLiquidGlassClearFill && settings.usesLiquidHudGlass
 		let fillColor =
 			usesLiquidGlass
 			? NSColor.clear
@@ -5032,10 +5145,14 @@ final class CaptureHostView: NSView {
 
 	private func configureChromeMaterialView(_ view: NSVisualEffectView) {
 		view.blendingMode = .behindWindow
+		view.material = .hudWindow
 		view.state = .active
 		view.isHidden = true
 		view.wantsLayer = true
 		view.layer?.cornerRadius = CaptureChrome.hudCornerRadius
+		if #available(macOS 10.15, *) {
+			view.layer?.cornerCurve = .continuous
+		}
 		view.layer?.masksToBounds = true
 	}
 
@@ -5044,12 +5161,12 @@ final class CaptureHostView: NSView {
 		view.wantsLayer = true
 		view.layer?.cornerRadius = CaptureChrome.hudCornerRadius
 		view.layer?.masksToBounds = true
-		view.layer?.zPosition = 50
+		view.layer?.zPosition = 2_000
 	}
 
 	private func updateChromeMaterialViews() {
-		for materialView in [hudMaterialView, loupeMaterialView] {
-			materialView.isHidden = true
+		if scene.mode != .live || !settings.usesClassicHudGlass || chrome.hostLocalFrozenSelecting {
+			hideClassicGlassMaterialViews()
 		}
 		if scene.mode != .live || !settings.usesLiquidHudGlass || chrome.hostLocalFrozenSelecting {
 			hideLiveLiquidGlassViews()
@@ -5058,14 +5175,13 @@ final class CaptureHostView: NSView {
 		updateLiveChromeBackdrops()
 	}
 
-	private func updateLiveLiquidGlassViews(hudFrame: CGRect?, loupeFrame: CGRect?) {
-		guard scene.mode == .live, settings.usesLiquidHudGlass, !chrome.hostLocalFrozenSelecting
-		else {
-			hideLiveLiquidGlassViews()
-			return
-		}
-		updateLiveLiquidGlassView(&hudLiquidGlassView, frame: hudFrame)
-		updateLiveLiquidGlassView(&loupeLiquidGlassView, frame: loupeFrame)
+	private func hideClassicGlassMaterialViews() {
+		hudMaterialView.isHidden = true
+		loupeMaterialView.isHidden = true
+	}
+
+	private func updateLiveLiquidGlassViews(hudFrame _: CGRect?, loupeFrame _: CGRect?) {
+		hideLiveLiquidGlassViews()
 	}
 
 	private func updateLiveLiquidGlassView(_ view: inout NSView?, frame: CGRect?) {
@@ -5096,9 +5212,11 @@ final class CaptureHostView: NSView {
 		loupeLiquidGlassView?.removeFromSuperview()
 		hudLiquidGlassView = nil
 		loupeLiquidGlassView = nil
+		lastLiveLiquidGlassUpdateUptime = 0
 	}
 
 	private func updateFrozenToolbarLiquidGlassView() {
+		let wasVisible = frozenToolbarLiquidGlassVisible
 		guard
 			scene.mode == .frozen,
 			settings.usesLiquidHudGlass,
@@ -5110,6 +5228,10 @@ final class CaptureHostView: NSView {
 		}
 		updateLiveLiquidGlassView(&toolbarLiquidGlassView, frame: layout.frame)
 		guard let toolbarLiquidGlassView else {
+			frozenToolbarLiquidGlassVisible = false
+			if wasVisible {
+				needsDisplay = true
+			}
 			return
 		}
 		if toolbarLiquidGlassContentView == nil {
@@ -5141,15 +5263,24 @@ final class CaptureHostView: NSView {
 		)
 		LiveChromeLiquidGlassBridge.setContentView(
 			toolbarLiquidGlassContentView, on: toolbarLiquidGlassView)
+		frozenToolbarLiquidGlassVisible = true
+		if !wasVisible {
+			needsDisplay = true
+		}
 	}
 
 	private func hideFrozenToolbarLiquidGlassView() {
+		let wasVisible = frozenToolbarLiquidGlassVisible
+		frozenToolbarLiquidGlassVisible = false
 		if let toolbarLiquidGlassView {
 			LiveChromeLiquidGlassBridge.setContentView(nil, on: toolbarLiquidGlassView)
 		}
 		toolbarLiquidGlassView?.removeFromSuperview()
 		toolbarLiquidGlassView = nil
 		toolbarLiquidGlassContentView = nil
+		if wasVisible {
+			needsDisplay = true
+		}
 	}
 
 	private func suppressLiveHoverChrome() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
@@ -3,66 +3,92 @@ import ApplicationServices
 import CoreGraphics
 import Foundation
 import RsnapHostBridge
+import SwiftUI
+
+private final class SettingsWindow: NSWindow {
+	override var canBecomeKey: Bool {
+		true
+	}
+
+	override var canBecomeMain: Bool {
+		true
+	}
+
+	override func performKeyEquivalent(with event: NSEvent) -> Bool {
+		if handleCommandShortcut(event) {
+			return true
+		}
+		return super.performKeyEquivalent(with: event)
+	}
+
+	override func keyDown(with event: NSEvent) {
+		if handleCommandShortcut(event) {
+			return
+		}
+		super.keyDown(with: event)
+	}
+
+	private func handleCommandShortcut(_ event: NSEvent) -> Bool {
+		let commandModifiers = event.modifierFlags.intersection([
+			.command, .option, .control, .shift,
+		])
+		guard commandModifiers == .command,
+			let character = event.charactersIgnoringModifiers?.lowercased()
+		else {
+			return false
+		}
+
+		switch character {
+		case "w":
+			performClose(nil)
+			return true
+		case "q":
+			NSApp.terminate(nil)
+			return true
+		default:
+			return false
+		}
+	}
+}
 
 @MainActor
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
-	private let settingsStore: NativeHostSettingsStore
-	private let outputDirectoryValueLabel = NSTextField(labelWithString: "")
-	private let prefixField = NSTextField(string: "")
-	private let namingControl = NSSegmentedControl(
-		labels: OutputNamingPreference.allCases.map(\.title), trackingMode: .selectOne, target: nil,
-		action: nil)
-	private let toolbarPlacementControl = NSSegmentedControl(
-		labels: ToolbarPlacementPreference.allCases.map(\.title), trackingMode: .selectOne,
-		target: nil, action: nil)
-	private let frozenResizeHandleOrientationControl = NSSegmentedControl(
-		labels: FrozenResizeHandleOrientationPreference.allCases.map(\.title),
-		trackingMode: .selectOne, target: nil, action: nil)
-	private let showAltHintKeycapButton = NSButton(
-		checkboxWithTitle: "Show Tab hint in HUD", target: nil, action: nil)
-	private let hudGlassEnabledButton = NSButton(
-		checkboxWithTitle: "Enable glass", target: nil, action: nil)
-	private let hudGlassModeControl = NSSegmentedControl(
-		labels: HudGlassModePreference.allCases.map(\.title), trackingMode: .selectOne,
-		target: nil, action: nil)
-	private let liquidGlassStyleControl = NSSegmentedControl(
-		labels: LiquidGlassStylePreference.allCases.map(\.title), trackingMode: .selectOne,
-		target: nil, action: nil)
-	private let loupeSampleSizeControl = NSSegmentedControl(
-		labels: LoupeSampleSizePreference.allCases.map(\.title), trackingMode: .selectOne,
-		target: nil, action: nil)
-	private let hudOpacitySlider = NSSlider(
-		value: 50, minValue: 0, maxValue: 100, target: nil, action: nil)
-	private let hudBlurSlider = NSSlider(
-		value: 50, minValue: 0, maxValue: 100, target: nil, action: nil)
-	private let hudTintSlider = NSSlider(
-		value: 50, minValue: 0, maxValue: 100, target: nil, action: nil)
-	private let hudTintColorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 44, height: 24))
-	private let hudOpacityValueLabel = NSTextField(labelWithString: "")
-	private let hudBlurValueLabel = NSTextField(labelWithString: "")
-	private let hudTintValueLabel = NSTextField(labelWithString: "")
-	private var glassTintOptionViews: [NSView] = []
-	private var classicGlassOptionViews: [NSView] = []
-	private var liquidGlassOptionViews: [NSView] = []
+	private let viewModel: NativeHostSettingsViewModel
+	private let onClose: () -> Void
 
-	init(settingsStore: NativeHostSettingsStore) {
-		self.settingsStore = settingsStore
+	init(settingsStore: NativeHostSettingsStore, onClose: @escaping () -> Void = {}) {
+		self.viewModel = NativeHostSettingsViewModel(settingsStore: settingsStore)
+		self.onClose = onClose
 
-		let contentRect = NSRect(x: 0, y: 0, width: 560, height: 640)
-		let window = NSWindow(
+		let contentRect = NSRect(x: 0, y: 0, width: 690, height: 430)
+		let window = SettingsWindow(
 			contentRect: contentRect,
-			styleMask: [.titled, .closable, .miniaturizable],
+			styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
 			backing: .buffered,
 			defer: false
 		)
 		window.title = "Settings"
+		window.titleVisibility = .hidden
+		window.titlebarAppearsTransparent = true
+		window.isMovableByWindowBackground = false
+		window.backgroundColor = .clear
+		window.isOpaque = false
+		if #available(macOS 11.0, *) {
+			window.titlebarSeparatorStyle = .none
+		}
 		window.isReleasedWhenClosed = false
+		window.contentMinSize = NSSize(width: 680, height: 420)
+		window.collectionBehavior.insert(.moveToActiveSpace)
 		super.init(window: window)
 
 		window.delegate = self
-		window.contentView = buildContentView()
+		let hostingController = NSHostingController(
+			rootView: NativeHostSettingsView(model: viewModel))
+		hostingController.view.wantsLayer = true
+		hostingController.view.layer?.backgroundColor = NSColor.clear.cgColor
+		window.contentViewController = hostingController
 		window.center()
-		refreshFromSettings()
+		viewModel.refresh()
 	}
 
 	@available(*, unavailable)
@@ -71,652 +97,16 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 	}
 
 	func present() {
+		NSApp.setActivationPolicy(.regular)
+		viewModel.refresh()
 		showWindow(nil)
+		NSRunningApplication.current.activate(options: [.activateAllWindows])
 		window?.makeKeyAndOrderFront(nil)
 		NSApp.activate(ignoringOtherApps: true)
 	}
 
-	private func buildContentView() -> NSView {
-		let root = NSView(frame: .zero)
-		root.translatesAutoresizingMaskIntoConstraints = false
-
-		let stack = NSStackView()
-		stack.orientation = .vertical
-		stack.alignment = .leading
-		stack.spacing = 18
-		stack.edgeInsets = NSEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
-		stack.translatesAutoresizingMaskIntoConstraints = false
-
-		stack.addArrangedSubview(makeSectionTitle("Output"))
-		stack.addArrangedSubview(makeOutputDirectoryRow())
-		stack.addArrangedSubview(makePrefixRow())
-		stack.addArrangedSubview(makeNamingRow())
-		stack.addArrangedSubview(makeSectionTitle("Overlay"))
-		stack.addArrangedSubview(makeOverlayRow())
-		stack.addArrangedSubview(makeHudGlassModeRow())
-		stack.addArrangedSubview(makeLoupeSampleSizeRow())
-		stack.addArrangedSubview(makeToolbarPlacementRow())
-		stack.addArrangedSubview(makeFrozenResizeHandleOrientationRow())
-
-		root.addSubview(stack)
-		NSLayoutConstraint.activate([
-			stack.leadingAnchor.constraint(equalTo: root.leadingAnchor),
-			stack.trailingAnchor.constraint(equalTo: root.trailingAnchor),
-			stack.topAnchor.constraint(equalTo: root.topAnchor),
-			stack.bottomAnchor.constraint(lessThanOrEqualTo: root.bottomAnchor),
-		])
-		return root
-	}
-
-	private func makeSectionTitle(_ title: String) -> NSTextField {
-		let label = NSTextField(labelWithString: title)
-		label.font = .systemFont(ofSize: 15, weight: .semibold)
-		return label
-	}
-
-	private func makeOutputDirectoryRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Output directory")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		outputDirectoryValueLabel.lineBreakMode = .byTruncatingMiddle
-		outputDirectoryValueLabel.font = .systemFont(ofSize: 12)
-		outputDirectoryValueLabel.textColor = .secondaryLabelColor
-		outputDirectoryValueLabel.setContentCompressionResistancePriority(
-			.defaultLow, for: .horizontal)
-
-		let chooseButton = NSButton(
-			title: "Choose…", target: self, action: #selector(chooseOutputDirectory))
-		let row = NSStackView(views: [outputDirectoryValueLabel, chooseButton])
-		row.orientation = .horizontal
-		row.alignment = .centerY
-		row.spacing = 12
-		container.addArrangedSubview(row)
-		return container
-	}
-
-	private func makePrefixRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Filename prefix")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		prefixField.target = self
-		prefixField.action = #selector(prefixChanged)
-		prefixField.placeholderString = "rsnap"
-		prefixField.translatesAutoresizingMaskIntoConstraints = false
-		prefixField.widthAnchor.constraint(equalToConstant: 240).isActive = true
-		container.addArrangedSubview(prefixField)
-		return container
-	}
-
-	private func makeNamingRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Output naming")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		namingControl.target = self
-		namingControl.action = #selector(namingChanged)
-		container.addArrangedSubview(namingControl)
-		return container
-	}
-
-	private func makeToolbarPlacementRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Frozen toolbar placement")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		let subtitle = NSTextField(labelWithString: "Applies on the next capture session.")
-		subtitle.font = .systemFont(ofSize: 12)
-		subtitle.textColor = .secondaryLabelColor
-		container.addArrangedSubview(subtitle)
-
-		toolbarPlacementControl.target = self
-		toolbarPlacementControl.action = #selector(toolbarPlacementChanged)
-		container.addArrangedSubview(toolbarPlacementControl)
-		return container
-	}
-
-	private func makeFrozenResizeHandleOrientationRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Frozen corner handle direction")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		let subtitle = NSTextField(
-			labelWithString: "Controls whether the corner brackets open outward or inward.")
-		subtitle.font = .systemFont(ofSize: 12)
-		subtitle.textColor = .secondaryLabelColor
-		container.addArrangedSubview(subtitle)
-
-		frozenResizeHandleOrientationControl.target = self
-		frozenResizeHandleOrientationControl.action = #selector(
-			frozenResizeHandleOrientationChanged)
-		container.addArrangedSubview(frozenResizeHandleOrientationControl)
-		return container
-	}
-
-	private func makeOverlayRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		showAltHintKeycapButton.target = self
-		showAltHintKeycapButton.action = #selector(showAltHintKeycapChanged)
-
-		container.addArrangedSubview(showAltHintKeycapButton)
-		return container
-	}
-
-	private func makeHudGlassModeRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Glass style")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		hudGlassEnabledButton.target = self
-		hudGlassEnabledButton.action = #selector(hudGlassEnabledChanged)
-		container.addArrangedSubview(hudGlassEnabledButton)
-
-		hudGlassModeControl.target = self
-		hudGlassModeControl.action = #selector(hudGlassModeChanged)
-		hudGlassModeControl.segmentStyle = .rounded
-		hudGlassModeControl.widthAnchor.constraint(equalToConstant: 260).isActive = true
-		if let liquidGlassSegment = HudGlassModePreference.allCases.firstIndex(of: .liquidGlass) {
-			hudGlassModeControl.setToolTip(
-				"Requires Liquid Glass support.", forSegment: liquidGlassSegment)
-		}
-		container.addArrangedSubview(hudGlassModeControl)
-
-		let tintRows = [
-			makeGlassSubsectionTitle("Glass tint"),
-			makeSliderRow(
-				title: "Tint", slider: hudTintSlider, valueLabel: hudTintValueLabel,
-				action: #selector(hudTintChanged)),
-			makeTintColorRow(),
-		]
-		glassTintOptionViews = tintRows
-		for row in tintRows {
-			container.addArrangedSubview(row)
-		}
-
-		let classicRows = [
-			makeGlassSubsectionTitle("Classic Glass options"),
-			makeSliderRow(
-				title: "Opacity", slider: hudOpacitySlider, valueLabel: hudOpacityValueLabel,
-				action: #selector(hudOpacityChanged)),
-			makeSliderRow(
-				title: "Blur", slider: hudBlurSlider, valueLabel: hudBlurValueLabel,
-				action: #selector(hudBlurChanged)),
-		]
-		classicGlassOptionViews = classicRows
-		for row in classicRows {
-			container.addArrangedSubview(row)
-		}
-
-		let liquidRows = [
-			makeGlassSubsectionTitle("Liquid Glass options"),
-			makeLiquidGlassStyleRow(),
-		]
-		liquidGlassOptionViews = liquidRows
-		for row in liquidRows {
-			container.addArrangedSubview(row)
-		}
-		return container
-	}
-
-	private func makeGlassSubsectionTitle(_ title: String) -> NSTextField {
-		let label = NSTextField(labelWithString: title)
-		label.font = .systemFont(ofSize: 12, weight: .medium)
-		label.textColor = .secondaryLabelColor
-		return label
-	}
-
-	private func makeLiquidGlassStyleRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Style")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		liquidGlassStyleControl.target = self
-		liquidGlassStyleControl.action = #selector(liquidGlassStyleChanged)
-		container.addArrangedSubview(liquidGlassStyleControl)
-		return container
-	}
-
-	private func makeLoupeSampleSizeRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let title = NSTextField(labelWithString: "Loupe sample size")
-		title.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(title)
-
-		loupeSampleSizeControl.target = self
-		loupeSampleSizeControl.action = #selector(loupeSampleSizeChanged)
-		container.addArrangedSubview(loupeSampleSizeControl)
-		return container
-	}
-
-	private func makeSliderRow(
-		title: String, slider: NSSlider, valueLabel: NSTextField, action: Selector
-	) -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let titleLabel = NSTextField(labelWithString: title)
-		titleLabel.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(titleLabel)
-
-		slider.target = self
-		slider.action = action
-
-		valueLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
-		valueLabel.textColor = .secondaryLabelColor
-		valueLabel.alignment = .right
-		valueLabel.widthAnchor.constraint(equalToConstant: 52).isActive = true
-
-		let row = NSStackView(views: [slider, valueLabel])
-		row.orientation = .horizontal
-		row.alignment = .centerY
-		row.spacing = 12
-		slider.widthAnchor.constraint(equalToConstant: 280).isActive = true
-		container.addArrangedSubview(row)
-		return container
-	}
-
-	private func makeTintColorRow() -> NSView {
-		let container = NSStackView()
-		container.orientation = .vertical
-		container.alignment = .leading
-		container.spacing = 6
-
-		let titleLabel = NSTextField(labelWithString: "Tint color")
-		titleLabel.font = .systemFont(ofSize: 13, weight: .medium)
-		container.addArrangedSubview(titleLabel)
-
-		hudTintColorWell.target = self
-		hudTintColorWell.action = #selector(hudTintColorChanged)
-
-		let hint = NSTextField(
-			labelWithString: "Tint strength applies to Classic and Liquid Glass.")
-		hint.font = .systemFont(ofSize: 12)
-		hint.textColor = .secondaryLabelColor
-
-		let row = NSStackView(views: [hudTintColorWell, hint])
-		row.orientation = .horizontal
-		row.alignment = .centerY
-		row.spacing = 12
-		container.addArrangedSubview(row)
-		return container
-	}
-
-	private func refreshFromSettings() {
-		let settings = settingsStore.settings
-		outputDirectoryValueLabel.stringValue = settings.outputDirectory.path
-		prefixField.stringValue = settings.outputFilenamePrefix
-		namingControl.selectedSegment =
-			OutputNamingPreference.allCases.firstIndex(of: settings.outputNaming) ?? 0
-		toolbarPlacementControl.selectedSegment =
-			ToolbarPlacementPreference.allCases.firstIndex(of: settings.toolbarPlacement) ?? 0
-		frozenResizeHandleOrientationControl.selectedSegment =
-			FrozenResizeHandleOrientationPreference.allCases.firstIndex(
-				of: settings.frozenResizeHandleOrientation) ?? 0
-		showAltHintKeycapButton.state = settings.showAltHintKeycap ? .on : .off
-		hudGlassEnabledButton.state = settings.hudGlassEnabled ? .on : .off
-		hudGlassModeControl.selectedSegment =
-			HudGlassModePreference.allCases.firstIndex(of: settings.resolvedHudGlassMode) ?? 0
-		for (index, mode) in HudGlassModePreference.allCases.enumerated() {
-			let supported =
-				mode != .liquidGlass || LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
-			hudGlassModeControl.setEnabled(supported, forSegment: index)
-		}
-		liquidGlassStyleControl.selectedSegment =
-			LiquidGlassStylePreference.allCases.firstIndex(of: settings.liquidGlassStyle) ?? 0
-		loupeSampleSizeControl.selectedSegment =
-			LoupeSampleSizePreference.allCases.firstIndex(of: settings.loupeSampleSize) ?? 0
-		hudOpacitySlider.doubleValue = settings.hudOpacity * 100
-		hudBlurSlider.doubleValue = settings.hudBlur * 100
-		hudTintSlider.doubleValue = settings.hudTint * 100
-		hudTintColorWell.color = NSColor(
-			calibratedHue: CGFloat(settings.hudTintHue),
-			saturation: 0.85,
-			brightness: 1,
-			alpha: 1
-		)
-		hudOpacityValueLabel.stringValue = "\(Int(settings.hudOpacity * 100))"
-		hudBlurValueLabel.stringValue = "\(Int(settings.hudBlur * 100))"
-		hudTintValueLabel.stringValue = "\(Int(settings.hudTint * 100))"
-		let glassEnabled = settings.hudGlassEnabled
-		let glassMode = settings.resolvedHudGlassMode
-		let classicGlassSelected = glassMode == .classicGlass
-		let liquidGlassSelected = glassMode == .liquidGlass
-		hudGlassModeControl.isEnabled = glassEnabled
-		for view in glassTintOptionViews {
-			view.isHidden = !glassEnabled
-		}
-		for view in classicGlassOptionViews {
-			view.isHidden = !glassEnabled || !classicGlassSelected
-		}
-		for view in liquidGlassOptionViews {
-			view.isHidden = !glassEnabled || !liquidGlassSelected
-		}
-		hudOpacitySlider.isEnabled = glassEnabled && classicGlassSelected
-		hudBlurSlider.isEnabled = glassEnabled && classicGlassSelected
-		hudTintSlider.isEnabled = glassEnabled
-		hudTintColorWell.isEnabled = glassEnabled
-		liquidGlassStyleControl.isEnabled = glassEnabled && liquidGlassSelected
-	}
-
-	@objc
-	private func chooseOutputDirectory() {
-		let panel = NSOpenPanel()
-		panel.canChooseDirectories = true
-		panel.canChooseFiles = false
-		panel.allowsMultipleSelection = false
-		panel.directoryURL = settingsStore.settings.outputDirectory
-		if panel.runModal() == .OK, let url = panel.url {
-			settingsStore.update { $0.outputDirectory = url }
-			refreshFromSettings()
-		}
-	}
-
-	@objc
-	private func prefixChanged() {
-		let prefix = prefixField.stringValue
-		settingsStore.update { $0.outputFilenamePrefix = prefix }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func namingChanged() {
-		let index = namingControl.selectedSegment
-		guard OutputNamingPreference.allCases.indices.contains(index) else {
-			return
-		}
-		settingsStore.update { $0.outputNaming = OutputNamingPreference.allCases[index] }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func toolbarPlacementChanged() {
-		let index = toolbarPlacementControl.selectedSegment
-		guard ToolbarPlacementPreference.allCases.indices.contains(index) else {
-			return
-		}
-		settingsStore.update { $0.toolbarPlacement = ToolbarPlacementPreference.allCases[index] }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func frozenResizeHandleOrientationChanged() {
-		let index = frozenResizeHandleOrientationControl.selectedSegment
-		guard FrozenResizeHandleOrientationPreference.allCases.indices.contains(index) else {
-			return
-		}
-		settingsStore.update {
-			$0.frozenResizeHandleOrientation =
-				FrozenResizeHandleOrientationPreference.allCases[index]
-		}
-		refreshFromSettings()
-	}
-
-	@objc
-	private func showAltHintKeycapChanged() {
-		settingsStore.update { $0.showAltHintKeycap = showAltHintKeycapButton.state == .on }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func hudGlassEnabledChanged() {
-		settingsStore.update { $0.hudGlassEnabled = hudGlassEnabledButton.state == .on }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func hudGlassModeChanged() {
-		let index = hudGlassModeControl.selectedSegment
-		guard HudGlassModePreference.allCases.indices.contains(index) else {
-			refreshFromSettings()
-			return
-		}
-		let mode = HudGlassModePreference.allCases[index]
-		if mode == .liquidGlass, !LiveChromeGlassMaterialSupport.isLiquidGlassAvailable {
-			refreshFromSettings()
-			return
-		}
-		settingsStore.update { $0.hudGlassMode = mode }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func liquidGlassStyleChanged() {
-		let index = liquidGlassStyleControl.selectedSegment
-		guard LiquidGlassStylePreference.allCases.indices.contains(index) else {
-			return
-		}
-		settingsStore.update {
-			$0.liquidGlassStyle = LiquidGlassStylePreference.allCases[index]
-		}
-		refreshFromSettings()
-	}
-
-	@objc
-	private func loupeSampleSizeChanged() {
-		let index = loupeSampleSizeControl.selectedSegment
-		guard LoupeSampleSizePreference.allCases.indices.contains(index) else {
-			return
-		}
-		settingsStore.update { $0.loupeSampleSize = LoupeSampleSizePreference.allCases[index] }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func hudOpacityChanged() {
-		settingsStore.update { $0.hudOpacity = hudOpacitySlider.doubleValue / 100.0 }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func hudBlurChanged() {
-		settingsStore.update { $0.hudBlur = hudBlurSlider.doubleValue / 100.0 }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func hudTintChanged() {
-		settingsStore.update { $0.hudTint = hudTintSlider.doubleValue / 100.0 }
-		refreshFromSettings()
-	}
-
-	@objc
-	private func hudTintColorChanged() {
-		let converted = hudTintColorWell.color.usingColorSpace(.deviceRGB) ?? hudTintColorWell.color
-		let hue = converted.hueComponent
-		settingsStore.update {
-			$0.hudTintHue = Double(hue)
-		}
-		refreshFromSettings()
-	}
-
-}
-
-@MainActor
-final class PermissionsWindowController: NSWindowController {
-	private struct Row {
-		let title: String
-		let kind: PermissionKind
-		let statusLabel: NSTextField
-		let actionButton: NSButton
-	}
-
-	private let rows: [Row]
-
-	init() {
-		let contentRect = NSRect(x: 0, y: 0, width: 520, height: 240)
-		let window = NSWindow(
-			contentRect: contentRect,
-			styleMask: [.titled, .closable, .miniaturizable],
-			backing: .buffered,
-			defer: false
-		)
-		window.title = "Permissions"
-		window.isReleasedWhenClosed = false
-
-		let screenRecordingStatus = NSTextField(labelWithString: "")
-		let accessibilityStatus = NSTextField(labelWithString: "")
-		let inputMonitoringStatus = NSTextField(labelWithString: "")
-
-		let screenRecordingButton = NSButton(
-			title: "Request / Open Settings", target: nil, action: nil)
-		let accessibilityButton = NSButton(
-			title: "Request / Open Settings", target: nil, action: nil)
-		let inputMonitoringButton = NSButton(
-			title: "Request / Open Settings", target: nil, action: nil)
-
-		rows = [
-			Row(
-				title: "Screen Recording", kind: .screenRecording,
-				statusLabel: screenRecordingStatus, actionButton: screenRecordingButton),
-			Row(
-				title: "Accessibility", kind: .accessibility, statusLabel: accessibilityStatus,
-				actionButton: accessibilityButton),
-			Row(
-				title: "Input Monitoring", kind: .inputMonitoring,
-				statusLabel: inputMonitoringStatus, actionButton: inputMonitoringButton),
-		]
-
-		super.init(window: window)
-
-		for row in rows {
-			row.actionButton.target = self
-			row.actionButton.action = #selector(requestPermission(_:))
-			row.actionButton.identifier = NSUserInterfaceItemIdentifier(
-				rawValue: String(row.kind.rawValue))
-		}
-
-		window.contentView = buildContentView()
-		window.center()
-		refreshStatuses()
-	}
-
-	@available(*, unavailable)
-	required init?(coder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
-	}
-
-	func present() {
-		showWindow(nil)
-		window?.makeKeyAndOrderFront(nil)
-		NSApp.activate(ignoringOtherApps: true)
-		refreshStatuses()
-	}
-
-	func refreshStatuses() {
-		for row in rows {
-			let granted = NativePermissions.status(for: row.kind)
-			let required = NativePermissions.requiredForCurrentNativeHost(row.kind)
-			row.statusLabel.stringValue =
-				granted ? "Granted" : (required ? "Required" : "Not needed")
-			row.statusLabel.textColor =
-				granted
-				? NSColor.systemGreen
-				: (required ? NSColor.secondaryLabelColor : NSColor.tertiaryLabelColor)
-			row.actionButton.isEnabled = !granted && required
-			row.actionButton.title = required ? "Request / Open Settings" : "Not used"
-		}
-	}
-
-	private func buildContentView() -> NSView {
-		let root = NSView(frame: .zero)
-		root.translatesAutoresizingMaskIntoConstraints = false
-
-		let stack = NSStackView()
-		stack.orientation = .vertical
-		stack.alignment = .leading
-		stack.spacing = 14
-		stack.edgeInsets = NSEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
-		stack.translatesAutoresizingMaskIntoConstraints = false
-
-		let intro = NSTextField(
-			wrappingLabelWithString:
-				"Normal native capture only needs Screen Recording. Accessibility and Input Monitoring are reserved for scroll automation."
-		)
-		intro.maximumNumberOfLines = 0
-		intro.textColor = .secondaryLabelColor
-		stack.addArrangedSubview(intro)
-
-		for row in rows {
-			let title = NSTextField(labelWithString: row.title)
-			title.font = .systemFont(ofSize: 13, weight: .medium)
-			let line = NSStackView(views: [title, row.statusLabel, row.actionButton])
-			line.orientation = .horizontal
-			line.alignment = .centerY
-			line.spacing = 12
-			stack.addArrangedSubview(line)
-		}
-
-		root.addSubview(stack)
-		NSLayoutConstraint.activate([
-			stack.leadingAnchor.constraint(equalTo: root.leadingAnchor),
-			stack.trailingAnchor.constraint(equalTo: root.trailingAnchor),
-			stack.topAnchor.constraint(equalTo: root.topAnchor),
-			stack.bottomAnchor.constraint(lessThanOrEqualTo: root.bottomAnchor),
-		])
-		return root
-	}
-
-	@objc
-	private func requestPermission(_ sender: NSButton) {
-		guard
-			let identifier = sender.identifier?.rawValue,
-			let rawValue = UInt32(identifier),
-			let kind = PermissionKind(rawValue: rawValue)
-		else {
-			return
-		}
-		guard NativePermissions.requiredForCurrentNativeHost(kind) else {
-			refreshStatuses()
-			return
-		}
-		_ = NativePermissions.request(kind)
-		refreshStatuses()
+	func windowWillClose(_: Notification) {
+		onClose()
 	}
 }
 
@@ -760,23 +150,29 @@ enum NativePermissions {
 		return granted
 	}
 
-	static func openSystemSettings(for kind: PermissionKind) {
-		let urlString: String
+	@discardableResult
+	static func openSystemSettings(for kind: PermissionKind) -> Bool {
+		let privacyQuery: String
 		switch kind {
 		case .screenRecording:
-			urlString =
-				"x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+			privacyQuery = "Privacy_ScreenCapture"
 		case .accessibility:
-			urlString =
-				"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+			privacyQuery = "Privacy_Accessibility"
 		case .inputMonitoring:
-			urlString =
-				"x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+			privacyQuery = "Privacy_ListenEvent"
 		}
 
-		guard let url = URL(string: urlString) else {
-			return
+		let modernURLString =
+			"x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?\(privacyQuery)"
+		if let modernURL = URL(string: modernURLString), NSWorkspace.shared.open(modernURL) {
+			return true
 		}
-		NSWorkspace.shared.open(url)
+
+		let fallbackURLString =
+			"x-apple.systempreferences:com.apple.preference.security?\(privacyQuery)"
+		guard let fallbackURL = URL(string: fallbackURLString) else {
+			return false
+		}
+		return NSWorkspace.shared.open(fallbackURL)
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -129,7 +129,7 @@ struct NativeHostSettings: Equatable {
 
 	static var defaults: NativeHostSettings {
 		NativeHostSettings(
-			captureHotkey: "alt+KeyX",
+			captureHotkey: "Option-X",
 			outputDirectory: FileManager.default.homeDirectoryForCurrentUser
 				.appendingPathComponent("Desktop", isDirectory: true),
 			outputFilenamePrefix: "rsnap",
@@ -144,7 +144,7 @@ struct NativeHostSettings: Equatable {
 			hudTint: 0.5,
 			hudTintHue: 215.0 / 360.0,
 			liquidGlassStyle: .clear,
-			loupeSampleSize: .medium
+			loupeSampleSize: .small
 		)
 	}
 
@@ -179,8 +179,93 @@ struct NativeHostSettings: Equatable {
 
 	private static func sanitizeCaptureHotkey(_ raw: String) -> String {
 		let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-		return trimmed.isEmpty ? defaults.captureHotkey : trimmed
+		guard !trimmed.isEmpty else {
+			return defaults.captureHotkey
+		}
+		return captureHotKeyPresentation(for: trimmed).displayTitle
 	}
+
+	static func captureHotKeyPresentation(for raw: String) -> CaptureHotKeyPresentation {
+		parseCaptureHotKeyPresentation(raw)
+			?? parseCaptureHotKeyPresentation(defaults.captureHotkey)
+			?? CaptureHotKeyPresentation(
+				displayTitle: "Option-X",
+				keyEquivalent: "x",
+				modifierMask: [.option])
+	}
+
+	private static func parseCaptureHotKeyPresentation(_ raw: String) -> CaptureHotKeyPresentation?
+	{
+		let tokens = captureHotKeyTokens(from: raw)
+		guard !tokens.isEmpty else {
+			return nil
+		}
+
+		var modifiers = NSEvent.ModifierFlags()
+		var keyEquivalent: String?
+		for token in tokens {
+			switch token.lowercased() {
+			case "alt", "option":
+				modifiers.insert(.option)
+			case "ctrl", "control":
+				modifiers.insert(.control)
+			case "shift":
+				modifiers.insert(.shift)
+			case "cmd", "command", "super", "meta", "win":
+				modifiers.insert(.command)
+			default:
+				keyEquivalent = normalizedMenuKeyEquivalent(for: token)
+			}
+		}
+
+		guard let keyEquivalent else {
+			return nil
+		}
+
+		var titleParts: [String] = []
+		if modifiers.contains(.control) {
+			titleParts.append("Control")
+		}
+		if modifiers.contains(.option) {
+			titleParts.append("Option")
+		}
+		if modifiers.contains(.shift) {
+			titleParts.append("Shift")
+		}
+		if modifiers.contains(.command) {
+			titleParts.append("Command")
+		}
+		titleParts.append(keyEquivalent.uppercased())
+		return CaptureHotKeyPresentation(
+			displayTitle: titleParts.joined(separator: "-"),
+			keyEquivalent: keyEquivalent,
+			modifierMask: modifiers
+		)
+	}
+
+	private static func normalizedMenuKeyEquivalent(for token: String) -> String? {
+		let normalized = token.lowercased()
+		let key = normalized.hasPrefix("key") ? String(normalized.dropFirst(3)) : normalized
+		guard key.count == 1, key.unicodeScalars.allSatisfy(\.isASCII) else {
+			return nil
+		}
+		return key
+	}
+
+	static func captureHotKeyTokens(from raw: String) -> [String] {
+		raw
+			.split { character in
+				character == "+" || character == "-"
+			}
+			.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+			.filter { !$0.isEmpty }
+	}
+}
+
+struct CaptureHotKeyPresentation: Equatable {
+	let displayTitle: String
+	let keyEquivalent: String
+	let modifierMask: NSEvent.ModifierFlags
 }
 
 enum OutputNamingPreference: String, CaseIterable {
@@ -266,11 +351,11 @@ enum LoupeSampleSizePreference: String, CaseIterable {
 	var title: String {
 		switch self {
 		case .small:
-			return "Small (15×15)"
+			return "15×15"
 		case .medium:
-			return "Medium (21×21)"
+			return "21×21"
 		case .large:
-			return "Large (31×31)"
+			return "31×31"
 		}
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -1,0 +1,1543 @@
+import AppKit
+import RsnapHostBridge
+import SwiftUI
+
+@MainActor
+final class NativeHostSettingsViewModel: ObservableObject {
+	@Published private(set) var settings: NativeHostSettings
+
+	private let settingsStore: NativeHostSettingsStore
+
+	init(settingsStore: NativeHostSettingsStore) {
+		self.settingsStore = settingsStore
+		self.settings = settingsStore.settings
+	}
+
+	func refresh() {
+		settings = settingsStore.settings
+	}
+
+	func update(_ mutate: (inout NativeHostSettings) -> Void) {
+		settingsStore.update(mutate)
+		settings = settingsStore.settings
+	}
+
+	func restoreDefaults() {
+		update { $0 = NativeHostSettings.defaults }
+	}
+
+	func chooseOutputDirectory() {
+		let panel = NSOpenPanel()
+		panel.canChooseDirectories = true
+		panel.canChooseFiles = false
+		panel.allowsMultipleSelection = false
+		panel.directoryURL = settings.outputDirectory
+		if panel.runModal() == .OK, let url = panel.url {
+			update { $0.outputDirectory = url }
+		}
+	}
+}
+
+struct NativeHostSettingsView: View {
+	@ObservedObject var model: NativeHostSettingsViewModel
+	@Environment(\.colorScheme) private var colorScheme
+	@State private var selectedSection: NativeHostSettingsSection = .appearance
+
+	var body: some View {
+		ZStack {
+			SettingsAtmosphere()
+
+			HStack(spacing: 0) {
+				SettingsSidebarBackdrop()
+					.frame(width: 164)
+					.overlay(alignment: .trailing) {
+						Rectangle()
+							.fill(sidebarDividerColor)
+							.frame(width: 1)
+					}
+				Color.clear
+			}
+			.ignoresSafeArea(.container, edges: .top)
+
+			HStack(spacing: 0) {
+				ZStack {
+					SettingsSidebarBackdrop()
+					SettingsRail(selectedSection: $selectedSection)
+				}
+				.frame(width: 164)
+				.overlay(alignment: .trailing) {
+					Rectangle()
+						.fill(sidebarDividerColor)
+						.frame(width: 1)
+				}
+
+				VStack(alignment: .leading, spacing: 9) {
+					SettingsContentHeader(
+						section: selectedSection,
+						restoreDefaults: model.restoreDefaults
+					)
+
+					SettingsSectionPreview(model: model, section: selectedSection)
+						.id("preview-\(selectedSection.rawValue)")
+						.transition(.opacity)
+
+					ScrollView {
+						Group {
+							switch selectedSection {
+							case .appearance:
+								AppearanceSettingsPanel(model: model)
+							case .capture:
+								CaptureSettingsPanel(model: model)
+							case .output:
+								OutputSettingsPanel(model: model)
+							case .permissions:
+								PermissionsSettingsPanel()
+							}
+						}
+						.id(selectedSection)
+						.transition(
+							.asymmetric(
+								insertion: .opacity.combined(with: .move(edge: .bottom)),
+								removal: .opacity.combined(with: .move(edge: .top))
+							)
+						)
+						.padding(.bottom, 10)
+					}
+					.scrollIndicators(.automatic)
+				}
+				.padding(.top, 9)
+				.padding(.horizontal, 18)
+				.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+			}
+		}
+		.controlSize(.small)
+		.animation(.spring(response: 0.34, dampingFraction: 0.86), value: selectedSection)
+		.frame(minWidth: 690, idealWidth: 690, minHeight: 420, idealHeight: 430)
+	}
+
+	private var sidebarDividerColor: Color {
+		colorScheme == .light ? Color.black.opacity(0.055) : Color.white.opacity(0.07)
+	}
+}
+
+private enum NativeHostSettingsSection: String, CaseIterable, Identifiable {
+	case appearance
+	case capture
+	case output
+	case permissions
+
+	var id: Self { self }
+
+	var title: String {
+		switch self {
+		case .appearance:
+			return "Appearance"
+		case .capture:
+			return "Capture"
+		case .output:
+			return "Output"
+		case .permissions:
+			return "Permissions"
+		}
+	}
+
+	var subtitle: String {
+		switch self {
+		case .appearance:
+			return "HUD style"
+		case .capture:
+			return "Shortcut"
+		case .output:
+			return "Files"
+		case .permissions:
+			return "Access"
+		}
+	}
+
+	var symbolName: String {
+		switch self {
+		case .appearance:
+			return "sparkles"
+		case .capture:
+			return "viewfinder"
+		case .output:
+			return "folder"
+		case .permissions:
+			return "lock.shield"
+		}
+	}
+}
+
+private struct SettingsSidebarBackdrop: View {
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		ZStack {
+			Rectangle()
+				.fill(Color(nsColor: .controlBackgroundColor))
+			if colorScheme == .light {
+				Color.white.opacity(0.18)
+			} else {
+				Color.black.opacity(0.08)
+			}
+		}
+	}
+}
+
+private struct SettingsRail: View {
+	@Binding var selectedSection: NativeHostSettingsSection
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 11) {
+			VStack(alignment: .leading, spacing: 3) {
+				Text("rsnap")
+					.font(.system(size: 18, weight: .semibold, design: .rounded))
+				Text("Settings")
+					.font(.system(size: 10, weight: .medium))
+					.foregroundStyle(.secondary)
+			}
+			.padding(.top, 17)
+
+			VStack(spacing: 4) {
+				ForEach(NativeHostSettingsSection.allCases) { section in
+					SettingsRailButton(
+						section: section,
+						isSelected: selectedSection == section
+					) {
+						withAnimation(.easeOut(duration: 0.16)) {
+							selectedSection = section
+						}
+					}
+				}
+			}
+
+			Spacer(minLength: 12)
+		}
+		.padding(.horizontal, 10)
+		.padding(.bottom, 12)
+		.frame(maxHeight: .infinity, alignment: .topLeading)
+	}
+}
+
+private struct SettingsRailButton: View {
+	let section: NativeHostSettingsSection
+	let isSelected: Bool
+	let action: () -> Void
+	@Environment(\.colorScheme) private var colorScheme
+	@State private var isHovered = false
+
+	var body: some View {
+		Button(action: action) {
+			HStack(spacing: 8) {
+				Image(systemName: section.symbolName)
+					.symbolRenderingMode(.hierarchical)
+					.font(.system(size: 12, weight: .semibold))
+					.foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+					.frame(width: 17, height: 17)
+				VStack(alignment: .leading, spacing: 2) {
+					Text(section.title)
+						.font(.system(size: 11.6, weight: .semibold))
+						.foregroundStyle(isSelected ? Color.primary : Color.primary.opacity(0.88))
+					Text(section.subtitle)
+						.font(.system(size: 9.2, weight: .medium))
+						.foregroundStyle(.secondary)
+				}
+				Spacer(minLength: 0)
+			}
+			.padding(.horizontal, 9)
+			.padding(.vertical, 5)
+			.frame(maxWidth: .infinity)
+			.contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+			.background {
+				if isSelected {
+					RoundedRectangle(cornerRadius: 9, style: .continuous)
+						.fill(
+							colorScheme == .light
+								? Color.black.opacity(0.055)
+								: Color.white.opacity(0.070)
+						)
+					HStack {
+						Capsule()
+							.fill(Color.accentColor)
+							.frame(width: 2, height: 16)
+						Spacer()
+					}
+					.padding(.leading, 1)
+				} else if isHovered {
+					RoundedRectangle(cornerRadius: 9, style: .continuous)
+						.fill(
+							colorScheme == .light
+								? Color.black.opacity(0.020)
+								: Color.white.opacity(0.030)
+						)
+				}
+			}
+		}
+		.buttonStyle(.plain)
+		.animation(.easeOut(duration: 0.14), value: isSelected)
+		.onHover { hovering in
+			withAnimation(.easeOut(duration: 0.14)) {
+				isHovered = hovering
+			}
+		}
+	}
+}
+
+private struct SettingsContentHeader: View {
+	let section: NativeHostSettingsSection
+	let restoreDefaults: () -> Void
+
+	var body: some View {
+		HStack(alignment: .center, spacing: 18) {
+			VStack(alignment: .leading, spacing: 5) {
+				Text(section.title)
+					.font(.system(size: 20, weight: .semibold))
+				Text(section.subtitle)
+					.font(.system(size: 10.5, weight: .medium))
+					.foregroundStyle(.secondary)
+			}
+			.frame(maxWidth: .infinity, alignment: .leading)
+
+			if section != .permissions {
+				Button("Restore Defaults", action: restoreDefaults)
+					.rsnapGlassButton(prominent: false)
+					.controlSize(.small)
+			}
+		}
+		.frame(height: 36)
+	}
+}
+
+private struct SettingsSectionPreview: View {
+	@ObservedObject var model: NativeHostSettingsViewModel
+	let section: NativeHostSettingsSection
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		ZStack {
+			RoundedRectangle(cornerRadius: 16, style: .continuous)
+				.fill(Color.clear)
+			RoundedRectangle(cornerRadius: 16, style: .continuous)
+				.fill(previewOverlay)
+			LinearGradient(
+				colors: [
+					tintColor.opacity(colorScheme == .light ? 0.045 : 0.060),
+					Color.clear,
+				],
+				startPoint: .topLeading,
+				endPoint: .bottomTrailing
+			)
+
+			HStack(spacing: 12) {
+				previewContent
+			}
+			.padding(.horizontal, 16)
+			.padding(.vertical, 9)
+		}
+		.frame(height: 58)
+		.settingsGlassSurface(cornerRadius: 13, role: .preview)
+	}
+
+	private var previewOverlay: Color {
+		colorScheme == .light ? Color.white.opacity(0.30) : Color.black.opacity(0.05)
+	}
+
+	@ViewBuilder
+	private var previewContent: some View {
+		switch section {
+		case .appearance:
+			RoundedRectangle(cornerRadius: 11, style: .continuous)
+				.fill(tintColor.gradient)
+				.frame(width: 30, height: 30)
+				.overlay {
+					RoundedRectangle(cornerRadius: 11, style: .continuous)
+						.stroke(Color.white.opacity(0.55), lineWidth: 1)
+				}
+			VStack(alignment: .leading, spacing: 2) {
+				Text("Live HUD")
+					.font(.system(size: 12.5, weight: .semibold))
+				Text("\(tintHex) · \(Int((model.settings.hudTint * 100).rounded()))% tint")
+					.font(.system(size: 9.5, weight: .medium, design: .monospaced))
+					.foregroundStyle(.secondary)
+			}
+			Spacer(minLength: 8)
+			SettingsPreviewPill(model.settings.resolvedHudGlassMode.title)
+			SettingsPreviewPill(model.settings.liquidGlassStyle.title)
+
+		case .capture:
+			Image(systemName: "viewfinder")
+				.font(.system(size: 21, weight: .semibold))
+				.foregroundStyle(Color.accentColor)
+				.frame(width: 30, height: 30)
+			VStack(alignment: .leading, spacing: 2) {
+				Text(shortcutTitle)
+					.font(.system(size: 12.5, weight: .semibold, design: .rounded))
+				Text(
+					"\(model.settings.toolbarPlacement.title) toolbar · \(model.settings.loupeSampleSize.title)"
+				)
+				.font(.system(size: 9.5, weight: .medium))
+				.foregroundStyle(.secondary)
+				.lineLimit(1)
+			}
+			Spacer(minLength: 8)
+			SettingsPreviewPill("Right-click exits")
+
+		case .output:
+			Image(systemName: "folder")
+				.font(.system(size: 21, weight: .semibold))
+				.foregroundStyle(Color.accentColor)
+				.frame(width: 30, height: 30)
+			VStack(alignment: .leading, spacing: 2) {
+				Text(abbreviatedPath(model.settings.outputDirectory))
+					.font(.system(size: 12, weight: .semibold))
+					.lineLimit(1)
+				Text(
+					"\(model.settings.outputFilenamePrefix) · \(model.settings.outputNaming.title)"
+				)
+				.font(.system(size: 9.5, weight: .medium))
+				.foregroundStyle(.secondary)
+				.lineLimit(1)
+			}
+			Spacer(minLength: 8)
+			SettingsPreviewPill("Ready")
+
+		case .permissions:
+			Image(systemName: "lock.shield")
+				.font(.system(size: 21, weight: .semibold))
+				.foregroundStyle(Color.accentColor)
+				.frame(width: 30, height: 30)
+			VStack(alignment: .leading, spacing: 2) {
+				Text("Native access")
+					.font(.system(size: 12, weight: .semibold))
+				Text("Required permissions for capture.")
+					.font(.system(size: 9.5, weight: .medium))
+					.foregroundStyle(.secondary)
+			}
+			Spacer(minLength: 8)
+			SettingsPreviewPill(permissionSummary)
+		}
+	}
+
+	private var tintColor: Color {
+		Color(hue: model.settings.hudTintHue, saturation: 0.72, brightness: 0.95)
+	}
+
+	private var tintHex: String {
+		let color = NSColor(
+			hue: CGFloat(model.settings.hudTintHue),
+			saturation: 0.72,
+			brightness: 0.95,
+			alpha: 1
+		)
+		let converted = color.usingColorSpace(.deviceRGB) ?? color
+		return String(
+			format: "#%02X%02X%02X",
+			Int((converted.redComponent * 255).rounded()),
+			Int((converted.greenComponent * 255).rounded()),
+			Int((converted.blueComponent * 255).rounded())
+		)
+	}
+
+	private var shortcutTitle: String {
+		NativeHostSettings.captureHotKeyPresentation(for: model.settings.captureHotkey)
+			.displayTitle
+	}
+
+	private var permissionSummary: String {
+		let required = [
+			PermissionKind.screenRecording,
+			.accessibility,
+			.inputMonitoring,
+		].filter { NativePermissions.requiredForCurrentNativeHost($0) }
+		let granted = required.filter { NativePermissions.status(for: $0) }.count
+		return "\(granted)/\(required.count) granted"
+	}
+
+	private func abbreviatedPath(_ url: URL) -> String {
+		let path = url.path
+		let home = FileManager.default.homeDirectoryForCurrentUser.path
+		if path == home {
+			return "~"
+		}
+		if path.hasPrefix(home + "/") {
+			return "~" + path.dropFirst(home.count)
+		}
+		return path
+	}
+}
+
+private struct SettingsPreviewPill: View {
+	let title: String
+	@Environment(\.colorScheme) private var colorScheme
+
+	init(_ title: String) {
+		self.title = title
+	}
+
+	var body: some View {
+		Text(title)
+			.font(.system(size: 9.5, weight: .semibold))
+			.lineLimit(1)
+			.padding(.horizontal, 7)
+			.padding(.vertical, 4)
+			.background(
+				colorScheme == .light ? Color.white.opacity(0.72) : Color.white.opacity(0.10),
+				in: Capsule()
+			)
+			.overlay {
+				Capsule()
+					.stroke(
+						colorScheme == .light
+							? Color.black.opacity(0.06)
+							: Color.white.opacity(0.10),
+						lineWidth: 1
+					)
+			}
+	}
+}
+
+private struct HudGlassModePicker: View {
+	let selection: HudGlassModePreference
+	let isEnabled: Bool
+	let onSelect: (HudGlassModePreference) -> Void
+
+	var body: some View {
+		HStack(spacing: 4) {
+			ForEach(HudGlassModePreference.allCases, id: \.rawValue) { mode in
+				let available =
+					mode != .liquidGlass || LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
+				ModernSegmentButton(
+					title: mode.title,
+					isSelected: selection == mode,
+					isEnabled: isEnabled && available
+				) {
+					onSelect(mode)
+				}
+				.help(available ? mode.title : "Requires Liquid Glass support.")
+			}
+		}
+		.padding(2)
+		.frame(width: 164)
+		.segmentedGlassBackground()
+	}
+}
+
+private struct LiquidGlassStylePicker: View {
+	let selection: LiquidGlassStylePreference
+	let isEnabled: Bool
+	let onSelect: (LiquidGlassStylePreference) -> Void
+
+	var body: some View {
+		HStack(spacing: 4) {
+			ForEach(LiquidGlassStylePreference.allCases, id: \.rawValue) { style in
+				ModernSegmentButton(
+					title: style.title,
+					isSelected: selection == style,
+					isEnabled: isEnabled
+				) {
+					onSelect(style)
+				}
+			}
+		}
+		.padding(2)
+		.frame(width: 124)
+		.segmentedGlassBackground()
+	}
+}
+
+private struct ToolbarPlacementPicker: View {
+	let selection: ToolbarPlacementPreference
+	let onSelect: (ToolbarPlacementPreference) -> Void
+
+	var body: some View {
+		HStack(spacing: 4) {
+			ForEach(ToolbarPlacementPreference.allCases, id: \.rawValue) { placement in
+				ModernSegmentButton(
+					title: placement.title,
+					isSelected: selection == placement,
+					isEnabled: true
+				) {
+					onSelect(placement)
+				}
+			}
+		}
+		.padding(2)
+		.frame(width: 124)
+		.segmentedGlassBackground()
+	}
+}
+
+private struct FrozenResizeHandleOrientationPicker: View {
+	let selection: FrozenResizeHandleOrientationPreference
+	let onSelect: (FrozenResizeHandleOrientationPreference) -> Void
+
+	var body: some View {
+		HStack(spacing: 4) {
+			ForEach(FrozenResizeHandleOrientationPreference.allCases, id: \.rawValue) {
+				orientation in
+				ModernSegmentButton(
+					title: orientation.title,
+					isSelected: selection == orientation,
+					isEnabled: true
+				) {
+					onSelect(orientation)
+				}
+			}
+		}
+		.padding(2)
+		.frame(width: 186)
+		.segmentedGlassBackground()
+	}
+}
+
+private struct LoupeSampleSizePicker: View {
+	let selection: LoupeSampleSizePreference
+	let onSelect: (LoupeSampleSizePreference) -> Void
+
+	var body: some View {
+		HStack(spacing: 4) {
+			ForEach(LoupeSampleSizePreference.allCases, id: \.rawValue) { size in
+				ModernSegmentButton(
+					title: size.title,
+					isSelected: selection == size,
+					isEnabled: true
+				) {
+					onSelect(size)
+				}
+			}
+		}
+		.padding(2)
+		.frame(width: 160)
+		.segmentedGlassBackground()
+	}
+}
+
+private struct OutputNamingPicker: View {
+	let selection: OutputNamingPreference
+	let onSelect: (OutputNamingPreference) -> Void
+
+	var body: some View {
+		HStack(spacing: 4) {
+			ForEach(OutputNamingPreference.allCases, id: \.rawValue) { naming in
+				ModernSegmentButton(
+					title: naming.title,
+					isSelected: selection == naming,
+					isEnabled: true
+				) {
+					onSelect(naming)
+				}
+			}
+		}
+		.padding(2)
+		.frame(width: 140)
+		.segmentedGlassBackground()
+	}
+}
+
+private struct ModernSegmentButton: View {
+	let title: String
+	let isSelected: Bool
+	let isEnabled: Bool
+	let action: () -> Void
+	@Environment(\.colorScheme) private var colorScheme
+	@State private var isHovered = false
+
+	var body: some View {
+		Button(action: action) {
+			ZStack {
+				Color.clear
+
+				if isHovered && !isSelected && isEnabled {
+					RoundedRectangle(cornerRadius: 6, style: .continuous)
+						.fill(
+							colorScheme == .light
+								? Color.black.opacity(0.035)
+								: Color.white.opacity(0.045)
+						)
+				}
+
+				if isSelected {
+					RoundedRectangle(cornerRadius: 6, style: .continuous)
+						.fill(
+							colorScheme == .light
+								? Color(nsColor: .controlBackgroundColor)
+								: Color.white.opacity(0.105)
+						)
+						.overlay {
+							RoundedRectangle(cornerRadius: 6, style: .continuous)
+								.stroke(
+									colorScheme == .light
+										? Color.black.opacity(0.055)
+										: Color.white.opacity(0.082),
+									lineWidth: 1
+								)
+						}
+				}
+
+				Text(title)
+					.font(.system(size: 9.3, weight: .semibold))
+					.lineLimit(1)
+					.minimumScaleFactor(0.9)
+					.foregroundStyle(isEnabled ? Color.primary : Color.secondary.opacity(0.54))
+					.padding(.horizontal, 7)
+			}
+			.frame(maxWidth: .infinity, minHeight: 20)
+			.contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+		}
+		.buttonStyle(.plain)
+		.disabled(!isEnabled)
+		.frame(maxWidth: .infinity)
+		.animation(.spring(response: 0.22, dampingFraction: 0.78), value: isSelected)
+		.animation(.easeOut(duration: 0.12), value: isHovered)
+		.onHover { hovering in
+			isHovered = hovering
+		}
+	}
+}
+
+private struct AppearanceSettingsPanel: View {
+	@ObservedObject var model: NativeHostSettingsViewModel
+
+	var body: some View {
+		SettingsPanel {
+			ModernSettingRow(
+				symbolName: "sparkles",
+				title: "Glass HUD",
+				subtitle: "Translucent capture chrome."
+			) {
+				Toggle(
+					"",
+					isOn: Binding(
+						get: { model.settings.hudGlassEnabled },
+						set: { value in model.update { $0.hudGlassEnabled = value } }
+					)
+				)
+				.labelsHidden()
+				.toggleStyle(.switch)
+			}
+
+			ModernSettingRow(
+				symbolName: "rectangle.3.group.bubble",
+				title: "Material",
+				subtitle: materialSubtitle
+			) {
+				HudGlassModePicker(
+					selection: model.settings.resolvedHudGlassMode,
+					isEnabled: model.settings.hudGlassEnabled,
+					onSelect: updateGlassMode
+				)
+				.disabled(!model.settings.hudGlassEnabled)
+			}
+
+			if model.settings.resolvedHudGlassMode == .liquidGlass {
+				ModernSettingRow(
+					symbolName: "circle.hexagongrid",
+					title: "Liquid Glass style",
+					subtitle: "Clear or Regular."
+				) {
+					LiquidGlassStylePicker(
+						selection: model.settings.liquidGlassStyle,
+						isEnabled: model.settings.hudGlassEnabled
+					) { value in
+						model.update { $0.liquidGlassStyle = value }
+					}
+					.disabled(!model.settings.hudGlassEnabled)
+				}
+			}
+
+			if model.settings.resolvedHudGlassMode == .classicGlass {
+				ModernSliderRow(
+					symbolName: "circle.lefthalf.filled",
+					title: "Opacity",
+					subtitle: "Background weight.",
+					value: Binding(
+						get: { model.settings.hudOpacity },
+						set: { value in model.update { $0.hudOpacity = value } }
+					),
+					isEnabled: model.settings.hudGlassEnabled
+				)
+
+				ModernSliderRow(
+					symbolName: "camera.filters",
+					title: "Blur",
+					subtitle: "Background separation.",
+					value: Binding(
+						get: { model.settings.hudBlur },
+						set: { value in model.update { $0.hudBlur = value } }
+					),
+					isEnabled: model.settings.hudGlassEnabled
+				)
+			}
+
+			ModernSliderRow(
+				symbolName: "eyedropper.halffull",
+				title: "Tint strength",
+				subtitle: "HUD accent weight.",
+				value: Binding(
+					get: { model.settings.hudTint },
+					set: { value in model.update { $0.hudTint = value } }
+				),
+				isEnabled: model.settings.hudGlassEnabled
+			)
+
+			ModernSettingRow(
+				symbolName: "paintpalette",
+				title: "Tint color",
+				subtitle: "HUD accent."
+			) {
+				ColorPicker(
+					"",
+					selection: tintColorBinding,
+					supportsOpacity: false
+				)
+				.labelsHidden()
+				.frame(width: 52)
+				.disabled(!model.settings.hudGlassEnabled)
+			}
+		}
+	}
+
+	private var materialSubtitle: String {
+		LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
+			? "Liquid Glass or blur."
+			: "Classic Glass fallback."
+	}
+
+	private var tintColorBinding: Binding<Color> {
+		Binding(
+			get: {
+				Color(
+					hue: model.settings.hudTintHue,
+					saturation: 0.72,
+					brightness: 0.95
+				)
+			},
+			set: { color in
+				let nsColor = NSColor(color)
+				let converted = nsColor.usingColorSpace(.deviceRGB) ?? nsColor
+				model.update { $0.hudTintHue = Double(converted.hueComponent) }
+			}
+		)
+	}
+
+	private func updateGlassMode(_ mode: HudGlassModePreference) {
+		if mode == .liquidGlass, !LiveChromeGlassMaterialSupport.isLiquidGlassAvailable {
+			model.refresh()
+			return
+		}
+		model.update { $0.hudGlassMode = mode }
+	}
+
+}
+
+private struct CaptureSettingsPanel: View {
+	@ObservedObject var model: NativeHostSettingsViewModel
+
+	var body: some View {
+		SettingsPanel {
+			ModernSettingRow(
+				symbolName: "keyboard",
+				title: "New capture shortcut",
+				subtitle: "Current: \(shortcutPresentation.displayTitle)."
+			) {
+				CaptureHotKeyField(model: model)
+			}
+
+			ModernSettingRow(
+				symbolName: "rectangle.bottomthird.inset.filled",
+				title: "Frozen toolbar",
+				subtitle: "Command bar position."
+			) {
+				ToolbarPlacementPicker(selection: model.settings.toolbarPlacement) { value in
+					model.update { $0.toolbarPlacement = value }
+				}
+			}
+
+			ModernSettingRow(
+				symbolName: "crop",
+				title: "Corner handles",
+				subtitle: "Resize bracket direction."
+			) {
+				FrozenResizeHandleOrientationPicker(
+					selection: model.settings.frozenResizeHandleOrientation
+				) { value in
+					model.update { $0.frozenResizeHandleOrientation = value }
+				}
+			}
+
+			ModernSettingRow(
+				symbolName: "plus.magnifyingglass",
+				title: "Loupe sample",
+				subtitle: "Color patch size."
+			) {
+				LoupeSampleSizePicker(selection: model.settings.loupeSampleSize) { value in
+					model.update { $0.loupeSampleSize = value }
+				}
+			}
+
+			ModernSettingRow(
+				symbolName: "lightbulb",
+				title: "HUD hint",
+				subtitle: "Show Tab keycap."
+			) {
+				Toggle(
+					"",
+					isOn: Binding(
+						get: { model.settings.showAltHintKeycap },
+						set: { value in model.update { $0.showAltHintKeycap = value } }
+					)
+				)
+				.labelsHidden()
+				.toggleStyle(.switch)
+			}
+		}
+	}
+
+	private var shortcutPresentation: CaptureHotKeyPresentation {
+		NativeHostSettings.captureHotKeyPresentation(for: model.settings.captureHotkey)
+	}
+}
+
+private struct CaptureHotKeyField: View {
+	@ObservedObject var model: NativeHostSettingsViewModel
+	@FocusState private var isFocused: Bool
+	@State private var draft = ""
+
+	var body: some View {
+		TextField("Option-X", text: $draft)
+			.font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+			.textFieldStyle(.roundedBorder)
+			.frame(width: 116)
+			.focused($isFocused)
+			.onAppear(perform: syncDraft)
+			.onSubmit(commitDraft)
+			.onChange(of: isFocused) { _, focused in
+				if focused {
+					syncDraft()
+				} else {
+					commitDraft()
+				}
+			}
+			.onChange(of: model.settings.captureHotkey) { _, _ in
+				if !isFocused {
+					syncDraft()
+				}
+			}
+	}
+
+	private func syncDraft() {
+		draft =
+			NativeHostSettings.captureHotKeyPresentation(
+				for: model.settings.captureHotkey
+			).displayTitle
+	}
+
+	private func commitDraft() {
+		let committed = NativeHostSettings.captureHotKeyPresentation(for: draft).displayTitle
+		if committed != model.settings.captureHotkey {
+			model.update { $0.captureHotkey = committed }
+		}
+		draft = committed
+	}
+}
+
+private struct PermissionsSettingsPanel: View {
+	@State private var refreshID = 0
+	private let primaryKind = PermissionKind.screenRecording
+
+	var body: some View {
+		VStack(spacing: 10) {
+			PermissionGrantCard(
+				kind: primaryKind,
+				refreshID: refreshID,
+				bundleURL: Self.appBundleURL,
+				appIcon: Self.appIcon,
+				openSettings: {
+					NativePermissions.openSystemSettings(for: primaryKind)
+				},
+				refresh: {
+					refreshID += 1
+				}
+			)
+
+			SettingsPanel {
+				ForEach(Self.rows) { row in
+					PermissionStatusRow(
+						row: row,
+						refreshID: refreshID,
+						openSettings: { kind in
+							NativePermissions.openSystemSettings(for: kind)
+							refreshID += 1
+						}
+					)
+				}
+			}
+		}
+	}
+
+	private static var appBundleURL: URL {
+		Bundle.main.bundleURL
+	}
+
+	private static var appIcon: NSImage {
+		NSWorkspace.shared.icon(forFile: appBundleURL.path)
+	}
+
+	private static let rows: [PermissionSettingsRow] = [
+		PermissionSettingsRow(
+			kind: .screenRecording,
+			title: "Screen Recording",
+			symbolName: "rectangle.on.rectangle"
+		),
+		PermissionSettingsRow(
+			kind: .accessibility,
+			title: "Accessibility",
+			symbolName: "accessibility"
+		),
+		PermissionSettingsRow(
+			kind: .inputMonitoring,
+			title: "Input Monitoring",
+			symbolName: "keyboard"
+		),
+	]
+}
+
+private struct PermissionSettingsRow: Identifiable {
+	let kind: PermissionKind
+	let title: String
+	let symbolName: String
+
+	var id: PermissionKind { kind }
+}
+
+private struct PermissionGrantCard: View {
+	let kind: PermissionKind
+	let refreshID: Int
+	let bundleURL: URL
+	let appIcon: NSImage
+	let openSettings: () -> Void
+	let refresh: () -> Void
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		HStack(alignment: .center, spacing: 12) {
+			ZStack {
+				Circle()
+					.fill(iconBackgroundColor)
+				Image(systemName: isGranted ? "checkmark.seal.fill" : "hand.draw.fill")
+					.symbolRenderingMode(.hierarchical)
+					.font(.system(size: 17, weight: .semibold))
+					.foregroundStyle(isGranted ? Color.green : Color.accentColor)
+			}
+			.frame(width: 34, height: 34)
+
+			VStack(alignment: .leading, spacing: 5) {
+				HStack(spacing: 7) {
+					Text(title)
+						.font(.system(size: 12.5, weight: .semibold))
+						.lineLimit(2)
+					PermissionStateBadge(
+						title: isGranted ? "Granted" : "Required",
+						style: isGranted ? .granted : .required
+					)
+				}
+				Text(subtitle)
+					.font(.system(size: 10, weight: .medium))
+					.foregroundStyle(.secondary)
+					.lineLimit(2)
+					.fixedSize(horizontal: false, vertical: true)
+			}
+			.layoutPriority(1)
+
+			Spacer(minLength: 8)
+
+			VStack(alignment: .trailing, spacing: 7) {
+				PermissionAppDragSource(bundleURL: bundleURL, icon: appIcon, label: "rsnap")
+					.frame(width: 112, height: 34)
+					.opacity(isGranted ? 0.76 : 1)
+
+				HStack(spacing: 6) {
+					Button {
+						openSettings()
+					} label: {
+						Label("Open", systemImage: "gearshape")
+					}
+					.rsnapGlassButton(prominent: false)
+					.controlSize(.small)
+
+					Button(action: refresh) {
+						Image(systemName: "arrow.clockwise")
+							.frame(width: 13, height: 13)
+					}
+					.rsnapGlassButton(prominent: false)
+					.controlSize(.small)
+					.help("Refresh status")
+				}
+			}
+		}
+		.padding(.horizontal, 14)
+		.padding(.vertical, 12)
+		.frame(maxWidth: .infinity, minHeight: 104, alignment: .leading)
+		.settingsGlassSurface(cornerRadius: 13, role: .panel)
+	}
+
+	private var isGranted: Bool {
+		_ = refreshID
+		return NativePermissions.status(for: kind)
+	}
+
+	private var title: String {
+		isGranted ? "Screen Recording ready" : "Drag rsnap into Screen Recording"
+	}
+
+	private var subtitle: String {
+		if isGranted {
+			return "The native capture host can see the screen."
+		}
+		return "Open System Settings, then drop the app chip into the allowed apps list."
+	}
+
+	private var iconBackgroundColor: Color {
+		if isGranted {
+			return Color.green.opacity(colorScheme == .light ? 0.12 : 0.18)
+		}
+		return Color.accentColor.opacity(colorScheme == .light ? 0.12 : 0.20)
+	}
+
+}
+
+private struct PermissionStatusRow: View {
+	let row: PermissionSettingsRow
+	let refreshID: Int
+	let openSettings: (PermissionKind) -> Void
+
+	var body: some View {
+		ModernSettingRow(
+			symbolName: row.symbolName,
+			title: row.title,
+			subtitle: subtitle
+		) {
+			HStack(spacing: 7) {
+				PermissionStateBadge(title: badgeTitle, style: badgeStyle)
+				if canOpen {
+					Button {
+						openSettings(row.kind)
+					} label: {
+						Image(systemName: "arrow.up.forward.app")
+							.frame(width: 13, height: 13)
+					}
+					.rsnapGlassButton(prominent: false)
+					.controlSize(.small)
+					.help("Open \(row.title)")
+				}
+			}
+		}
+	}
+
+	private var isGranted: Bool {
+		_ = refreshID
+		return NativePermissions.status(for: row.kind)
+	}
+
+	private var isRequired: Bool {
+		NativePermissions.requiredForCurrentNativeHost(row.kind)
+	}
+
+	private var subtitle: String {
+		if isGranted {
+			return "Granted."
+		}
+		return isRequired ? "Required for native capture." : "Not used by current host."
+	}
+
+	private var badgeTitle: String {
+		if isGranted {
+			return "Granted"
+		}
+		return isRequired ? "Required" : "Not Used"
+	}
+
+	private var badgeStyle: PermissionStateBadge.Style {
+		if isGranted {
+			return .granted
+		}
+		return isRequired ? .required : .muted
+	}
+
+	private var canOpen: Bool {
+		isRequired && !isGranted
+	}
+}
+
+private struct PermissionStateBadge: View {
+	enum Style {
+		case granted
+		case required
+		case muted
+	}
+
+	let title: String
+	let style: Style
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		Text(title)
+			.font(.system(size: 9.2, weight: .semibold))
+			.lineLimit(1)
+			.padding(.horizontal, 7)
+			.padding(.vertical, 4)
+			.foregroundStyle(foregroundColor)
+			.background(backgroundColor, in: Capsule())
+			.overlay {
+				Capsule()
+					.stroke(borderColor, lineWidth: 1)
+			}
+	}
+
+	private var foregroundColor: Color {
+		switch style {
+		case .granted:
+			return Color.green
+		case .required:
+			return Color.accentColor
+		case .muted:
+			return Color.secondary
+		}
+	}
+
+	private var backgroundColor: Color {
+		switch style {
+		case .granted:
+			return Color.green.opacity(colorScheme == .light ? 0.10 : 0.16)
+		case .required:
+			return Color.accentColor.opacity(colorScheme == .light ? 0.10 : 0.18)
+		case .muted:
+			return Color.secondary.opacity(colorScheme == .light ? 0.08 : 0.12)
+		}
+	}
+
+	private var borderColor: Color {
+		switch style {
+		case .granted:
+			return Color.green.opacity(colorScheme == .light ? 0.20 : 0.26)
+		case .required:
+			return Color.accentColor.opacity(colorScheme == .light ? 0.20 : 0.28)
+		case .muted:
+			return Color.secondary.opacity(colorScheme == .light ? 0.14 : 0.20)
+		}
+	}
+}
+
+private struct OutputSettingsPanel: View {
+	@ObservedObject var model: NativeHostSettingsViewModel
+
+	var body: some View {
+		SettingsPanel {
+			ModernSettingRow(
+				symbolName: "folder",
+				title: "Save location",
+				subtitle: abbreviatedPath(model.settings.outputDirectory)
+			) {
+				Button("Choose", action: model.chooseOutputDirectory)
+					.rsnapGlassButton(prominent: false)
+					.controlSize(.small)
+			}
+
+			ModernSettingRow(
+				symbolName: "textformat.abc",
+				title: "Filename prefix",
+				subtitle: "Safe filename text."
+			) {
+				TextField(
+					"rsnap",
+					text: Binding(
+						get: { model.settings.outputFilenamePrefix },
+						set: { value in model.update { $0.outputFilenamePrefix = value } }
+					)
+				)
+				.textFieldStyle(.roundedBorder)
+				.frame(width: 172)
+			}
+
+			ModernSettingRow(
+				symbolName: "number",
+				title: "Naming",
+				subtitle: "Filename style."
+			) {
+				OutputNamingPicker(selection: model.settings.outputNaming) { value in
+					model.update { $0.outputNaming = value }
+				}
+			}
+		}
+	}
+
+	private func abbreviatedPath(_ url: URL) -> String {
+		let path = url.path
+		let home = FileManager.default.homeDirectoryForCurrentUser.path
+		if path == home {
+			return "~"
+		}
+		if path.hasPrefix(home + "/") {
+			return "~" + path.dropFirst(home.count)
+		}
+		return path
+	}
+}
+
+private struct SettingsPanel<Content: View>: View {
+	let content: Content
+
+	init(@ViewBuilder content: () -> Content) {
+		self.content = content()
+	}
+
+	var body: some View {
+		VStack(spacing: 0) {
+			content
+		}
+		.frame(maxWidth: .infinity, alignment: .topLeading)
+		.settingsGlassSurface(cornerRadius: 10, role: .panel)
+	}
+}
+
+private struct ModernSettingRow<Control: View>: View {
+	let symbolName: String
+	let title: String
+	let subtitle: String
+	let control: Control
+	@Environment(\.colorScheme) private var colorScheme
+	@State private var isHovered = false
+
+	init(
+		symbolName: String,
+		title: String,
+		subtitle: String,
+		@ViewBuilder control: () -> Control
+	) {
+		self.symbolName = symbolName
+		self.title = title
+		self.subtitle = subtitle
+		self.control = control()
+	}
+
+	var body: some View {
+		HStack(alignment: .center, spacing: 12) {
+			Image(systemName: symbolName)
+				.symbolRenderingMode(.hierarchical)
+				.font(.system(size: 12.5, weight: .semibold))
+				.foregroundStyle(Color.secondary.opacity(colorScheme == .light ? 0.78 : 0.90))
+				.frame(width: 20, height: 20)
+
+			VStack(alignment: .leading, spacing: 3) {
+				Text(title)
+					.font(.system(size: 11, weight: .semibold))
+				Text(subtitle)
+					.font(.system(size: 9.2, weight: .medium))
+					.foregroundStyle(.secondary)
+					.lineLimit(1)
+					.minimumScaleFactor(0.92)
+			}
+			.layoutPriority(1)
+
+			Spacer(minLength: 12)
+
+			control
+		}
+		.padding(.horizontal, 12)
+		.padding(.vertical, 5)
+		.frame(minHeight: 42)
+		.background {
+			if isHovered {
+				Rectangle()
+					.fill(
+						colorScheme == .light
+							? Color.black.opacity(0.018)
+							: Color.white.opacity(0.026)
+					)
+			}
+		}
+		.overlay(alignment: .bottom) {
+			Rectangle()
+				.fill(
+					colorScheme == .light
+						? Color.black.opacity(0.035)
+						: Color.white.opacity(0.052)
+				)
+				.frame(height: 1)
+				.padding(.leading, 44)
+		}
+		.contentShape(Rectangle())
+		.onHover { hovering in
+			withAnimation(.easeOut(duration: 0.14)) {
+				isHovered = hovering
+			}
+		}
+	}
+}
+
+private struct ModernSliderRow: View {
+	let symbolName: String
+	let title: String
+	let subtitle: String
+	@Binding var value: Double
+	let isEnabled: Bool
+
+	var body: some View {
+		ModernSettingRow(symbolName: symbolName, title: title, subtitle: subtitle) {
+			HStack(spacing: 12) {
+				Slider(value: $value, in: 0...1)
+					.frame(width: 116)
+				Text("\(Int((value * 100).rounded()))")
+					.font(.system(size: 11, weight: .semibold, design: .monospaced))
+					.foregroundStyle(.secondary)
+					.frame(width: 30, alignment: .trailing)
+			}
+			.disabled(!isEnabled)
+		}
+	}
+}
+
+private struct SettingsAtmosphere: View {
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		ZStack {
+			Rectangle()
+				.fill(Color(nsColor: .windowBackgroundColor))
+			if colorScheme == .light {
+				Color.white.opacity(0.16)
+			} else {
+				Color.black.opacity(0.08)
+			}
+		}
+		.ignoresSafeArea()
+	}
+}
+
+extension View {
+	@ViewBuilder
+	fileprivate func rsnapGlassButton(prominent: Bool) -> some View {
+		if prominent {
+			self.buttonStyle(.borderedProminent)
+		} else {
+			self.buttonStyle(.bordered)
+		}
+	}
+
+	fileprivate func segmentedGlassBackground() -> some View {
+		self.modifier(SegmentedGlassBackgroundModifier())
+	}
+
+	fileprivate func settingsGlassSurface(cornerRadius: CGFloat, role: SettingsGlassRole)
+		-> some View
+	{
+		self.modifier(SettingsGlassSurfaceModifier(cornerRadius: cornerRadius, role: role))
+	}
+}
+
+private struct SegmentedGlassBackgroundModifier: ViewModifier {
+	@Environment(\.colorScheme) private var colorScheme
+
+	func body(content: Content) -> some View {
+		content
+			.background(
+				colorScheme == .light ? Color.black.opacity(0.040) : Color.white.opacity(0.052),
+				in: .rect(cornerRadius: 8, style: .continuous)
+			)
+			.overlay {
+				RoundedRectangle(cornerRadius: 8, style: .continuous)
+					.stroke(
+						colorScheme == .light
+							? Color.black.opacity(0.048)
+							: Color.white.opacity(0.074),
+						lineWidth: 1
+					)
+			}
+	}
+}
+
+private enum SettingsGlassRole {
+	case panel
+	case preview
+}
+
+private struct SettingsGlassSurfaceModifier: ViewModifier {
+	let cornerRadius: CGFloat
+	let role: SettingsGlassRole
+	@Environment(\.colorScheme) private var colorScheme
+
+	@ViewBuilder
+	func body(content: Content) -> some View {
+		switch role {
+		case .panel:
+			content
+				.background(panelFill, in: shape)
+				.overlay {
+					RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+						.stroke(panelBorderColor, lineWidth: 1)
+						.allowsHitTesting(false)
+				}
+		case .preview:
+			content
+				.background(.regularMaterial, in: shape)
+				.background(baseTint, in: shape)
+				.overlay(alignment: .top) {
+					LinearGradient(
+						colors: [
+							Color.white.opacity(colorScheme == .light ? 0.54 : 0.12),
+							Color.white.opacity(0),
+						],
+						startPoint: .top,
+						endPoint: .bottom
+					)
+					.frame(height: 34)
+					.clipShape(shape)
+					.allowsHitTesting(false)
+				}
+				.overlay {
+					RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+						.stroke(borderGradient, lineWidth: 1)
+						.allowsHitTesting(false)
+				}
+				.shadow(color: shadowColor, radius: 7, y: 2)
+		}
+	}
+
+	private var shape: RoundedRectangle {
+		RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+	}
+
+	private var baseTint: Color {
+		switch role {
+		case .panel:
+			return panelFill
+		case .preview:
+			return colorScheme == .light ? Color.white.opacity(0.28) : Color.black.opacity(0.035)
+		}
+	}
+
+	private var panelFill: Color {
+		colorScheme == .light
+			? Color(nsColor: .controlBackgroundColor)
+			: Color.white.opacity(0.032)
+	}
+
+	private var panelBorderColor: Color {
+		colorScheme == .light ? Color.black.opacity(0.062) : Color.white.opacity(0.058)
+	}
+
+	private var borderGradient: LinearGradient {
+		LinearGradient(
+			colors: [
+				colorScheme == .light ? Color.white.opacity(0.72) : Color.white.opacity(0.12),
+				colorScheme == .light ? Color.black.opacity(0.050) : Color.white.opacity(0.065),
+			],
+			startPoint: .topLeading,
+			endPoint: .bottomTrailing
+		)
+	}
+
+	private var shadowColor: Color {
+		colorScheme == .light ? Color.black.opacity(0.045) : Color.black.opacity(0.14)
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/PermissionAppDragSource.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/PermissionAppDragSource.swift
@@ -1,0 +1,156 @@
+import AppKit
+import SwiftUI
+
+struct PermissionAppDragSource: NSViewRepresentable {
+	let bundleURL: URL
+	let icon: NSImage
+	let label: String
+
+	func makeNSView(context: Context) -> PermissionAppDragSourceView {
+		PermissionAppDragSourceView(bundleURL: bundleURL, icon: icon, label: label)
+	}
+
+	func updateNSView(_ nsView: PermissionAppDragSourceView, context: Context) {
+		nsView.configure(bundleURL: bundleURL, icon: icon, label: label)
+	}
+}
+
+final class PermissionAppDragSourceView: NSView, NSDraggingSource {
+	private var bundleURL: URL
+	private var icon: NSImage
+	private var label: String
+	private var dragStarted = false
+
+	init(bundleURL: URL, icon: NSImage, label: String) {
+		self.bundleURL = bundleURL
+		self.icon = icon
+		self.label = label
+		super.init(frame: .zero)
+		wantsLayer = true
+		layer?.cornerCurve = .continuous
+		toolTip = "Drag rsnap to System Settings"
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	override var isFlipped: Bool {
+		true
+	}
+
+	override var intrinsicContentSize: NSSize {
+		NSSize(width: 112, height: 34)
+	}
+
+	func configure(bundleURL: URL, icon: NSImage, label: String) {
+		self.bundleURL = bundleURL
+		self.icon = icon
+		self.label = label
+		needsDisplay = true
+		invalidateIntrinsicContentSize()
+	}
+
+	override func resetCursorRects() {
+		addCursorRect(bounds, cursor: .openHand)
+	}
+
+	override func mouseDragged(with event: NSEvent) {
+		guard !dragStarted else {
+			return
+		}
+		dragStarted = true
+
+		let draggingItem = NSDraggingItem(pasteboardWriter: bundleURL as NSURL)
+		draggingItem.setDraggingFrame(bounds, contents: dragImage())
+		let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
+		session.animatesToStartingPositionsOnCancelOrFail = true
+	}
+
+	override func mouseUp(with event: NSEvent) {
+		dragStarted = false
+	}
+
+	func draggingSession(
+		_ session: NSDraggingSession,
+		sourceOperationMaskFor context: NSDraggingContext
+	) -> NSDragOperation {
+		.copy
+	}
+
+	func draggingSession(
+		_ session: NSDraggingSession,
+		endedAt screenPoint: NSPoint,
+		operation: NSDragOperation
+	) {
+		dragStarted = false
+	}
+
+	override func draw(_ dirtyRect: NSRect) {
+		super.draw(dirtyRect)
+		drawChip(in: bounds)
+	}
+
+	private func dragImage() -> NSImage {
+		guard bounds.width > 1, bounds.height > 1,
+			let rep = bitmapImageRepForCachingDisplay(in: bounds)
+		else {
+			return icon
+		}
+
+		cacheDisplay(in: bounds, to: rep)
+		let image = NSImage(size: bounds.size)
+		image.addRepresentation(rep)
+		return image
+	}
+
+	private func drawChip(in rect: NSRect) {
+		let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+		let chipRect = rect.insetBy(dx: 1, dy: 1)
+		let path = NSBezierPath(
+			roundedRect: chipRect,
+			xRadius: chipRect.height / 2,
+			yRadius: chipRect.height / 2
+		)
+
+		(isDark
+			? NSColor.white.withAlphaComponent(0.10)
+			: NSColor.white.withAlphaComponent(0.76)).setFill()
+		path.fill()
+
+		(isDark
+			? NSColor.white.withAlphaComponent(0.15)
+			: NSColor.black.withAlphaComponent(0.08)).setStroke()
+		path.lineWidth = 1
+		path.stroke()
+
+		let iconSize: CGFloat = 20
+		let iconRect = NSRect(
+			x: 8,
+			y: (rect.height - iconSize) / 2,
+			width: iconSize,
+			height: iconSize
+		)
+		icon.draw(in: iconRect, from: .zero, operation: .sourceOver, fraction: 1)
+
+		let paragraph = NSMutableParagraphStyle()
+		paragraph.lineBreakMode = .byTruncatingTail
+		let labelRect = NSRect(
+			x: iconRect.maxX + 6,
+			y: (rect.height - 16) / 2,
+			width: max(0, rect.width - iconRect.maxX - 16),
+			height: 17
+		)
+		(label as NSString).draw(
+			in: labelRect,
+			withAttributes: [
+				.font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+				.foregroundColor: isDark
+					? NSColor.white.withAlphaComponent(0.92)
+					: NSColor.black.withAlphaComponent(0.78),
+				.paragraphStyle: paragraph,
+			]
+		)
+	}
+}

--- a/packages/rsnap-overlay/src/host_live_sampling_macos.rs
+++ b/packages/rsnap-overlay/src/host_live_sampling_macos.rs
@@ -1,7 +1,5 @@
 //! Public macOS live-frame sampling bridge used by the native host FFI layer.
 
-use image::imageops;
-
 use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
 use crate::state::{GlobalPoint, LiveCursorSample, MonitorRect};
 
@@ -68,12 +66,12 @@ impl HostMacLiveSampler {
 	}
 
 	#[must_use]
-	/// Returns a cached RGBA region from the latest monitor frame when one is already warm.
+	/// Returns a fresh RGBA region from the live monitor stream when possible.
 	///
-	/// This does not block on a fresh capture. When the latest frame is unavailable, the
-	/// underlying stream is primed and `None` is returned.
+	/// This keeps stationary native-host color sampling responsive to animated content
+	/// without falling back to slower window-list captures.
 	pub fn peek_region_rgba(
-		&self,
+		&mut self,
 		monitor: MonitorRect,
 		origin: GlobalPoint,
 		width: u32,
@@ -82,16 +80,8 @@ impl HostMacLiveSampler {
 		let width = i32::try_from(width).ok()?;
 		let height = i32::try_from(height).ok()?;
 		let rect = monitor.clip_global_rect(origin.x, origin.y, width, height)?;
-		let snapshot = self.stream.peek_latest_rgba_snapshot(monitor)?;
 		let rect_px = monitor.local_rect_to_pixels(rect);
-		let image = imageops::crop_imm(
-			snapshot.image.as_ref(),
-			rect_px.x,
-			rect_px.y,
-			rect_px.width.max(1),
-			rect_px.height.max(1),
-		)
-		.to_image();
+		let image = self.stream.latest_rgba_region(monitor, rect_px)?;
 
 		Some(HostRgbaRegion {
 			width: image.width(),

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -675,7 +675,15 @@ struct SharedLatestFrame {
 	pending_stream_filter_complete_monitor: Mutex<Option<StreamGenerationStatus>>,
 }
 impl SharedLatestFrame {
-	fn reset(&self) {
+	fn reset(&self, retired_stream: Option<StreamGenerationStatus>) {
+		match self.frames.lock() {
+			Ok(mut guard) => *guard = None,
+			Err(poisoned) => {
+				let mut guard = poisoned.into_inner();
+
+				*guard = None;
+			},
+		}
 		match self.pending_monitor.lock() {
 			Ok(mut guard) => *guard = None,
 			Err(poisoned) => {
@@ -700,13 +708,17 @@ impl SharedLatestFrame {
 				*guard = None;
 			},
 		}
-		match self.active_stream_generation.lock() {
-			Ok(mut guard) => *guard = None,
-			Err(poisoned) => {
-				let mut guard = poisoned.into_inner();
+		if let Some(retired_stream) = retired_stream {
+			match self.active_stream_generation.lock() {
+				Ok(mut guard) => {
+					*guard = Some(StreamGenerationStatus::retired_after(retired_stream))
+				},
+				Err(poisoned) => {
+					let mut guard = poisoned.into_inner();
 
-				*guard = None;
-			},
+					*guard = Some(StreamGenerationStatus::retired_after(retired_stream));
+				},
+			}
 		}
 		match self.stream_filter_status.lock() {
 			Ok(mut guard) => *guard = None,
@@ -1250,6 +1262,14 @@ struct StreamGenerationStatus {
 	monitor_id: u32,
 	stream_generation: u64,
 }
+impl StreamGenerationStatus {
+	fn retired_after(status: Self) -> Self {
+		Self {
+			monitor_id: status.monitor_id,
+			stream_generation: status.stream_generation.wrapping_add(1),
+		}
+	}
+}
 
 struct StoreFrameOutcome {
 	completed_ensure: bool,
@@ -1548,11 +1568,15 @@ fn handle_stream_worker_request(
 			)
 		},
 		WorkerRequest::Reset => {
+			let retired_stream = state.as_ref().map(|state| StreamGenerationStatus {
+				monitor_id: state.monitor_id,
+				stream_generation: state.stream_generation,
+			});
 			teardown_stream(state);
 
 			*last_setup_attempt_at = None;
 
-			shared_latest_frame.reset();
+			shared_latest_frame.reset(retired_stream);
 
 			true
 		},
@@ -3427,6 +3451,37 @@ mod tests {
 			shared.latest_frame_for_monitor(7).map(|frame| frame.stream_generation),
 			Some(2)
 		);
+	}
+
+	#[test]
+	fn reset_discards_cached_frames_and_rejects_retired_stream_frames() {
+		let shared = live_frame_stream_macos::SharedLatestFrame::default();
+		let pixel_buffer = test_pixel_buffer();
+		let retired_frame = live_frame_stream_macos::QueuedPixelBufferFrame {
+			frame_seq: 1,
+			stream_generation: 1,
+			captured_at: std::time::Instant::now(),
+			pixel_buffer: pixel_buffer.clone(),
+		};
+
+		shared.activate_stream_generation(7, 1);
+		let _ = shared.store(7, &retired_frame);
+
+		assert_eq!(
+			shared.latest_frame_for_monitor(7).map(|frame| frame.stream_generation),
+			Some(1)
+		);
+
+		shared.reset(Some(live_frame_stream_macos::StreamGenerationStatus {
+			monitor_id: 7,
+			stream_generation: 1,
+		}));
+
+		assert!(shared.latest_frame_for_monitor(7).is_none());
+
+		let _ = shared.store(7, &retired_frame);
+
+		assert!(shared.latest_frame_for_monitor(7).is_none());
 	}
 
 	#[test]

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -708,6 +708,7 @@ impl SharedLatestFrame {
 				*guard = None;
 			},
 		}
+
 		if let Some(retired_stream) = retired_stream {
 			match self.active_stream_generation.lock() {
 				Ok(mut guard) => {
@@ -720,6 +721,7 @@ impl SharedLatestFrame {
 				},
 			}
 		}
+
 		match self.stream_filter_status.lock() {
 			Ok(mut guard) => *guard = None,
 			Err(poisoned) => {
@@ -1542,6 +1544,25 @@ fn stream_worker_loop(
 	teardown_stream(&mut state);
 }
 
+fn handle_reset_request(
+	state: &mut Option<StreamState>,
+	last_setup_attempt_at: &mut Option<Instant>,
+	shared_latest_frame: Arc<SharedLatestFrame>,
+) -> bool {
+	let retired_stream = state.as_ref().map(|state| StreamGenerationStatus {
+		monitor_id: state.monitor_id,
+		stream_generation: state.stream_generation,
+	});
+
+	teardown_stream(state);
+
+	*last_setup_attempt_at = None;
+
+	shared_latest_frame.reset(retired_stream);
+
+	true
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_stream_worker_request(
 	request: WorkerRequest,
@@ -1568,17 +1589,7 @@ fn handle_stream_worker_request(
 			)
 		},
 		WorkerRequest::Reset => {
-			let retired_stream = state.as_ref().map(|state| StreamGenerationStatus {
-				monitor_id: state.monitor_id,
-				stream_generation: state.stream_generation,
-			});
-			teardown_stream(state);
-
-			*last_setup_attempt_at = None;
-
-			shared_latest_frame.reset(retired_stream);
-
-			true
+			handle_reset_request(state, last_setup_attempt_at, shared_latest_frame)
 		},
 		WorkerRequest::RefreshMonitor { monitor } => handle_refresh_monitor_request(
 			state,
@@ -3465,6 +3476,7 @@ mod tests {
 		};
 
 		shared.activate_stream_generation(7, 1);
+
 		let _ = shared.store(7, &retired_frame);
 
 		assert_eq!(

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -203,8 +203,6 @@ stage_app_bundle() {
   <string>$APP_VERSION</string>
   <key>LSMinimumSystemVersion</key>
   <string>$MIN_SYSTEM_VERSION</string>
-  <key>LSUIElement</key>
-  <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
   <key>NSPrincipalClass</key>
@@ -232,10 +230,7 @@ PLIST
 }
 
 resolve_signing_identity() {
-	local requested_identity identity_list preferred_identity=""
-	if [[ "${RSNAP_NATIVE_HOST_SKIP_SIGN:-0}" == "1" ]]; then
-		return 1
-	fi
+	local requested_identity identity_list identity
 
 	requested_identity="${RSNAP_NATIVE_HOST_SIGN_IDENTITY:-$DEFAULT_SIGN_IDENTITY}"
 	identity_list="$(security find-identity -v -p codesigning 2>/dev/null || true)"
@@ -257,15 +252,7 @@ resolve_signing_identity() {
 			RESOLVED_SIGN_IDENTITY="$identity"
 			return 0
 		fi
-		if [[ -z "$preferred_identity" && -n "$identity" && "$identity" == Sign\ to\ Run\ Locally* ]]; then
-			preferred_identity="$identity"
-		fi
 	done <<<"$identity_list"
-
-	if [[ -n "$preferred_identity" ]]; then
-		RESOLVED_SIGN_IDENTITY="$preferred_identity"
-		return 0
-	fi
 
 	return 1
 }
@@ -290,20 +277,9 @@ sign_staged_app_bundle() {
 		return
 	fi
 
-	if [[ "${RSNAP_NATIVE_HOST_SKIP_SIGN:-0}" == "1" ]]; then
-		echo "warning: skipping stable codesign identity; using ad-hoc signing for $APP_BUNDLE" >&2
-		codesign \
-			--force \
-			--deep \
-			--sign - \
-			"${entitlements_arg[@]}" \
-			"$APP_BUNDLE"
-		return
-	fi
-
 	echo "error: no valid macOS codesigning identity matching \"$requested_identity\" was found." >&2
 	echo "error: import the real signing certificate or set RSNAP_NATIVE_HOST_SIGN_IDENTITY to a valid identity." >&2
-	echo "error: use RSNAP_NATIVE_HOST_SKIP_SIGN=1 only for non-persistent local staging or CI packaging." >&2
+	echo "error: rsnap native host staging requires a stable codesigning identity." >&2
 	exit 1
 }
 

--- a/scripts/smoke/lib/native-hud-follow-summary.py
+++ b/scripts/smoke/lib/native-hud-follow-summary.py
@@ -143,6 +143,8 @@ reported = [
     "live_chrome.sample_refresh_duration",
     "live_chrome.background_sample_duration",
     "live_chrome.update_duration",
+    "live_chrome.main_queue_tick_wait",
+    "live_chrome.snapshot_duration",
     "live_chrome.layer_render_duration",
     "live_chrome.layer_chrome_render_gap",
     "live_chrome.active_layer_chrome_render_gap",

--- a/scripts/smoke/native-hud-follow-macos.sh
+++ b/scripts/smoke/native-hud-follow-macos.sh
@@ -72,7 +72,7 @@ sleep 0.4
 
 osascript <<'APPLESCRIPT' >/dev/null
 tell application "System Events"
-	keystroke "x" using option down
+	key code 7 using option down
 end tell
 APPLESCRIPT
 sleep 0.2


### PR DESCRIPTION
## Summary
- modernize the native Settings window, permission flow, hotkey/menu behavior, and related settings specs
- keep live HUD/loupe/toolbar chrome on overlay layers while preserving z-order and signed launch behavior
- restore fast stationary color sampling and reject stale startup-prewarm stream frames before first capture

## Validation
- `cargo make fmt-check`
- `cargo make lint-swift`
- `cargo test -p rsnap-overlay reset_discards_cached_frames_and_rejects_retired_stream_frames`
- `cargo make lint-rust`
- `scripts/smoke/native-hud-follow-macos.sh`
- `cargo make test-macos-native-host-stage`
- `git diff --check`