### PR TITLE
Expose capture overlay to external tools

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -110,7 +110,12 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	private var telemetryContext = TelemetryContext(
 		captureID: 0, source: "capture", startedAtUptime: 0)
 
-	func start(for screens: [NSScreen], captureID: UInt64 = 0, source: String = "capture") {
+	func start(
+		for screens: [NSScreen],
+		captureID: UInt64 = 0,
+		source: String = "capture",
+		refreshContentFilter: Bool = false
+	) {
 		let setupStartedAt = ProcessInfo.processInfo.systemUptime
 		let targets = screens.compactMap(Self.displayTarget(for:))
 		guard !targets.isEmpty else {
@@ -123,7 +128,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		stateLock.lock()
 		let unchanged = activeDisplayIDs == targetIDs && displayTargets == nextTargets
 		displayTargets = nextTargets
-		if unchanged, !streams.isEmpty {
+		if unchanged, !streams.isEmpty, !refreshContentFilter {
 			updateTelemetryContextLocked(
 				captureID: captureID,
 				source: source,
@@ -137,7 +142,8 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let requestGeneration = generation
 		activeDisplayIDs = targetIDs
 		setupDisplayIDs = targetIDs
-		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
+		latestFrames =
+			refreshContentFilter ? [:] : latestFrames.filter { targetIDs.contains($0.key) }
 		updateTelemetryContextLocked(
 			captureID: captureID,
 			source: source,

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -371,7 +371,7 @@ private final class LiveChromeBackdropWindow: NSWindow {
 		animationBehavior = .none
 		isOpaque = false
 		level = NSWindow.Level(rawValue: NSWindow.Level.screenSaver.rawValue - 1)
-		sharingType = .none
+		sharingType = .readOnly
 		titleVisibility = .hidden
 		titlebarAppearsTransparent = true
 		orderOut(nil)

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -548,6 +548,12 @@ final class CaptureSessionController: NSObject {
 				focusPoint: startPoint,
 				initialWindowSnapshots: initialWindowSnapshots
 			)
+			frozenFrameAuthority.start(
+				for: NSScreen.screens,
+				captureID: captureID,
+				source: "capture_overlay_visible",
+				refreshContentFilter: true
+			)
 			let overlayShowMilliseconds =
 				NativeHostTelemetry.milliseconds(since: overlayShowStartedAt)
 			(NSApp.delegate as? NativeHostApplicationController)?.window =
@@ -2755,7 +2761,7 @@ final class CaptureOverlayWindow: NSPanel {
 		isMovable = false
 		isOpaque = false
 		level = .screenSaver
-		sharingType = .none
+		sharingType = .readOnly
 		titleVisibility = .hidden
 		titlebarAppearsTransparent = true
 	}
@@ -3117,12 +3123,18 @@ final class CaptureHostView: NSView {
 		}
 		window?.disableScreenUpdatesUntilFlush()
 		window?.displayIfNeeded()
+		finishFrozenFirstDisplayHandoff()
+	}
+
+	private func finishFrozenFirstDisplayHandoff() {
 		pendingFrozenFirstDisplay = false
 		frozenFirstDisplayCompletionQueued = false
 		lastLivePreviewSnapshot = nil
 		if scene.mode != .live {
 			liveRenderer.stop()
 		}
+		needsDisplay = true
+		displayIfNeeded()
 	}
 
 	fileprivate func seedInitialState(
@@ -3209,14 +3221,7 @@ final class CaptureHostView: NSView {
 			return
 		}
 		window?.disableScreenUpdatesUntilFlush()
-		frozenFirstDisplayCompletionQueued = false
-		pendingFrozenFirstDisplay = false
-		lastLivePreviewSnapshot = nil
-		needsDisplay = true
-		displayIfNeeded()
-		if scene.mode != .live {
-			liveRenderer.stop()
-		}
+		finishFrozenFirstDisplayHandoff()
 	}
 
 	override func layout() {


### PR DESCRIPTION
## Summary
- make the native capture overlay and live chrome backdrop externally capturable via `sharingType = .readOnly`
- refresh the frozen-frame ScreenCaptureKit filter after the overlay is visible so rsnap does not capture its own overlay into frozen frames
- unify frozen first-frame handoff cleanup so the live renderer is stopped before the final frozen repaint

## Validation
- `git diff --check`
- `cargo make lint-swift`
- `./scripts/build_and_run.sh run`
- runtime probe while capture overlay was active: one rsnap overlay window, `sharing=1`
- manual frozen-entry screenshot check after automated drag selection: old live selection shadow no longer appeared in the frozen frame

## Notes
- Alt-X launch latency is intentionally out of scope for this PR.
