### PR TITLE
Stabilize native frozen handoff

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -111,6 +111,8 @@ args = [
 	"--parallel",
 	"native/macos-host/Sources",
 	"scripts/smoke/lib/live-hud-mouse-path.swift",
+	"scripts/smoke/lib/mask-probe-capture.swift",
+	"scripts/smoke/lib/visual-background-window.swift",
 ]
 
 [tasks.lint-swiftlint]
@@ -339,6 +341,8 @@ args = [
 	"--parallel",
 	"native/macos-host/Sources",
 	"scripts/smoke/lib/live-hud-mouse-path.swift",
+	"scripts/smoke/lib/mask-probe-capture.swift",
+	"scripts/smoke/lib/visual-background-window.swift",
 ]
 
 [tasks.fmt-swift-check]

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -34,8 +34,9 @@ overlay runtime integration tests, and scroll-capture session semantics tests.
 | `scripts/smoke/replay-scroll-capture-self-check.sh` | Script entrypoint | deterministic replay | Runs the worker-pairwise replay self-check without a user trace. |
 | `scripts/smoke/analyze-scroll-capture-trace.sh` | Script entrypoint | deterministic replay | Emits summary-only replay analysis for semantic drift triage. |
 | `scripts/smoke/native-hud-follow-macos.sh` | Script entrypoint | live macOS smoke | Drives the default native-host HUD-follow smoke with a smooth high-rate cursor path. |
+| `scripts/smoke/native-visual-contract-macos.sh` | Script entrypoint | live macOS smoke | Drives Option-X, a drag-region frozen handoff, screenshots rsnap itself, and gates no-pending-frame/no-scrim-drop toolbar content/material contract telemetry. |
 | `scripts/smoke/self-check-macos.sh` | Script entrypoint | smoke readiness | Verifies macOS smoke tooling and replay self-check without the real GUI run. |
-| `scripts/smoke/macos.sh` | Script entrypoint | smoke aggregation | Runs native HUD follow plus recorded-trace replay. |
+| `scripts/smoke/macos.sh` | Script entrypoint | smoke aggregation | Runs native HUD follow, native visual contract, and recorded-trace replay. |
 | `scripts/perf/local.sh` | Script entrypoint | deterministic benches | Runs the committed Criterion smoke-sized benchmark sweep. |
 | `scripts/perf/self-check-macos.sh` | Script entrypoint | perf aggregation | Runs local deterministic benches plus macOS smoke readiness. |
 | `scripts/perf/macos.sh` | Script entrypoint | perf aggregation | Runs local deterministic benches plus `scripts/smoke/macos.sh`. |

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -31,6 +31,8 @@ Use the smallest command that matches the regression surface:
   `cargo bench -p rsnap-overlay --bench scroll_capture -- --sample-size 10 --warm-up-time 0.1 --measurement-time 0.1`
 - Native-host live chrome regressions:
   `scripts/smoke/native-hud-follow-macos.sh`
+- Native-host visual/material or live-to-frozen handoff regressions:
+  `scripts/smoke/native-visual-contract-macos.sh`
 - General local deterministic performance sweep before or after a change:
   `scripts/perf/local.sh`
 - Dedicated macOS environment validation without driving the real smoke scenario:
@@ -59,7 +61,8 @@ worker-pairwise self-check path when no recorded user trace is available.
     ready without treating it as an end-to-end performance assertion.
 - `scripts/perf/macos.sh`
   - Runs `scripts/perf/local.sh`, then runs `scripts/smoke/macos.sh`.
-  - That means the native-host HUD-follow smoke plus recorded-live-trace scroll-capture replay.
+  - That means the native-host HUD-follow smoke, native visual contract smoke, plus
+    recorded-live-trace scroll-capture replay.
   - Use this only on a dedicated logged-in macOS desktop session with the expected Screen
     Recording and automation permissions.
 
@@ -103,6 +106,15 @@ Dedicated macOS smoke:
 - Covers the native-host HUD-follow desktop path. The hard follow gate uses active pointer-movement
   cadence (`live_chrome.active_layer_chrome_render_gap`) rather than startup, Tab-expand, or close
   transition gaps.
+- Interpret cadence metrics by class:
+  - display-bound visual presentation metrics are gated against
+    `min(active display maximum refresh rate, 120 Hz)`, so a `60 Hz` monitor has a `16.67 ms`
+    visible-frame budget.
+  - sampling metrics such as `live_chrome.sample_refresh_gap` are gated against fixed `120 Hz`
+    / `8.33 ms` while the live HUD/loupe is active, even on a `60 Hz` monitor.
+  - live-to-frozen handoff timing is a one-shot latency path: use `snapshotSource`,
+    `snapshotWaitMs`, `presentMs`, and `frozen_first_display_handoff` together, and do not treat a
+    delayed post-latch ScreenCaptureKit frame as permission to delay the toolbar.
 - Scroll-capture correctness is now exercised by deterministic replay.
 - Is meant for dedicated-host or manual validation, not a flaky shared-runner PR gate.
 
@@ -127,6 +139,19 @@ Dedicated macOS smoke:
   regressed.
 - `scripts/perf/macos.sh` failures with healthy local benches:
   suspect live overlay cadence, desktop-session conditions, or smoke-harness environment drift.
+- `scripts/smoke/native-visual-contract-macos.sh` failures:
+  treat them as native-host visual or behavior contract regressions. The smoke runs Liquid Glass and
+  Classic Glass cases, screenshots rsnap's own frozen overlay, and verifies frozen handoff timing,
+  toolbar visibility, Liquid toolbar content draw, material selection, and that live-to-frozen did
+  not display a pending half-frame before the complete frozen UI. It also samples outside the
+  selection during release so a disappearing/reappearing scrim fails even if the final screenshot
+  looks correct. The Liquid path keeps the stricter handoff threshold; the Classic path allows a
+  wider first-frame budget because blur/material work can be heavier while still catching material
+  disappearance and gross handoff regressions. The Classic blur may settle immediately after the
+  first visible frozen toolbar frame so toolbar availability stays responsive.
+  If toolbar visibility is correct but release feels delayed, compare `snapshotWaitMs` and
+  `presentMs`: `snapshotWaitMs` indicates frame-source waiting, while `presentMs` indicates
+  synchronous frozen-frame/material installation before the first visible frozen frame.
 
 ## Related docs
 

--- a/docs/runbook/telemetry-debugging.md
+++ b/docs/runbook/telemetry-debugging.md
@@ -113,7 +113,14 @@ warm sampling, window snapshots, or overlay show timing.
 
 If the chain stops at `capture_timing.freeze_commit_failed`, inspect
 `FrozenFrameAuthority` entries for ScreenCaptureKit content lookup, stream start, or first
-frame timing.
+frame timing. On static desktops, successful freezes may report `snapshotSource=latest_unchanged`;
+that is expected when no post-latch ScreenCaptureKit frame was emitted because the excluded overlay
+was the only thing moving.
+Fast freezes should usually report `snapshotSource=authority_latest` or `live_sampler_latest`.
+Those sources mean the release handoff used an already-warm frame instead of waiting for another
+ScreenCaptureKit frame. If `snapshotSource=window_list_below_overlay` appears in release-handoff
+telemetry, treat it as a regression: full-monitor window-list capture is too slow and visually
+inconsistent for the first frozen frame.
 
 If `capture_timing.copy_capture` is slow, compare `captureImageMs`, `makeImageMs`, and
 `writePasteboardMs` before changing capture code.

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -38,10 +38,15 @@ This contract applies to performance tracking for actively rendered rsnap surfac
 This contract does not require idle surfaces to redraw continuously when there is no interaction
 or animation.
 
-## Active render cadence contract
+## Cadence classes
 
-For actively rendered rsnap UI and overlay paths, target cadence is derived from the active
-display:
+rsnap tracks two different cadence classes. They must not be collapsed into one number during
+implementation, telemetry review, or smoke interpretation.
+
+### Display-bound presentation cadence
+
+Visible presentation is constrained by the active display. For actively rendered UI and overlay
+paths that the user sees on screen, target cadence is:
 
 `min(active display maximum refresh rate, 120 Hz)`
 
@@ -50,8 +55,9 @@ Practical meaning:
 - On a `120 Hz` or faster display, the target frame budget is `8.33 ms`.
 - On a `60 Hz` display, the target frame budget is `16.67 ms`.
 - If the display refresh rate is unavailable, rsnap uses the conservative `60 Hz` fallback.
-- Position-only live chrome following may sample up to `120 Hz` even on a `60 Hz` display, but
-  content refresh and acceptance gates are judged against the active display target.
+- A `60 Hz` panel cannot physically display `120` distinct visual updates per second. On that
+  hardware, the visual contract is one responsive update per display frame, not impossible
+  `8.33 ms` presentation.
 
 Target frame budget:
 
@@ -59,6 +65,41 @@ Target frame budget:
 | --- | --- |
 | `120 Hz` | `8.33 ms` |
 | `60 Hz` | `16.67 ms` |
+
+Display-bound surfaces include:
+
+- live overlay, HUD, loupe, and selection chrome presentation
+- frozen toolbar and frozen selection chrome presentation
+- CALayer/AppKit frame-clock metrics such as `live_chrome.frame_tick_gap`,
+  `live_chrome.layer_chrome_render_gap`, and `live_chrome.active_layer_chrome_render_gap`
+
+### Fixed 120 Hz sampling and state cadence
+
+Sampling and state feeds are not limited by what the display can present. While the relevant live
+surface is active, these paths target `120 Hz` / `8.33 ms` even on a `60 Hz` display:
+
+- live color RGB sampling, including stationary pointer sampling over dynamic backgrounds
+- loupe patch sampling
+- internal sample-feed refresh metrics such as `live_chrome.sample_refresh_gap`
+- input-state ingestion or prediction work where a faster internal feed avoids missed visible
+  frames
+
+The user may only see the latest sampled value on the next display frame, but the backing value
+must still be refreshed at the fixed sampling cadence so dynamic content does not appear stale.
+
+### One-shot handoff latency
+
+Mode transitions are not continuous cadence loops, but they are user-visible. The live-to-frozen
+release handoff must avoid waiting for a future ScreenCaptureKit frame when an already-warm frame
+is available. The intended path is:
+
+1. use an already-warm frozen-authority or live-sampler frame immediately,
+2. present the frozen frame, toolbar, and scrim in one continuous handoff,
+3. perform cleanup such as secondary-window collapse after the first frozen frame is installed.
+
+The handoff must not show a pending half-frame, remove/re-add the outside-selection scrim, or
+delay toolbar visibility on a static desktop just because ScreenCaptureKit has not emitted a new
+post-latch frame.
 
 This cadence contract is normative even when current logs or smoke harnesses use coarser warning
 thresholds.
@@ -90,9 +131,9 @@ Surface:
 - live cursor sample apply path
 
 Primary metrics:
-- effective active redraw cadence against the active display target frame budget
+- effective active redraw cadence against the display-bound target frame budget
 - phase timings for redraw-related work
-- live sample apply latency
+- live sample cadence and apply latency against the fixed `120 Hz` sampling target
 
 Diagnostic signals:
 - `overlay.window_renderer_acquire_frame`
@@ -118,6 +159,12 @@ Primary metrics:
 Required measurement style:
 - dedicated macOS smoke today, with deterministic component baselines added only when they measure
   the native-host path directly
+
+Current coarse smoke surfaces:
+- `scripts/smoke/native-hud-follow-macos.sh` for live HUD/loupe follow cadence
+- `scripts/smoke/native-visual-contract-macos.sh` for live-to-frozen handoff, toolbar visibility
+  and content draw, self-screenshot readiness, no pending-frame/no-scrim-drop flash, and Liquid
+  Glass versus Classic Glass material contract
 
 ### Scenario 3: scroll-capture and image-processing hot paths
 
@@ -164,7 +211,7 @@ The current overlay runtime already exposes several useful diagnostic thresholds
   `live_chrome.update_duration` report external frozen-toolbar/window update paths when those
   paths are active; live HUD/loupe position should not depend on moving external windows.
 - Native-host `live_chrome.frame_tick_gap` reports the active live-frame clock interval. It should
-  cluster around the active display target budget during live capture.
+  cluster around the display-bound target budget during live capture.
 - Native-host `live_chrome.layer_render_duration` reports the in-overlay CALayer presentation path
   for live/frozen preview rendering when live chrome is not moved as separate windows.
 - Native-host `live_chrome.layer_chrome_render_duration` reports the in-overlay HUD/loupe content
@@ -176,8 +223,8 @@ The current overlay runtime already exposes several useful diagnostic thresholds
   and close transitions do not mask or invent moving-pointer regressions.
 - Native-host `live_chrome.sample_refresh_gap` reports the color/loupe sampling feed cadence while
   live capture is active.
-- Native-host `live_chrome.sample_refresh_gap` is gated against the pointer/sample target cadence,
-  which may run at `120 Hz` even when the active display target is `60 Hz`.
+- Native-host `live_chrome.sample_refresh_gap` is gated against the fixed `120 Hz` sampling target,
+  even when the active display target is `60 Hz`.
 
 These values are useful for diagnosis, but they are not the full performance contract:
 
@@ -188,19 +235,17 @@ These values are useful for diagnosis, but they are not the full performance con
 
 ## Current cadence implementation status
 
-The current contract treats display refresh-rate discovery as part of cadence derivation.
-Implementation status should be judged against the active target:
+Implementation status should be judged against the cadence class for the surface being measured:
 
-- active interaction paths must target `min(active display maximum refresh rate, 120 Hz)`
-- live chrome position-only following may poll up to `120 Hz` to avoid one missed timer becoming a
-  visible multi-frame stall
-- content sampling, color sampling, and loupe patch refresh must stay on the pointer/sample target
-  cadence while the live HUD/loupe is visible, including stationary pointers over dynamic
-  backgrounds; movement may be coalesced to that cadence, but not intentionally downsampled
+- visible interaction paths must target `min(active display maximum refresh rate, 120 Hz)`
+- sampling paths must target fixed `120 Hz` while active, including stationary pointers over
+  dynamic backgrounds
+- movement and sampling work may be coalesced to the relevant cadence, but must not be
+  intentionally downsampled below that cadence class
 
 Remaining performance work should focus on measurement coverage, redraw localization, benchmark
-baselines, and removing any refresh-rate-derived cadence paths before claiming contract
-compliance.
+baselines, and keeping display-bound presentation metrics separate from fixed-120Hz sampling
+metrics before claiming contract compliance.
 
 ## Minimum artifact set for contract compliance
 

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -99,6 +99,14 @@ Do not encode values into the event name; emit values as fields.
 - Boolean values use `true` or `false`.
 - Pixel dimensions use `width` and `height`.
 - OS display identifiers use `displayID`.
+- Frozen capture frame provenance uses `snapshotSource`; `post_token` means ScreenCaptureKit
+  produced a frame after the frozen latch, `latest_unchanged` means no newer frame arrived
+  and the current stream's latest same-sequence frame was used for an unchanged/static desktop,
+  `authority_latest` means the frozen-authority stream's already-warm frame was used immediately
+  for the release handoff, `live_sampler_latest` means the already-warm live sampler supplied the
+  release-time monitor frame. The release handoff must not use a synchronous full-monitor
+  `CGWindowList` capture as a first-frame fallback because that path can add visible latency and
+  can differ subtly from the live ScreenCaptureKit frame in window shadow/framing treatment.
 - Rust identifiers use snake_case unless they are mirroring existing platform names.
 
 ## Capture Correlation

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -17,6 +17,7 @@ struct FrozenFrameSnapshot {
 	let image: CGImage
 	let sequence: UInt64
 	let capturedAtUptime: TimeInterval
+	let source: String
 
 	func ageMilliseconds(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Double {
 		max(0, now - capturedAtUptime) * 1_000
@@ -127,23 +128,34 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 
 		stateLock.lock()
 		let unchanged = activeDisplayIDs == targetIDs && displayTargets == nextTargets
+		let streamsCoverTargets = Set(streams.keys) == targetIDs
+		let setupInProgressForTargets = setupDisplayIDs == targetIDs
 		displayTargets = nextTargets
-		if unchanged, !streams.isEmpty, !refreshContentFilter {
+		if unchanged, streamsCoverTargets || setupInProgressForTargets {
 			updateTelemetryContextLocked(
 				captureID: captureID,
 				source: source,
 				startedAtUptime: setupStartedAt,
 				targetIDs: targetIDs
 			)
+			let requestGeneration = generation
 			stateLock.unlock()
+			if refreshContentFilter, streamsCoverTargets {
+				refreshContentFilters(
+					for: targets,
+					generation: requestGeneration,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: setupStartedAt
+				)
+			}
 			return
 		}
 		generation &+= 1
 		let requestGeneration = generation
 		activeDisplayIDs = targetIDs
 		setupDisplayIDs = targetIDs
-		latestFrames =
-			refreshContentFilter ? [:] : latestFrames.filter { targetIDs.contains($0.key) }
+		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
 		updateTelemetryContextLocked(
 			captureID: captureID,
 			source: source,
@@ -158,6 +170,22 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			staleStream.stop()
 		}
 
+		configureStreamsFromShareableContent(
+			targets: targets,
+			generation: requestGeneration,
+			captureID: captureID,
+			source: source,
+			startedAtUptime: setupStartedAt
+		)
+	}
+
+	private func configureStreamsFromShareableContent(
+		targets: [DisplayTarget],
+		generation requestGeneration: UInt64,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval
+	) {
 		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) {
 			[weak self] content, error in
 			guard let self else {
@@ -177,7 +205,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
 					captureID: captureID,
 					source: source,
-					totalMilliseconds: NativeHostTelemetry.milliseconds(since: setupStartedAt),
+					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
 					success: false,
 					displayCount: targets.count,
 					windowCount: 0
@@ -188,7 +216,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
 				captureID: captureID,
 				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: setupStartedAt),
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
 				success: true,
 				displayCount: content.displays.count,
 				windowCount: content.windows.count
@@ -199,6 +227,89 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 				generation: requestGeneration,
 				captureID: captureID,
 				source: source
+			)
+		}
+	}
+
+	private func refreshContentFilters(
+		for targets: [DisplayTarget],
+		generation requestGeneration: UInt64,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval
+	) {
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) {
+			[weak self] content, error in
+			guard let self else {
+				return
+			}
+			guard self.isCurrentGeneration(requestGeneration) else {
+				return
+			}
+			guard let content else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_lookup_failed",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: String(describing: error)
+				)
+				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+					captureID: captureID,
+					source: source,
+					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+					success: false,
+					displayCount: targets.count,
+					windowCount: 0
+				)
+				return
+			}
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: true,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+			for target in targets {
+				guard let filter = Self.contentFilter(for: target, in: content) else {
+					continue
+				}
+				self.updateContentFilter(
+					filter,
+					displayID: target.displayID,
+					generation: requestGeneration,
+					captureID: captureID,
+					source: source
+				)
+			}
+		}
+	}
+
+	private func updateContentFilter(
+		_ filter: SCContentFilter,
+		displayID: CGDirectDisplayID,
+		generation requestGeneration: UInt64,
+		captureID: UInt64,
+		source: String
+	) {
+		stateLock.lock()
+		let stream = generation == requestGeneration ? streams[displayID]?.stream : nil
+		stateLock.unlock()
+		guard let stream else {
+			return
+		}
+		stream.updateContentFilter(filter) { error in
+			guard let error else {
+				return
+			}
+			NativeHostTelemetry.frozenAuthorityWarning(
+				"frozen_authority.content_filter_update_failed",
+				captureID: captureID,
+				source: source,
+				displayID: displayID,
+				error: String(describing: error)
 			)
 		}
 	}
@@ -253,10 +364,20 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			return nil
 		}
 		let minimumSequence = token?.minSequence ?? 0
+		var source = "post_token"
 		var record = freshRecordLocked(displayID: displayID, minimumSequence: minimumSequence)
 		while record == nil, Date() < deadline {
 			stateLock.wait(until: deadline)
 			record = freshRecordLocked(displayID: displayID, minimumSequence: minimumSequence)
+		}
+		if record == nil,
+			let fallbackRecord = unchangedRecordLocked(
+				displayID: displayID,
+				minimumSequence: minimumSequence
+			)
+		{
+			record = fallbackRecord
+			source = "latest_unchanged"
 		}
 		stateLock.unlock()
 
@@ -268,7 +389,29 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			displayFrame: record.displayFrame,
 			image: image,
 			sequence: record.sequence,
-			capturedAtUptime: record.capturedAtUptime
+			capturedAtUptime: record.capturedAtUptime,
+			source: source
+		)
+	}
+
+	func latestSnapshot(containing point: CGPoint) -> FrozenFrameSnapshot? {
+		stateLock.lock()
+		let displayID = displayTargets.first(where: { $0.value.frame.contains(point) })?.key
+		let record = displayID.flatMap {
+			freshRecordLocked(displayID: $0, minimumSequence: 0)
+		}
+		stateLock.unlock()
+
+		guard let record, let image = Self.makeImage(from: record.pixelBuffer) else {
+			return nil
+		}
+		return FrozenFrameSnapshot(
+			displayID: record.displayID,
+			displayFrame: record.displayFrame,
+			image: image,
+			sequence: record.sequence,
+			capturedAtUptime: record.capturedAtUptime,
+			source: "authority_latest"
 		)
 	}
 
@@ -287,6 +430,17 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		return nil
 	}
 
+	private func unchangedRecordLocked(displayID: CGDirectDisplayID, minimumSequence: UInt64)
+		-> FrameRecord?
+	{
+		guard minimumSequence > 0, let record = latestFrames[displayID],
+			record.sequence == minimumSequence
+		else {
+			return nil
+		}
+		return record
+	}
+
 	private func configureStreams(
 		content: SCShareableContent,
 		targets: [DisplayTarget],
@@ -294,26 +448,9 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		captureID: UInt64,
 		source: String
 	) {
-		let currentPID = getpid()
-		let excludedApplications = content.applications.filter { $0.processID == currentPID }
-		let excludedWindows = content.windows.filter {
-			$0.owningApplication?.processID == currentPID
-		}
-
 		for target in targets {
-			guard let display = content.displays.first(where: { $0.displayID == target.displayID })
-			else {
+			guard let filter = Self.contentFilter(for: target, in: content) else {
 				continue
-			}
-			let filter: SCContentFilter
-			if !excludedApplications.isEmpty {
-				filter = SCContentFilter(
-					display: display,
-					excludingApplications: excludedApplications,
-					exceptingWindows: []
-				)
-			} else {
-				filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
 			}
 
 			let output = FrozenFrameStreamOutput(
@@ -364,6 +501,29 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			}
 		}
 		finishSetup(generation: requestGeneration)
+	}
+
+	private static func contentFilter(
+		for target: DisplayTarget,
+		in content: SCShareableContent
+	) -> SCContentFilter? {
+		guard let display = content.displays.first(where: { $0.displayID == target.displayID })
+		else {
+			return nil
+		}
+		let currentPID = getpid()
+		let excludedApplications = content.applications.filter { $0.processID == currentPID }
+		if !excludedApplications.isEmpty {
+			return SCContentFilter(
+				display: display,
+				excludingApplications: excludedApplications,
+				exceptingWindows: []
+			)
+		}
+		let excludedWindows = content.windows.filter {
+			$0.owningApplication?.processID == currentPID
+		}
+		return SCContentFilter(display: display, excludingWindows: excludedWindows)
 	}
 
 	private func store(

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
@@ -156,6 +156,25 @@ final class LiveFrameStreamBroker {
 		return nil
 	}
 
+	func cachedMonitorImage(containing point: CGPoint) -> (frame: CGRect, image: CGImage)? {
+		guard let monitor = monitor(containing: point) else {
+			return nil
+		}
+		stateLock.lock()
+		let sampler = self.sampler
+		let encodedMonitor = samplerMonitorSnapshot(for: monitor)
+		stateLock.unlock()
+		guard let sampler else {
+			return nil
+		}
+		guard let snapshot = try? sampler.peekLatestMonitorImage(monitor: encodedMonitor),
+			let image = cgImage(width: snapshot.width, height: snapshot.height, rgba: snapshot.rgba)
+		else {
+			return nil
+		}
+		return (frame: monitor.appKitFrame, image: image)
+	}
+
 	func prime(at point: CGPoint?) {
 		guard let point, let monitor = monitor(containing: point) else {
 			return

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -536,7 +536,7 @@ final class LiveFrameClockDriver: @unchecked Sendable {
 		"live_chrome.frame_tick_gap",
 		category: "LiveChromeTelemetry"
 	)
-	private var timer: Timer?
+	private var timer: DispatchSourceTimer?
 	private var currentTargetFramesPerSecond: Int?
 	private var lastTickUptime: TimeInterval?
 
@@ -550,21 +550,28 @@ final class LiveFrameClockDriver: @unchecked Sendable {
 		}
 
 		stop()
-		let timer = Timer(
-			timeInterval: NativeHostDisplayRefresh.timerInterval(
-				forTargetFramesPerSecond: sanitizedTarget),
-			repeats: true
-		) { [weak self] _ in
+		let timer = DispatchSource.makeTimerSource(queue: .main)
+		let intervalNanoseconds = max(
+			1,
+			Int(
+				(NativeHostDisplayRefresh.timerInterval(
+					forTargetFramesPerSecond: sanitizedTarget) * 1_000_000_000.0)
+					.rounded())
+		)
+		timer.schedule(
+			deadline: .now(),
+			repeating: .nanoseconds(intervalNanoseconds),
+			leeway: .nanoseconds(0)
+		)
+		timer.setEventHandler { [weak self] in
 			self?.tick()
 		}
-		timer.tolerance = 0
 		stateLock.lock()
 		self.timer = timer
 		currentTargetFramesPerSecond = sanitizedTarget
 		lastTickUptime = nil
 		stateLock.unlock()
-		RunLoop.main.add(timer, forMode: .common)
-		timer.fire()
+		timer.resume()
 	}
 
 	private func tick() {
@@ -591,7 +598,7 @@ final class LiveFrameClockDriver: @unchecked Sendable {
 		currentTargetFramesPerSecond = nil
 		lastTickUptime = nil
 		stateLock.unlock()
-		timer.invalidate()
+		timer.cancel()
 	}
 
 	deinit {
@@ -1567,9 +1574,10 @@ final class LiveOverlayRenderer {
 			transform: nil
 		)
 		let glassEnabled = settings.usesClassicHudGlass
+		let hasNativeLiquidGlass = settings.usesLiquidHudGlass
 		let opacity = CaptureChrome.effectiveHudOpacity(settings: settings)
 		let hasInlineGlass = glassEnabled && glassImage != nil
-		let hasGlass = hasInlineGlass || glassEnabled
+		let hasGlass = hasInlineGlass || glassEnabled || hasNativeLiquidGlass
 
 		container.cornerRadius = cornerRadius
 		container.shadowColor = palette.shadow.cgColor

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -4,6 +4,7 @@ import CoreImage
 import CoreText
 import Darwin
 import Foundation
+import QuartzCore
 import RsnapHostBridge
 import Vision
 
@@ -1333,7 +1334,7 @@ final class CaptureSessionController: NSObject {
 		let token =
 			frozenFrameLatchToken ?? frozenFrameAuthority.latchToken(containing: selectionCenter)
 		let snapshotStartedAt = ProcessInfo.processInfo.systemUptime
-		let frozenFrame = frozenFrameAuthority.snapshot(
+		let frozenFrame = snapshotForFrozenCommit(
 			containing: selectionCenter,
 			after: token,
 			maxWait: frozenFrameLatchWait()
@@ -1363,10 +1364,6 @@ final class CaptureSessionController: NSObject {
 		chromeState.frozenSelectionInteraction = nil
 		chromeState.frozenDisplayFrame = frozenFrame.displayFrame
 		chromeState.frozenDisplayImage = frozenFrame.image
-		let baseImageStartedAt = ProcessInfo.processInfo.systemUptime
-		chromeState.frozenBaseImage = frozenBaseImageFromDisplay(for: selection)
-		let baseImageMilliseconds =
-			NativeHostTelemetry.milliseconds(since: baseImageStartedAt)
 		let hostOwnedFrozenScene = hostOwnedFrozenPresentationScene(for: selection)
 		let presentStartedAt = ProcessInfo.processInfo.systemUptime
 		overlayController?.presentFrozenFirstFrame(
@@ -1375,6 +1372,10 @@ final class CaptureSessionController: NSObject {
 			settings: settingsStore.settings
 		)
 		let presentMilliseconds = NativeHostTelemetry.milliseconds(since: presentStartedAt)
+		let baseImageStartedAt = ProcessInfo.processInfo.systemUptime
+		chromeState.frozenBaseImage = frozenBaseImageFromDisplay(for: selection)
+		let baseImageMilliseconds =
+			NativeHostTelemetry.milliseconds(since: baseImageStartedAt)
 		NativeHostTelemetry.freezeCommitTiming(
 			captureID: captureID,
 			totalMilliseconds: NativeHostTelemetry.milliseconds(since: commitStartedAt),
@@ -1384,6 +1385,7 @@ final class CaptureSessionController: NSObject {
 			frameAgeMilliseconds: frozenFrame.ageMilliseconds(),
 			displayID: frozenFrame.displayID,
 			sequence: frozenFrame.sequence,
+			snapshotSource: frozenFrame.source,
 			hadLatchToken: hadLatchToken,
 			baseReady: chromeState.frozenBaseImage != nil
 		)
@@ -1392,6 +1394,60 @@ final class CaptureSessionController: NSObject {
 
 	private func frozenFrameLatchWait() -> TimeInterval {
 		min(0.040, max(0.018, NativeHostDisplayRefresh.frameInterval * 2.5))
+	}
+
+	private func snapshotForFrozenCommit(
+		containing point: CGPoint,
+		after token: FrozenFrameLatchToken?,
+		maxWait: TimeInterval
+	) -> FrozenFrameSnapshot? {
+		if let snapshot = frozenFrameAuthority.latestSnapshot(containing: point) {
+			return snapshot
+		}
+		if let snapshot = liveSamplerSnapshotForFrozenCommit(near: point, allowsWait: false) {
+			return snapshot
+		}
+		if let snapshot = frozenFrameAuthority.snapshot(
+			containing: point,
+			after: token,
+			maxWait: maxWait
+		) {
+			return snapshot
+		}
+		if let snapshot = liveSamplerSnapshotForFrozenCommit(near: point, allowsWait: true) {
+			return snapshot
+		}
+		return nil
+	}
+
+	private func liveSamplerSnapshotForFrozenCommit(
+		near point: CGPoint,
+		allowsWait: Bool
+	) -> FrozenFrameSnapshot? {
+		let captured =
+			allowsWait
+			? overlayController?.latestMonitorImage(near: point)
+			: overlayController?.cachedMonitorImage(near: point)
+		guard let captured
+		else {
+			return nil
+		}
+		let displayID =
+			NSScreen.screens.first(where: { $0.frame.contains(point) })
+			.flatMap(Self.displayID(for:)) ?? 0
+		return FrozenFrameSnapshot(
+			displayID: displayID,
+			displayFrame: captured.frame,
+			image: captured.image,
+			sequence: 0,
+			capturedAtUptime: ProcessInfo.processInfo.systemUptime,
+			source: "live_sampler_latest"
+		)
+	}
+
+	private static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+		(screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+			.uint32Value
 	}
 
 	private func hostOwnedFrozenPresentationScene(for selection: CGRect) -> SceneSnapshot {
@@ -2283,10 +2339,7 @@ final class CaptureOverlayController {
 		windowSnapshotFeed.start(
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
 		chromeSampleFeed.start(
-			targetFramesPerSecond: NativeHostDisplayRefresh.pointerFollowFramesPerSecond(
-				for: focusedWindow?.screen
-					?? NSScreen.screens.first(where: { $0.frame.contains(focusPoint) })
-			))
+			targetFramesPerSecond: NativeHostDisplayRefresh.samplingFramesPerSecond())
 		chromeSampleFeed.updateDemand(
 			point: focusPoint,
 			sidePixels: 1,
@@ -2332,14 +2385,16 @@ final class CaptureOverlayController {
 			return
 		}
 
-		primaryWindow.disableScreenUpdatesUntilFlush()
 		primaryWindow.hostView.installFrozenFirstFrame(
 			scene: scene,
 			chrome: chrome,
-			settings: settings
+			settings: settings,
+			rendersPendingFrame: false
 		)
-		primaryWindow.displayIfNeeded()
-		prepareFrozenPresentation(for: selection)
+		primaryWindow.hostView.finishFrozenFirstFrameInstall()
+		DispatchQueue.main.async { [weak self] in
+			self?.prepareFrozenPresentation(for: selection)
+		}
 	}
 
 	func focusWindow(at point: CGPoint) {
@@ -2423,17 +2478,10 @@ final class CaptureOverlayController {
 		liveFrameStream.latestMonitorImage(containing: point)
 	}
 
-	fileprivate func currentMonitorImageBelowOverlay(
+	fileprivate func cachedMonitorImage(
 		near point: CGPoint
 	) -> (frame: CGRect, image: CGImage)? {
-		guard
-			let source = frozenCaptureJobSource(near: point),
-			let monitorFrame = NSScreen.screens.first(where: { $0.frame.contains(point) })?.frame,
-			let image = Self.captureImageBelowOverlay(in: monitorFrame, source: source)
-		else {
-			return nil
-		}
-		return (frame: monitorFrame, image: image)
+		liveFrameStream.cachedMonitorImage(containing: point)
 	}
 
 	fileprivate func updateLivePreviewDemand(
@@ -2781,6 +2829,7 @@ final class CaptureHostView: NSView {
 		private var settings = NativeHostSettings.defaults
 		private var hoveredToolbarAction: ToolbarItemKind?
 		private var items: [Item] = []
+		var didDraw: (() -> Void)?
 
 		override var isOpaque: Bool { false }
 
@@ -2788,12 +2837,13 @@ final class CaptureHostView: NSView {
 			nil
 		}
 
+		@discardableResult
 		func update(
 			theme: CaptureChromeTheme,
 			settings: NativeHostSettings,
 			hoveredToolbarAction: ToolbarItemKind?,
 			items: [Item]
-		) {
+		) -> Bool {
 			let changed =
 				self.theme != theme || self.settings != settings
 				|| self.hoveredToolbarAction != hoveredToolbarAction || self.items != items
@@ -2804,6 +2854,7 @@ final class CaptureHostView: NSView {
 			if changed {
 				needsDisplay = true
 			}
+			return changed
 		}
 
 		override func draw(_ dirtyRect: NSRect) {
@@ -2845,6 +2896,7 @@ final class CaptureHostView: NSView {
 					context: context
 				)
 			}
+			didDraw?()
 		}
 
 		private func drawToolbarGlyph(
@@ -2968,10 +3020,10 @@ final class CaptureHostView: NSView {
 	private let loupeMaterialView = PassthroughVisualEffectView(frame: .zero)
 	private var hudLiquidGlassView: NSView?
 	private var loupeLiquidGlassView: NSView?
-	private var lastLiveLiquidGlassUpdateUptime: TimeInterval = 0
 	private var toolbarLiquidGlassView: NSView?
 	private var toolbarLiquidGlassContentView: FrozenToolbarRenderView?
 	private var frozenToolbarLiquidGlassVisible = false
+	private var frozenToolbarLiquidGlassContentDrawn = false
 	private var trackingAreaRef: NSTrackingArea?
 	private var hoveredToolbarAction: ToolbarItemKind?
 	private var lastCursorPresentation: CursorPresentation?
@@ -2988,6 +3040,9 @@ final class CaptureHostView: NSView {
 	private var sampleUpdatedLiveChromeRenderInProgress = false
 	private var pendingFrozenFirstDisplay = false
 	private var frozenFirstDisplayCompletionQueued = false
+	private var frozenFirstDisplayHandoffStartedAt: TimeInterval?
+	private var frozenFirstDisplayPendingFrameDisplayed = false
+	private var defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
 	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
 	private var latestLiveChromeSample: LiveChromeSample?
 	private var latestLiveRgbSample: RGBSample?
@@ -3037,6 +3092,9 @@ final class CaptureHostView: NSView {
 		let transitioningToFrozen = previousMode == .live && scene.mode == .frozen
 		if scene.mode != .frozen {
 			frozenFirstDisplayCompletionQueued = false
+			frozenFirstDisplayHandoffStartedAt = nil
+			frozenFirstDisplayPendingFrameDisplayed = false
+			defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
 		}
 		self.scene = scene
 		self.chrome = chrome
@@ -3070,6 +3128,7 @@ final class CaptureHostView: NSView {
 			liveHighlightedWindowPreview = nil
 			if transitioningToFrozen {
 				pendingFrozenFirstDisplay = true
+				frozenFirstDisplayHandoffStartedAt = ProcessInfo.processInfo.systemUptime
 			}
 		}
 		refreshHoveredToolbarAction()
@@ -3122,19 +3181,80 @@ final class CaptureHostView: NSView {
 			return
 		}
 		window?.disableScreenUpdatesUntilFlush()
-		window?.displayIfNeeded()
 		finishFrozenFirstDisplayHandoff()
 	}
 
 	private func finishFrozenFirstDisplayHandoff() {
+		let handoffStartedAt = frozenFirstDisplayHandoffStartedAt
 		pendingFrozenFirstDisplay = false
 		frozenFirstDisplayCompletionQueued = false
+		frozenFirstDisplayHandoffStartedAt = nil
+		let pendingFrameDisplayed = frozenFirstDisplayPendingFrameDisplayed
+		frozenFirstDisplayPendingFrameDisplayed = false
+		let deferredClassicToolbarGlass =
+			defersFrozenToolbarClassicGlassUntilAfterFirstDisplay
+		let materialStartedAt = ProcessInfo.processInfo.systemUptime
+		updateChromeMaterialViews()
+		let materialMilliseconds = NativeHostTelemetry.milliseconds(since: materialStartedAt)
+		let shouldStopLiveRenderer = scene.mode != .live
 		lastLivePreviewSnapshot = nil
-		if scene.mode != .live {
+		window?.disableScreenUpdatesUntilFlush()
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		let liveRendererStopStartedAt = ProcessInfo.processInfo.systemUptime
+		if shouldStopLiveRenderer {
 			liveRenderer.stop()
 		}
+		let liveRendererStopMilliseconds =
+			NativeHostTelemetry.milliseconds(since: liveRendererStopStartedAt)
 		needsDisplay = true
+		let displayStartedAt = ProcessInfo.processInfo.systemUptime
 		displayIfNeeded()
+		let displayMilliseconds = NativeHostTelemetry.milliseconds(since: displayStartedAt)
+		CATransaction.commit()
+		if deferredClassicToolbarGlass {
+			DispatchQueue.main.async { [weak self] in
+				guard let self else {
+					return
+				}
+				self.defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
+				self.needsDisplay = true
+			}
+		}
+		if let handoffStartedAt {
+			emitFrozenFirstDisplayHandoffTiming(
+				startedAt: handoffStartedAt,
+				materialMilliseconds: materialMilliseconds,
+				liveRendererStopMilliseconds: liveRendererStopMilliseconds,
+				displayMilliseconds: displayMilliseconds,
+				pendingFrameDisplayed: pendingFrameDisplayed
+			)
+		}
+	}
+
+	private func emitFrozenFirstDisplayHandoffTiming(
+		startedAt: TimeInterval,
+		materialMilliseconds: Double,
+		liveRendererStopMilliseconds: Double,
+		displayMilliseconds: Double,
+		pendingFrameDisplayed: Bool
+	) {
+		NativeHostTelemetry.frozenFirstDisplayHandoffTiming(
+			captureID: controller?.activeTelemetryCaptureID ?? 0,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAt),
+			materialMilliseconds: materialMilliseconds,
+			liveRendererStopMilliseconds: liveRendererStopMilliseconds,
+			displayMilliseconds: displayMilliseconds,
+			toolbarVisible: frozenToolbarVisibleForContract(),
+			toolbarItemCount: visibleToolbarItems().count,
+			usesLiquidHudGlass: settings.usesLiquidHudGlass,
+			usesClassicHudGlass: settings.usesClassicHudGlass,
+			liquidGlassAvailable: LiveChromeGlassMaterialSupport.isLiquidGlassAvailable,
+			frozenToolbarLiquidGlassVisible: frozenToolbarLiquidGlassVisible,
+			frozenToolbarLiquidGlassContentDrawn: frozenToolbarLiquidGlassContentDrawn,
+			frozenSelectionEditable: chrome.frozenSelectionEditable,
+			pendingFrameDisplayed: pendingFrameDisplayed
+		)
 	}
 
 	fileprivate func seedInitialState(
@@ -3148,6 +3268,9 @@ final class CaptureHostView: NSView {
 		liveHoverChromeSuppressed = false
 		pendingFrozenFirstDisplay = false
 		frozenFirstDisplayCompletionQueued = false
+		frozenFirstDisplayHandoffStartedAt = nil
+		frozenFirstDisplayPendingFrameDisplayed = false
+		defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
 		lastLivePreviewSnapshot = nil
 		if scene.mode == .live {
 			seedLivePointerPreview(scene.pointer, recordsInputLatency: false)
@@ -3195,7 +3318,8 @@ final class CaptureHostView: NSView {
 	fileprivate func installFrozenFirstFrame(
 		scene: SceneSnapshot,
 		chrome: CaptureChromeState,
-		settings: NativeHostSettings
+		settings: NativeHostSettings,
+		rendersPendingFrame: Bool = true
 	) {
 		let retainedLivePreview = lastLivePreviewSnapshot ?? currentLivePreviewSnapshot()
 		self.scene = scene
@@ -3204,16 +3328,22 @@ final class CaptureHostView: NSView {
 		liveHoverChromeSuppressed = false
 		pendingFrozenFirstDisplay = retainedLivePreview != nil || scene.frozenSelection != nil
 		frozenFirstDisplayCompletionQueued = false
+		frozenFirstDisplayHandoffStartedAt =
+			pendingFrozenFirstDisplay ? ProcessInfo.processInfo.systemUptime : nil
+		frozenFirstDisplayPendingFrameDisplayed = false
+		defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = settings.usesClassicHudGlass
 		lastLivePreviewSnapshot = retainedLivePreview
 		resetLivePointerPreview()
 		liveHighlightedWindowPreview = nil
 		refreshHoveredToolbarAction()
 		syncVisibleCursor()
-		updateChromeMaterialViews()
 		needsDisplay = true
 		controller?.updateLivePreviewDemand(
 			point: nil, settings: settings, includeLoupePatch: false)
-		liveRenderer.renderNow()
+		if rendersPendingFrame {
+			frozenFirstDisplayPendingFrameDisplayed = pendingFrozenFirstDisplay
+			liveRenderer.renderNow()
+		}
 	}
 
 	fileprivate func finishFrozenFirstFrameInstall() {
@@ -3408,13 +3538,19 @@ final class CaptureHostView: NSView {
 			break
 		case .frozen:
 			if pendingFrozenFirstDisplay {
+				frozenFirstDisplayPendingFrameDisplayed = true
 				scheduleFrozenFirstFrameInstallCompletionIfNeeded()
 				return
 			}
-			drawFrozenDisplaySurface(in: context)
 			if let selection = localFrozenSelectionRect().map(pixelAlignedSelectionRect) {
+				drawFrozenDisplaySurface(in: context)
+				let toolbarScrimExclusionPath = frozenToolbarScrimExclusionPath(for: selection)
 				drawSelectionScrim(
-					for: selection, in: context, alpha: CaptureChrome.frozenScrimAlpha)
+					for: selection,
+					in: context,
+					alpha: CaptureChrome.frozenScrimAlpha,
+					excluding: toolbarScrimExclusionPath
+				)
 				drawDashedSelectionBorder(
 					around: selection,
 					in: context,
@@ -3466,6 +3602,7 @@ final class CaptureHostView: NSView {
 
 		context.saveGState()
 		context.interpolationQuality = .high
+		context.clip(to: bounds)
 		context.draw(image, in: frame)
 		context.restoreGState()
 	}
@@ -3904,7 +4041,12 @@ final class CaptureHostView: NSView {
 		context.stroke(centerRect)
 	}
 
-	private func drawSelectionScrim(for focusRect: CGRect, in context: CGContext, alpha: CGFloat) {
+	private func drawSelectionScrim(
+		for focusRect: CGRect,
+		in context: CGContext,
+		alpha: CGFloat,
+		excluding exclusionPath: CGPath? = nil
+	) {
 		let scrimColor = NSColor(calibratedWhite: 0, alpha: alpha)
 		let visibleFocusRect = focusRect.intersection(bounds)
 		if visibleFocusRect.isNull || visibleFocusRect.width <= 0 || visibleFocusRect.height <= 0 {
@@ -3916,6 +4058,9 @@ final class CaptureHostView: NSView {
 		let path = CGMutablePath()
 		path.addRect(bounds)
 		path.addRect(visibleFocusRect)
+		if let exclusionPath {
+			path.addPath(exclusionPath)
+		}
 		context.saveGState()
 		context.setFillColor(scrimColor.cgColor)
 		context.addPath(path)
@@ -4321,6 +4466,37 @@ final class CaptureHostView: NSView {
 		return FrozenToolbarLayout(frame: frame, items: itemFrames)
 	}
 
+	private func frozenToolbarScrimExclusionPath(for selection: CGRect) -> CGPath? {
+		guard settings.usesLiquidHudGlass, frozenToolbarLiquidGlassVisible,
+			let toolbarFrame = toolbarLayout(for: selection)?.frame
+		else {
+			return nil
+		}
+		let visibleSelection = selection.intersection(bounds)
+		if !visibleSelection.isNull, toolbarFrame.intersects(visibleSelection) {
+			return nil
+		}
+		return CGPath(
+			roundedRect: toolbarFrame,
+			cornerWidth: CaptureChrome.hudCornerRadius,
+			cornerHeight: CaptureChrome.hudCornerRadius,
+			transform: nil
+		)
+	}
+
+	private func frozenToolbarVisibleForContract() -> Bool {
+		guard scene.mode == .frozen,
+			let selection = localFrozenSelectionRect(),
+			toolbarLayout(for: selection) != nil
+		else {
+			return false
+		}
+		if settings.usesLiquidHudGlass {
+			return frozenToolbarLiquidGlassVisible && frozenToolbarLiquidGlassContentDrawn
+		}
+		return true
+	}
+
 	private func visibleToolbarItems() -> [ToolbarItem] {
 		scene.toolbarItems.map { item in
 			var item = item
@@ -4382,7 +4558,10 @@ final class CaptureHostView: NSView {
 	}
 
 	private func drawFrozenToolbar(for selection: CGRect, in context: CGContext) {
-		guard !settings.usesLiquidHudGlass || !frozenToolbarLiquidGlassVisible else {
+		guard
+			!settings.usesLiquidHudGlass || !frozenToolbarLiquidGlassVisible
+				|| !frozenToolbarLiquidGlassContentDrawn
+		else {
 			return
 		}
 		guard let layout = toolbarLayout(for: selection) else {
@@ -4396,7 +4575,8 @@ final class CaptureHostView: NSView {
 			theme: theme,
 			strongShadow: false,
 			surfaceKind: .toolbar,
-			allowsLiquidGlassClearFill: false
+			allowsLiquidGlassClearFill: false,
+			allowsClassicGlass: !defersFrozenToolbarClassicGlassUntilAfterFirstDisplay
 		)
 
 		for item in layout.items {
@@ -4705,7 +4885,7 @@ final class CaptureHostView: NSView {
 	private func moveLiveChromeLayers() {
 		let frames = currentLiveChromeLayerFrames()
 		hideClassicGlassMaterialViews()
-		hideLiveLiquidGlassViews()
+		moveExistingLiveLiquidGlassViews(hudFrame: frames.hud, loupeFrame: frames.loupe)
 		liveRenderer.moveLiveChrome(hudFrame: frames.hud, loupeFrame: frames.loupe)
 	}
 
@@ -4840,6 +5020,9 @@ final class CaptureHostView: NSView {
 		deferredLiveShutdownWorkItem?.cancel()
 		deferredLiveShutdownWorkItem = nil
 		pendingFrozenFirstDisplay = false
+		frozenFirstDisplayHandoffStartedAt = nil
+		frozenFirstDisplayPendingFrameDisplayed = false
+		defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
 		lastLivePreviewSnapshot = nil
 		hideLiveLiquidGlassViews()
 		guard scene.mode != .live else {
@@ -4992,7 +5175,8 @@ final class CaptureHostView: NSView {
 		theme: CaptureChromeTheme,
 		strongShadow: Bool,
 		surfaceKind: GlassSurfaceKind,
-		allowsLiquidGlassClearFill: Bool = true
+		allowsLiquidGlassClearFill: Bool = true,
+		allowsClassicGlass: Bool = true
 	) {
 		let palette = CaptureChrome.palette(for: theme, settings: settings)
 		let pillPath = NSBezierPath(
@@ -5001,7 +5185,8 @@ final class CaptureHostView: NSView {
 			yRadius: CaptureChrome.hudCornerRadius
 		)
 		let glassImage =
-			settings.usesClassicHudGlass ? glassPatch(for: surfaceKind, frame: frame) : nil
+			settings.usesClassicHudGlass && allowsClassicGlass
+			? glassPatch(for: surfaceKind, frame: frame) : nil
 		let hasGlass = glassImage != nil
 		context.saveGState()
 		if strongShadow {
@@ -5166,7 +5351,15 @@ final class CaptureHostView: NSView {
 		view.wantsLayer = true
 		view.layer?.cornerRadius = CaptureChrome.hudCornerRadius
 		view.layer?.masksToBounds = true
-		view.layer?.zPosition = 2_000
+		view.layer?.zPosition = 50
+	}
+
+	private func configureFrozenToolbarContentView(_ view: FrozenToolbarRenderView) {
+		view.isHidden = true
+		view.wantsLayer = true
+		view.layer?.backgroundColor = NSColor.clear.cgColor
+		view.layer?.isOpaque = false
+		view.layer?.zPosition = 310
 	}
 
 	private func updateChromeMaterialViews() {
@@ -5174,10 +5367,20 @@ final class CaptureHostView: NSView {
 			hideClassicGlassMaterialViews()
 		}
 		if scene.mode != .live || !settings.usesLiquidHudGlass || chrome.hostLocalFrozenSelecting {
-			hideLiveLiquidGlassViews()
+			hideLiveLiquidGlassViews(removing: false)
 		}
-		updateFrozenToolbarLiquidGlassView()
-		updateLiveChromeBackdrops()
+		if scene.mode == .frozen {
+			updateFrozenToolbarLiquidGlassView()
+		} else if frozenToolbarLiquidGlassVisible {
+			hideFrozenToolbarLiquidGlassView()
+		} else if scene.mode == .live, settings.usesLiquidHudGlass {
+			prewarmFrozenToolbarLiquidGlassViewIfNeeded()
+		}
+		if scene.mode == .live {
+			updateLiveChromeBackdrops()
+		} else {
+			controller?.updateLiveChromeBackdrops(nil)
+		}
 	}
 
 	private func hideClassicGlassMaterialViews() {
@@ -5185,8 +5388,38 @@ final class CaptureHostView: NSView {
 		loupeMaterialView.isHidden = true
 	}
 
-	private func updateLiveLiquidGlassViews(hudFrame _: CGRect?, loupeFrame _: CGRect?) {
-		hideLiveLiquidGlassViews()
+	private func updateLiveLiquidGlassViews(hudFrame: CGRect?, loupeFrame: CGRect?) {
+		guard scene.mode == .live, settings.usesLiquidHudGlass, !chrome.hostLocalFrozenSelecting
+		else {
+			hideLiveLiquidGlassViews(removing: false)
+			return
+		}
+		updateLiveLiquidGlassView(&hudLiquidGlassView, frame: hudFrame)
+		updateLiveLiquidGlassView(&loupeLiquidGlassView, frame: loupeFrame)
+	}
+
+	private func moveExistingLiveLiquidGlassViews(hudFrame: CGRect?, loupeFrame: CGRect?) {
+		guard scene.mode == .live, settings.usesLiquidHudGlass, !chrome.hostLocalFrozenSelecting
+		else {
+			hideLiveLiquidGlassViews(removing: false)
+			return
+		}
+		moveExistingLiveLiquidGlassView(hudLiquidGlassView, frame: hudFrame)
+		moveExistingLiveLiquidGlassView(loupeLiquidGlassView, frame: loupeFrame)
+	}
+
+	private func moveExistingLiveLiquidGlassView(_ view: NSView?, frame: CGRect?) {
+		guard let view else {
+			return
+		}
+		guard let frame else {
+			view.isHidden = true
+			return
+		}
+		if view.frame != frame {
+			view.frame = frame
+		}
+		view.isHidden = false
 	}
 
 	private func updateLiveLiquidGlassView(_ view: inout NSView?, frame: CGRect?) {
@@ -5212,12 +5445,44 @@ final class CaptureHostView: NSView {
 		activeView.isHidden = false
 	}
 
-	private func hideLiveLiquidGlassViews() {
-		hudLiquidGlassView?.removeFromSuperview()
-		loupeLiquidGlassView?.removeFromSuperview()
-		hudLiquidGlassView = nil
-		loupeLiquidGlassView = nil
-		lastLiveLiquidGlassUpdateUptime = 0
+	private func prewarmFrozenToolbarLiquidGlassViewIfNeeded() {
+		guard toolbarLiquidGlassView == nil else {
+			return
+		}
+		guard let createdView = LiveChromeLiquidGlassBridge.makeGlassView() else {
+			return
+		}
+		configureChromeLiquidGlassView(createdView)
+		LiveChromeLiquidGlassBridge.update(createdView, settings: settings)
+		createdView.frame = .zero
+		createdView.isHidden = true
+		createdView.layer?.zPosition = 300
+		addSubview(createdView, positioned: .below, relativeTo: nil)
+		toolbarLiquidGlassView = createdView
+
+		let contentView = FrozenToolbarRenderView(frame: .zero)
+		configureFrozenToolbarContentView(contentView)
+		contentView.didDraw = { [weak self] in
+			guard let self, !self.frozenToolbarLiquidGlassContentDrawn else {
+				return
+			}
+			self.frozenToolbarLiquidGlassContentDrawn = true
+			self.needsDisplay = true
+		}
+		LiveChromeLiquidGlassBridge.setContentView(contentView, on: createdView)
+		toolbarLiquidGlassContentView = contentView
+	}
+
+	private func hideLiveLiquidGlassViews(removing: Bool = true) {
+		if removing {
+			hudLiquidGlassView?.removeFromSuperview()
+			loupeLiquidGlassView?.removeFromSuperview()
+			hudLiquidGlassView = nil
+			loupeLiquidGlassView = nil
+		} else {
+			hudLiquidGlassView?.isHidden = true
+			loupeLiquidGlassView?.isHidden = true
+		}
 	}
 
 	private func updateFrozenToolbarLiquidGlassView() {
@@ -5234,23 +5499,43 @@ final class CaptureHostView: NSView {
 		updateLiveLiquidGlassView(&toolbarLiquidGlassView, frame: layout.frame)
 		guard let toolbarLiquidGlassView else {
 			frozenToolbarLiquidGlassVisible = false
+			frozenToolbarLiquidGlassContentDrawn = false
+			toolbarLiquidGlassContentView?.removeFromSuperview()
+			toolbarLiquidGlassContentView = nil
 			if wasVisible {
 				needsDisplay = true
 			}
 			return
 		}
+		toolbarLiquidGlassView.layer?.zPosition = 300
 		if toolbarLiquidGlassContentView == nil {
 			toolbarLiquidGlassContentView = FrozenToolbarRenderView(
 				frame: CGRect(origin: .zero, size: layout.frame.size))
+			if let toolbarLiquidGlassContentView {
+				configureFrozenToolbarContentView(toolbarLiquidGlassContentView)
+			}
+			toolbarLiquidGlassContentView?.didDraw = { [weak self] in
+				guard let self, !self.frozenToolbarLiquidGlassContentDrawn else {
+					return
+				}
+				self.frozenToolbarLiquidGlassContentDrawn = true
+				self.needsDisplay = true
+			}
+			frozenToolbarLiquidGlassContentDrawn = false
 		}
 		guard let toolbarLiquidGlassContentView else {
 			return
 		}
 		let contentFrame = CGRect(origin: .zero, size: layout.frame.size)
 		if toolbarLiquidGlassContentView.frame != contentFrame {
+			let previousSize = toolbarLiquidGlassContentView.frame.size
 			toolbarLiquidGlassContentView.frame = contentFrame
+			if previousSize != contentFrame.size {
+				frozenToolbarLiquidGlassContentDrawn = false
+				toolbarLiquidGlassContentView.needsDisplay = true
+			}
 		}
-		toolbarLiquidGlassContentView.update(
+		if toolbarLiquidGlassContentView.update(
 			theme: chromeTheme(),
 			settings: settings,
 			hoveredToolbarAction: hoveredToolbarAction,
@@ -5265,12 +5550,26 @@ final class CaptureHostView: NSView {
 					selected: item.selected
 				)
 			}
-		)
+		) {
+			frozenToolbarLiquidGlassContentDrawn = false
+		}
 		LiveChromeLiquidGlassBridge.setContentView(
 			toolbarLiquidGlassContentView, on: toolbarLiquidGlassView)
+		toolbarLiquidGlassContentView.isHidden = false
+		flushFrozenToolbarLiquidGlassContentIfNeeded()
 		frozenToolbarLiquidGlassVisible = true
 		if !wasVisible {
 			needsDisplay = true
+		}
+	}
+
+	private func flushFrozenToolbarLiquidGlassContentIfNeeded() {
+		guard !frozenToolbarLiquidGlassContentDrawn, let toolbarLiquidGlassContentView else {
+			return
+		}
+		toolbarLiquidGlassContentView.displayIfNeeded()
+		if !frozenToolbarLiquidGlassContentDrawn {
+			toolbarLiquidGlassContentView.display()
 		}
 	}
 
@@ -5280,9 +5579,8 @@ final class CaptureHostView: NSView {
 		if let toolbarLiquidGlassView {
 			LiveChromeLiquidGlassBridge.setContentView(nil, on: toolbarLiquidGlassView)
 		}
-		toolbarLiquidGlassView?.removeFromSuperview()
-		toolbarLiquidGlassView = nil
-		toolbarLiquidGlassContentView = nil
+		toolbarLiquidGlassView?.isHidden = true
+		toolbarLiquidGlassContentView?.isHidden = true
 		if wasVisible {
 			needsDisplay = true
 		}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostDisplayRefresh.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostDisplayRefresh.swift
@@ -20,9 +20,11 @@ enum NativeHostDisplayRefresh {
 	}
 
 	static func pointerFollowFramesPerSecond(for screen: NSScreen?) -> Int {
-		let screenFramesPerSecond = screenMaximumFramesPerSecond(screen)
-		return min(
-			maximumTargetFramesPerSecond, max(screenFramesPerSecond * 2, screenFramesPerSecond))
+		targetFramesPerSecond(for: screen)
+	}
+
+	static func samplingFramesPerSecond() -> Int {
+		maximumTargetFramesPerSecond
 	}
 
 	static func frameInterval(for screen: NSScreen?) -> TimeInterval {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -210,11 +210,12 @@ enum NativeHostTelemetry {
 		frameAgeMilliseconds: Double,
 		displayID: UInt32,
 		sequence: UInt64,
+		snapshotSource: String,
 		hadLatchToken: Bool,
 		baseReady: Bool
 	) {
 		captureTimingLogger.info(
-			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.freeze_commit totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) snapshotWaitMs=\(snapshotWaitMilliseconds, format: .fixed(precision: 2), privacy: .public) baseImageMs=\(baseImageMilliseconds, format: .fixed(precision: 2), privacy: .public) presentMs=\(presentMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) displayID=\(displayID, privacy: .public) sequence=\(sequence, privacy: .public) hadLatchToken=\(hadLatchToken, privacy: .public) baseReady=\(baseReady, privacy: .public)"
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.freeze_commit totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) snapshotWaitMs=\(snapshotWaitMilliseconds, format: .fixed(precision: 2), privacy: .public) baseImageMs=\(baseImageMilliseconds, format: .fixed(precision: 2), privacy: .public) presentMs=\(presentMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) displayID=\(displayID, privacy: .public) sequence=\(sequence, privacy: .public) snapshotSource=\(snapshotSource, privacy: .public) hadLatchToken=\(hadLatchToken, privacy: .public) baseReady=\(baseReady, privacy: .public)"
 		)
 	}
 
@@ -226,6 +227,27 @@ enum NativeHostTelemetry {
 	) {
 		captureTimingLogger.warning(
 			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.freeze_commit_failed totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) snapshotWaitMs=\(snapshotWaitMilliseconds, format: .fixed(precision: 2), privacy: .public) hadLatchToken=\(hadLatchToken, privacy: .public)"
+		)
+	}
+
+	static func frozenFirstDisplayHandoffTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		materialMilliseconds: Double,
+		liveRendererStopMilliseconds: Double,
+		displayMilliseconds: Double,
+		toolbarVisible: Bool,
+		toolbarItemCount: Int,
+		usesLiquidHudGlass: Bool,
+		usesClassicHudGlass: Bool,
+		liquidGlassAvailable: Bool,
+		frozenToolbarLiquidGlassVisible: Bool,
+		frozenToolbarLiquidGlassContentDrawn: Bool,
+		frozenSelectionEditable: Bool,
+		pendingFrameDisplayed: Bool
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.frozen_first_display_handoff totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) materialMs=\(materialMilliseconds, format: .fixed(precision: 2), privacy: .public) liveRendererStopMs=\(liveRendererStopMilliseconds, format: .fixed(precision: 2), privacy: .public) displayMs=\(displayMilliseconds, format: .fixed(precision: 2), privacy: .public) toolbarVisible=\(toolbarVisible, privacy: .public) toolbarItemCount=\(toolbarItemCount, privacy: .public) usesLiquidHudGlass=\(usesLiquidHudGlass, privacy: .public) usesClassicHudGlass=\(usesClassicHudGlass, privacy: .public) liquidGlassAvailable=\(liquidGlassAvailable, privacy: .public) frozenToolbarLiquidGlassVisible=\(frozenToolbarLiquidGlassVisible, privacy: .public) frozenToolbarLiquidGlassContentDrawn=\(frozenToolbarLiquidGlassContentDrawn, privacy: .public) frozenSelectionEditable=\(frozenSelectionEditable, privacy: .public) pendingFrameDisplayed=\(pendingFrameDisplayed, privacy: .public)"
 		)
 	}
 

--- a/scripts/smoke/lib/live-hud-mouse-path.swift
+++ b/scripts/smoke/lib/live-hud-mouse-path.swift
@@ -93,6 +93,19 @@ func sleepUntil(_ deadline: UInt64) {
 	_ = mach_wait_until(deadline)
 }
 
+func writeMaskProbePhase(_ phase: String) {
+	guard let path = ProcessInfo.processInfo.environment["MASK_PROBE_PHASE_PATH"], !path.isEmpty
+	else {
+		return
+	}
+	do {
+		try phase.write(toFile: path, atomically: true, encoding: .utf8)
+	} catch {
+		fputs("failed to write mask probe phase: \(error)\n", stderr)
+		exit(1)
+	}
+}
+
 func moveSmooth(points: [CGPoint], durationMs: Int, rateHz: Int, cycles: Int) {
 	let driver = MousePathDriver()
 	let minX = points.map(\.x).min() ?? 0
@@ -119,8 +132,56 @@ func moveSmooth(points: [CGPoint], durationMs: Int, rateHz: Int, cycles: Int) {
 	}
 }
 
+func dragRegion(points: [CGPoint], durationMs: Int, rateHz: Int) {
+	let driver = MousePathDriver()
+	let start = points[0]
+	let end = points[1]
+	let sampleCount = max(2, durationMs * max(rateHz, 1) / 1_000)
+	let stepTicks = machTicks(forNanoseconds: UInt64(1_000_000_000 / max(rateHz, 1)))
+	writeMaskProbePhase("pre")
+	driver.mouseEvent(.mouseMoved, at: start)
+	sleepMs(120)
+	driver.mouseEvent(.leftMouseDown, at: start)
+	writeMaskProbePhase("dragging")
+	sleepMs(16)
+	let dragStart = mach_absolute_time()
+
+	for index in 1...sampleCount {
+		let progress = CGFloat(index) / CGFloat(sampleCount)
+		let point = CGPoint(
+			x: start.x + (end.x - start.x) * progress,
+			y: start.y + (end.y - start.y) * progress
+		)
+		driver.mouseEvent(.leftMouseDragged, at: point)
+		sleepUntil(dragStart + UInt64(index) * stepTicks)
+	}
+	driver.mouseEvent(.leftMouseUp, at: end)
+	writeMaskProbePhase("released")
+	if ProcessInfo.processInfo.environment["MASK_PROBE_PHASE_PATH"] != nil {
+		sleepMs(useconds_t(readInt("MASK_PROBE_POST_RELEASE_MS", default: 360)))
+	}
+}
+
+func clickPoint(points: [CGPoint]) {
+	let driver = MousePathDriver()
+	let point = points[0]
+	driver.mouseEvent(.mouseMoved, at: point)
+	sleepMs(120)
+	driver.mouseEvent(.leftMouseDown, at: point)
+	sleepMs(24)
+	driver.mouseEvent(.leftMouseUp, at: point)
+}
+
 let points = readPoints("PATH_POINTS")
 switch readString("PATH_MODE", default: "smooth") {
+case "click-point":
+	clickPoint(points: points)
+case "drag-region":
+	dragRegion(
+		points: points,
+		durationMs: readInt("PATH_DURATION_MS", default: 260),
+		rateHz: readInt("PATH_RATE_HZ", default: 120)
+	)
 case "waypoints":
 	moveAlong(
 		points: points,

--- a/scripts/smoke/lib/mask-probe-capture.swift
+++ b/scripts/smoke/lib/mask-probe-capture.swift
@@ -1,0 +1,237 @@
+import CoreGraphics
+import CoreMedia
+import CoreVideo
+import Foundation
+import ScreenCaptureKit
+
+func readInt(_ key: String, default value: Int) -> Int {
+	if let raw = ProcessInfo.processInfo.environment[key], let parsed = Int(raw) {
+		return parsed
+	}
+	return value
+}
+
+func readRequiredString(_ key: String) -> String {
+	guard let value = ProcessInfo.processInfo.environment[key], !value.isEmpty else {
+		fputs("missing env \(key)\n", stderr)
+		exit(2)
+	}
+	return value
+}
+
+func readOptionalString(_ key: String) -> String? {
+	guard let value = ProcessInfo.processInfo.environment[key], !value.isEmpty else {
+		return nil
+	}
+	return value
+}
+
+func readRequiredPoint(_ key: String) -> CGPoint {
+	let raw = readRequiredString(key)
+	let parts = raw.split(separator: ",")
+	guard parts.count == 2, let x = Double(parts[0]), let y = Double(parts[1]) else {
+		fputs("invalid point env for \(key): \(raw)\n", stderr)
+		exit(2)
+	}
+	return CGPoint(x: x, y: y)
+}
+
+@available(macOS 12.3, *)
+final class MaskProbeCapture: NSObject, SCStreamOutput {
+	private struct Sample {
+		let phase: String
+		let uptime: TimeInterval
+		let luminance: Double
+	}
+
+	private let outputPath: String
+	private let phasePath: String
+	private let readyPath: String?
+	private let point: CGPoint
+	private let displayFrame: CGRect
+	private let lock = NSLock()
+	private var samples: [Sample] = []
+	private var wroteReady = false
+
+	init(
+		outputPath: String,
+		phasePath: String,
+		readyPath: String?,
+		point: CGPoint,
+		displayFrame: CGRect
+	) {
+		self.outputPath = outputPath
+		self.phasePath = phasePath
+		self.readyPath = readyPath
+		self.point = point
+		self.displayFrame = displayFrame
+	}
+
+	func stream(
+		_ stream: SCStream,
+		didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+		of type: SCStreamOutputType
+	) {
+		guard type == .screen,
+			sampleBuffer.isValid,
+			let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
+			let luminance = sampleLuminance(pixelBuffer)
+		else {
+			return
+		}
+		lock.lock()
+		samples.append(
+			Sample(
+				phase: currentPhase(),
+				uptime: ProcessInfo.processInfo.systemUptime,
+				luminance: luminance
+			)
+		)
+		writeReadyIfNeeded()
+		lock.unlock()
+	}
+
+	func writeSamples() {
+		lock.lock()
+		let samples = self.samples
+		lock.unlock()
+
+		var output = "phase,uptime,luminance\n"
+		for sample in samples {
+			output +=
+				"\(sample.phase),\(String(format: "%.6f", sample.uptime)),\(String(format: "%.6f", sample.luminance))\n"
+		}
+		do {
+			try output.write(toFile: outputPath, atomically: true, encoding: .utf8)
+		} catch {
+			fputs("failed to write mask probe samples: \(error)\n", stderr)
+			exit(1)
+		}
+	}
+
+	private func currentPhase() -> String {
+		guard
+			let phase = try? String(contentsOfFile: phasePath, encoding: .utf8)
+				.trimmingCharacters(in: .whitespacesAndNewlines),
+			!phase.isEmpty
+		else {
+			return "pre"
+		}
+		return phase
+	}
+
+	private func writeReadyIfNeeded() {
+		guard !wroteReady, let readyPath else {
+			return
+		}
+		wroteReady = true
+		do {
+			try "ready\n".write(toFile: readyPath, atomically: true, encoding: .utf8)
+		} catch {
+			fputs("failed to write mask probe ready marker: \(error)\n", stderr)
+		}
+	}
+
+	private func sampleLuminance(_ pixelBuffer: CVPixelBuffer) -> Double? {
+		CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+		defer {
+			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
+		}
+		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+			return nil
+		}
+		let width = CVPixelBufferGetWidth(pixelBuffer)
+		let height = CVPixelBufferGetHeight(pixelBuffer)
+		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+		guard width > 0, height > 0, displayFrame.width > 0, displayFrame.height > 0 else {
+			return nil
+		}
+
+		let normalizedX = (point.x - displayFrame.minX) / displayFrame.width
+		let normalizedY = (point.y - displayFrame.minY) / displayFrame.height
+		let centerX = Int((normalizedX * CGFloat(width)).rounded())
+		let centerY = Int((normalizedY * CGFloat(height)).rounded())
+		let radius = 2
+		let minX = max(0, centerX - radius)
+		let maxX = min(width - 1, centerX + radius)
+		let minY = max(0, centerY - radius)
+		let maxY = min(height - 1, centerY + radius)
+
+		let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
+		var total = 0.0
+		var count = 0
+		for y in minY...maxY {
+			for x in minX...maxX {
+				let index = y * bytesPerRow + x * 4
+				let blue = Double(pointer[index]) / 255.0
+				let green = Double(pointer[index + 1]) / 255.0
+				let red = Double(pointer[index + 2]) / 255.0
+				total += 0.2126 * red + 0.7152 * green + 0.0722 * blue
+				count += 1
+			}
+		}
+		return count > 0 ? total / Double(count) : nil
+	}
+}
+
+@available(macOS 12.3, *)
+func runMaskProbe() async throws {
+	let outputPath = readRequiredString("MASK_PROBE_OUTPUT")
+	let phasePath = readRequiredString("MASK_PROBE_PHASE_PATH")
+	let readyPath = readOptionalString("MASK_PROBE_READY_PATH")
+	let point = readRequiredPoint("MASK_PROBE_POINT")
+	let durationMs = readInt("MASK_PROBE_DURATION_MS", default: 1_400)
+	let rateHz = readInt("MASK_PROBE_RATE_HZ", default: 60)
+
+	let content = try await SCShareableContent.current
+	guard
+		let display = content.displays.first(where: { $0.displayID == CGMainDisplayID() })
+			?? content.displays.first
+	else {
+		fputs("missing shareable display for mask probe\n", stderr)
+		exit(1)
+	}
+
+	let configuration = SCStreamConfiguration()
+	configuration.width = display.width
+	configuration.height = display.height
+	configuration.pixelFormat = kCVPixelFormatType_32BGRA
+	configuration.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(max(1, rateHz)))
+	configuration.queueDepth = 4
+
+	let filter = SCContentFilter(display: display, excludingWindows: [])
+	let capture = MaskProbeCapture(
+		outputPath: outputPath,
+		phasePath: phasePath,
+		readyPath: readyPath,
+		point: point,
+		displayFrame: display.frame
+	)
+	let stream = SCStream(filter: filter, configuration: configuration, delegate: nil)
+	try stream.addStreamOutput(
+		capture,
+		type: .screen,
+		sampleHandlerQueue: DispatchQueue(label: "ink.hack.rsnap.mask-probe", qos: .userInteractive)
+	)
+	try await stream.startCapture()
+	try await Task.sleep(nanoseconds: UInt64(max(1, durationMs)) * 1_000_000)
+	try await stream.stopCapture()
+	capture.writeSamples()
+}
+
+if #available(macOS 12.3, *) {
+	let semaphore = DispatchSemaphore(value: 0)
+	Task {
+		do {
+			try await runMaskProbe()
+		} catch {
+			fputs("mask probe failed: \(error)\n", stderr)
+			exit(1)
+		}
+		semaphore.signal()
+	}
+	semaphore.wait()
+} else {
+	fputs("mask probe requires macOS 12.3 or newer\n", stderr)
+	exit(1)
+}

--- a/scripts/smoke/lib/native-hud-follow-summary.py
+++ b/scripts/smoke/lib/native-hud-follow-summary.py
@@ -117,7 +117,7 @@ else:
     target_hz = 120
     latest_capture_id = None
 target_budget_ms = 1_000 / target_hz
-sample_target_hz = max(target_hz, min(target_hz * 2, 120))
+sample_target_hz = 120
 display_gap_budget_ms = target_budget_ms + 1.0
 sample_gap_budget_ms = (1_000 / sample_target_hz) + 1.0
 print(

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -1,0 +1,300 @@
+import os
+import re
+import statistics
+import struct
+import sys
+import time
+from datetime import datetime
+
+
+def threshold(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return float(raw)
+
+
+def mode_threshold(name: str, default: float) -> float:
+    mode_name = f"{expected_mode.upper()}_{name}"
+    raw = os.environ.get(mode_name)
+    if raw is not None and raw != "":
+        return float(raw)
+    return threshold(name, default)
+
+
+def fields(line: str) -> dict[str, str]:
+    parsed = {}
+    for token in line.split():
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        parsed[key] = value.strip('"')
+    return parsed
+
+
+def bool_field(values: dict[str, str], key: str) -> bool:
+    return values.get(key, "").lower() == "true"
+
+
+def float_field(values: dict[str, str], key: str) -> float:
+    return float(values.get(key, "0"))
+
+
+def int_field(values: dict[str, str], key: str) -> int:
+    return int(values.get(key, "0"))
+
+
+def png_dimensions(path: str) -> tuple[int, int] | None:
+    with open(path, "rb") as handle:
+        header = handle.read(24)
+    if len(header) < 24 or header[:8] != b"\x89PNG\r\n\x1a\n" or header[12:16] != b"IHDR":
+        return None
+    return struct.unpack(">II", header[16:24])
+
+
+def line_epoch(line: str) -> float | None:
+    try:
+        parsed = datetime.strptime(line[:23], "%Y-%m-%d %H:%M:%S.%f")
+    except ValueError:
+        return None
+    return time.mktime(parsed.timetuple()) + parsed.microsecond / 1_000_000
+
+
+if len(sys.argv) != 2:
+    print("usage: native-visual-contract-summary.py <all.log>", file=sys.stderr)
+    sys.exit(2)
+
+log_path = sys.argv[1]
+expected_mode = os.environ.get("EXPECTED_HUD_GLASS_MODE", "liquid").strip().lower()
+screenshot_path = os.environ.get("VISUAL_SCREENSHOT_PATH", "").strip()
+mask_probe_path = os.environ.get("MASK_PROBE_PATH", "").strip()
+expected_min_freeze_commits = int(os.environ.get("EXPECTED_MIN_FREEZE_COMMITS", "1") or "1")
+smoke_started_epoch = float(os.environ.get("SMOKE_STARTED_EPOCH", "0") or "0")
+run_id_re = re.compile(r"runID=([^ ]+)")
+event_re = re.compile(r"event=([^ ]+)")
+
+with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+    lines = [
+        line
+        for line in handle
+        if smoke_started_epoch <= 0
+        or (line_epoch(line) is not None and line_epoch(line) >= smoke_started_epoch - 1)
+    ]
+
+latest_start_run_id = None
+latest_any_run_id = None
+for line in lines:
+    run_id_match = run_id_re.search(line)
+    if not run_id_match:
+        continue
+    run_id = run_id_match.group(1)
+    latest_any_run_id = run_id
+    event_match = event_re.search(line)
+    if event_match and event_match.group(1) == "capture_timing.start_capture":
+        latest_start_run_id = run_id
+
+latest_run_id = latest_start_run_id or latest_any_run_id
+if latest_run_id is None:
+    print("[smoke] FAIL missing native host runID", file=sys.stderr)
+    sys.exit(1)
+
+print(f"[smoke] runID {latest_run_id}")
+
+events: dict[str, list[dict[str, str]]] = {}
+for line in lines:
+    run_id_match = run_id_re.search(line)
+    if not run_id_match or run_id_match.group(1) != latest_run_id:
+        continue
+    event_match = event_re.search(line)
+    if not event_match:
+        continue
+    events.setdefault(event_match.group(1), []).append(fields(line))
+
+failures: list[str] = []
+for required_event in [
+    "capture_timing.start_capture",
+    "capture_timing.freeze_commit",
+    "capture_timing.frozen_first_display_handoff",
+]:
+    if required_event not in events:
+        failures.append(f"missing event {required_event}")
+
+freeze_commit = events.get("capture_timing.freeze_commit", [{}])[-1]
+handoff = events.get("capture_timing.frozen_first_display_handoff", [{}])[-1]
+freeze_commits = events.get("capture_timing.freeze_commit", [])
+freeze_commit_failures = events.get("capture_timing.freeze_commit_failed", [])
+
+if len(freeze_commits) < expected_min_freeze_commits:
+    failures.append(
+        "freeze commit count too small: "
+        f"{len(freeze_commits)} < {expected_min_freeze_commits}"
+    )
+if freeze_commit_failures:
+    failures.append(
+        "freeze commit failure events observed: "
+        f"{len(freeze_commit_failures)}"
+    )
+
+if freeze_commit:
+    total_ms = float_field(freeze_commit, "totalMs")
+    present_ms = float_field(freeze_commit, "presentMs")
+    snapshot_wait_ms = float_field(freeze_commit, "snapshotWaitMs")
+    base_ready = bool_field(freeze_commit, "baseReady")
+    snapshot_source = freeze_commit.get("snapshotSource", "unknown")
+    max_total_ms = threshold("MAX_FREEZE_COMMIT_MS", 90.0)
+    max_present_ms = mode_threshold(
+        "MAX_FREEZE_PRESENT_MS",
+        55.0 if expected_mode == "classic" else 35.0,
+    )
+    max_snapshot_wait_ms = threshold("MAX_FREEZE_SNAPSHOT_WAIT_MS", 45.0)
+    print(
+        "[smoke] freeze_commit "
+        f"totalMs={total_ms:.2f} presentMs={present_ms:.2f} "
+        f"snapshotWaitMs={snapshot_wait_ms:.2f} snapshotSource={snapshot_source} "
+        f"baseReady={base_ready}"
+    )
+    if total_ms > max_total_ms:
+        failures.append(f"freeze_commit totalMs={total_ms:.2f} exceeds {max_total_ms:.2f}")
+    if present_ms > max_present_ms:
+        failures.append(f"freeze_commit presentMs={present_ms:.2f} exceeds {max_present_ms:.2f}")
+    if snapshot_wait_ms > max_snapshot_wait_ms:
+        failures.append(
+            f"freeze_commit snapshotWaitMs={snapshot_wait_ms:.2f} "
+            f"exceeds {max_snapshot_wait_ms:.2f}"
+        )
+    if snapshot_source == "window_list_below_overlay":
+        failures.append("freeze_commit used synchronous window-list fallback for frozen handoff")
+    if not base_ready:
+        failures.append("freeze_commit did not prepare the frozen base image")
+
+if handoff:
+    total_ms = float_field(handoff, "totalMs")
+    material_ms = float_field(handoff, "materialMs")
+    live_renderer_stop_ms = float_field(handoff, "liveRendererStopMs")
+    display_ms = float_field(handoff, "displayMs")
+    toolbar_visible = bool_field(handoff, "toolbarVisible")
+    toolbar_item_count = int_field(handoff, "toolbarItemCount")
+    uses_liquid = bool_field(handoff, "usesLiquidHudGlass")
+    uses_classic = bool_field(handoff, "usesClassicHudGlass")
+    liquid_available = bool_field(handoff, "liquidGlassAvailable")
+    liquid_toolbar_visible = bool_field(handoff, "frozenToolbarLiquidGlassVisible")
+    liquid_toolbar_content_drawn = bool_field(
+        handoff, "frozenToolbarLiquidGlassContentDrawn"
+    )
+    pending_frame_displayed = bool_field(handoff, "pendingFrameDisplayed")
+    max_handoff_ms = mode_threshold(
+        "MAX_FROZEN_HANDOFF_MS",
+        55.0 if expected_mode == "classic" else 35.0,
+    )
+    print(
+        "[smoke] frozen_handoff "
+        f"totalMs={total_ms:.2f} materialMs={material_ms:.2f} "
+        f"liveRendererStopMs={live_renderer_stop_ms:.2f} displayMs={display_ms:.2f} "
+        f"toolbarVisible={toolbar_visible} "
+        f"toolbarItemCount={toolbar_item_count} usesLiquidHudGlass={uses_liquid} "
+        f"usesClassicHudGlass={uses_classic} liquidGlassAvailable={liquid_available} "
+        f"frozenToolbarLiquidGlassVisible={liquid_toolbar_visible} "
+        f"frozenToolbarLiquidGlassContentDrawn={liquid_toolbar_content_drawn} "
+        f"pendingFrameDisplayed={pending_frame_displayed}"
+    )
+    if total_ms > max_handoff_ms:
+        failures.append(f"frozen_handoff totalMs={total_ms:.2f} exceeds {max_handoff_ms:.2f}")
+    if not toolbar_visible:
+        failures.append("frozen handoff did not make the toolbar visible")
+    if toolbar_item_count < 10:
+        failures.append(f"frozen toolbar item count too small: {toolbar_item_count}")
+    if pending_frame_displayed:
+        failures.append("live-to-frozen handoff displayed a pending frame before the full frozen UI")
+    if expected_mode == "liquid" and liquid_available:
+        if not uses_liquid:
+            failures.append("Liquid Glass is available but frozen handoff did not use it")
+        if not liquid_toolbar_visible:
+            failures.append("Liquid Glass toolbar view was not visible after frozen handoff")
+        if not liquid_toolbar_content_drawn:
+            failures.append("Liquid Glass toolbar content did not draw after frozen handoff")
+    elif expected_mode == "liquid" and not uses_classic:
+        failures.append("Liquid Glass unavailable but classic glass fallback was not active")
+    elif expected_mode == "classic":
+        if not uses_classic:
+            failures.append("Classic Glass mode did not activate the classic blur contract")
+        if uses_liquid or liquid_toolbar_visible:
+            failures.append("Classic Glass mode unexpectedly used Liquid Glass toolbar chrome")
+    elif expected_mode not in {"liquid", "classic"}:
+        failures.append(f"unknown EXPECTED_HUD_GLASS_MODE={expected_mode}")
+
+if screenshot_path:
+    try:
+        size = os.path.getsize(screenshot_path)
+        dimensions = png_dimensions(screenshot_path)
+    except OSError as exc:
+        failures.append(f"visual screenshot missing: {exc}")
+    else:
+        if dimensions is None:
+            failures.append(f"visual screenshot is not a PNG: {screenshot_path}")
+        else:
+            width, height = dimensions
+            print(
+                "[smoke] visual_screenshot "
+                f"path={screenshot_path} width={width} height={height} bytes={size}"
+            )
+            if width < 500 or height < 400:
+                failures.append(f"visual screenshot too small: {width}x{height}")
+            if size < 20_000:
+                failures.append(f"visual screenshot suspiciously small: {size} bytes")
+
+if mask_probe_path:
+    try:
+        with open(mask_probe_path, "r", encoding="utf-8", errors="replace") as handle:
+            rows = [line.strip().split(",") for line in handle if line.strip()]
+    except OSError as exc:
+        failures.append(f"mask probe missing: {exc}")
+    else:
+        values: dict[str, list[float]] = {"dragging": [], "released": []}
+        for row in rows[1:]:
+            if len(row) != 3 or row[0] not in values:
+                continue
+            try:
+                values[row[0]].append(float(row[2]))
+            except ValueError:
+                continue
+        dragging = values["dragging"]
+        released = values["released"]
+        if len(dragging) < 5 or len(released) < 5:
+            failures.append(
+                f"mask probe sample count too small: dragging={len(dragging)} released={len(released)}"
+            )
+        else:
+            stable_dragging = dragging[len(dragging) // 3 :]
+            baseline = statistics.median(stable_dragging)
+            released_min = min(released)
+            released_max = max(released)
+            rise = released_max - baseline
+            drop = baseline - released_min
+            ratio = released_max / max(0.05, baseline)
+            drop_ratio = baseline / max(0.05, released_min)
+            max_rise = threshold("MAX_MASK_LUMINANCE_RISE", 0.12)
+            max_drop = threshold("MAX_MASK_LUMINANCE_DROP", 0.12)
+            max_ratio = threshold("MAX_MASK_LUMINANCE_RATIO", 1.35)
+            print(
+                "[smoke] mask_probe "
+                f"path={mask_probe_path} baseline={baseline:.4f} "
+                f"releasedMin={released_min:.4f} releasedMax={released_max:.4f} "
+                f"drop={drop:.4f} rise={rise:.4f} "
+                f"dropRatio={drop_ratio:.2f} riseRatio={ratio:.2f} "
+                f"draggingSamples={len(dragging)} releasedSamples={len(released)}"
+            )
+            if rise > max_rise and ratio > max_ratio:
+                failures.append(
+                    "live-to-frozen handoff let the outside-selection scrim brighten "
+                    f"(rise={rise:.4f}, ratio={ratio:.2f})"
+                )
+            if drop > max_drop and drop_ratio > max_ratio:
+                failures.append(
+                    "live-to-frozen handoff double-darkened the outside-selection scrim "
+                    f"(drop={drop:.4f}, ratio={drop_ratio:.2f})"
+                )
+
+if failures:
+    for failure in failures:
+        print(f"[smoke] FAIL {failure}", file=sys.stderr)
+    sys.exit(1)

--- a/scripts/smoke/lib/visual-background-window.swift
+++ b/scripts/smoke/lib/visual-background-window.swift
@@ -1,0 +1,31 @@
+import AppKit
+import Foundation
+
+final class VisualBackgroundDelegate: NSObject, NSApplicationDelegate {
+	private var window: NSWindow?
+
+	func applicationDidFinishLaunching(_: Notification) {
+		let frame = NSScreen.main?.frame ?? CGRect(x: 0, y: 0, width: 1280, height: 720)
+		let window = NSWindow(
+			contentRect: frame,
+			styleMask: [.borderless],
+			backing: .buffered,
+			defer: false
+		)
+		window.backgroundColor = NSColor(calibratedWhite: 0.88, alpha: 1)
+		window.isOpaque = true
+		window.ignoresMouseEvents = true
+		window.level = .normal
+		window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+		window.orderFrontRegardless()
+		self.window = window
+		fputs("ready\n", stdout)
+		fflush(stdout)
+	}
+}
+
+let app = NSApplication.shared
+let delegate = VisualBackgroundDelegate()
+app.setActivationPolicy(.accessory)
+app.delegate = delegate
+app.run()

--- a/scripts/smoke/macos.sh
+++ b/scripts/smoke/macos.sh
@@ -10,11 +10,13 @@ Usage: macos.sh
 
 Runs the macOS smoke sequence:
   1. native-host HUD-follow smoke
-  2. recorded live-trace replay in worker-pairwise mode
+  2. native-host frozen visual/behavior contract smoke
+  3. recorded live-trace replay in worker-pairwise mode
 EOF
     exit 0
     ;;
 esac
 
 "$SCRIPT_DIR/native-hud-follow-macos.sh"
+"$SCRIPT_DIR/native-visual-contract-macos.sh"
 "$SCRIPT_DIR/replay-scroll-capture.sh"

--- a/scripts/smoke/native-hud-follow-macos.sh
+++ b/scripts/smoke/native-hud-follow-macos.sh
@@ -21,7 +21,7 @@ Useful overrides:
   PATH_RATE_HZ=120                 smooth path event rate
   PATH_DURATION_MS=2500            smooth path duration
   PATH_CYCLES=3                    smooth path lissajous cycles
-  HUD_FOLLOW_CASES=hud,loupe       run collapsed HUD and expanded loupe phases
+  HUD_FOLLOW_CASES=hud,loupe       run collapsed HUD and expanded loupe cases
   MAX_SAMPLE_REFRESH_GAP_P95_MS    default: pointer/sample target budget + 1ms
   MAX_ACTIVE_LAYER_CHROME_RENDER_GAP_P95_MS default: active display target budget + 1ms
   MAX_LAYER_CHROME_RENDER_DURATION_P95_MS default: active display target budget
@@ -64,19 +64,8 @@ HUD_FOLLOW_CASES="${USER_HUD_FOLLOW_CASES:-hud,loupe}"
 OVERLAY_SETTLE_S="${OVERLAY_SETTLE_S:-0.35}"
 POST_PATH_SETTLE_S="${POST_PATH_SETTLE_S:-0.6}"
 POST_CLOSE_SETTLE_S="${POST_CLOSE_SETTLE_S:-0.25}"
-RSNAP_TELEMETRY_LAST="${RSNAP_TELEMETRY_LAST:-3m}"
+RSNAP_TELEMETRY_LAST="${RSNAP_TELEMETRY_LAST:-10s}"
 export PATH_MODE PATH_DRIVER PATH_DURATION_MS PATH_RATE_HZ PATH_CYCLES RSNAP_TELEMETRY_LAST
-
-"$ROOT_DIR/scripts/build_and_run.sh" verify >/tmp/rsnap-native-hud-follow-build.out
-sleep 0.4
-
-osascript <<'APPLESCRIPT' >/dev/null
-tell application "System Events"
-	key code 7 using option down
-end tell
-APPLESCRIPT
-sleep 0.2
-live_hud_focus_rsnap_overlay
 
 if [[ -z "$DISPLAY_BOUNDS" ]]; then
 	DISPLAY_BOUNDS="$(live_hud_read_main_display_bounds | tr -d ' ')"
@@ -90,17 +79,33 @@ echo "[smoke] path mode: $PATH_MODE driver=$PATH_DRIVER rate_hz=$PATH_RATE_HZ du
 echo "[smoke] cases: $HUD_FOLLOW_CASES"
 echo "[smoke] path points: $PATH_POINTS"
 
-sleep "$OVERLAY_SETTLE_S"
-IFS=',' read -r -a HUD_FOLLOW_CASE_ARRAY <<<"$HUD_FOLLOW_CASES"
-for case_name in "${HUD_FOLLOW_CASE_ARRAY[@]}"; do
-	case_name="$(echo "$case_name" | tr -d '[:space:]')"
+press_capture_hotkey() {
+	osascript <<'APPLESCRIPT' >/dev/null
+tell application "System Events"
+	key code 7 using option down
+end tell
+APPLESCRIPT
+}
+
+run_hud_follow_case() {
+	local case_name="$1"
+
+	"$ROOT_DIR/scripts/build_and_run.sh" verify >/tmp/rsnap-native-hud-follow-build.out
+	sleep 1.0
+	press_capture_hotkey
+	sleep 0.4
+	press_capture_hotkey
+	sleep 0.2
+	live_hud_focus_rsnap_overlay
+	sleep "$OVERLAY_SETTLE_S"
+
 	case "$case_name" in
 		hud)
-			echo "[smoke] phase: hud"
+			echo "[smoke] case: hud"
 			live_hud_run_mouse_path
 			;;
 		loupe)
-			echo "[smoke] phase: loupe"
+			echo "[smoke] case: loupe"
 			live_hud_focus_rsnap_overlay
 			live_hud_press_tab
 			# Let the loupe patch populate once before testing expanded HUD rendering.
@@ -108,19 +113,26 @@ for case_name in "${HUD_FOLLOW_CASE_ARRAY[@]}"; do
 			live_hud_run_mouse_path
 			;;
 		"")
+			return 0
 			;;
 		*)
 			echo "unknown HUD follow case: $case_name" >&2
 			exit 2
 			;;
 	esac
-done
-sleep "$POST_PATH_SETTLE_S"
-live_hud_focus_rsnap_overlay
-live_hud_press_escape >/dev/null 2>&1 || true
-sleep "$POST_CLOSE_SETTLE_S"
+	sleep "$POST_PATH_SETTLE_S"
+	live_hud_focus_rsnap_overlay
+	live_hud_press_escape >/dev/null 2>&1 || true
+	sleep "$POST_CLOSE_SETTLE_S"
 
-OUT_DIR="$("$ROOT_DIR/scripts/telemetry/native-host.sh" collect)"
-echo "[smoke] telemetry: $OUT_DIR"
-python3 "$SCRIPT_DIR/lib/native-hud-follow-summary.py" "$OUT_DIR/all.log"
+	OUT_DIR="$("$ROOT_DIR/scripts/telemetry/native-host.sh" collect)"
+	echo "[smoke] telemetry: $OUT_DIR"
+	python3 "$SCRIPT_DIR/lib/native-hud-follow-summary.py" "$OUT_DIR/all.log"
+}
+
+IFS=',' read -r -a HUD_FOLLOW_CASE_ARRAY <<<"$HUD_FOLLOW_CASES"
+for case_name in "${HUD_FOLLOW_CASE_ARRAY[@]}"; do
+	case_name="$(echo "$case_name" | tr -d '[:space:]')"
+	run_hud_follow_case "$case_name"
+done
 echo "[smoke] PASS"

--- a/scripts/smoke/native-visual-contract-macos.sh
+++ b/scripts/smoke/native-visual-contract-macos.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/smoke/lib/live-hud.sh
+source "$SCRIPT_DIR/lib/live-hud.sh"
+
+usage() {
+	cat <<'EOF'
+Usage: native-visual-contract-macos.sh [--self-check] [--help]
+
+Runs the native macOS visual/behavior contract smoke:
+  1. force representative Liquid Glass and Classic Glass preferences
+  2. build, sign, and launch the native host app
+  3. start capture with Option-X
+  4. drag a frozen selection and release
+  5. capture rsnap's own frozen overlay and gate toolbar/material contract telemetry
+
+Useful overrides:
+  VISUAL_CONTRACT_CASES=liquid,classic
+  REPEATED_CLICK_FREEZES=2
+  DRAG_DURATION_MS=260
+  PATH_RATE_HZ=120
+  MAX_FREEZE_COMMIT_MS=90
+  MAX_FREEZE_PRESENT_MS=35
+  MAX_FREEZE_SNAPSHOT_WAIT_MS=45
+  MAX_FROZEN_HANDOFF_MS=35
+  CLASSIC_MAX_FREEZE_PRESENT_MS=55
+  CLASSIC_MAX_FROZEN_HANDOFF_MS=55
+EOF
+}
+
+case "${1:-}" in
+	--help|-h)
+		usage
+		exit 0
+		;;
+	--self-check)
+		live_hud_self_check
+		exit $?
+		;;
+	"")
+		;;
+	*)
+		usage >&2
+		exit 2
+		;;
+esac
+
+live_hud_self_check
+ROOT_DIR="$(live_hud_repo_root)"
+live_hud_init_environment "$ROOT_DIR"
+
+DRAG_DURATION_MS="${DRAG_DURATION_MS:-260}"
+PATH_RATE_HZ="${PATH_RATE_HZ:-120}"
+VISUAL_CONTRACT_CASES="${VISUAL_CONTRACT_CASES:-liquid,classic}"
+OVERLAY_SETTLE_S="${OVERLAY_SETTLE_S:-0.25}"
+POST_FREEZE_SETTLE_S="${POST_FREEZE_SETTLE_S:-0.25}"
+POST_CLOSE_SETTLE_S="${POST_CLOSE_SETTLE_S:-0.25}"
+REPEATED_CLICK_FREEZES="${REPEATED_CLICK_FREEZES:-2}"
+RSNAP_TELEMETRY_LAST="${RSNAP_TELEMETRY_LAST:-3m}"
+export RSNAP_TELEMETRY_LAST
+
+PREF_DOMAIN="${RSNAP_PREF_DOMAIN:-ink.hack.rsnap}"
+PREF_SNAPSHOT="$(mktemp "${TMPDIR:-/tmp}/rsnap-prefs.XXXXXX.plist")"
+PREF_SNAPSHOT_EXISTS=0
+VISUAL_BACKGROUND_PID=""
+
+restore_preferences() {
+	if [[ -n "$VISUAL_BACKGROUND_PID" ]]; then
+		kill "$VISUAL_BACKGROUND_PID" >/dev/null 2>&1 || true
+	fi
+	if [[ "$PREF_SNAPSHOT_EXISTS" == "1" ]]; then
+		defaults import "$PREF_DOMAIN" "$PREF_SNAPSHOT" >/dev/null 2>&1 || true
+	else
+		for key in captureHotkey hudGlassEnabled hudGlassMode liquidGlassStyle toolbarPlacement loupeSampleSize; do
+			defaults delete "$PREF_DOMAIN" "$key" >/dev/null 2>&1 || true
+		done
+	fi
+	rm -f "$PREF_SNAPSHOT"
+}
+
+if defaults export "$PREF_DOMAIN" "$PREF_SNAPSHOT" >/dev/null 2>&1; then
+	PREF_SNAPSHOT_EXISTS=1
+fi
+trap restore_preferences EXIT
+
+press_capture_hotkey() {
+	osascript <<'APPLESCRIPT' >/dev/null
+tell application "System Events"
+	key code 7 using option down
+end tell
+APPLESCRIPT
+}
+
+capture_visual_screenshot() {
+	local screenshot_path="$1"
+	local attempt
+
+	for attempt in 1 2 3; do
+		if /usr/sbin/screencapture -x "$screenshot_path" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.2
+	done
+	return 1
+}
+
+start_visual_background() {
+	local ready_path="$1"
+	rm -f "$ready_path"
+	swift "$SCRIPT_DIR/lib/visual-background-window.swift" >"$ready_path" &
+	VISUAL_BACKGROUND_PID="$!"
+}
+
+stop_visual_background() {
+	if [[ -n "$VISUAL_BACKGROUND_PID" ]]; then
+		kill "$VISUAL_BACKGROUND_PID" >/dev/null 2>&1 || true
+		VISUAL_BACKGROUND_PID=""
+	fi
+}
+
+wait_visual_background_ready() {
+	local ready_path="$1"
+	local attempt
+
+	for attempt in {1..40}; do
+		if grep -q '^ready$' "$ready_path" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.05
+	done
+	return 1
+}
+
+wait_mask_probe_ready() {
+	local ready_path="$1"
+	local attempt
+
+	for attempt in {1..80}; do
+		if grep -q '^ready$' "$ready_path" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.05
+	done
+	return 1
+}
+
+if [[ -z "$DISPLAY_BOUNDS" ]]; then
+	DISPLAY_BOUNDS="$(live_hud_read_main_display_bounds | tr -d ' ')"
+fi
+if [[ -z "$PATH_POINTS" ]]; then
+	PATH_POINTS="$(
+		python3 - "$DISPLAY_BOUNDS" <<'PY'
+import sys
+
+left, top, right, bottom = map(int, sys.argv[1].replace(" ", "").split(","))
+width = right - left
+height = bottom - top
+if width < 500 or height < 400:
+    raise SystemExit("display too small for native visual contract smoke")
+
+start = (left + width * 38 // 100, top + height * 38 // 100)
+end = (left + width * 62 // 100, top + height * 62 // 100)
+print(f"{start[0]},{start[1]};{end[0]},{end[1]}")
+PY
+	)"
+fi
+
+echo "[smoke] display bounds: $DISPLAY_BOUNDS"
+echo "[smoke] drag points: $PATH_POINTS duration_ms=$DRAG_DURATION_MS rate_hz=$PATH_RATE_HZ"
+
+CLICK_POINTS="$(
+	python3 - "$DISPLAY_BOUNDS" <<'PY'
+import sys
+
+left, top, right, bottom = map(int, sys.argv[1].replace(" ", "").split(","))
+width = right - left
+height = bottom - top
+if width < 500 or height < 400:
+    raise SystemExit("display too small for native visual contract smoke")
+
+x = left + width * 50 // 100
+y = top + height * 50 // 100
+print(f"{x},{y};{x},{y}")
+PY
+)"
+echo "[smoke] click point: ${CLICK_POINTS%%;*} repeated=$REPEATED_CLICK_FREEZES"
+
+configure_case_preferences() {
+	local case_name="$1"
+
+	defaults write "$PREF_DOMAIN" captureHotkey -string Option-X
+	defaults write "$PREF_DOMAIN" hudGlassEnabled -bool true
+	defaults write "$PREF_DOMAIN" liquidGlassStyle -string clear
+	defaults write "$PREF_DOMAIN" toolbarPlacement -string bottom
+	defaults write "$PREF_DOMAIN" loupeSampleSize -string small
+	case "$case_name" in
+		liquid)
+			defaults write "$PREF_DOMAIN" hudGlassMode -string liquid_glass
+			;;
+		classic)
+			defaults write "$PREF_DOMAIN" hudGlassMode -string classic_glass
+			;;
+		*)
+			echo "unknown visual contract case: $case_name" >&2
+			exit 2
+			;;
+	esac
+}
+
+run_visual_case() {
+	local case_name="$1"
+	local case_tmp_dir screenshot_path background_ready_path case_started_epoch out_dir
+
+	case_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/rsnap-visual-${case_name}.XXXXXX")"
+	screenshot_path="$case_tmp_dir/frozen.png"
+	background_ready_path="$case_tmp_dir/background.ready"
+	case_started_epoch="$(date +%s)"
+
+	configure_case_preferences "$case_name"
+	echo "[smoke] case: $case_name"
+	start_visual_background "$background_ready_path"
+	if ! wait_visual_background_ready "$background_ready_path"; then
+		stop_visual_background
+		echo "[smoke] FAIL visual background did not become ready" >&2
+		return 1
+	fi
+	"$ROOT_DIR/scripts/build_and_run.sh" verify >/tmp/rsnap-native-visual-contract-build.out
+	sleep 1.0
+	live_hud_press_escape >/dev/null 2>&1 || true
+
+	for ((click_index = 1; click_index <= REPEATED_CLICK_FREEZES; click_index++)); do
+		echo "[smoke] repeated click freeze $click_index/$REPEATED_CLICK_FREEZES"
+		press_capture_hotkey
+		sleep "$OVERLAY_SETTLE_S"
+		live_hud_focus_rsnap_overlay
+		PATH_MODE=click-point \
+		PATH_DRIVER=event \
+		PATH_POINTS="$CLICK_POINTS" \
+		swift "$(live_hud_cursor_helper)"
+		sleep "$POST_FREEZE_SETTLE_S"
+		live_hud_focus_rsnap_overlay
+		live_hud_press_escape >/dev/null 2>&1 || true
+		sleep "$POST_CLOSE_SETTLE_S"
+	done
+
+	press_capture_hotkey
+	sleep 0.4
+	press_capture_hotkey
+	sleep "$OVERLAY_SETTLE_S"
+	live_hud_focus_rsnap_overlay
+
+	local mask_probe_path mask_probe_phase_path mask_probe_ready_path mask_probe_point mask_probe_pid
+	mask_probe_path="$case_tmp_dir/mask-probe.csv"
+	mask_probe_phase_path="$case_tmp_dir/mask-probe.phase"
+	mask_probe_ready_path="$case_tmp_dir/mask-probe.ready"
+	printf 'pre' >"$mask_probe_phase_path"
+	rm -f "$mask_probe_ready_path"
+	mask_probe_point="$(
+		python3 - "$DISPLAY_BOUNDS" "$PATH_POINTS" <<'PY'
+import sys
+
+left, top, right, bottom = map(int, sys.argv[1].replace(" ", "").split(","))
+start_raw, end_raw = sys.argv[2].split(";")[:2]
+sx, sy = map(float, start_raw.split(","))
+ex, ey = map(float, end_raw.split(","))
+min_x, max_x = sorted((sx, ex))
+min_y, max_y = sorted((sy, ey))
+selection_width = max_x - min_x
+selection_height = max_y - min_y
+sample_x = max_x + max(96, selection_width * 0.18)
+if sample_x > right - 96:
+    sample_x = min_x - max(96, selection_width * 0.18)
+sample_y = min_y + selection_height * 0.45
+sample_x = min(max(sample_x, left + 32), right - 32)
+sample_y = min(max(sample_y, top + 32), bottom - 32)
+print(f"{sample_x:.0f},{sample_y:.0f}")
+PY
+	)"
+
+	MASK_PROBE_OUTPUT="$mask_probe_path" \
+	MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
+	MASK_PROBE_READY_PATH="$mask_probe_ready_path" \
+	MASK_PROBE_POINT="$mask_probe_point" \
+	MASK_PROBE_DURATION_MS="${MASK_PROBE_DURATION_MS:-2400}" \
+	MASK_PROBE_RATE_HZ="${MASK_PROBE_RATE_HZ:-60}" \
+	swift "$SCRIPT_DIR/lib/mask-probe-capture.swift" &
+	mask_probe_pid="$!"
+	if ! wait_mask_probe_ready "$mask_probe_ready_path"; then
+		kill "$mask_probe_pid" >/dev/null 2>&1 || true
+		wait "$mask_probe_pid" >/dev/null 2>&1 || true
+		live_hud_focus_rsnap_overlay
+		live_hud_press_escape >/dev/null 2>&1 || true
+		stop_visual_background
+		echo "[smoke] FAIL mask probe did not produce a ready sample" >&2
+		return 1
+	fi
+
+	PATH_MODE=drag-region \
+	PATH_DRIVER=event \
+	PATH_POINTS="$PATH_POINTS" \
+	PATH_DURATION_MS="$DRAG_DURATION_MS" \
+	PATH_RATE_HZ="$PATH_RATE_HZ" \
+	MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
+	swift "$(live_hud_cursor_helper)"
+	if ! wait "$mask_probe_pid"; then
+		live_hud_focus_rsnap_overlay
+		live_hud_press_escape >/dev/null 2>&1 || true
+		stop_visual_background
+		echo "[smoke] FAIL mask probe capture failed" >&2
+		return 1
+	fi
+
+	sleep "$POST_FREEZE_SETTLE_S"
+	if ! capture_visual_screenshot "$screenshot_path"; then
+		live_hud_focus_rsnap_overlay
+		live_hud_press_escape >/dev/null 2>&1 || true
+		stop_visual_background
+		echo "[smoke] FAIL could not capture visual screenshot: $screenshot_path" >&2
+		return 1
+	fi
+	live_hud_focus_rsnap_overlay
+	live_hud_press_escape >/dev/null 2>&1 || true
+	sleep "$POST_CLOSE_SETTLE_S"
+	stop_visual_background
+
+	out_dir="$("$ROOT_DIR/scripts/telemetry/native-host.sh" collect)"
+	echo "[smoke] telemetry: $out_dir"
+	EXPECTED_HUD_GLASS_MODE="$case_name" \
+	EXPECTED_MIN_FREEZE_COMMITS="$((REPEATED_CLICK_FREEZES + 1))" \
+	VISUAL_SCREENSHOT_PATH="$screenshot_path" \
+	MASK_PROBE_PATH="$mask_probe_path" \
+	SMOKE_STARTED_EPOCH="$case_started_epoch" \
+	python3 "$SCRIPT_DIR/lib/native-visual-contract-summary.py" "$out_dir/all.log"
+}
+
+IFS=',' read -r -a VISUAL_CONTRACT_CASE_ARRAY <<<"$VISUAL_CONTRACT_CASES"
+for case_name in "${VISUAL_CONTRACT_CASE_ARRAY[@]}"; do
+	case_name="$(echo "$case_name" | tr -d '[:space:]')"
+	[[ -n "$case_name" ]] || continue
+	run_visual_case "$case_name"
+done
+echo "[smoke] PASS"


### PR DESCRIPTION
## Summary
- keep FrozenFrameAuthority frames alive while refreshing ScreenCaptureKit content filters
- restore full-display frozen rendering and Liquid Glass toolbar content hosting
- add native visual contract smoke coverage for repeated click freezes, toolbar visibility, and mask stability

## Validation
- cargo make build-swift-strict
- cargo make lint-swift-format
- cargo make test-macos-native-host-stage
- git diff --check
- VISUAL_CONTRACT_CASES=liquid scripts/smoke/native-visual-contract-macos.sh
- VISUAL_CONTRACT_CASES=classic scripts/smoke/native-visual-contract-macos.sh