### PR TITLE
Fix native capture selection stability

### DIFF
--- a/docs/reference/live-sampling.md
+++ b/docs/reference/live-sampling.md
@@ -17,7 +17,7 @@ Spec boundary: `docs/spec/capture-session.md`
 
 Governing performance contract: `docs/spec/performance.md`
 
-Date: 2026-03-02
+Date: 2026-05-01
 
 ## Active-lane note
 
@@ -79,7 +79,7 @@ Fallback behavior:
 - Live sampling is strict stream-only.
 - If stream sampling is unavailable (for example unavailable permission), live RGB/Loupe samples
   remain empty rather than triggering xcap-style full-frame capture.
-- Freeze/export still uses the existing still capture plane.
+- Freeze commit uses the frozen-frame authority stream, not the live-sampler latest-monitor cache.
 
 ## macOS implementation details
 
@@ -106,12 +106,42 @@ Fallback behavior:
   - Desktop layer
 - This keeps behavior stable and avoids false window outlines.
 
+## Frozen-frame freshness boundary
+
+The live sampler's latest-monitor APIs are cache-oriented. They can return the last warm stream
+frame without proving when that frame was captured, and the Swift FFI bridge does not currently
+carry the source frame age or sequence. That is acceptable for live RGB/Loupe sampling, where the
+next stream tick can correct the HUD, but it is not acceptable for the frozen screenshot first
+frame.
+
+Frozen commit must use `FrozenFrameAuthority` or another source with equivalent provenance:
+
+- The frame must carry a real capture timestamp and stream sequence.
+- `post_token` is preferred: the frame sequence advanced after the frozen latch.
+- `latest_unchanged` is allowed only for a fresh same-sequence frame on an unchanged/static
+  desktop.
+- Cache-only `peekLatestMonitorImage`, `take_latest_monitor_rgba`, or wrappers that synthesize
+  `capturedAt` at call time must not feed the frozen first frame.
+- A frozen-authority stream warmed before overlay windows became visible must be replaced after
+  those windows are on screen, but replacement must be a hot handoff: keep the previous
+  self-capture-excluding stream alive until the replacement stream is configured so fast click
+  selection cannot fail with `no_fresh_frame` solely because content-filter lookup is still
+  running. Once the replacement stream is ready, the first Frozen display frame must come from a
+  self-capture-excluding filter, not from a pre-overlay filter that can see rsnap's own live mask,
+  border, badge, or toolbar.
+- If no freshness-proven frame is available, fail the freeze with `no_fresh_frame` instead of
+  showing a screenshot from seconds earlier.
+
+This is the guard against the old regression where a quick drag could freeze a frame that came from
+seconds-old live-stream cache data while telemetry incorrectly reported it as current.
+
 ## Current capture-plane split
 
 The current implementation already keeps capture responsibilities split by quality profile:
 
 - `Live` plane: stream-first, low-latency RGB/Loupe and live outline updates.
-- `Freeze/export` plane: higher-cost still capture for full screenshot quality.
+- `Freeze first-frame` plane: freshness-proven frozen authority frames for the immediate handoff.
+- `Export` plane: higher-cost output capture after frozen mode is established.
 
 Linux/Windows details remain out of scope for the current macOS-first contract.
 
@@ -119,5 +149,5 @@ Linux/Windows details remain out of scope for the current macOS-first contract.
 
 - [x] Implemented macOS `SCStream` live path for cursor samples (RGB/Loupe).
 - [x] Removed live full-display refresh dependency from cursor path.
-- [x] Kept freeze/export on the existing still-capture flow.
-- [ ] Add opt-in diagnostics for frame age and sample latency.
+- [x] Kept frozen first-frame commit off cache-only live-sampler full-monitor snapshots.
+- [ ] Add opt-in diagnostics for live sample latency beyond frozen `frameAgeMs`.

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -33,13 +33,13 @@ overlay runtime integration tests, and scroll-capture session semantics tests.
 | `scripts/smoke/replay-scroll-capture.sh` | Script entrypoint | deterministic replay | Runs the latest recorded trace through worker-pairwise replay. |
 | `scripts/smoke/replay-scroll-capture-self-check.sh` | Script entrypoint | deterministic replay | Runs the worker-pairwise replay self-check without a user trace. |
 | `scripts/smoke/analyze-scroll-capture-trace.sh` | Script entrypoint | deterministic replay | Emits summary-only replay analysis for semantic drift triage. |
-| `scripts/smoke/native-hud-follow-macos.sh` | Script entrypoint | live macOS smoke | Drives the default native-host HUD-follow smoke with a smooth high-rate cursor path. |
-| `scripts/smoke/native-visual-contract-macos.sh` | Script entrypoint | live macOS smoke | Drives Option-X, a drag-region frozen handoff, screenshots rsnap itself, and gates no-pending-frame/no-scrim-drop toolbar content/material contract telemetry. |
+| `scripts/smoke/native-hud-follow-macos.sh` | Script entrypoint | live macOS perf smoke | Dedicated HUD/loupe follow-cadence smoke for performance work, not part of the default macOS smoke aggregation. |
+| `scripts/smoke/native-visual-contract-macos.sh` | Script entrypoint | live macOS smoke | Core native-host behavior contract: repeated real click freezes, repeated held drag freezes, in-drag and frozen screenshots, click/drag editability, border-leak, scrim, and handoff telemetry gates. |
 | `scripts/smoke/self-check-macos.sh` | Script entrypoint | smoke readiness | Verifies macOS smoke tooling and replay self-check without the real GUI run. |
-| `scripts/smoke/macos.sh` | Script entrypoint | smoke aggregation | Runs native HUD follow, native visual contract, and recorded-trace replay. |
+| `scripts/smoke/macos.sh` | Script entrypoint | smoke aggregation | Runs the core native visual contract, then recorded-trace replay when a local trace exists or replay self-check when it does not. |
 | `scripts/perf/local.sh` | Script entrypoint | deterministic benches | Runs the committed Criterion smoke-sized benchmark sweep. |
 | `scripts/perf/self-check-macos.sh` | Script entrypoint | perf aggregation | Runs local deterministic benches plus macOS smoke readiness. |
-| `scripts/perf/macos.sh` | Script entrypoint | perf aggregation | Runs local deterministic benches plus `scripts/smoke/macos.sh`. |
+| `scripts/perf/macos.sh` | Script entrypoint | perf aggregation | Runs local deterministic benches, the dedicated HUD-follow perf smoke, the core native visual contract, and recorded-trace replay. |
 | `packages/rsnap-overlay/src/overlay/replay_support.rs` tests | Deterministic replay / bench | replay harness | Trace round-trip, replay mode selection, and summary classification. |
 | `packages/rsnap-overlay/benches/scroll_capture.rs` | Deterministic replay / bench | hot-path perf | Stable fingerprint, overlap-match, and one-step session commit baselines. |
 | `packages/rsnap-overlay/src/overlay/tests/worker_tick_runtime.rs` | Overlay runtime integration | overlay runtime | Request issuance, retry timing, backoff, and fresh-input worker scheduling. |
@@ -50,6 +50,8 @@ overlay runtime integration tests, and scroll-capture session semantics tests.
 
 - Prefer deleting or merging a script only when another remaining script still provides the same
   stable entrypoint value.
+- Keep native-host smoke entrypoints on `scripts/build_and_run.sh`; raw `swift build` is not a
+  substitute because the Swift executable must be relinked after Rust `rsnap-host-ffi` changes.
 - Prefer deleting or merging a runtime test only when its remaining assertions are already owned by
   `scroll_capture/tests.rs` and it no longer proves runtime state-machine behavior.
 - Prefer extracting shared fixtures when two layers intentionally cover different behavior with the

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -31,7 +31,8 @@ Use the smallest command that matches the regression surface:
   `cargo bench -p rsnap-overlay --bench scroll_capture -- --sample-size 10 --warm-up-time 0.1 --measurement-time 0.1`
 - Native-host live chrome regressions:
   `scripts/smoke/native-hud-follow-macos.sh`
-- Native-host visual/material or live-to-frozen handoff regressions:
+- Native-host click/drag selection, border leakage, mask stability, visual/material, or
+  live-to-frozen handoff regressions:
   `scripts/smoke/native-visual-contract-macos.sh`
 - General local deterministic performance sweep before or after a change:
   `scripts/perf/local.sh`
@@ -60,11 +61,15 @@ worker-pairwise self-check path when no recorded user trace is available.
   - Use this to validate that the dedicated macOS environment, permissions, and smoke harness are
     ready without treating it as an end-to-end performance assertion.
 - `scripts/perf/macos.sh`
-  - Runs `scripts/perf/local.sh`, then runs `scripts/smoke/macos.sh`.
-  - That means the native-host HUD-follow smoke, native visual contract smoke, plus
-    recorded-live-trace scroll-capture replay.
+  - Runs `scripts/perf/local.sh`, the dedicated native-host HUD-follow perf smoke, the core native
+    visual contract smoke, plus recorded-live-trace scroll-capture replay.
   - Use this only on a dedicated logged-in macOS desktop session with the expected Screen
     Recording and automation permissions.
+- `scripts/smoke/macos.sh`
+  - Runs the core native visual contract smoke.
+  - Runs recorded-live-trace replay when a local `manifest.json` exists under the scroll-capture
+    trace directory; otherwise it runs `scripts/smoke/replay-scroll-capture-self-check.sh` so a
+    missing optional trace does not fail unrelated native-host validation.
 
 For the downward scroll-capture rebuild, the expected verification sequence is:
 
@@ -128,6 +133,10 @@ Dedicated macOS smoke:
   worker-pairwise overlay or session logic before attempting more desktop-session repro. If the
   command reports that no trace manifests were found, that is an operator/setup failure: record a
   fresh live trace first or rerun the example with `--trace <manifest-path>`.
+- `scripts/smoke/macos.sh` choosing replay self-check:
+  treat it as expected when the machine has no recorded scroll-capture trace. It is not evidence
+  for or against the latest user-recorded live trace; run `scripts/smoke/replay-scroll-capture.sh`
+  with a real trace when scroll-capture replay evidence is required.
 - `scripts/smoke/replay-scroll-capture-self-check.sh` failures:
   treat them as deterministic regressions in the replay harness itself, not as evidence about the
   latest user-recorded live trace.

--- a/docs/runbook/telemetry-debugging.md
+++ b/docs/runbook/telemetry-debugging.md
@@ -22,6 +22,11 @@ Use the signed release path when testing user-visible native-host behavior:
 RSNAP_NATIVE_HOST_FORCE_REBUILD=1 ./scripts/build_and_run.sh run
 ```
 
+`scripts/build_and_run.sh` is the authority for launched native-host builds. It rebuilds
+`rsnap-host-ffi` and removes the cached Swift executable before `swift build` so changed Rust ABI
+or core semantics are relinked into the `.app`; do not validate native-host behavior with a raw
+`swift build` product.
+
 Use the streaming mode when you need live logs while reproducing:
 
 ```sh
@@ -116,11 +121,14 @@ If the chain stops at `capture_timing.freeze_commit_failed`, inspect
 frame timing. On static desktops, successful freezes may report `snapshotSource=latest_unchanged`;
 that is expected when no post-latch ScreenCaptureKit frame was emitted because the excluded overlay
 was the only thing moving.
-Fast freezes should usually report `snapshotSource=authority_latest` or `live_sampler_latest`.
-Those sources mean the release handoff used an already-warm frame instead of waiting for another
-ScreenCaptureKit frame. If `snapshotSource=window_list_below_overlay` appears in release-handoff
-telemetry, treat it as a regression: full-monitor window-list capture is too slow and visually
-inconsistent for the first frozen frame.
+Fast freezes should usually report `snapshotSource=post_token`; fresh static handoffs may report
+`snapshotSource=latest_unchanged`. In both cases, check `frameAgeMs`: it must reflect the actual
+source frame age and should stay within the frozen authority freshness guard. If
+`snapshotSource=live_sampler_latest`, `authority_latest`, or `window_list_below_overlay` appears in
+release-handoff telemetry, treat it as a regression. The first two sources mean the frozen handoff
+has fallen back to an obsolete cache-only/latest-frame shortcut; the last means full-monitor
+window-list capture has returned to the handoff path, which is too slow and visually inconsistent
+for the first frozen frame.
 
 If `capture_timing.copy_capture` is slow, compare `captureImageMs`, `makeImageMs`, and
 `writePasteboardMs` before changing capture code.

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -123,13 +123,14 @@ product level rather than binding itself to a particular window toolkit or shell
   capture, copies the recognized text to the clipboard, and exits.
 - In Frozen mode, the toolbar remains part of the floating HUD set. The live loupe is hidden after
   freeze and may be recreated only when a later live-mode transition needs it.
-- In Frozen mode, every successful live-mode selection may be repositioned by dragging inside the
-  bright selected area and resized from its edges and corners. This includes dragged regions,
-  window-click captures, and the fullscreen fallback when no window is hit.
-- Frozen editability is a property of the committed selection, not of the live entry gesture. The
-  system must not regress into a state where only drag-created regions can be moved while
-  point-selected window/fullscreen captures are locked. All edits stay on the current monitor, and
-  thin edited captures down to `1x1` remain valid.
+- In Frozen mode, only drag-created region selections may be repositioned by dragging inside the
+  bright selected area and resized from edges and corners.
+- Window-click captures and the fullscreen fallback when no window is hit are fixed selections:
+  they MUST NOT show move/resize affordances, MUST NOT enter the open-hand/resize cursor state, and
+  MUST NOT commit a frozen selection transform when dragged.
+- Frozen editability is a property of the committed selection. It is true only for live drag region
+  captures and false for point-selected window/fullscreen captures. All edits stay on the current
+  monitor, and thin edited captures down to `1x1` remain valid.
 - Frozen toolbar placement and expansion invariants are governed by
   `docs/spec/frozen-toolbar-layout.md`.
 - Pen behavior is governed by `docs/spec/annotation-pen.md`.

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -71,6 +71,9 @@ product level rather than binding itself to a particular window toolkit or shell
 - Hovering over a window in live mode shows an obvious targeting outline that follows the current
   target, remains legible in light and dark themes, and does not require moving away to another
   window before the current target becomes active.
+- Moving the pointer to live-mode desktop space with no recognized window MUST clear the window
+  targeting outline and mask immediately; the previous recognized window must not remain highlighted
+  as a stale target.
 - Pressing the primary button in live mode MUST NOT clear, flash, or remove the current
   targeting mask/scrim while the pointer is still below the drag threshold. The hover target may
   be replaced by a drag preview only after the drag preview exists; there must be no blank

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -53,6 +53,9 @@ product level rather than binding itself to a particular window toolkit or shell
    externally capturable by system screenshot and screen-recording tools. Internal self-capture
    correctness comes from rsnap's own capture filters and handoff logic, not window content
    protection.
+   External tools being allowed to capture rsnap UI is only a debugging/export affordance. rsnap's
+   own Frozen first frame MUST NOT capture rsnap's live mask, dashed selection border, size badge,
+   toolbar, loupe, or transitional Frozen UI into the frozen display image.
 8. The product contract does not require any specific platform window implementation. Focus,
    cursor, keyboard, and IME correctness are mandatory outcomes, regardless of how the native host
    achieves them.
@@ -68,9 +71,25 @@ product level rather than binding itself to a particular window toolkit or shell
 - Hovering over a window in live mode shows an obvious targeting outline that follows the current
   target, remains legible in light and dark themes, and does not require moving away to another
   window before the current target becomes active.
+- Pressing the primary button in live mode MUST NOT clear, flash, or remove the current
+  targeting mask/scrim while the pointer is still below the drag threshold. The hover target may
+  be replaced by a drag preview only after the drag preview exists; there must be no blank
+  mouse-down interval before release.
 - Left click + drag freezes a cropped region on the cursor monitor.
-- Live drag preview begins as soon as the pointer moves away from the press point; thin captures
-  down to `1x1` pixels are valid frozen selections.
+- Live drag preview begins only after the native host has observed enough held-pointer movement to
+  distinguish drag intent from ordinary click jitter. After that intent threshold is crossed, thin
+  captures down to `1x1` pixels are valid frozen selections.
+- Live drag preview chrome is owned by the overlay view that received the primary press. Other
+  overlay views must not render the canonical drag preview, and preview strokes/scrims must be
+  clipped to their owning overlay bounds; horizontal or vertical lines must never extend past the
+  selection or leak toward the desktop edge.
+- Releasing the primary button, canceling capture, or failing a freeze request MUST clear all
+  host-local live-drag state before the next pointer move. A stale `live_selection_preview` kept
+  for request handoff must not continue rendering as an active drag preview after release.
+- If the primary-button release is observed by a different overlay view than the one that began
+  the drag, the release still owns the whole live interaction: all overlay-local queued drag
+  updates must be canceled, the owner preview must stop following the mouse, and no later queued
+  `liveDragged` update may recreate the released preview.
 - Left click without drag hit-tests the window under the cursor on the same monitor and freezes
   that window bounds.
 - If no window is hit, the click path falls back to freezing the current monitor fullscreen.
@@ -101,12 +120,13 @@ product level rather than binding itself to a particular window toolkit or shell
   capture, copies the recognized text to the clipboard, and exits.
 - In Frozen mode, the toolbar remains part of the floating HUD set. The live loupe is hidden after
   freeze and may be recreated only when a later live-mode transition needs it.
-- In Frozen mode, a dragged-region capture may be repositioned by dragging inside the bright
-  selected area and may be resized from its edges and corners; all edits stay on the current
-  monitor, and thin edited captures down to `1x1` remain valid.
-- In Frozen mode, a window-click capture remains locked to the captured window bounds: it does not
-  expose resize handles and does not enter drag/resize pointer affordances while the pointer tool
-  is selected.
+- In Frozen mode, every successful live-mode selection may be repositioned by dragging inside the
+  bright selected area and resized from its edges and corners. This includes dragged regions,
+  window-click captures, and the fullscreen fallback when no window is hit.
+- Frozen editability is a property of the committed selection, not of the live entry gesture. The
+  system must not regress into a state where only drag-created regions can be moved while
+  point-selected window/fullscreen captures are locked. All edits stay on the current monitor, and
+  thin edited captures down to `1x1` remain valid.
 - Frozen toolbar placement and expansion invariants are governed by
   `docs/spec/frozen-toolbar-layout.md`.
 - Pen behavior is governed by `docs/spec/annotation-pen.md`.
@@ -117,6 +137,10 @@ product level rather than binding itself to a particular window toolkit or shell
   single visible handoff instead of waiting on a later visible capture swap.
 - The live-to-Frozen handoff MUST NOT flash through a blank surface, a mask/scrim-only state, or
   any other intermediate mode-switch artifact.
+- The live-to-Frozen handoff MUST NOT show a doubled mask/scrim caused by capturing rsnap's own
+  capture UI into the frozen display image. Frozen-frame streams that were created before capture
+  overlay windows became visible must be rebuilt or invalidated before their frames can be used for
+  the first Frozen display image.
 - Frozen-mode display readiness and export readiness are separate:
   - pointer drag/reposition, pen, arrow, text, spotlight, and toolbar visibility are
     display-driven

--- a/docs/spec/host-core-protocol.md
+++ b/docs/spec/host-core-protocol.md
@@ -49,6 +49,8 @@ The live capture contract now also requires:
 - explicit primary-interaction events for `started`, `updated`, and `completed` so the Rust core
   owns live drag preview and freeze-target selection semantics
 - `SceneModel.live_selection_preview` for the canonical live drag rectangle prior to frozen commit
+- `HostRequest::RequestFreezeSnapshot.selection_editable` for the core-owned decision about
+  whether the committed Frozen selection may be moved or resized after commit
 - `SceneModel.active_monitor`, `SceneModel.highlighted_window`, and `SceneModel.cursor_intent` as
   the only semantic inputs the native host uses for live hover glow and frozen cursor mapping
 
@@ -56,13 +58,17 @@ The host must not retain its own product-state copy of:
 
 - pending frozen selection rectangles
 - live drag preview rectangles
+- whether the next frozen selection should be movable/resizable
 - frozen resize-cursor hit testing
 
 Those semantics belong to `rsnap-capture-core` and must cross the native boundary through
-`SceneModel` / `HostEvent`, not through host-local shadow state.
+`SceneModel` / `HostEvent` / `HostRequest`, not through host-local shadow state. In particular,
+native hosts must not infer Frozen editability from `SceneModel.live_selection_preview == selection`;
+click-targeted window/fullscreen selections can also occupy that field during request handoff and
+must remain editable when `selection_editable` is set.
 
-The one allowed exception is transient host-local frozen transform presentation while a dragged
-region is being interactively moved or resized after Frozen entry. In that case the native host may
+The one allowed exception is transient host-local frozen transform presentation while a committed
+selection is being interactively moved or resized after Frozen entry. In that case the native host may
 hold a short-lived display snapshot, editability flag, and in-progress selection rect derived from
 the last committed `SceneModel.frozen_selection`, but it must publish the committed rect back
 through `HostReport::FreezeSnapshotCommitted` and must not invent a second durable product state for
@@ -95,6 +101,7 @@ The ABI surface must mirror the semantic models above, including:
 - active monitor and highlighted window snapshots on pointer and primary-interaction events
 - live selection preview rectangles on copied-out scene snapshots
 - primary-interaction host events as distinct ABI event kinds
+- frozen snapshot request editability as an explicit field on `RsnapHostRequestValue`
 
 The ABI layer must stay thin:
 

--- a/docs/spec/host-core-protocol.md
+++ b/docs/spec/host-core-protocol.md
@@ -63,9 +63,10 @@ The host must not retain its own product-state copy of:
 
 Those semantics belong to `rsnap-capture-core` and must cross the native boundary through
 `SceneModel` / `HostEvent` / `HostRequest`, not through host-local shadow state. In particular,
-native hosts must not infer Frozen editability from `SceneModel.live_selection_preview == selection`;
-click-targeted window/fullscreen selections can also occupy that field during request handoff and
-must remain editable when `selection_editable` is set.
+native hosts must not infer Frozen editability from `SceneModel.live_selection_preview == selection`.
+Only `HostRequest::RequestFreezeSnapshot.selection_editable` may decide whether the committed
+Frozen selection can be moved or resized; click-targeted window/fullscreen selections must remain
+fixed when that field is false.
 
 The one allowed exception is transient host-local frozen transform presentation while a committed
 selection is being interactively moved or resized after Frozen entry. In that case the native host may

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -90,12 +90,17 @@ must still be refreshed at the fixed sampling cadence so dynamic content does no
 ### One-shot handoff latency
 
 Mode transitions are not continuous cadence loops, but they are user-visible. The live-to-frozen
-release handoff must avoid waiting for a future ScreenCaptureKit frame when an already-warm frame
-is available. The intended path is:
+release handoff must avoid waiting for a future ScreenCaptureKit frame when a freshness-proven
+frozen authority frame is already available. The intended path is:
 
-1. use an already-warm frozen-authority or live-sampler frame immediately,
+1. use a `post_token` frozen authority frame, or a fresh `latest_unchanged` authority frame for an
+   unchanged/static desktop,
 2. present the frozen frame, toolbar, and scrim in one continuous handoff,
 3. perform cleanup such as secondary-window collapse after the first frozen frame is installed.
+
+The handoff must not use cache-only live-sampler latest-monitor snapshots unless they carry real
+source frame age and sequence metadata. A wrapper that stamps cached pixels with the current call
+time can hide seconds-stale screenshots and is a correctness regression.
 
 The handoff must not show a pending half-frame, remove/re-add the outside-selection scrim, or
 delay toolbar visibility on a static desktop just because ScreenCaptureKit has not emitted a new

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -100,13 +100,15 @@ Do not encode values into the event name; emit values as fields.
 - Pixel dimensions use `width` and `height`.
 - OS display identifiers use `displayID`.
 - Frozen capture frame provenance uses `snapshotSource`; `post_token` means ScreenCaptureKit
-  produced a frame after the frozen latch, `latest_unchanged` means no newer frame arrived
-  and the current stream's latest same-sequence frame was used for an unchanged/static desktop,
-  `authority_latest` means the frozen-authority stream's already-warm frame was used immediately
-  for the release handoff, `live_sampler_latest` means the already-warm live sampler supplied the
-  release-time monitor frame. The release handoff must not use a synchronous full-monitor
-  `CGWindowList` capture as a first-frame fallback because that path can add visible latency and
-  can differ subtly from the live ScreenCaptureKit frame in window shadow/framing treatment.
+  produced a frame after the frozen latch, and `latest_unchanged` means no newer frame arrived
+  but the frozen authority still had a fresh same-sequence frame for an unchanged/static desktop.
+  `frameAgeMs` must be derived from the source frame's real capture timestamp, not from the time a
+  wrapper copied cached pixels. The release handoff must not use cache-only live-sampler
+  latest-monitor snapshots, including `peekLatestMonitorImage` or `take_latest_monitor_rgba`,
+  unless that API is extended to expose freshness-proven frame age and sequence. The release
+  handoff must also not use a synchronous full-monitor `CGWindowList` capture as a first-frame
+  fallback because that path can add visible latency and can differ subtly from the live
+  ScreenCaptureKit frame in window shadow/framing treatment.
 - Rust identifiers use snake_case unless they are mirroring existing platform names.
 
 ## Capture Correlation

--- a/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
+++ b/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
@@ -182,7 +182,7 @@ public struct SceneSnapshot: Equatable, Sendable {
 public enum HostRequest: Equatable, Sendable {
 	case startLiveCapture
 	case stopLiveCapture
-	case requestFreezeSnapshot(selection: CGRect)
+	case requestFreezeSnapshot(selection: CGRect, selectionEditable: Bool)
 	case copyCapture
 	case saveCapture
 	case recognizeText
@@ -547,7 +547,10 @@ public final class RsnapHostSession {
 			guard request.has_selection != 0 else {
 				throw HostBridgeError.invalidRequestKind(request.kind)
 			}
-			return .requestFreezeSnapshot(selection: decode(rect: request.selection))
+			return .requestFreezeSnapshot(
+				selection: decode(rect: request.selection),
+				selectionEditable: request.selection_editable != 0
+			)
 		case RSNAP_HOST_REQUEST_COPY_CAPTURE.rawValue:
 			return .copyCapture
 		case RSNAP_HOST_REQUEST_SAVE_CAPTURE.rawValue:
@@ -829,6 +832,10 @@ public final class RsnapLiveSampler: @unchecked Sendable {
 		)
 	}
 
+	/// Returns the live sampler's cache-only full-monitor snapshot.
+	///
+	/// This API does not expose the original frame capture time or stream sequence. Do not use it
+	/// as a frozen screenshot source unless the FFI contract is extended to prove freshness.
 	public func peekLatestMonitorImage(
 		monitor: MonitorSnapshot
 	) throws -> RGBARegionSnapshot? {

--- a/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
+++ b/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
@@ -194,9 +194,9 @@ enum RsnapHostBridgeProbe {
 			try session.takeNextRequest()
 				== .requestFreezeSnapshot(
 					selection: clickSelection,
-					selectionEditable: true)
+					selectionEditable: false)
 		else {
-			fatalError("expected an editable click-window freeze request")
+			fatalError("expected a fixed click-window freeze request")
 		}
 		try session.send(report: .freezeSnapshotCommitted(selection: clickSelection))
 		try session.send(
@@ -208,8 +208,52 @@ enum RsnapHostBridgeProbe {
 			)
 		)
 		scene = try session.currentScene()
-		guard scene.mode == .frozen, scene.cursorIntent == .grab else {
+		guard scene.mode == .frozen, scene.cursorIntent == .default else {
 			fatalError("unexpected click-window frozen cursor: \(scene)")
+		}
+
+		try session.enterLive()
+		_ = try session.takeNextRequest()
+		let fullscreenMonitor = MonitorSnapshot(
+			id: 10,
+			frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+			scaleFactorX1000: 2_000
+		)
+		try session.send(
+			event: .primaryInteractionStarted(
+				point: CGPoint(x: 700, y: 500),
+				activeMonitor: fullscreenMonitor,
+				highlightedWindow: nil
+			)
+		)
+		try session.send(
+			event: .primaryInteractionCompleted(
+				point: CGPoint(x: 700, y: 500),
+				activeMonitor: fullscreenMonitor,
+				highlightedWindow: nil
+			)
+		)
+		let fullscreenSelection = fullscreenMonitor.frame
+		guard
+			try session.takeNextRequest()
+				== .requestFreezeSnapshot(
+					selection: fullscreenSelection,
+					selectionEditable: false)
+		else {
+			fatalError("expected a fixed fullscreen fallback freeze request")
+		}
+		try session.send(report: .freezeSnapshotCommitted(selection: fullscreenSelection))
+		try session.send(
+			event: .pointerMoved(
+				point: CGPoint(x: 700, y: 500),
+				rgb: nil,
+				activeMonitor: nil,
+				highlightedWindow: nil
+			)
+		)
+		scene = try session.currentScene()
+		guard scene.mode == .frozen, scene.cursorIntent == .default else {
+			fatalError("unexpected fullscreen frozen cursor: \(scene)")
 		}
 
 		try session.enterLive()

--- a/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
+++ b/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
@@ -84,7 +84,8 @@ enum RsnapHostBridgeProbe {
 		guard
 			try session.takeNextRequest()
 				== .requestFreezeSnapshot(
-					selection: CGRect(x: 120, y: 180, width: 140, height: 140))
+					selection: CGRect(x: 120, y: 180, width: 140, height: 140),
+					selectionEditable: true)
 		else {
 			fatalError("expected a freeze snapshot request")
 		}

--- a/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
+++ b/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
@@ -166,6 +166,54 @@ enum RsnapHostBridgeProbe {
 
 		try session.enterLive()
 		_ = try session.takeNextRequest()
+		let clickSelection = CGRect(x: 300, y: 220, width: 360, height: 260)
+		let clickWindow = WindowSnapshot(windowID: 88, frame: clickSelection)
+		try session.send(
+			event: .primaryInteractionStarted(
+				point: CGPoint(x: 420, y: 340),
+				activeMonitor: MonitorSnapshot(
+					id: 9,
+					frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+					scaleFactorX1000: 2_000
+				),
+				highlightedWindow: clickWindow
+			)
+		)
+		try session.send(
+			event: .primaryInteractionCompleted(
+				point: CGPoint(x: 420, y: 340),
+				activeMonitor: MonitorSnapshot(
+					id: 9,
+					frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+					scaleFactorX1000: 2_000
+				),
+				highlightedWindow: clickWindow
+			)
+		)
+		guard
+			try session.takeNextRequest()
+				== .requestFreezeSnapshot(
+					selection: clickSelection,
+					selectionEditable: true)
+		else {
+			fatalError("expected an editable click-window freeze request")
+		}
+		try session.send(report: .freezeSnapshotCommitted(selection: clickSelection))
+		try session.send(
+			event: .pointerMoved(
+				point: CGPoint(x: 420, y: 340),
+				rgb: nil,
+				activeMonitor: nil,
+				highlightedWindow: nil
+			)
+		)
+		scene = try session.currentScene()
+		guard scene.mode == .frozen, scene.cursorIntent == .grab else {
+			fatalError("unexpected click-window frozen cursor: \(scene)")
+		}
+
+		try session.enterLive()
+		_ = try session.takeNextRequest()
 		try session.send(
 			event: .pointerMoved(
 				point: CGPoint(x: 200, y: 260),
@@ -190,6 +238,22 @@ enum RsnapHostBridgeProbe {
 			scene.highlightedWindow?.frame == CGRect(x: 1500, y: 100, width: 500, height: 400)
 		else {
 			fatalError("unexpected live monitor/window scene: \(scene)")
+		}
+		try session.send(
+			event: .pointerMoved(
+				point: CGPoint(x: 2600, y: 800),
+				rgb: nil,
+				activeMonitor: MonitorSnapshot(
+					id: 11,
+					frame: CGRect(x: 1440, y: 0, width: 1728, height: 1117),
+					scaleFactorX1000: 2_000
+				),
+				highlightedWindow: nil
+			)
+		)
+		scene = try session.currentScene()
+		guard scene.highlightedWindow == nil else {
+			fatalError("stale live highlighted window was not cleared: \(scene)")
 		}
 
 		print("rsnap-host-bridge probe ok")

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -25,6 +25,8 @@ struct FrozenFrameSnapshot {
 }
 
 final class FrozenFrameAuthority: @unchecked Sendable {
+	private static let maximumSnapshotAgeMilliseconds = 150.0
+
 	private struct DisplayTarget: Equatable {
 		let displayID: CGDirectDisplayID
 		let frame: CGRect
@@ -115,7 +117,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		for screens: [NSScreen],
 		captureID: UInt64 = 0,
 		source: String = "capture",
-		refreshContentFilter: Bool = false
+		rebuildContentFilter: Bool = false
 	) {
 		let setupStartedAt = ProcessInfo.processInfo.systemUptime
 		let targets = screens.compactMap(Self.displayTarget(for:))
@@ -131,24 +133,29 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let streamsCoverTargets = Set(streams.keys) == targetIDs
 		let setupInProgressForTargets = setupDisplayIDs == targetIDs
 		displayTargets = nextTargets
-		if unchanged, streamsCoverTargets || setupInProgressForTargets {
+		// When overlay windows become visible, discard pre-overlay streams instead of updating
+		// filters in place. Keep the old stream running until the replacement is configured so a
+		// fast click immediately after overlay presentation can still freeze a fresh frame.
+		if rebuildContentFilter, unchanged, streamsCoverTargets {
+			setupDisplayIDs = targetIDs
+			stateLock.unlock()
+			rebuildStreamsFromShareableContent(
+				targets: targets,
+				targetIDs: targetIDs,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: setupStartedAt
+			)
+			return
+		}
+		if unchanged, streamsCoverTargets || setupInProgressForTargets, !rebuildContentFilter {
 			updateTelemetryContextLocked(
 				captureID: captureID,
 				source: source,
 				startedAtUptime: setupStartedAt,
 				targetIDs: targetIDs
 			)
-			let requestGeneration = generation
 			stateLock.unlock()
-			if refreshContentFilter, streamsCoverTargets {
-				refreshContentFilters(
-					for: targets,
-					generation: requestGeneration,
-					captureID: captureID,
-					source: source,
-					startedAtUptime: setupStartedAt
-				)
-			}
 			return
 		}
 		generation &+= 1
@@ -177,6 +184,80 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			source: source,
 			startedAtUptime: setupStartedAt
 		)
+	}
+
+	private func rebuildStreamsFromShareableContent(
+		targets: [DisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval
+	) {
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) {
+			[weak self] content, error in
+			guard let self else {
+				return
+			}
+			guard let content else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_lookup_failed",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: String(describing: error)
+				)
+				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+					captureID: captureID,
+					source: source,
+					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+					success: false,
+					displayCount: targets.count,
+					windowCount: 0
+				)
+				self.finishSetup(targetIDs: targetIDs)
+				return
+			}
+
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: true,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+
+			self.stateLock.lock()
+			guard self.activeDisplayIDs == targetIDs else {
+				self.stateLock.unlock()
+				return
+			}
+			self.generation &+= 1
+			let requestGeneration = self.generation
+			self.setupDisplayIDs = targetIDs
+			self.latestFrames = self.latestFrames.filter { targetIDs.contains($0.key) }
+			self.updateTelemetryContextLocked(
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				targetIDs: targetIDs
+			)
+			let staleStreams = self.streams.values
+			self.streams.removeAll()
+			self.stateLock.unlock()
+
+			for staleStream in staleStreams {
+				staleStream.stop()
+			}
+
+			self.configureStreams(
+				content: content,
+				targets: targets,
+				generation: requestGeneration,
+				captureID: captureID,
+				source: source
+			)
+		}
 	}
 
 	private func configureStreamsFromShareableContent(
@@ -231,89 +312,6 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 	}
 
-	private func refreshContentFilters(
-		for targets: [DisplayTarget],
-		generation requestGeneration: UInt64,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval
-	) {
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) {
-			[weak self] content, error in
-			guard let self else {
-				return
-			}
-			guard self.isCurrentGeneration(requestGeneration) else {
-				return
-			}
-			guard let content else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_lookup_failed",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: String(describing: error)
-				)
-				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-					captureID: captureID,
-					source: source,
-					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-					success: false,
-					displayCount: targets.count,
-					windowCount: 0
-				)
-				return
-			}
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: true,
-				displayCount: content.displays.count,
-				windowCount: content.windows.count
-			)
-			for target in targets {
-				guard let filter = Self.contentFilter(for: target, in: content) else {
-					continue
-				}
-				self.updateContentFilter(
-					filter,
-					displayID: target.displayID,
-					generation: requestGeneration,
-					captureID: captureID,
-					source: source
-				)
-			}
-		}
-	}
-
-	private func updateContentFilter(
-		_ filter: SCContentFilter,
-		displayID: CGDirectDisplayID,
-		generation requestGeneration: UInt64,
-		captureID: UInt64,
-		source: String
-	) {
-		stateLock.lock()
-		let stream = generation == requestGeneration ? streams[displayID]?.stream : nil
-		stateLock.unlock()
-		guard let stream else {
-			return
-		}
-		stream.updateContentFilter(filter) { error in
-			guard let error else {
-				return
-			}
-			NativeHostTelemetry.frozenAuthorityWarning(
-				"frozen_authority.content_filter_update_failed",
-				captureID: captureID,
-				source: source,
-				displayID: displayID,
-				error: String(describing: error)
-			)
-		}
-	}
-
 	func stop() {
 		stateLock.lock()
 		generation &+= 1
@@ -363,17 +361,16 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			stateLock.unlock()
 			return nil
 		}
-		let minimumSequence = token?.minSequence ?? 0
 		var source = "post_token"
-		var record = freshRecordLocked(displayID: displayID, minimumSequence: minimumSequence)
+		var record = freshRecordLocked(displayID: displayID, token: token)
 		while record == nil, Date() < deadline {
 			stateLock.wait(until: deadline)
-			record = freshRecordLocked(displayID: displayID, minimumSequence: minimumSequence)
+			record = freshRecordLocked(displayID: displayID, token: token)
 		}
 		if record == nil,
 			let fallbackRecord = unchangedRecordLocked(
 				displayID: displayID,
-				minimumSequence: minimumSequence
+				token: token
 			)
 		{
 			record = fallbackRecord
@@ -394,51 +391,46 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		)
 	}
 
-	func latestSnapshot(containing point: CGPoint) -> FrozenFrameSnapshot? {
-		stateLock.lock()
-		let displayID = displayTargets.first(where: { $0.value.frame.contains(point) })?.key
-		let record = displayID.flatMap {
-			freshRecordLocked(displayID: $0, minimumSequence: 0)
-		}
-		stateLock.unlock()
-
-		guard let record, let image = Self.makeImage(from: record.pixelBuffer) else {
-			return nil
-		}
-		return FrozenFrameSnapshot(
-			displayID: record.displayID,
-			displayFrame: record.displayFrame,
-			image: image,
-			sequence: record.sequence,
-			capturedAtUptime: record.capturedAtUptime,
-			source: "authority_latest"
-		)
-	}
-
-	private func freshRecordLocked(displayID: CGDirectDisplayID, minimumSequence: UInt64)
+	private func freshRecordLocked(displayID: CGDirectDisplayID, token: FrozenFrameLatchToken?)
 		-> FrameRecord?
 	{
 		guard let record = latestFrames[displayID] else {
 			return nil
 		}
-		if record.sequence > minimumSequence {
+		guard Self.isFreshForSnapshot(record) else {
+			return nil
+		}
+		guard let token else {
 			return record
 		}
-		if minimumSequence == 0, record.ageMilliseconds() <= 150 {
+		if record.capturedAtUptime >= token.startedAtUptime {
+			return record
+		}
+		if record.sequence > token.minSequence {
+			return record
+		}
+		if token.minSequence == 0 {
 			return record
 		}
 		return nil
 	}
 
-	private func unchangedRecordLocked(displayID: CGDirectDisplayID, minimumSequence: UInt64)
+	private func unchangedRecordLocked(displayID: CGDirectDisplayID, token: FrozenFrameLatchToken?)
 		-> FrameRecord?
 	{
-		guard minimumSequence > 0, let record = latestFrames[displayID],
-			record.sequence == minimumSequence
+		guard let token, token.minSequence > 0, let record = latestFrames[displayID],
+			record.sequence == token.minSequence
 		else {
 			return nil
 		}
+		// ScreenCaptureKit display streams may not emit another frame while the display is
+		// visually unchanged. The latched authority frame remains the current display image in
+		// that case, even when its wall-clock age exceeds the normal post-token freshness budget.
 		return record
+	}
+
+	private static func isFreshForSnapshot(_ record: FrameRecord) -> Bool {
+		record.ageMilliseconds() <= maximumSnapshotAgeMilliseconds
 	}
 
 	private func configureStreams(
@@ -563,6 +555,15 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	private func finishSetup(generation requestGeneration: UInt64) {
 		stateLock.lock()
 		if generation == requestGeneration {
+			setupDisplayIDs = nil
+			stateLock.broadcast()
+		}
+		stateLock.unlock()
+	}
+
+	private func finishSetup(targetIDs: Set<CGDirectDisplayID>) {
+		stateLock.lock()
+		if setupDisplayIDs == targetIDs {
 			setupDisplayIDs = nil
 			stateLock.broadcast()
 		}

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -31,7 +31,7 @@ struct FrozenFrameSnapshot {
 final class FrozenFrameAuthority: @unchecked Sendable {
 	private static let maximumSnapshotAgeMilliseconds = 150.0
 	private static let selfCaptureFilterRetryInterval: TimeInterval = 0.035
-	private static let selfCaptureFilterRetryWindow: TimeInterval = 1.0
+	private static let selfCaptureFilterRetryWindow: TimeInterval = 2.5
 
 	private struct DisplayTarget: Equatable {
 		let displayID: CGDirectDisplayID
@@ -438,6 +438,26 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			minSequence: tokenRecord?.sequence ?? 0,
 			startedAtUptime: ProcessInfo.processInfo.systemUptime
 		)
+	}
+
+	func needsSelfCaptureCompleteFrame(containing point: CGPoint) -> Bool {
+		stateLock.lock()
+		defer {
+			stateLock.unlock()
+		}
+		guard selfCaptureFilterRequired else {
+			return false
+		}
+		guard let displayID = displayTargets.first(where: { $0.value.frame.contains(point) })?.key
+		else {
+			return false
+		}
+		guard let record = latestFrames[displayID],
+			let eligibleRecord = snapshotEligibleRecordLocked(record)
+		else {
+			return true
+		}
+		return !eligibleRecord.selfCaptureFilterComplete
 	}
 
 	func snapshot(

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -460,6 +460,20 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		return !eligibleRecord.selfCaptureFilterComplete
 	}
 
+	func hasSelfCaptureCompleteFrame(containing point: CGPoint) -> Bool {
+		stateLock.lock()
+		defer {
+			stateLock.unlock()
+		}
+		guard let displayID = displayTargets.first(where: { $0.value.frame.contains(point) })?.key,
+			let record = latestFrames[displayID],
+			let eligibleRecord = snapshotEligibleRecordLocked(record)
+		else {
+			return false
+		}
+		return eligibleRecord.selfCaptureFilterComplete
+	}
+
 	func snapshot(
 		containing point: CGPoint,
 		after token: FrozenFrameLatchToken?,

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -7,6 +7,7 @@ import ScreenCaptureKit
 
 struct FrozenFrameLatchToken {
 	let displayID: CGDirectDisplayID
+	let generation: UInt64
 	let minSequence: UInt64
 	let startedAtUptime: TimeInterval
 }
@@ -15,9 +16,12 @@ struct FrozenFrameSnapshot {
 	let displayID: CGDirectDisplayID
 	let displayFrame: CGRect
 	let image: CGImage
+	let generation: UInt64
 	let sequence: UInt64
 	let capturedAtUptime: TimeInterval
 	let source: String
+	let selfCaptureSafe: Bool
+	let selfCaptureFilterComplete: Bool
 
 	func ageMilliseconds(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Double {
 		max(0, now - capturedAtUptime) * 1_000
@@ -26,6 +30,8 @@ struct FrozenFrameSnapshot {
 
 final class FrozenFrameAuthority: @unchecked Sendable {
 	private static let maximumSnapshotAgeMilliseconds = 150.0
+	private static let selfCaptureFilterRetryInterval: TimeInterval = 0.035
+	private static let selfCaptureFilterRetryWindow: TimeInterval = 1.0
 
 	private struct DisplayTarget: Equatable {
 		let displayID: CGDirectDisplayID
@@ -39,8 +45,10 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let displayID: CGDirectDisplayID
 		let displayFrame: CGRect
 		let pixelBuffer: CVPixelBuffer
+		let generation: UInt64
 		let sequence: UInt64
 		let capturedAtUptime: TimeInterval
+		let selfCaptureFilterComplete: Bool
 
 		func ageMilliseconds(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Double {
 			max(0, now - capturedAtUptime) * 1_000
@@ -97,13 +105,23 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 	}
 
+	private struct PreparedContentFilter {
+		let filter: SCContentFilter
+		let selfCaptureFilterComplete: Bool
+		let expectedWindowCount: Int
+		let matchedWindowCount: Int
+	}
+
 	private let stateLock = NSCondition()
 	private let outputQueue = DispatchQueue(
 		label: "ink.hack.rsnap.native-host.frozen-frame-authority-output",
 		qos: .userInteractive
 	)
 	private var generation: UInt64 = 0
+	private var setupRequestID: UInt64 = 0
 	private var setupDisplayIDs: Set<CGDirectDisplayID>?
+	private var selfCaptureFilterRequired = false
+	private var selfCaptureUnsafeAfterUptime: TimeInterval?
 	private var activeDisplayIDs: Set<CGDirectDisplayID> = []
 	private var displayTargets: [CGDirectDisplayID: DisplayTarget] = [:]
 	private var streams: [CGDirectDisplayID: DisplayStream] = [:]
@@ -117,7 +135,8 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		for screens: [NSScreen],
 		captureID: UInt64 = 0,
 		source: String = "capture",
-		rebuildContentFilter: Bool = false
+		rebuildContentFilter: Bool = false,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID> = []
 	) {
 		let setupStartedAt = ProcessInfo.processInfo.systemUptime
 		let targets = screens.compactMap(Self.displayTarget(for:))
@@ -133,18 +152,34 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let streamsCoverTargets = Set(streams.keys) == targetIDs
 		let setupInProgressForTargets = setupDisplayIDs == targetIDs
 		displayTargets = nextTargets
+		if rebuildContentFilter {
+			selfCaptureFilterRequired = true
+			selfCaptureUnsafeAfterUptime = setupStartedAt
+		}
 		// When overlay windows become visible, discard pre-overlay streams instead of updating
 		// filters in place. Keep the old stream running until the replacement is configured so a
-		// fast click immediately after overlay presentation can still freeze a fresh frame.
+		// fast click can still freeze a fresh frame, but only if that frame came from a complete
+		// self-capture-excluding filter.
 		if rebuildContentFilter, unchanged, streamsCoverTargets {
+			setupRequestID &+= 1
+			let requestID = setupRequestID
 			setupDisplayIDs = targetIDs
+			updateTelemetryContextLocked(
+				captureID: captureID,
+				source: source,
+				startedAtUptime: setupStartedAt,
+				targetIDs: targetIDs
+			)
 			stateLock.unlock()
 			rebuildStreamsFromShareableContent(
 				targets: targets,
 				targetIDs: targetIDs,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
 				captureID: captureID,
 				source: source,
-				startedAtUptime: setupStartedAt
+				startedAtUptime: setupStartedAt,
+				retryUntilUptime: setupStartedAt + Self.selfCaptureFilterRetryWindow,
+				requestID: requestID
 			)
 			return
 		}
@@ -159,9 +194,14 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			return
 		}
 		generation &+= 1
+		setupRequestID &+= 1
 		let requestGeneration = generation
 		activeDisplayIDs = targetIDs
 		setupDisplayIDs = targetIDs
+		if !rebuildContentFilter {
+			selfCaptureFilterRequired = false
+			selfCaptureUnsafeAfterUptime = nil
+		}
 		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
 		updateTelemetryContextLocked(
 			captureID: captureID,
@@ -179,6 +219,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 
 		configureStreamsFromShareableContent(
 			targets: targets,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
 			generation: requestGeneration,
 			captureID: captureID,
 			source: source,
@@ -189,11 +230,14 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	private func rebuildStreamsFromShareableContent(
 		targets: [DisplayTarget],
 		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
 		captureID: UInt64,
 		source: String,
-		startedAtUptime: TimeInterval
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		requestID: UInt64
 	) {
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) {
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
 			[weak self] content, error in
 			guard let self else {
 				return
@@ -226,9 +270,44 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 				displayCount: content.displays.count,
 				windowCount: content.windows.count
 			)
+			guard self.isCurrentSetupRequest(requestID, targetIDs: targetIDs) else {
+				return
+			}
+			let preparedFilters = Self.contentFilters(
+				for: targets,
+				in: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs
+			)
+			guard Self.filtersAreComplete(preparedFilters, for: targets) else {
+				if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
+					DispatchQueue.global(qos: .userInteractive).asyncAfter(
+						deadline: .now() + Self.selfCaptureFilterRetryInterval
+					) { [weak self] in
+						self?.rebuildStreamsFromShareableContent(
+							targets: targets,
+							targetIDs: targetIDs,
+							selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+							captureID: captureID,
+							source: source,
+							startedAtUptime: startedAtUptime,
+							retryUntilUptime: retryUntilUptime,
+							requestID: requestID
+						)
+					}
+					return
+				}
+				self.logIncompleteFilters(
+					preparedFilters,
+					targets: targets,
+					captureID: captureID,
+					source: source
+				)
+				self.finishSetup(targetIDs: targetIDs)
+				return
+			}
 
 			self.stateLock.lock()
-			guard self.activeDisplayIDs == targetIDs else {
+			guard self.setupRequestID == requestID, self.activeDisplayIDs == targetIDs else {
 				self.stateLock.unlock()
 				return
 			}
@@ -251,8 +330,8 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			}
 
 			self.configureStreams(
-				content: content,
 				targets: targets,
+				preparedFilters: preparedFilters,
 				generation: requestGeneration,
 				captureID: captureID,
 				source: source
@@ -262,12 +341,13 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 
 	private func configureStreamsFromShareableContent(
 		targets: [DisplayTarget],
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
 		generation requestGeneration: UInt64,
 		captureID: UInt64,
 		source: String,
 		startedAtUptime: TimeInterval
 	) {
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) {
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
 			[weak self] content, error in
 			guard let self else {
 				return
@@ -302,9 +382,14 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 				displayCount: content.displays.count,
 				windowCount: content.windows.count
 			)
+			let preparedFilters = Self.contentFilters(
+				for: targets,
+				in: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs
+			)
 			self.configureStreams(
-				content: content,
 				targets: targets,
+				preparedFilters: preparedFilters,
 				generation: requestGeneration,
 				captureID: captureID,
 				source: source
@@ -315,8 +400,11 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	func stop() {
 		stateLock.lock()
 		generation &+= 1
+		setupRequestID &+= 1
 		activeDisplayIDs.removeAll()
 		setupDisplayIDs = nil
+		selfCaptureFilterRequired = false
+		selfCaptureUnsafeAfterUptime = nil
 		displayTargets.removeAll()
 		latestFrames.removeAll()
 		firstFrameStartUptimes.removeAll()
@@ -341,9 +429,13 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		else {
 			return nil
 		}
+		let latestRecord = latestFrames[displayID]
+		let tokenRecord =
+			latestRecord.flatMap { snapshotEligibleRecordLocked($0) }
 		return FrozenFrameLatchToken(
 			displayID: displayID,
-			minSequence: latestFrames[displayID]?.sequence ?? 0,
+			generation: tokenRecord?.generation ?? 0,
+			minSequence: tokenRecord?.sequence ?? 0,
 			startedAtUptime: ProcessInfo.processInfo.systemUptime
 		)
 	}
@@ -363,10 +455,6 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 		var source = "post_token"
 		var record = freshRecordLocked(displayID: displayID, token: token)
-		while record == nil, Date() < deadline {
-			stateLock.wait(until: deadline)
-			record = freshRecordLocked(displayID: displayID, token: token)
-		}
 		if record == nil,
 			let fallbackRecord = unchangedRecordLocked(
 				displayID: displayID,
@@ -375,6 +463,19 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		{
 			record = fallbackRecord
 			source = "latest_unchanged"
+		}
+		while record == nil, Date() < deadline {
+			stateLock.wait(until: deadline)
+			record = freshRecordLocked(displayID: displayID, token: token)
+			if record == nil,
+				let fallbackRecord = unchangedRecordLocked(
+					displayID: displayID,
+					token: token
+				)
+			{
+				record = fallbackRecord
+				source = "latest_unchanged"
+			}
 		}
 		stateLock.unlock()
 
@@ -385,32 +486,39 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			displayID: record.displayID,
 			displayFrame: record.displayFrame,
 			image: image,
+			generation: record.generation,
 			sequence: record.sequence,
 			capturedAtUptime: record.capturedAtUptime,
-			source: source
+			source: source,
+			selfCaptureSafe: true,
+			selfCaptureFilterComplete: record.selfCaptureFilterComplete
 		)
 	}
 
 	private func freshRecordLocked(displayID: CGDirectDisplayID, token: FrozenFrameLatchToken?)
 		-> FrameRecord?
 	{
-		guard let record = latestFrames[displayID] else {
+		guard let record = latestFrames[displayID],
+			let eligibleRecord = snapshotEligibleRecordLocked(record)
+		else {
 			return nil
 		}
-		guard Self.isFreshForSnapshot(record) else {
+		guard eligibleRecord.selfCaptureFilterComplete || Self.isFreshForSnapshot(record) else {
 			return nil
 		}
 		guard let token else {
-			return record
+			return eligibleRecord
 		}
-		if record.capturedAtUptime >= token.startedAtUptime {
-			return record
+		if eligibleRecord.capturedAtUptime >= token.startedAtUptime {
+			return eligibleRecord
 		}
-		if record.sequence > token.minSequence {
-			return record
+		if eligibleRecord.generation == token.generation,
+			eligibleRecord.sequence > token.minSequence
+		{
+			return eligibleRecord
 		}
 		if token.minSequence == 0 {
-			return record
+			return eligibleRecord
 		}
 		return nil
 	}
@@ -419,14 +527,41 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		-> FrameRecord?
 	{
 		guard let token, token.minSequence > 0, let record = latestFrames[displayID],
-			record.sequence == token.minSequence
+			let eligibleRecord = snapshotEligibleRecordLocked(record),
+			eligibleRecord.generation == token.generation,
+			eligibleRecord.sequence == token.minSequence
 		else {
 			return nil
 		}
+		if !eligibleRecord.selfCaptureFilterComplete, !Self.isFreshForSnapshot(eligibleRecord) {
+			return nil
+		}
 		// ScreenCaptureKit display streams may not emit another frame while the display is
-		// visually unchanged. The latched authority frame remains the current display image in
-		// that case, even when its wall-clock age exceeds the normal post-token freshness budget.
+		// visually unchanged. A complete self-capture-excluding stream may stand in for a
+		// post-token frame on a static desktop; pre-overlay frames may do that only while still
+		// inside the freshness budget, because older pre-overlay pixels are indistinguishable from
+		// a stale video frame.
+		return eligibleRecord
+	}
+
+	private func snapshotEligibleRecordLocked(_ record: FrameRecord) -> FrameRecord? {
+		if !isSelfCaptureSafeLocked(record) {
+			return nil
+		}
 		return record
+	}
+
+	private func isSelfCaptureSafeLocked(_ record: FrameRecord) -> Bool {
+		if record.selfCaptureFilterComplete {
+			return true
+		}
+		guard selfCaptureFilterRequired else {
+			return true
+		}
+		guard let unsafeAfterUptime = selfCaptureUnsafeAfterUptime else {
+			return false
+		}
+		return record.capturedAtUptime < unsafeAfterUptime
 	}
 
 	private static func isFreshForSnapshot(_ record: FrameRecord) -> Bool {
@@ -434,27 +569,29 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	}
 
 	private func configureStreams(
-		content: SCShareableContent,
 		targets: [DisplayTarget],
+		preparedFilters: [CGDirectDisplayID: PreparedContentFilter],
 		generation requestGeneration: UInt64,
 		captureID: UInt64,
 		source: String
 	) {
 		for target in targets {
-			guard let filter = Self.contentFilter(for: target, in: content) else {
+			guard let preparedFilter = preparedFilters[target.displayID] else {
 				continue
 			}
 
 			let output = FrozenFrameStreamOutput(
 				displayID: target.displayID,
-				displayFrame: target.frame
+				displayFrame: target.frame,
+				generation: requestGeneration,
+				selfCaptureFilterComplete: preparedFilter.selfCaptureFilterComplete
 			) { [weak self] frame in
 				self?.store(frame: frame, generation: requestGeneration)
 			} telemetrySnapshot: { [weak self] in
 				self?.currentTelemetrySnapshot() ?? (captureID: captureID, source: source)
 			}
 			let stream = SCStream(
-				filter: filter, configuration: Self.streamConfiguration(for: target),
+				filter: preparedFilter.filter, configuration: Self.streamConfiguration(for: target),
 				delegate: output)
 			do {
 				try stream.addStreamOutput(
@@ -471,11 +608,23 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			}
 
 			stateLock.lock()
-			let shouldStart = generation == requestGeneration
+			let shouldStart =
+				generation == requestGeneration
+				&& (!selfCaptureFilterRequired || preparedFilter.selfCaptureFilterComplete)
 			if shouldStart {
 				streams[target.displayID] = DisplayStream(stream: stream, output: output)
 			}
 			stateLock.unlock()
+			if selfCaptureFilterRequired, !preparedFilter.selfCaptureFilterComplete {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.self_capture_filter_incomplete",
+					captureID: captureID,
+					source: source,
+					displayID: target.displayID,
+					error:
+						"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
+				)
+			}
 			guard shouldStart else {
 				continue
 			}
@@ -495,10 +644,72 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		finishSetup(generation: requestGeneration)
 	}
 
+	private func logIncompleteFilters(
+		_ preparedFilters: [CGDirectDisplayID: PreparedContentFilter],
+		targets: [DisplayTarget],
+		captureID: UInt64,
+		source: String
+	) {
+		for target in targets {
+			guard let preparedFilter = preparedFilters[target.displayID] else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.self_capture_filter_incomplete",
+					captureID: captureID,
+					source: source,
+					displayID: target.displayID,
+					error: "missingFilter"
+				)
+				continue
+			}
+			guard !preparedFilter.selfCaptureFilterComplete else {
+				continue
+			}
+			NativeHostTelemetry.frozenAuthorityWarning(
+				"frozen_authority.self_capture_filter_incomplete",
+				captureID: captureID,
+				source: source,
+				displayID: target.displayID,
+				error:
+					"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
+			)
+		}
+	}
+
+	private static func filtersAreComplete(
+		_ preparedFilters: [CGDirectDisplayID: PreparedContentFilter],
+		for targets: [DisplayTarget]
+	) -> Bool {
+		targets.allSatisfy { target in
+			preparedFilters[target.displayID]?.selfCaptureFilterComplete == true
+		}
+	}
+
+	private static func contentFilters(
+		for targets: [DisplayTarget],
+		in content: SCShareableContent,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>
+	) -> [CGDirectDisplayID: PreparedContentFilter] {
+		Dictionary(
+			uniqueKeysWithValues: targets.compactMap { target in
+				guard
+					let filter = contentFilter(
+						for: target,
+						in: content,
+						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs
+					)
+				else {
+					return nil
+				}
+				return (target.displayID, filter)
+			}
+		)
+	}
+
 	private static func contentFilter(
 		for target: DisplayTarget,
-		in content: SCShareableContent
-	) -> SCContentFilter? {
+		in content: SCShareableContent,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>
+	) -> PreparedContentFilter? {
 		guard let display = content.displays.first(where: { $0.displayID == target.displayID })
 		else {
 			return nil
@@ -506,16 +717,30 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let currentPID = getpid()
 		let excludedApplications = content.applications.filter { $0.processID == currentPID }
 		if !excludedApplications.isEmpty {
-			return SCContentFilter(
-				display: display,
-				excludingApplications: excludedApplications,
-				exceptingWindows: []
+			return PreparedContentFilter(
+				filter: SCContentFilter(
+					display: display,
+					excludingApplications: excludedApplications,
+					exceptingWindows: []
+				),
+				selfCaptureFilterComplete: true,
+				expectedWindowCount: selfCaptureExceptionWindowIDs.count,
+				matchedWindowCount: selfCaptureExceptionWindowIDs.count
 			)
 		}
 		let excludedWindows = content.windows.filter {
 			$0.owningApplication?.processID == currentPID
 		}
-		return SCContentFilter(display: display, excludingWindows: excludedWindows)
+		let matchedWindowIDs = Set(excludedWindows.map(\.windowID))
+		let missingWindowIDs = selfCaptureExceptionWindowIDs.subtracting(matchedWindowIDs)
+		let hasCompleteWindowExclusion =
+			!selfCaptureExceptionWindowIDs.isEmpty && missingWindowIDs.isEmpty
+		return PreparedContentFilter(
+			filter: SCContentFilter(display: display, excludingWindows: excludedWindows),
+			selfCaptureFilterComplete: hasCompleteWindowExclusion,
+			expectedWindowCount: selfCaptureExceptionWindowIDs.count,
+			matchedWindowCount: selfCaptureExceptionWindowIDs.count - missingWindowIDs.count
+		)
 	}
 
 	private func store(
@@ -524,7 +749,9 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	) {
 		var firstFrameTelemetry: TelemetryContext?
 		stateLock.lock()
-		if generation == requestGeneration, activeDisplayIDs.contains(frame.displayID) {
+		if generation == requestGeneration, activeDisplayIDs.contains(frame.displayID),
+			isSelfCaptureSafeLocked(frame)
+		{
 			if !firstFrameLoggedDisplayIDs.contains(frame.displayID) {
 				firstFrameLoggedDisplayIDs.insert(frame.displayID)
 				let startedAt =
@@ -547,7 +774,10 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 				totalMilliseconds: NativeHostTelemetry.milliseconds(
 					since: firstFrameTelemetry.startedAtUptime),
 				frameAgeMilliseconds: frame.ageMilliseconds(),
-				sequence: frame.sequence
+				sequence: frame.sequence,
+				generation: frame.generation,
+				selfCaptureSafe: true,
+				selfCaptureFilterComplete: frame.selfCaptureFilterComplete
 			)
 		}
 	}
@@ -573,6 +803,15 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	private func isCurrentGeneration(_ requestGeneration: UInt64) -> Bool {
 		stateLock.lock()
 		let isCurrent = generation == requestGeneration
+		stateLock.unlock()
+		return isCurrent
+	}
+
+	private func isCurrentSetupRequest(_ requestID: UInt64, targetIDs: Set<CGDirectDisplayID>)
+		-> Bool
+	{
+		stateLock.lock()
+		let isCurrent = setupRequestID == requestID && activeDisplayIDs == targetIDs
 		stateLock.unlock()
 		return isCurrent
 	}
@@ -682,6 +921,8 @@ private final class FrozenFrameStreamOutput: NSObject, SCStreamOutput, SCStreamD
 {
 	private let displayID: CGDirectDisplayID
 	private let displayFrame: CGRect
+	private let generation: UInt64
+	private let selfCaptureFilterComplete: Bool
 	private let onFrame: (FrozenFrameAuthority.FrameRecord) -> Void
 	private let telemetrySnapshot: () -> (captureID: UInt64, source: String)
 	private var sequence: UInt64 = 0
@@ -689,11 +930,15 @@ private final class FrozenFrameStreamOutput: NSObject, SCStreamOutput, SCStreamD
 	init(
 		displayID: CGDirectDisplayID,
 		displayFrame: CGRect,
+		generation: UInt64,
+		selfCaptureFilterComplete: Bool,
 		onFrame: @escaping (FrozenFrameAuthority.FrameRecord) -> Void,
 		telemetrySnapshot: @escaping () -> (captureID: UInt64, source: String)
 	) {
 		self.displayID = displayID
 		self.displayFrame = displayFrame
+		self.generation = generation
+		self.selfCaptureFilterComplete = selfCaptureFilterComplete
 		self.onFrame = onFrame
 		self.telemetrySnapshot = telemetrySnapshot
 	}
@@ -713,8 +958,10 @@ private final class FrozenFrameStreamOutput: NSObject, SCStreamOutput, SCStreamD
 				displayID: displayID,
 				displayFrame: displayFrame,
 				pixelBuffer: pixelBuffer,
+				generation: generation,
 				sequence: sequence,
-				capturedAtUptime: ProcessInfo.processInfo.systemUptime
+				capturedAtUptime: ProcessInfo.processInfo.systemUptime,
+				selfCaptureFilterComplete: selfCaptureFilterComplete
 			)
 		)
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
@@ -132,49 +132,6 @@ final class LiveFrameStreamBroker {
 		)
 	}
 
-	func latestMonitorImage(containing point: CGPoint) -> (frame: CGRect, image: CGImage)? {
-		guard let monitor = monitor(containing: point) else {
-			return nil
-		}
-		stateLock.lock()
-		let sampler = self.sampler
-		let encodedMonitor = samplerMonitorSnapshot(for: monitor)
-		stateLock.unlock()
-		guard let sampler else {
-			return nil
-		}
-		for _ in 0..<3 {
-			if let snapshot = try? sampler.peekLatestMonitorImage(monitor: encodedMonitor),
-				let image = cgImage(
-					width: snapshot.width, height: snapshot.height, rgba: snapshot.rgba)
-			{
-				return (frame: monitor.appKitFrame, image: image)
-			}
-			prime(monitor: monitor)
-			Thread.sleep(forTimeInterval: 1.0 / 120.0)
-		}
-		return nil
-	}
-
-	func cachedMonitorImage(containing point: CGPoint) -> (frame: CGRect, image: CGImage)? {
-		guard let monitor = monitor(containing: point) else {
-			return nil
-		}
-		stateLock.lock()
-		let sampler = self.sampler
-		let encodedMonitor = samplerMonitorSnapshot(for: monitor)
-		stateLock.unlock()
-		guard let sampler else {
-			return nil
-		}
-		guard let snapshot = try? sampler.peekLatestMonitorImage(monitor: encodedMonitor),
-			let image = cgImage(width: snapshot.width, height: snapshot.height, rgba: snapshot.rgba)
-		else {
-			return nil
-		}
-		return (frame: monitor.appKitFrame, image: image)
-	}
-
 	func prime(at point: CGPoint?) {
 		guard let point, let monitor = monitor(containing: point) else {
 			return

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -971,6 +971,7 @@ final class LiveOverlayRenderer {
 	private weak var hostView: NSView?
 	private let rootLayer = CALayer()
 	private let frozenDisplayLayer = CALayer()
+	private let scrimLayer = CAShapeLayer()
 	private let topScrimLayer = CALayer()
 	private let leftScrimLayer = CALayer()
 	private let rightScrimLayer = CALayer()
@@ -1092,10 +1093,14 @@ final class LiveOverlayRenderer {
 
 	private func configureLayers() {
 		rootLayer.zPosition = 100
-		rootLayer.masksToBounds = false
+		rootLayer.masksToBounds = true
 		frozenDisplayLayer.isHidden = true
 		frozenDisplayLayer.zPosition = LayerZ.frozenDisplay
 		rootLayer.addSublayer(frozenDisplayLayer)
+		scrimLayer.fillRule = .evenOdd
+		scrimLayer.isHidden = true
+		scrimLayer.zPosition = LayerZ.scrim
+		rootLayer.addSublayer(scrimLayer)
 		for scrimLayer in [topScrimLayer, leftScrimLayer, rightScrimLayer, bottomScrimLayer] {
 			rootLayer.addSublayer(scrimLayer)
 			scrimLayer.isHidden = true
@@ -1275,6 +1280,7 @@ final class LiveOverlayRenderer {
 	private func renderFocus(_ snapshot: LivePreviewSnapshot) {
 		let focusRect = snapshot.dragSelectionLocal ?? snapshot.hoverSelectionLocal
 		guard let focusRect else {
+			scrimLayer.isHidden = true
 			for scrimLayer in [topScrimLayer, leftScrimLayer, rightScrimLayer, bottomScrimLayer] {
 				scrimLayer.isHidden = true
 			}
@@ -1289,27 +1295,10 @@ final class LiveOverlayRenderer {
 		let scrimAlpha = CGFloat(CaptureChrome.liveScrimAlpha)
 		let scrimColor = NSColor(calibratedWhite: 0, alpha: scrimAlpha).cgColor
 		let bounds = snapshot.bounds
-		let rects = [
-			CGRect(
-				x: bounds.minX, y: bounds.minY, width: bounds.width,
-				height: max(0, focusRect.minY - bounds.minY)),
-			CGRect(
-				x: bounds.minX, y: focusRect.minY, width: max(0, focusRect.minX - bounds.minX),
-				height: focusRect.height),
-			CGRect(
-				x: focusRect.maxX, y: focusRect.minY, width: max(0, bounds.maxX - focusRect.maxX),
-				height: focusRect.height),
-			CGRect(
-				x: bounds.minX, y: focusRect.maxY, width: bounds.width,
-				height: max(0, bounds.maxY - focusRect.maxY)),
-		]
-		for (layer, rect) in zip(
-			[topScrimLayer, leftScrimLayer, rightScrimLayer, bottomScrimLayer], rects)
-		{
-			layer.backgroundColor = scrimColor
-			layer.frame = rect
-			layer.isHidden = rect.width <= 0 || rect.height <= 0
+		for legacyScrimLayer in [topScrimLayer, leftScrimLayer, rightScrimLayer, bottomScrimLayer] {
+			legacyScrimLayer.isHidden = true
 		}
+		updateScrimLayer(bounds: bounds, focusRect: focusRect, color: scrimColor)
 
 		if snapshot.frozenPending {
 			hoverGlowLayer.isHidden = true
@@ -1323,7 +1312,19 @@ final class LiveOverlayRenderer {
 				pixelsPerPoint: pixelsPerPoint
 			)
 			let borderRect = focusRect.insetBy(dx: -borderOutset, dy: -borderOutset)
-			let frozenPath = CaptureChrome.dashedBorderPath(for: borderRect)
+			let layerFrame = dashedBorderLayerFrame(
+				for: borderRect,
+				lineWidth: CaptureChrome.frozenDashedBorderWidth + 0.75
+			)
+			let localBorderRect = borderRect.offsetBy(
+				dx: -layerFrame.minX,
+				dy: -layerFrame.minY
+			)
+			let frozenPath = CaptureChrome.dashedBorderPath(for: localBorderRect)
+			for layer in [dragBorderOutlineLayer, dragBorderLayer] {
+				layer.frame = layerFrame
+				layer.masksToBounds = true
+			}
 			dragBorderOutlineLayer.path = frozenPath
 			dragBorderOutlineLayer.strokeColor =
 				NSColor(calibratedRed: 229 / 255, green: 247 / 255, blue: 1, alpha: 116 / 255)
@@ -1352,7 +1353,19 @@ final class LiveOverlayRenderer {
 				pixelsPerPoint: pixelsPerPoint
 			)
 			let borderRect = dragSelection.insetBy(dx: -borderOutset, dy: -borderOutset)
-			let dragPath = CaptureChrome.dashedBorderPath(for: borderRect)
+			let layerFrame = dashedBorderLayerFrame(
+				for: borderRect,
+				lineWidth: CaptureChrome.liveDashedBorderWidth + 0.75
+			)
+			let localBorderRect = borderRect.offsetBy(
+				dx: -layerFrame.minX,
+				dy: -layerFrame.minY
+			)
+			let dragPath = CaptureChrome.dashedBorderPath(for: localBorderRect)
+			for layer in [dragBorderOutlineLayer, dragBorderLayer] {
+				layer.frame = layerFrame
+				layer.masksToBounds = true
+			}
 			dragBorderOutlineLayer.path = dragPath
 			dragBorderOutlineLayer.strokeColor =
 				NSColor(calibratedRed: 229 / 255, green: 247 / 255, blue: 1, alpha: 116 / 255)
@@ -1410,6 +1423,24 @@ final class LiveOverlayRenderer {
 			contentsScale: contentsScale,
 			animates: animatesFlow
 		)
+	}
+
+	private func dashedBorderLayerFrame(for borderRect: CGRect, lineWidth: CGFloat) -> CGRect {
+		let padding = max(lineWidth + 2, 4)
+		return borderRect.insetBy(dx: -padding, dy: -padding)
+	}
+
+	private func updateScrimLayer(bounds: CGRect, focusRect: CGRect, color: CGColor) {
+		let path = CGMutablePath()
+		path.addRect(bounds)
+		let visibleFocusRect = focusRect.intersection(bounds)
+		if !visibleFocusRect.isNull, visibleFocusRect.width > 0, visibleFocusRect.height > 0 {
+			path.addRect(visibleFocusRect)
+		}
+		scrimLayer.frame = bounds
+		scrimLayer.path = path
+		scrimLayer.fillColor = color
+		scrimLayer.isHidden = false
 	}
 
 	private func shouldAnimateSelectionFlow(_ snapshot: LivePreviewSnapshot) -> Bool {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -1002,6 +1002,10 @@ final class CaptureSessionController: NSObject {
 			do {
 				try self.session?.send(report: .freezeSnapshotCommitted(selection: nextSelection))
 				try self.syncCore()
+				NativeHostTelemetry.captureEvent(
+					"capture.frozen_selection_transform_commit",
+					captureID: captureID
+				)
 			} catch {
 				NativeHostTelemetry.captureWarning(
 					"capture.frozen_selection_transform_commit_failed",
@@ -5079,10 +5083,10 @@ final class CaptureHostView: NSView {
 
 	private func refreshLiveHighlightedWindowPreview(at globalPoint: CGPoint?) {
 		guard let globalPoint else {
+			liveHighlightedWindowPreview = nil
 			return
 		}
-		liveHighlightedWindowPreview =
-			controller?.previewHighlightedWindow(at: globalPoint) ?? liveHighlightedWindowPreview
+		liveHighlightedWindowPreview = controller?.previewHighlightedWindow(at: globalPoint)
 	}
 
 	private func updateLiveChromeBackdrops() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -430,7 +430,8 @@ final class CaptureSessionController: NSObject {
 	func warmLiveSamplingIfPossible(
 		at point: CGPoint,
 		source: String = "capture",
-		captureID: UInt64 = 0
+		captureID: UInt64 = 0,
+		excludeSelfFromFrozenAuthority: Bool = false
 	) -> LiveChromeSample? {
 		let warmStartedAt = ProcessInfo.processInfo.systemUptime
 		let screenCount = NSScreen.screens.count
@@ -449,7 +450,12 @@ final class CaptureSessionController: NSObject {
 		}
 		let screens = NSScreen.screens
 		let frozenAuthorityStartedAt = ProcessInfo.processInfo.systemUptime
-		frozenFrameAuthority.start(for: screens, captureID: captureID, source: source)
+		frozenFrameAuthority.start(
+			for: screens,
+			captureID: captureID,
+			source: source,
+			rebuildContentFilter: excludeSelfFromFrozenAuthority
+		)
 		let frozenAuthorityStartMilliseconds =
 			NativeHostTelemetry.milliseconds(since: frozenAuthorityStartedAt)
 		let liveStreamStartedAt = ProcessInfo.processInfo.systemUptime
@@ -507,7 +513,10 @@ final class CaptureSessionController: NSObject {
 			prepareLiveSamplingForCaptureStart()
 			let warmStartedAt = ProcessInfo.processInfo.systemUptime
 			let initialSample = warmLiveSamplingIfPossible(
-				at: startPoint, source: "start_capture", captureID: captureID)
+				at: startPoint,
+				source: "start_capture",
+				captureID: captureID
+			)
 			let warmMilliseconds = NativeHostTelemetry.milliseconds(since: warmStartedAt)
 			frozenFrameLatchToken = nil
 			let desktopFrame = CaptureOverlayController.desktopFrame
@@ -553,7 +562,8 @@ final class CaptureSessionController: NSObject {
 				for: NSScreen.screens,
 				captureID: captureID,
 				source: "capture_overlay_visible",
-				rebuildContentFilter: true
+				rebuildContentFilter: true,
+				selfCaptureExceptionWindowIDs: overlayController.selfCaptureExceptionWindowIDs
 			)
 			let overlayShowMilliseconds =
 				NativeHostTelemetry.milliseconds(since: overlayShowStartedAt)
@@ -1404,6 +1414,9 @@ final class CaptureSessionController: NSObject {
 			displayID: frozenFrame.displayID,
 			sequence: frozenFrame.sequence,
 			snapshotSource: frozenFrame.source,
+			snapshotGeneration: frozenFrame.generation,
+			selfCaptureSafe: frozenFrame.selfCaptureSafe,
+			selfCaptureFilterComplete: frozenFrame.selfCaptureFilterComplete,
 			hadLatchToken: hadLatchToken,
 			baseReady: chromeState.frozenBaseImage != nil
 		)
@@ -1411,7 +1424,7 @@ final class CaptureSessionController: NSObject {
 	}
 
 	private func frozenFrameLatchWait() -> TimeInterval {
-		min(0.040, max(0.018, NativeHostDisplayRefresh.frameInterval * 2.5))
+		max(1.5, NativeHostDisplayRefresh.frameInterval * 2.5)
 	}
 
 	private func snapshotForFrozenCommit(
@@ -2271,6 +2284,10 @@ final class CaptureOverlayController {
 
 	var primaryWindow: NSWindow? {
 		windows.first(where: { $0.windowNumber == focusedWindowNumber }) ?? windows.first
+	}
+
+	fileprivate var selfCaptureExceptionWindowIDs: Set<CGWindowID> {
+		Set(windows.map { CGWindowID($0.windowNumber) })
 	}
 
 	fileprivate func show(

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -91,6 +91,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	private let globalHotKeys = GlobalHotKeyCenter()
 	private var lifecycleActivity: NSObjectProtocol?
 	private var liveSamplingPrewarmWorkItem: DispatchWorkItem?
+	private var selfCaptureRegistrationWindow: NSWindow?
 	private var didBootstrap = false
 	@objc public dynamic var window: NSWindow?
 	private lazy var sessionController: CaptureSessionController = {
@@ -127,6 +128,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		Self.applyApplicationIcon()
 		configureStatusItem()
 		configureGlobalHotKeys()
+		showSelfCaptureRegistrationWindow()
 		NotificationCenter.default.addObserver(
 			self,
 			selector: #selector(settingsDidChange),
@@ -144,6 +146,31 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 
 	public func applicationDidFinishLaunching(_ notification: Notification) {
 		finishLaunching()
+	}
+
+	private func showSelfCaptureRegistrationWindow() {
+		guard selfCaptureRegistrationWindow == nil else {
+			return
+		}
+		let screenFrame = NSScreen.main?.frame ?? CGRect(x: 0, y: 0, width: 1, height: 1)
+		let window = NSWindow(
+			contentRect: CGRect(x: screenFrame.minX, y: screenFrame.minY, width: 1, height: 1),
+			styleMask: [.borderless],
+			backing: .buffered,
+			defer: false
+		)
+		window.alphaValue = 0.001
+		window.backgroundColor = .clear
+		window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+		window.hasShadow = false
+		window.ignoresMouseEvents = true
+		window.isOpaque = false
+		window.isReleasedWhenClosed = false
+		window.level = .normal
+		window.sharingType = .readOnly
+		window.orderFrontRegardless()
+		selfCaptureRegistrationWindow = window
+		NativeHostTelemetry.lifecycleDebug("native_host.self_capture_registration_window_visible")
 	}
 
 	public func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -353,7 +380,8 @@ final class CaptureSessionController: NSObject {
 		let desktopFrame: CGRect
 	}
 
-	private static let coldSelfCaptureCompleteFrameWait: TimeInterval = 3.5
+	private static let displayFirstFrameWait: TimeInterval = 0.025
+	private static let coldSelfCaptureRecoveryWait: TimeInterval = 3.5
 
 	private let settingsStore: NativeHostSettingsStore
 	private let liveFrameStream = LiveFrameStreamBroker()
@@ -560,13 +588,21 @@ final class CaptureSessionController: NSObject {
 				focusPoint: startPoint,
 				initialWindowSnapshots: initialWindowSnapshots
 			)
-			frozenFrameAuthority.start(
-				for: NSScreen.screens,
-				captureID: captureID,
-				source: "capture_overlay_visible",
-				rebuildContentFilter: true,
-				selfCaptureExceptionWindowIDs: overlayController.selfCaptureExceptionWindowIDs
-			)
+			if frozenFrameAuthority.hasSelfCaptureCompleteFrame(containing: startPoint) {
+				NativeHostTelemetry.captureEvent(
+					"capture.self_capture_rebuild_skipped",
+					captureID: captureID,
+					detail: "startup_complete_filter"
+				)
+			} else {
+				frozenFrameAuthority.start(
+					for: NSScreen.screens,
+					captureID: captureID,
+					source: "capture_overlay_visible",
+					rebuildContentFilter: true,
+					selfCaptureExceptionWindowIDs: overlayController.selfCaptureExceptionWindowIDs
+				)
+			}
 			let overlayShowMilliseconds =
 				NativeHostTelemetry.milliseconds(since: overlayShowStartedAt)
 			(NSApp.delegate as? NativeHostApplicationController)?.window =
@@ -1426,12 +1462,8 @@ final class CaptureSessionController: NSObject {
 		try session.send(report: .freezeSnapshotCommitted(selection: selection))
 	}
 
-	private func frozenFrameLatchWait(containing point: CGPoint) -> TimeInterval {
-		let hotWait = max(1.5, NativeHostDisplayRefresh.frameInterval * 2.5)
-		guard frozenFrameAuthority.needsSelfCaptureCompleteFrame(containing: point) else {
-			return hotWait
-		}
-		return max(hotWait, Self.coldSelfCaptureCompleteFrameWait)
+	private func frozenFrameLatchWait(containing _: CGPoint) -> TimeInterval {
+		Self.displayFirstFrameWait
 	}
 
 	private func snapshotForFrozenCommit(
@@ -1439,10 +1471,20 @@ final class CaptureSessionController: NSObject {
 		after token: FrozenFrameLatchToken?,
 		maxWait: TimeInterval
 	) -> FrozenFrameSnapshot? {
-		return frozenFrameAuthority.snapshot(
+		if let frozenFrame = frozenFrameAuthority.snapshot(
 			containing: point,
 			after: token,
 			maxWait: maxWait
+		) {
+			return frozenFrame
+		}
+		guard frozenFrameAuthority.needsSelfCaptureCompleteFrame(containing: point) else {
+			return nil
+		}
+		return frozenFrameAuthority.snapshot(
+			containing: point,
+			after: token,
+			maxWait: max(0, Self.coldSelfCaptureRecoveryWait - maxWait)
 		)
 	}
 
@@ -1750,15 +1792,16 @@ final class CaptureSessionController: NSObject {
 		guard let screen = screen(containing: point) else {
 			return nil
 		}
-		let screenNumber =
-			(screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
-			.uint32Value
-			?? 0
 		return MonitorSnapshot(
-			id: screenNumber,
+			id: Self.displayID(for: screen) ?? 0,
 			frame: screen.frame,
 			scaleFactorX1000: UInt32((screen.backingScaleFactor * 1_000).rounded())
 		)
+	}
+
+	private static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+		(screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+			.uint32Value
 	}
 
 	private func highlightedWindow(at point: CGPoint) -> WindowSnapshot? {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -969,6 +969,9 @@ final class CaptureSessionController: NSObject {
 		at point: CGPoint,
 		selection: CGRect
 	) -> Bool {
+		guard chromeState.frozenSelectionEditable else {
+			return false
+		}
 		guard
 			let monitorFrame = screen(containing: CGPoint(x: selection.midX, y: selection.midY))?
 				.frame
@@ -1431,7 +1434,10 @@ final class CaptureSessionController: NSObject {
 		chromeState.frozenSelectionInteraction = nil
 		chromeState.frozenDisplayFrame = frozenFrame.displayFrame
 		chromeState.frozenDisplayImage = frozenFrame.image
-		let hostOwnedFrozenScene = hostOwnedFrozenPresentationScene(for: selection)
+		let hostOwnedFrozenScene = hostOwnedFrozenPresentationScene(
+			for: selection,
+			editable: editable
+		)
 		let presentStartedAt = ProcessInfo.processInfo.systemUptime
 		overlayController?.presentFrozenFirstFrame(
 			scene: hostOwnedFrozenScene,
@@ -1488,10 +1494,12 @@ final class CaptureSessionController: NSObject {
 		)
 	}
 
-	private func hostOwnedFrozenPresentationScene(for selection: CGRect) -> SceneSnapshot {
+	private func hostOwnedFrozenPresentationScene(for selection: CGRect, editable: Bool)
+		-> SceneSnapshot
+	{
 		SceneSnapshot(
 			mode: .frozen,
-			cursorIntent: .grab,
+			cursorIntent: editable ? .grab : .default,
 			pointer: scene.pointer,
 			activeMonitor: nil,
 			highlightedWindow: nil,
@@ -4121,6 +4129,9 @@ final class CaptureHostView: NSView {
 			{
 				if [ToolbarItemKind.pen, .arrow, .mosaic, .spotlight].contains(selectedModeTool) {
 					return .crosshair
+				}
+				if selectedModeTool == .pointer, !chrome.frozenSelectionEditable {
+					return .arrow
 				}
 				if selectedModeTool == .pointer,
 					let pointer = currentGlobalMousePoint(),

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -353,6 +353,8 @@ final class CaptureSessionController: NSObject {
 		let desktopFrame: CGRect
 	}
 
+	private static let coldSelfCaptureCompleteFrameWait: TimeInterval = 3.5
+
 	private let settingsStore: NativeHostSettingsStore
 	private let liveFrameStream = LiveFrameStreamBroker()
 	private let frozenFrameAuthority = FrozenFrameAuthority()
@@ -1362,7 +1364,7 @@ final class CaptureSessionController: NSObject {
 		let frozenFrame = snapshotForFrozenCommit(
 			containing: selectionCenter,
 			after: token,
-			maxWait: frozenFrameLatchWait()
+			maxWait: frozenFrameLatchWait(containing: selectionCenter)
 		)
 		let snapshotWaitMilliseconds =
 			NativeHostTelemetry.milliseconds(since: snapshotStartedAt)
@@ -1423,8 +1425,12 @@ final class CaptureSessionController: NSObject {
 		try session.send(report: .freezeSnapshotCommitted(selection: selection))
 	}
 
-	private func frozenFrameLatchWait() -> TimeInterval {
-		max(1.5, NativeHostDisplayRefresh.frameInterval * 2.5)
+	private func frozenFrameLatchWait(containing point: CGPoint) -> TimeInterval {
+		let hotWait = max(1.5, NativeHostDisplayRefresh.frameInterval * 2.5)
+		guard frozenFrameAuthority.needsSelfCaptureCompleteFrame(containing: point) else {
+			return hotWait
+		}
+		return max(hotWait, Self.coldSelfCaptureCompleteFrameWait)
 	}
 
 	private func snapshotForFrozenCommit(

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -553,7 +553,7 @@ final class CaptureSessionController: NSObject {
 				for: NSScreen.screens,
 				captureID: captureID,
 				source: "capture_overlay_visible",
-				refreshContentFilter: true
+				rebuildContentFilter: true
 			)
 			let overlayShowMilliseconds =
 				NativeHostTelemetry.milliseconds(since: overlayShowStartedAt)
@@ -710,6 +710,8 @@ final class CaptureSessionController: NSObject {
 			)
 			try syncCore()
 		} catch {
+			chromeState.endHostLocalFrozenSelecting()
+			refreshOverlay()
 			NativeHostTelemetry.captureWarning(
 				"capture.primary_interaction_begin_failed",
 				captureID: currentCaptureTelemetryID,
@@ -730,7 +732,6 @@ final class CaptureSessionController: NSObject {
 			if frozenFrameLatchToken == nil {
 				frozenFrameLatchToken = frozenFrameAuthority.latchToken(containing: point)
 			}
-			beginHostLocalFrozenSelectingIfPossible(at: point)
 			let liveInputs = currentLiveInputs(at: point)
 			try session?.send(
 				event: .pointerMoved(
@@ -764,12 +765,12 @@ final class CaptureSessionController: NSObject {
 			return
 		}
 
+		overlayController?.markLivePrimaryInteractionReleased(at: point)
 		do {
 			liveFrameStream.prime(at: point)
 			if frozenFrameLatchToken == nil {
 				frozenFrameLatchToken = frozenFrameAuthority.latchToken(containing: point)
 			}
-			beginHostLocalFrozenSelectingIfPossible(at: point)
 			let liveInputs = currentLiveInputs(at: point)
 			try session?.send(
 				event: .pointerMoved(
@@ -787,7 +788,13 @@ final class CaptureSessionController: NSObject {
 				)
 			)
 			try syncCore()
+			if scene.mode == .live {
+				chromeState.endHostLocalFrozenSelecting()
+				refreshOverlay()
+			}
 		} catch {
+			chromeState.endHostLocalFrozenSelecting()
+			refreshOverlay()
 			NativeHostTelemetry.captureWarning(
 				"capture.primary_interaction_complete_failed",
 				captureID: currentCaptureTelemetryID,
@@ -795,6 +802,14 @@ final class CaptureSessionController: NSObject {
 				error: String(describing: error)
 			)
 		}
+	}
+
+	func registerLivePrimaryInteractionOwner(_ owner: CaptureHostView) {
+		overlayController?.registerLivePrimaryInteractionOwner(owner)
+	}
+
+	func completeLivePrimaryInteraction(from sender: CaptureHostView, at point: CGPoint) {
+		overlayController?.completeLivePrimaryInteraction(from: sender, at: point)
 	}
 
 	func copySelection() {
@@ -1274,10 +1289,10 @@ final class CaptureSessionController: NSObject {
 			break
 		case .stopLiveCapture:
 			tearDownCapture()
-		case .requestFreezeSnapshot(let selection):
+		case .requestFreezeSnapshot(let selection, let selectionEditable):
 			try commitFrozenSelection(
 				selection,
-				editable: scene.liveSelectionPreview == selection
+				editable: selectionEditable
 			)
 		case .copyCapture:
 			try performCopy()
@@ -1342,6 +1357,9 @@ final class CaptureSessionController: NSObject {
 		let snapshotWaitMilliseconds =
 			NativeHostTelemetry.milliseconds(since: snapshotStartedAt)
 		guard let frozenFrame else {
+			frozenFrameLatchToken = nil
+			chromeState.endHostLocalFrozenSelecting()
+			refreshOverlay()
 			NativeHostTelemetry.captureWarning(
 				"capture.freeze_commit_failed",
 				captureID: captureID,
@@ -1401,53 +1419,11 @@ final class CaptureSessionController: NSObject {
 		after token: FrozenFrameLatchToken?,
 		maxWait: TimeInterval
 	) -> FrozenFrameSnapshot? {
-		if let snapshot = frozenFrameAuthority.latestSnapshot(containing: point) {
-			return snapshot
-		}
-		if let snapshot = liveSamplerSnapshotForFrozenCommit(near: point, allowsWait: false) {
-			return snapshot
-		}
-		if let snapshot = frozenFrameAuthority.snapshot(
+		return frozenFrameAuthority.snapshot(
 			containing: point,
 			after: token,
 			maxWait: maxWait
-		) {
-			return snapshot
-		}
-		if let snapshot = liveSamplerSnapshotForFrozenCommit(near: point, allowsWait: true) {
-			return snapshot
-		}
-		return nil
-	}
-
-	private func liveSamplerSnapshotForFrozenCommit(
-		near point: CGPoint,
-		allowsWait: Bool
-	) -> FrozenFrameSnapshot? {
-		let captured =
-			allowsWait
-			? overlayController?.latestMonitorImage(near: point)
-			: overlayController?.cachedMonitorImage(near: point)
-		guard let captured
-		else {
-			return nil
-		}
-		let displayID =
-			NSScreen.screens.first(where: { $0.frame.contains(point) })
-			.flatMap(Self.displayID(for:)) ?? 0
-		return FrozenFrameSnapshot(
-			displayID: displayID,
-			displayFrame: captured.frame,
-			image: captured.image,
-			sequence: 0,
-			capturedAtUptime: ProcessInfo.processInfo.systemUptime,
-			source: "live_sampler_latest"
 		)
-	}
-
-	private static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
-		(screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
-			.uint32Value
 	}
 
 	private func hostOwnedFrozenPresentationScene(for selection: CGRect) -> SceneSnapshot {
@@ -2271,6 +2247,7 @@ final class CaptureOverlayController {
 	private weak var controller: CaptureSessionController?
 	private var windows: [CaptureOverlayWindow] = []
 	private var retiringWindows: [CaptureOverlayWindow] = []
+	private weak var livePrimaryInteractionOwner: CaptureHostView?
 	private var focusedWindowNumber: Int?
 	private var collapsedForFrozen = false
 	private let liveFrameStream: LiveFrameStreamBroker
@@ -2369,6 +2346,36 @@ final class CaptureOverlayController {
 		}
 	}
 
+	fileprivate func markLivePrimaryInteractionReleased(at point: CGPoint) {
+		if let owner = livePrimaryInteractionOwner, owner.hasLivePrimaryInteraction {
+			owner.markLivePrimaryInteractionReleased(at: point)
+			return
+		}
+		for window in windows where window.hostView.hasLivePrimaryInteraction {
+			window.hostView.markLivePrimaryInteractionReleased(at: point)
+		}
+	}
+
+	fileprivate func registerLivePrimaryInteractionOwner(_ owner: CaptureHostView) {
+		livePrimaryInteractionOwner = owner
+	}
+
+	fileprivate func completeLivePrimaryInteraction(from sender: CaptureHostView, at point: CGPoint)
+	{
+		guard
+			let owner = livePrimaryInteractionOwner,
+			owner.hasLivePrimaryInteraction
+		else {
+			if sender.hasLivePrimaryInteraction {
+				sender.completeOwnedLivePrimaryInteraction(at: point)
+				livePrimaryInteractionOwner = nil
+			}
+			return
+		}
+		owner.completeOwnedLivePrimaryInteraction(at: point)
+		livePrimaryInteractionOwner = nil
+	}
+
 	fileprivate func presentFrozenFirstFrame(
 		scene: SceneSnapshot,
 		chrome: CaptureChromeState,
@@ -2376,7 +2383,13 @@ final class CaptureOverlayController {
 	) {
 		guard
 			scene.mode == .frozen,
-			let selection = scene.frozenSelection,
+			let selection = scene.frozenSelection
+		else {
+			update(scene: scene, chrome: chrome, settings: settings)
+			return
+		}
+		prepareFrozenPresentation(for: selection)
+		guard
 			let primaryWindow = windows.first(where: {
 				$0.frame.contains(CGPoint(x: selection.midX, y: selection.midY))
 			}) ?? windows.first
@@ -2392,9 +2405,6 @@ final class CaptureOverlayController {
 			rendersPendingFrame: false
 		)
 		primaryWindow.hostView.finishFrozenFirstFrameInstall()
-		DispatchQueue.main.async { [weak self] in
-			self?.prepareFrozenPresentation(for: selection)
-		}
 	}
 
 	func focusWindow(at point: CGPoint) {
@@ -2428,11 +2438,13 @@ final class CaptureOverlayController {
 
 		let windowsToRetire = windows
 		windows.removeAll()
+		livePrimaryInteractionOwner = nil
 		focusedWindowNumber = nil
 		collapsedForFrozen = false
 		(NSApp.delegate as? NativeHostApplicationController)?.window = nil
 
 		for window in windowsToRetire {
+			window.hostView.clearLivePrimaryInteractionState(rendersImmediately: false)
 			window.hostView.finishLivePresentationTelemetry(reason: "close")
 			window.hostView.controller = nil
 			window.ignoresMouseEvents = true
@@ -2470,18 +2482,6 @@ final class CaptureOverlayController {
 
 	func cachedRegionImage(in rect: CGRect) -> CGImage? {
 		liveFrameStream.region(in: rect)
-	}
-
-	fileprivate func latestMonitorImage(
-		near point: CGPoint
-	) -> (frame: CGRect, image: CGImage)? {
-		liveFrameStream.latestMonitorImage(containing: point)
-	}
-
-	fileprivate func cachedMonitorImage(
-		near point: CGPoint
-	) -> (frame: CGRect, image: CGImage)? {
-		liveFrameStream.cachedMonitorImage(containing: point)
 	}
 
 	fileprivate func updateLivePreviewDemand(
@@ -2817,6 +2817,8 @@ final class CaptureOverlayWindow: NSPanel {
 
 @MainActor
 final class CaptureHostView: NSView {
+	private static let liveDragIntentThreshold: CGFloat = 3
+
 	private final class FrozenToolbarRenderView: NSView {
 		struct Item: Equatable {
 			let kind: ToolbarItemKind
@@ -3031,6 +3033,11 @@ final class CaptureHostView: NSView {
 	private var queuedPointerWorkItem: DispatchWorkItem?
 	private var lastHoverPointerDispatchUptime: TimeInterval = 0
 	private var lastDragPointerDispatchUptime: TimeInterval = 0
+	private var liveDragStartGlobal: CGPoint?
+	private var liveDragReleasedGlobal: CGPoint?
+	private var liveDragExceededThreshold = false
+	private var livePrimaryCompletionInFlight = false
+	private var liveMouseUpMonitor: Any?
 	private var livePointerPreviewGlobal: CGPoint?
 	private var livePointerPreviewInputUptime: TimeInterval?
 	private var livePointerPreviewInputSequence: UInt64 = 0
@@ -3090,6 +3097,8 @@ final class CaptureHostView: NSView {
 		let previousSettings = self.settings
 		let previousMode = self.scene.mode
 		let transitioningToFrozen = previousMode == .live && scene.mode == .frozen
+		let hostLocalFrozenSelectingEnded =
+			previousChrome.hostLocalFrozenSelecting && !chrome.hostLocalFrozenSelecting
 		if scene.mode != .frozen {
 			frozenFirstDisplayCompletionQueued = false
 			frozenFirstDisplayHandoffStartedAt = nil
@@ -3099,6 +3108,9 @@ final class CaptureHostView: NSView {
 		self.scene = scene
 		self.chrome = chrome
 		self.settings = settings
+		if hostLocalFrozenSelectingEnded {
+			clearLivePrimaryInteractionState(rendersImmediately: false)
+		}
 		if previousMode != scene.mode {
 			window?.acceptsMouseMovedEvents = true
 			updateTrackingAreas()
@@ -3117,6 +3129,7 @@ final class CaptureHostView: NSView {
 				liveHighlightedWindowPreview = scene.highlightedWindow
 			}
 		} else {
+			clearLivePrimaryInteractionState(rendersImmediately: false)
 			if scene.mode == .hidden {
 				liveHoverChromeSuppressed = false
 				pendingFrozenFirstDisplay = false
@@ -3149,6 +3162,7 @@ final class CaptureHostView: NSView {
 			}
 		} else {
 			if transitioningToFrozen {
+				liveRenderer.renderNow()
 				needsDisplay = true
 				completeFrozenFirstDisplayHandoff()
 			} else {
@@ -3276,6 +3290,7 @@ final class CaptureHostView: NSView {
 			seedLivePointerPreview(scene.pointer, recordsInputLatency: false)
 			liveHighlightedWindowPreview = scene.highlightedWindow
 		} else {
+			clearLivePrimaryInteractionState(rendersImmediately: false)
 			resetLivePointerPreview()
 			liveHighlightedWindowPreview = nil
 		}
@@ -3321,7 +3336,8 @@ final class CaptureHostView: NSView {
 		settings: NativeHostSettings,
 		rendersPendingFrame: Bool = true
 	) {
-		let retainedLivePreview = lastLivePreviewSnapshot ?? currentLivePreviewSnapshot()
+		let retainedLivePreview =
+			rendersPendingFrame ? (lastLivePreviewSnapshot ?? currentLivePreviewSnapshot()) : nil
 		self.scene = scene
 		self.chrome = chrome
 		self.settings = settings
@@ -3333,6 +3349,7 @@ final class CaptureHostView: NSView {
 		frozenFirstDisplayPendingFrameDisplayed = false
 		defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = settings.usesClassicHudGlass
 		lastLivePreviewSnapshot = retainedLivePreview
+		clearLivePrimaryInteractionState(rendersImmediately: false)
 		resetLivePointerPreview()
 		liveHighlightedWindowPreview = nil
 		refreshHoveredToolbarAction()
@@ -3340,8 +3357,8 @@ final class CaptureHostView: NSView {
 		needsDisplay = true
 		controller?.updateLivePreviewDemand(
 			point: nil, settings: settings, includeLoupePatch: false)
-		if rendersPendingFrame {
-			frozenFirstDisplayPendingFrameDisplayed = pendingFrozenFirstDisplay
+		if rendersPendingFrame, pendingFrozenFirstDisplay {
+			frozenFirstDisplayPendingFrameDisplayed = true
 			liveRenderer.renderNow()
 		}
 	}
@@ -3403,6 +3420,9 @@ final class CaptureHostView: NSView {
 		}
 		let point = globalPoint(from: event)
 		if scene.mode == .live {
+			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
+				return
+			}
 			liveChromeMouseEventCount += 1
 			updateLivePointerPreview(to: point, rendersImmediately: true)
 			return
@@ -3418,8 +3438,14 @@ final class CaptureHostView: NSView {
 
 		if scene.mode == .live {
 			let point = globalPoint(from: event)
+			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
+				return
+			}
+			if liveDragDistance(from: point) >= Self.liveDragIntentThreshold {
+				liveDragExceededThreshold = true
+			}
 			updateLivePointerPreview(to: point, rendersImmediately: false)
-			queuePointerEvent(.liveDragged(point))
+			queuePointerEvent(liveDragExceededThreshold ? .liveDragged(point) : .moved(point))
 		} else {
 			controller?.continueFrozenInteraction(to: globalPoint(from: event))
 			syncVisibleCursor()
@@ -3434,6 +3460,12 @@ final class CaptureHostView: NSView {
 			break
 		case .live:
 			suppressLiveHoverChrome()
+			liveDragStartGlobal = point
+			liveDragReleasedGlobal = nil
+			liveDragExceededThreshold = false
+			livePrimaryCompletionInFlight = false
+			controller?.registerLivePrimaryInteractionOwner(self)
+			installLiveMouseUpMonitor()
 			updateLivePointerPreview(to: point, rendersImmediately: true)
 			controller?.beginPrimaryInteraction(at: point)
 		case .frozen:
@@ -3453,8 +3485,7 @@ final class CaptureHostView: NSView {
 	override func mouseUp(with event: NSEvent) {
 		let point = globalPoint(from: event)
 		if scene.mode == .live {
-			updateLivePointerPreview(to: point, rendersImmediately: true)
-			controller?.completePrimaryInteraction(at: point)
+			controller?.completeLivePrimaryInteraction(from: self, at: point)
 		} else if scene.mode == .frozen {
 			controller?.completeFrozenInteraction(at: point)
 			syncVisibleCursor()
@@ -3719,6 +3750,39 @@ final class CaptureHostView: NSView {
 		localRect(from: chrome.frozenDisplayFrame)
 	}
 
+	private func currentImmediateLiveDragSelectionLocal() -> CGRect? {
+		guard scene.mode == .live, let dragStart = liveDragStartGlobal, let window else {
+			return nil
+		}
+		guard liveDragExceededThreshold else {
+			return nil
+		}
+		let current =
+			liveDragReleasedGlobal ?? livePointerPreviewGlobal ?? scene.pointer ?? dragStart
+		let windowFrame = window.frame
+		guard windowFrame.contains(dragStart) else {
+			return nil
+		}
+		let normalized = windowFrame.normalizedRect(anchor: dragStart, current: current)
+		guard max(normalized.width, normalized.height) >= 1 else {
+			return nil
+		}
+		let globalRect = CGRect(
+			x: normalized.minX,
+			y: normalized.minY,
+			width: max(normalized.width, 1),
+			height: max(normalized.height, 1)
+		)
+		return localRect(from: globalRect)
+	}
+
+	private func liveDragDistance(from point: CGPoint) -> CGFloat {
+		guard let dragStart = liveDragStartGlobal else {
+			return 0
+		}
+		return max(abs(point.x - dragStart.x), abs(point.y - dragStart.y))
+	}
+
 	private func localPointer() -> CGPoint? {
 		guard let globalPoint = livePointerPreviewGlobal ?? scene.pointer else {
 			return nil
@@ -3767,9 +3831,112 @@ final class CaptureHostView: NSView {
 		lastLivePointerEventUptime = nil
 	}
 
+	fileprivate func markLivePrimaryInteractionReleased(at point: CGPoint) {
+		guard scene.mode == .live, liveDragStartGlobal != nil else {
+			return
+		}
+		let completionPoint = liveDragCompletionPoint(for: point)
+		livePrimaryCompletionInFlight = true
+		liveDragReleasedGlobal = completionPoint
+		liveHoverChromeSuppressed = false
+		removeLiveMouseUpMonitor()
+		cancelQueuedPointerDispatch()
+		updateLivePointerPreview(
+			to: completionPoint,
+			rendersImmediately: true,
+			rendersFullPreview: liveDragExceededThreshold
+		)
+	}
+
+	fileprivate var hasLivePrimaryInteraction: Bool {
+		scene.mode == .live && liveDragStartGlobal != nil
+	}
+
+	fileprivate func completeOwnedLivePrimaryInteraction(at point: CGPoint) {
+		guard scene.mode == .live, liveDragStartGlobal != nil, !livePrimaryCompletionInFlight else {
+			return
+		}
+		let completionPoint = liveDragCompletionPoint(for: point)
+		markLivePrimaryInteractionReleased(at: point)
+		if let controller {
+			controller.completePrimaryInteraction(at: completionPoint)
+		} else {
+			clearLivePrimaryInteractionState(rendersImmediately: true)
+		}
+	}
+
+	@discardableResult
+	private func recoverReleasedLivePrimaryInteractionIfNeeded(at point: CGPoint) -> Bool {
+		guard
+			scene.mode == .live,
+			liveDragStartGlobal != nil,
+			!livePrimaryCompletionInFlight,
+			!isPrimaryMouseButtonPressed()
+		else {
+			return false
+		}
+		controller?.completeLivePrimaryInteraction(from: self, at: point)
+		return true
+	}
+
+	private func liveDragCompletionPoint(for point: CGPoint) -> CGPoint {
+		liveDragExceededThreshold ? point : liveDragStartGlobal ?? point
+	}
+
+	private func isPrimaryMouseButtonPressed() -> Bool {
+		(NSEvent.pressedMouseButtons & 1) == 1
+	}
+
+	fileprivate func clearLivePrimaryInteractionState(rendersImmediately: Bool) {
+		cancelQueuedPointerDispatch()
+		liveHoverChromeSuppressed = false
+		liveDragStartGlobal = nil
+		liveDragReleasedGlobal = nil
+		liveDragExceededThreshold = false
+		livePrimaryCompletionInFlight = false
+		removeLiveMouseUpMonitor()
+		if rendersImmediately, scene.mode == .live {
+			liveRenderer.renderNow()
+		}
+	}
+
+	private func installLiveMouseUpMonitor() {
+		removeLiveMouseUpMonitor()
+		liveMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp]) {
+			[weak self] event in
+			guard let self else {
+				return event
+			}
+			if self.scene.mode == .live,
+				self.liveDragStartGlobal != nil,
+				!self.livePrimaryCompletionInFlight
+			{
+				self.controller?.completeLivePrimaryInteraction(
+					from: self,
+					at: self.globalPoint(fromAnyEvent: event)
+				)
+			}
+			return event
+		}
+	}
+
+	private func removeLiveMouseUpMonitor() {
+		if let liveMouseUpMonitor {
+			NSEvent.removeMonitor(liveMouseUpMonitor)
+			self.liveMouseUpMonitor = nil
+		}
+	}
+
+	private func cancelQueuedPointerDispatch() {
+		queuedPointerWorkItem?.cancel()
+		queuedPointerWorkItem = nil
+		queuedPointerEvent = nil
+	}
+
 	private func updateLivePointerPreview(
 		to globalPoint: CGPoint,
-		rendersImmediately: Bool
+		rendersImmediately: Bool,
+		rendersFullPreview: Bool = false
 	) {
 		guard scene.mode == .live else {
 			return
@@ -3779,7 +3946,11 @@ final class CaptureHostView: NSView {
 		if pointerChanged || rendersImmediately {
 			updateLivePreviewSampleDemand()
 			moveLiveChromeLayers()
-			liveRenderer.renderLiveChromeNow()
+			if rendersFullPreview {
+				liveRenderer.renderNow()
+			} else {
+				liveRenderer.renderLiveChromeNow()
+			}
 		}
 	}
 
@@ -3995,6 +4166,13 @@ final class CaptureHostView: NSView {
 			return NSEvent.mouseLocation
 		}
 		return window.convertPoint(toScreen: event.locationInWindow)
+	}
+
+	private func globalPoint(fromAnyEvent event: NSEvent) -> CGPoint {
+		guard let eventWindow = event.window else {
+			return NSEvent.mouseLocation
+		}
+		return eventWindow.convertPoint(toScreen: event.locationInWindow)
 	}
 
 	private func currentGlobalMousePoint() -> CGPoint? {
@@ -4707,10 +4885,15 @@ final class CaptureHostView: NSView {
 
 	private func currentRendererPreviewSnapshot() -> LivePreviewSnapshot? {
 		if scene.mode == .live {
-			let snapshot =
-				chrome.hostLocalFrozenSelecting
-				? currentHostLocalFrozenSelectingPreviewSnapshot()
-				: currentLivePreviewSnapshot()
+			let snapshot: LivePreviewSnapshot?
+			if chrome.hostLocalFrozenSelecting {
+				snapshot =
+					currentHostLocalFrozenSelectingPreviewSnapshot()
+					?? lastLivePreviewSnapshot
+					?? currentLivePreviewSnapshot(usesSceneDragPreview: false)
+			} else {
+				snapshot = currentLivePreviewSnapshot()
+			}
 			lastLivePreviewSnapshot = snapshot
 			return snapshot
 		}
@@ -4725,11 +4908,9 @@ final class CaptureHostView: NSView {
 			return nil
 		}
 
-		let dragSelectionLocal = localRect(from: scene.liveSelectionPreview)
-		let hoverSelectionLocal =
-			dragSelectionLocal == nil
-			? localRect(from: liveHighlightedWindowPreview?.frame ?? scene.highlightedWindow?.frame)
-			: nil
+		guard let dragSelectionLocal = currentImmediateLiveDragSelectionLocal() else {
+			return nil
+		}
 		let rgbSample = latestLiveRgbSample
 		return LivePreviewSnapshot(
 			bounds: bounds,
@@ -4740,8 +4921,8 @@ final class CaptureHostView: NSView {
 			frozenDisplayImage: chrome.frozenDisplayImage,
 			pointerLocal: nil,
 			dragSelectionLocal: dragSelectionLocal,
-			hoverSelectionLocal: hoverSelectionLocal,
-			selectionSizeText: dragSelectionLocal.map(selectionSizeText(for:)),
+			hoverSelectionLocal: nil,
+			selectionSizeText: selectionSizeText(for: dragSelectionLocal),
 			hudFrame: nil,
 			loupeFrame: nil,
 			positionDisplay: currentPositionDisplay(),
@@ -4788,18 +4969,24 @@ final class CaptureHostView: NSView {
 		)
 	}
 
-	private func currentLivePreviewSnapshot() -> LivePreviewSnapshot? {
+	private func currentLivePreviewSnapshot(
+		usesSceneDragPreview: Bool = true
+	) -> LivePreviewSnapshot? {
 		guard scene.mode == .live else {
 			return nil
 		}
 
-		let polledPoint = currentGlobalMousePoint() ?? NSEvent.mouseLocation
-		if let currentPreview = livePointerPreviewGlobal {
-			if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y) >= 0.5 {
-				applyPolledLivePointerPreview(polledPoint)
+		if !livePrimaryCompletionInFlight {
+			let polledPoint = currentGlobalMousePoint() ?? NSEvent.mouseLocation
+			if let currentPreview = livePointerPreviewGlobal {
+				if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y)
+					>= 0.5
+				{
+					applyPolledLivePointerPreview(polledPoint)
+				}
+			} else {
+				applyPolledLivePointerPreview(polledPoint, recordsInputLatency: false)
 			}
-		} else {
-			applyPolledLivePointerPreview(polledPoint, recordsInputLatency: false)
 		}
 
 		refreshLiveHighlightedWindowPreview(at: livePointerPreviewGlobal ?? scene.pointer)
@@ -4808,7 +4995,10 @@ final class CaptureHostView: NSView {
 		let chromeSample = currentLiveChromeSample()
 		let rgbSample = liveRgbSample(from: chromeSample)
 		let loupePatch = scene.loupeVisible ? chromeSample?.loupePatch : nil
-		let dragSelectionLocal = localRect(from: scene.liveSelectionPreview)
+		let dragSelectionLocal =
+			currentImmediateLiveDragSelectionLocal()
+			?? (usesSceneDragPreview && liveDragStartGlobal != nil && liveDragExceededThreshold
+				? localRect(from: scene.liveSelectionPreview) : nil)
 		let hoverSelectionLocal =
 			dragSelectionLocal == nil
 			? localRect(from: liveHighlightedWindowPreview?.frame ?? scene.highlightedWindow?.frame)
@@ -5639,6 +5829,9 @@ final class CaptureHostView: NSView {
 		case .moved(let point):
 			controller?.pointerMoved(to: point)
 		case .liveDragged(let point):
+			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
+				return
+			}
 			controller?.continuePrimaryInteraction(to: point)
 		}
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -933,9 +933,6 @@ final class CaptureSessionController: NSObject {
 		at point: CGPoint,
 		selection: CGRect
 	) -> Bool {
-		guard chromeState.frozenSelectionEditable else {
-			return false
-		}
 		guard
 			let monitorFrame = screen(containing: CGPoint(x: selection.midX, y: selection.midY))?
 				.frame
@@ -4076,19 +4073,13 @@ final class CaptureHostView: NSView {
 			if let interaction = chrome.frozenSelectionInteraction {
 				return cursorPresentation(for: cursorIntent(for: interaction.kind, active: true))
 			}
-			if let selectedModeTool = visibleToolbarItems().first(where: { $0.selected })?.kind,
-				selectedModeTool == .pointer,
-				!chrome.frozenSelectionEditable
-			{
-				return .arrow
-			}
 			if let selection = chrome.frozenSelectionSnapshot ?? scene.frozenSelection,
 				let selectedModeTool = visibleToolbarItems().first(where: { $0.selected })?.kind
 			{
 				if [ToolbarItemKind.pen, .arrow, .mosaic, .spotlight].contains(selectedModeTool) {
 					return .crosshair
 				}
-				if selectedModeTool == .pointer, chrome.frozenSelectionEditable,
+				if selectedModeTool == .pointer,
 					let pointer = currentGlobalMousePoint(),
 					let intent = editableFrozenCursorIntent(at: pointer, selection: selection)
 				{
@@ -5028,7 +5019,7 @@ final class CaptureHostView: NSView {
 				? localRect(from: scene.liveSelectionPreview) : nil)
 		let hoverSelectionLocal =
 			dragSelectionLocal == nil
-			? localRect(from: liveHighlightedWindowPreview?.frame ?? scene.highlightedWindow?.frame)
+			? localRect(from: liveHighlightedWindowPreview?.frame)
 			: nil
 		let positionDisplay = currentPositionDisplay()
 		let colorDisplay = currentLiveColorDisplay(for: rgbSample)

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -194,10 +194,13 @@ enum NativeHostTelemetry {
 		displayID: UInt32,
 		totalMilliseconds: Double,
 		frameAgeMilliseconds: Double,
-		sequence: UInt64
+		sequence: UInt64,
+		generation: UInt64,
+		selfCaptureSafe: Bool,
+		selfCaptureFilterComplete: Bool
 	) {
 		frozenAuthorityLogger.info(
-			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) source=\(source, privacy: .public) event=capture_timing.frozen_authority_first_frame displayID=\(displayID, privacy: .public) totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) sequence=\(sequence, privacy: .public)"
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) source=\(source, privacy: .public) event=capture_timing.frozen_authority_first_frame displayID=\(displayID, privacy: .public) totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) generation=\(generation, privacy: .public) sequence=\(sequence, privacy: .public) selfCaptureSafe=\(selfCaptureSafe, privacy: .public) selfCaptureFilterComplete=\(selfCaptureFilterComplete, privacy: .public)"
 		)
 	}
 
@@ -211,11 +214,14 @@ enum NativeHostTelemetry {
 		displayID: UInt32,
 		sequence: UInt64,
 		snapshotSource: String,
+		snapshotGeneration: UInt64,
+		selfCaptureSafe: Bool,
+		selfCaptureFilterComplete: Bool,
 		hadLatchToken: Bool,
 		baseReady: Bool
 	) {
 		captureTimingLogger.info(
-			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.freeze_commit totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) snapshotWaitMs=\(snapshotWaitMilliseconds, format: .fixed(precision: 2), privacy: .public) baseImageMs=\(baseImageMilliseconds, format: .fixed(precision: 2), privacy: .public) presentMs=\(presentMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) displayID=\(displayID, privacy: .public) sequence=\(sequence, privacy: .public) snapshotSource=\(snapshotSource, privacy: .public) hadLatchToken=\(hadLatchToken, privacy: .public) baseReady=\(baseReady, privacy: .public)"
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.freeze_commit totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) snapshotWaitMs=\(snapshotWaitMilliseconds, format: .fixed(precision: 2), privacy: .public) baseImageMs=\(baseImageMilliseconds, format: .fixed(precision: 2), privacy: .public) presentMs=\(presentMilliseconds, format: .fixed(precision: 2), privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) displayID=\(displayID, privacy: .public) generation=\(snapshotGeneration, privacy: .public) sequence=\(sequence, privacy: .public) snapshotSource=\(snapshotSource, privacy: .public) selfCaptureSafe=\(selfCaptureSafe, privacy: .public) selfCaptureFilterComplete=\(selfCaptureFilterComplete, privacy: .public) hadLatchToken=\(hadLatchToken, privacy: .public) baseReady=\(baseReady, privacy: .public)"
 		)
 	}
 

--- a/packages/rsnap-capture-core/src/protocol.rs
+++ b/packages/rsnap-capture-core/src/protocol.rs
@@ -211,6 +211,8 @@ pub enum HostRequest {
 	RequestFreezeSnapshot {
 		/// Selection rectangle that should become the first visible frozen frame.
 		selection: GlobalRect,
+		/// Whether the frozen selection may be moved or resized after commit.
+		selection_editable: bool,
 	},
 	/// Perform a host-owned effect.
 	PerformHostEffect(HostEffectKind),

--- a/packages/rsnap-capture-core/src/session.rs
+++ b/packages/rsnap-capture-core/src/session.rs
@@ -606,6 +606,32 @@ mod tests {
 	}
 
 	#[test]
+	fn live_pointer_update_without_window_clears_previous_highlight() {
+		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
+		session.enter_live();
+
+		let _ = session.pop_host_request();
+
+		session.handle_host_event(HostEvent::PointerMoved {
+			point: GlobalPoint::new(120, 180),
+			rgb: None,
+			active_monitor: Some(active_monitor()),
+			highlighted_window: Some(highlighted_window()),
+		});
+		session.handle_host_event(HostEvent::PointerMoved {
+			point: GlobalPoint::new(900, 700),
+			rgb: None,
+			active_monitor: Some(active_monitor()),
+			highlighted_window: None,
+		});
+
+		assert_eq!(session.scene_model().pointer, Some(GlobalPoint::new(900, 700)));
+		assert_eq!(session.scene_model().active_monitor, Some(active_monitor()));
+		assert_eq!(session.scene_model().highlighted_window, None);
+	}
+
+	#[test]
 	fn primary_click_freezes_highlighted_window_editable() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
 
@@ -633,6 +659,41 @@ mod tests {
 				selection_editable: true,
 			})
 		);
+	}
+
+	#[test]
+	fn primary_click_frozen_window_selection_keeps_grab_cursor() {
+		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
+		session.enter_live();
+
+		let _ = session.pop_host_request();
+
+		session.handle_host_event(HostEvent::PrimaryInteractionStarted {
+			point: GlobalPoint::new(20, 30),
+			active_monitor: Some(active_monitor()),
+			highlighted_window: Some(highlighted_window()),
+		});
+		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
+			point: GlobalPoint::new(20, 30),
+			active_monitor: Some(active_monitor()),
+			highlighted_window: Some(highlighted_window()),
+		});
+		let selection = highlighted_window().global_rect().unwrap();
+		assert_eq!(
+			session.pop_host_request(),
+			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: true })
+		);
+
+		session.handle_host_report(HostReport::FreezeSnapshotCommitted { selection });
+		session.handle_host_event(HostEvent::PointerMoved {
+			point: GlobalPoint::new(80, 90),
+			rgb: None,
+			active_monitor: None,
+			highlighted_window: None,
+		});
+
+		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Grab);
 	}
 
 	#[test]

--- a/packages/rsnap-capture-core/src/session.rs
+++ b/packages/rsnap-capture-core/src/session.rs
@@ -518,13 +518,14 @@ mod tests {
 
 	fn enter_frozen_with_drag_selection(session: &mut CaptureSessionCore, selection: GlobalRect) {
 		session.enter_live();
-		let _ = session.pop_host_request();
 
+		let _ = session.pop_host_request();
 		let start = GlobalPoint::new(selection.x, selection.y);
 		let end = GlobalPoint::new(
 			selection.x.saturating_add_unsigned(selection.width),
 			selection.y.saturating_add_unsigned(selection.height),
 		);
+
 		session.handle_host_event(HostEvent::PrimaryInteractionStarted {
 			point: start,
 			active_monitor: Some(active_monitor()),
@@ -535,6 +536,7 @@ mod tests {
 			active_monitor: Some(active_monitor()),
 			highlighted_window: Some(highlighted_window()),
 		});
+
 		assert_eq!(
 			session.pop_host_request(),
 			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: true })
@@ -557,6 +559,7 @@ mod tests {
 	#[test]
 	fn freeze_commit_enables_frozen_actions() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
 		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
 
 		assert_eq!(session.scene_model().mode, CaptureMode::Frozen);
@@ -567,7 +570,9 @@ mod tests {
 	#[test]
 	fn pointer_update_tracks_rgb_and_frozen_grab() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
 		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
+
 		session.handle_host_event(HostEvent::PointerMoved {
 			point: GlobalPoint::new(40, 40),
 			rgb: Some(Rgb::new(1, 2, 3)),
@@ -582,7 +587,9 @@ mod tests {
 	#[test]
 	fn frozen_pointer_cursor_tracks_resize_edges() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
 		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
+
 		session.handle_host_event(HostEvent::PointerMoved {
 			point: GlobalPoint::new(110, 45),
 			rgb: None,
@@ -661,6 +668,7 @@ mod tests {
 			active_monitor: Some(active_monitor()),
 			highlighted_window: Some(highlighted_window()),
 		});
+
 		assert_eq!(session.scene_model().live_selection_preview, None);
 
 		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
@@ -696,7 +704,9 @@ mod tests {
 			active_monitor: Some(active_monitor()),
 			highlighted_window: Some(highlighted_window()),
 		});
+
 		let selection = highlighted_window().global_rect().unwrap();
+
 		assert_eq!(
 			session.pop_host_request(),
 			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: false })
@@ -731,9 +741,11 @@ mod tests {
 			active_monitor: Some(active_monitor()),
 			highlighted_window: None,
 		});
+
 		let monitor = active_monitor();
 		let selection =
 			GlobalRect::new(monitor.origin.x, monitor.origin.y, monitor.width, monitor.height);
+
 		assert_eq!(
 			session.pop_host_request(),
 			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: false })

--- a/packages/rsnap-capture-core/src/session.rs
+++ b/packages/rsnap-capture-core/src/session.rs
@@ -23,6 +23,8 @@ pub struct CaptureSessionCore {
 	selected_toolbar_item: ToolbarItemKind,
 	live_press_start: Option<GlobalPoint>,
 	live_press_target: Option<crate::geometry::GlobalRect>,
+	pending_frozen_selection_editable: bool,
+	frozen_selection_editable: bool,
 	pending_requests: VecDeque<HostRequest>,
 }
 impl CaptureSessionCore {
@@ -35,6 +37,8 @@ impl CaptureSessionCore {
 			selected_toolbar_item: ToolbarItemKind::Pointer,
 			live_press_start: None,
 			live_press_target: None,
+			pending_frozen_selection_editable: false,
+			frozen_selection_editable: false,
 			pending_requests: VecDeque::new(),
 		}
 	}
@@ -64,6 +68,8 @@ impl CaptureSessionCore {
 		self.selected_toolbar_item = ToolbarItemKind::Pointer;
 		self.live_press_start = None;
 		self.live_press_target = None;
+		self.pending_frozen_selection_editable = false;
+		self.frozen_selection_editable = false;
 
 		self.refresh_toolbar_actions();
 		self.pending_requests.push_back(HostRequest::StartLiveCapture);
@@ -146,7 +152,13 @@ impl CaptureSessionCore {
 				self.scene.frozen_selection = Some(selection);
 				self.scene.active_monitor = None;
 				self.scene.highlighted_window = None;
-				self.scene.cursor_intent = CursorIntent::Grab;
+				self.frozen_selection_editable = self.pending_frozen_selection_editable;
+				self.pending_frozen_selection_editable = false;
+				self.scene.cursor_intent = if self.frozen_selection_editable {
+					CursorIntent::Grab
+				} else {
+					CursorIntent::Default
+				};
 				self.scene.status_message = None;
 
 				self.refresh_toolbar_actions();
@@ -307,6 +319,7 @@ impl CaptureSessionCore {
 		} else {
 			None
 		};
+		let selection_editable = release_drag_selection.is_some();
 		let selection = if had_live_press {
 			release_drag_selection
 				.or(self.live_press_target)
@@ -328,13 +341,12 @@ impl CaptureSessionCore {
 		self.live_press_target = None;
 
 		if let Some(selection) = selection {
+			self.pending_frozen_selection_editable = selection_editable;
 			self.scene.live_selection_preview = Some(selection);
 			self.scene.status_message = None;
 
-			self.pending_requests.push_back(HostRequest::RequestFreezeSnapshot {
-				selection,
-				selection_editable: true,
-			});
+			self.pending_requests
+				.push_back(HostRequest::RequestFreezeSnapshot { selection, selection_editable });
 		}
 	}
 
@@ -343,9 +355,13 @@ impl CaptureSessionCore {
 			CaptureMode::Hidden => CursorIntent::Default,
 			CaptureMode::Live => CursorIntent::Default,
 			CaptureMode::Frozen => {
-				self.scene.frozen_selection.map_or(CursorIntent::Default, |selection| {
-					self.frozen_cursor_intent(point, selection)
-				})
+				if !self.frozen_selection_editable {
+					CursorIntent::Default
+				} else {
+					self.scene.frozen_selection.map_or(CursorIntent::Default, |selection| {
+						self.frozen_cursor_intent(point, selection)
+					})
+				}
 			},
 		};
 	}
@@ -500,6 +516,33 @@ mod tests {
 		WindowRect { window_id: Some(42), x: 10, y: 20, width: 320, height: 240 }
 	}
 
+	fn enter_frozen_with_drag_selection(session: &mut CaptureSessionCore, selection: GlobalRect) {
+		session.enter_live();
+		let _ = session.pop_host_request();
+
+		let start = GlobalPoint::new(selection.x, selection.y);
+		let end = GlobalPoint::new(
+			selection.x.saturating_add_unsigned(selection.width),
+			selection.y.saturating_add_unsigned(selection.height),
+		);
+		session.handle_host_event(HostEvent::PrimaryInteractionStarted {
+			point: start,
+			active_monitor: Some(active_monitor()),
+			highlighted_window: Some(highlighted_window()),
+		});
+		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
+			point: end,
+			active_monitor: Some(active_monitor()),
+			highlighted_window: Some(highlighted_window()),
+		});
+		assert_eq!(
+			session.pop_host_request(),
+			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: true })
+		);
+
+		session.handle_host_report(HostReport::FreezeSnapshotCommitted { selection });
+	}
+
 	#[test]
 	fn enter_live_requests_capture_and_default_cursor() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
@@ -514,19 +557,7 @@ mod tests {
 	#[test]
 	fn freeze_commit_enables_frozen_actions() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
-
-		session.enter_live();
-
-		let _ = session.pop_host_request();
-
-		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
-			point: GlobalPoint::new(40, 60),
-			active_monitor: Some(active_monitor()),
-			highlighted_window: Some(highlighted_window()),
-		});
-		session.handle_host_report(HostReport::FreezeSnapshotCommitted {
-			selection: GlobalRect::new(10, 20, 100, 50),
-		});
+		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
 
 		assert_eq!(session.scene_model().mode, CaptureMode::Frozen);
 		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Grab);
@@ -536,14 +567,7 @@ mod tests {
 	#[test]
 	fn pointer_update_tracks_rgb_and_frozen_grab() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
-
-		session.enter_live();
-
-		let _ = session.pop_host_request();
-
-		session.handle_host_report(HostReport::FreezeSnapshotCommitted {
-			selection: GlobalRect::new(10, 20, 100, 50),
-		});
+		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
 		session.handle_host_event(HostEvent::PointerMoved {
 			point: GlobalPoint::new(40, 40),
 			rgb: Some(Rgb::new(1, 2, 3)),
@@ -558,14 +582,7 @@ mod tests {
 	#[test]
 	fn frozen_pointer_cursor_tracks_resize_edges() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
-
-		session.enter_live();
-
-		let _ = session.pop_host_request();
-
-		session.handle_host_report(HostReport::FreezeSnapshotCommitted {
-			selection: GlobalRect::new(10, 20, 100, 50),
-		});
+		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
 		session.handle_host_event(HostEvent::PointerMoved {
 			point: GlobalPoint::new(110, 45),
 			rgb: None,
@@ -632,7 +649,7 @@ mod tests {
 	}
 
 	#[test]
-	fn primary_click_freezes_highlighted_window_editable() {
+	fn primary_click_freezes_highlighted_window_not_editable() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
 
 		session.enter_live();
@@ -656,13 +673,13 @@ mod tests {
 			session.pop_host_request(),
 			Some(HostRequest::RequestFreezeSnapshot {
 				selection: highlighted_window().global_rect().unwrap(),
-				selection_editable: true,
+				selection_editable: false,
 			})
 		);
 	}
 
 	#[test]
-	fn primary_click_frozen_window_selection_keeps_grab_cursor() {
+	fn primary_click_frozen_window_selection_keeps_default_cursor() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
 
 		session.enter_live();
@@ -682,7 +699,7 @@ mod tests {
 		let selection = highlighted_window().global_rect().unwrap();
 		assert_eq!(
 			session.pop_host_request(),
-			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: true })
+			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: false })
 		);
 
 		session.handle_host_report(HostReport::FreezeSnapshotCommitted { selection });
@@ -693,7 +710,44 @@ mod tests {
 			highlighted_window: None,
 		});
 
-		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Grab);
+		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Default);
+	}
+
+	#[test]
+	fn primary_click_fullscreen_fallback_is_not_editable() {
+		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
+		session.enter_live();
+
+		let _ = session.pop_host_request();
+
+		session.handle_host_event(HostEvent::PrimaryInteractionStarted {
+			point: GlobalPoint::new(20, 30),
+			active_monitor: Some(active_monitor()),
+			highlighted_window: None,
+		});
+		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
+			point: GlobalPoint::new(20, 30),
+			active_monitor: Some(active_monitor()),
+			highlighted_window: None,
+		});
+		let monitor = active_monitor();
+		let selection =
+			GlobalRect::new(monitor.origin.x, monitor.origin.y, monitor.width, monitor.height);
+		assert_eq!(
+			session.pop_host_request(),
+			Some(HostRequest::RequestFreezeSnapshot { selection, selection_editable: false })
+		);
+
+		session.handle_host_report(HostReport::FreezeSnapshotCommitted { selection });
+		session.handle_host_event(HostEvent::PointerMoved {
+			point: GlobalPoint::new(80, 90),
+			rgb: None,
+			active_monitor: None,
+			highlighted_window: None,
+		});
+
+		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Default);
 	}
 
 	#[test]

--- a/packages/rsnap-capture-core/src/session.rs
+++ b/packages/rsnap-capture-core/src/session.rs
@@ -301,14 +301,28 @@ impl CaptureSessionCore {
 	}
 
 	fn finalize_live_selection(&mut self, point: GlobalPoint, active_monitor: Option<MonitorRect>) {
-		let selection = self
-			.scene
-			.live_selection_preview
-			.or(self.live_press_target)
-			.or_else(|| {
-				resolve_live_target(self.scene.active_monitor, self.scene.highlighted_window)
-			})
-			.or_else(|| Some(default_live_selection(point, active_monitor)));
+		let had_live_press = self.live_press_start.is_some();
+		let release_drag_selection = if had_live_press {
+			self.compute_live_selection_preview(point, active_monitor)
+		} else {
+			None
+		};
+		let selection = if had_live_press {
+			release_drag_selection
+				.or(self.live_press_target)
+				.or_else(|| {
+					resolve_live_target(self.scene.active_monitor, self.scene.highlighted_window)
+				})
+				.or_else(|| Some(default_live_selection(point, active_monitor)))
+		} else {
+			self.scene
+				.live_selection_preview
+				.or(self.live_press_target)
+				.or_else(|| {
+					resolve_live_target(self.scene.active_monitor, self.scene.highlighted_window)
+				})
+				.or_else(|| Some(default_live_selection(point, active_monitor)))
+		};
 
 		self.live_press_start = None;
 		self.live_press_target = None;
@@ -317,7 +331,10 @@ impl CaptureSessionCore {
 			self.scene.live_selection_preview = Some(selection);
 			self.scene.status_message = None;
 
-			self.pending_requests.push_back(HostRequest::RequestFreezeSnapshot { selection });
+			self.pending_requests.push_back(HostRequest::RequestFreezeSnapshot {
+				selection,
+				selection_editable: true,
+			});
 		}
 	}
 
@@ -589,7 +606,7 @@ mod tests {
 	}
 
 	#[test]
-	fn primary_drag_updates_live_preview_and_freezes_with_preview_selection() {
+	fn primary_click_freezes_highlighted_window_editable() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
 
 		session.enter_live();
@@ -601,36 +618,25 @@ mod tests {
 			active_monitor: Some(active_monitor()),
 			highlighted_window: Some(highlighted_window()),
 		});
-		session.handle_host_event(HostEvent::PrimaryInteractionUpdated {
-			point: GlobalPoint::new(80, 110),
-			active_monitor: Some(active_monitor()),
-			highlighted_window: Some(highlighted_window()),
-		});
-
-		assert_eq!(
-			session.scene_model().live_selection_preview,
-			Some(GlobalRect::new(20, 30, 60, 80))
-		);
+		assert_eq!(session.scene_model().live_selection_preview, None);
 
 		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
-			point: GlobalPoint::new(80, 110),
+			point: GlobalPoint::new(20, 30),
 			active_monitor: Some(active_monitor()),
 			highlighted_window: Some(highlighted_window()),
 		});
 
-		assert_eq!(session.scene_model().mode, CaptureMode::Live);
-		assert_eq!(
-			session.scene_model().live_selection_preview,
-			Some(GlobalRect::new(20, 30, 60, 80))
-		);
 		assert_eq!(
 			session.pop_host_request(),
-			Some(HostRequest::RequestFreezeSnapshot { selection: GlobalRect::new(20, 30, 60, 80) })
+			Some(HostRequest::RequestFreezeSnapshot {
+				selection: highlighted_window().global_rect().unwrap(),
+				selection_editable: true,
+			})
 		);
 	}
 
 	#[test]
-	fn primary_drag_allows_thin_preview_once_drag_threshold_is_crossed() {
+	fn primary_drag_freezes_release_rect_editable_with_thin_preview_allowed() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
 
 		session.enter_live();
@@ -654,40 +660,7 @@ mod tests {
 		);
 
 		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
-			point: GlobalPoint::new(21, 30),
-			active_monitor: Some(active_monitor()),
-			highlighted_window: Some(highlighted_window()),
-		});
-
-		assert_eq!(
-			session.pop_host_request(),
-			Some(HostRequest::RequestFreezeSnapshot { selection: GlobalRect::new(20, 30, 1, 1) })
-		);
-	}
-
-	#[test]
-	fn primary_interaction_below_drag_threshold_stays_click_targeted() {
-		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
-
-		session.enter_live();
-
-		let _ = session.pop_host_request();
-
-		session.handle_host_event(HostEvent::PrimaryInteractionStarted {
-			point: GlobalPoint::new(20, 30),
-			active_monitor: Some(active_monitor()),
-			highlighted_window: Some(highlighted_window()),
-		});
-		session.handle_host_event(HostEvent::PrimaryInteractionUpdated {
-			point: GlobalPoint::new(20, 30),
-			active_monitor: Some(active_monitor()),
-			highlighted_window: Some(highlighted_window()),
-		});
-
-		assert_eq!(session.scene_model().live_selection_preview, None);
-
-		session.handle_host_event(HostEvent::PrimaryInteractionCompleted {
-			point: GlobalPoint::new(20, 30),
+			point: GlobalPoint::new(90, 130),
 			active_monitor: Some(active_monitor()),
 			highlighted_window: Some(highlighted_window()),
 		});
@@ -695,7 +668,8 @@ mod tests {
 		assert_eq!(
 			session.pop_host_request(),
 			Some(HostRequest::RequestFreezeSnapshot {
-				selection: highlighted_window().global_rect().unwrap(),
+				selection: GlobalRect::new(20, 30, 70, 100),
+				selection_editable: true,
 			})
 		);
 	}

--- a/packages/rsnap-host-ffi/include/rsnap_host_ffi.h
+++ b/packages/rsnap-host-ffi/include/rsnap_host_ffi.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#define RSNAP_HOST_FFI_ABI_VERSION 13u
+#define RSNAP_HOST_FFI_ABI_VERSION 14u
 #define RSNAP_TOOLBAR_ITEM_CAPACITY 16u
 #define RSNAP_STATUS_MESSAGE_CAPACITY 256u
 #define RSNAP_LIVE_SAMPLE_PATCH_CAPACITY 4096u
@@ -211,6 +211,7 @@ typedef struct RsnapHostRequestValue {
 	uint32_t kind;
 	struct RsnapRect selection;
 	uint8_t has_selection;
+	uint8_t selection_editable;
 } RsnapHostRequestValue;
 
 typedef struct RsnapLiveSample {

--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -21,7 +21,7 @@ use rsnap_capture_core::{
 use rsnap_overlay::host_live_sampling_macos::HostMacLiveSampler;
 
 /// ABI version exported by the thin C host bridge.
-pub const RSNAP_HOST_FFI_ABI_VERSION: u32 = 13;
+pub const RSNAP_HOST_FFI_ABI_VERSION: u32 = 14;
 
 const RSNAP_TOOLBAR_ITEM_CAPACITY: usize = 16;
 const RSNAP_STATUS_MESSAGE_CAPACITY: usize = 256;
@@ -527,6 +527,8 @@ pub struct RsnapHostRequestValue {
 	pub selection: RsnapRect,
 	/// Non-zero when `selection` is populated.
 	pub has_selection: u8,
+	/// Non-zero when the frozen selection may be moved or resized after commit.
+	pub selection_editable: u8,
 }
 
 /// Creates a new opaque session handle.
@@ -973,6 +975,9 @@ pub unsafe extern "C" fn rsnap_live_sampler_peek_latest_monitor_rgba(
 
 /// Transfers ownership of the latest cached full-monitor RGBA snapshot buffer to the caller.
 ///
+/// This cache-only payload does not expose the original frame age or sequence, so callers must not
+/// use it as the first frozen screenshot frame.
+///
 /// # Safety
 ///
 /// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
@@ -1306,10 +1311,13 @@ fn encode_host_request(request: HostRequest) -> RsnapHostRequestValue {
 			kind: RsnapHostRequestKind::StopLiveCapture as u32,
 			..RsnapHostRequestValue::default()
 		},
-		HostRequest::RequestFreezeSnapshot { selection } => RsnapHostRequestValue {
-			kind: RsnapHostRequestKind::RequestFreezeSnapshot as u32,
-			selection: encode_rect(selection),
-			has_selection: 1,
+		HostRequest::RequestFreezeSnapshot { selection, selection_editable } => {
+			RsnapHostRequestValue {
+				kind: RsnapHostRequestKind::RequestFreezeSnapshot as u32,
+				selection: encode_rect(selection),
+				has_selection: 1,
+				selection_editable: u8::from(selection_editable),
+			}
 		},
 		HostRequest::PerformHostEffect(effect) => RsnapHostRequestValue {
 			kind: match effect {
@@ -1645,6 +1653,7 @@ mod tests {
 		assert_eq!(request.kind, RsnapHostRequestKind::RequestFreezeSnapshot as u32);
 		assert_eq!(request.has_selection, 1);
 		assert_eq!(request.selection, RsnapRect { x: 20, y: 30, width: 60, height: 80 });
+		assert_eq!(request.selection_editable, 1);
 
 		unsafe { crate::rsnap_session_destroy(handle) };
 	}

--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -1604,7 +1604,7 @@ mod tests {
 	}
 
 	#[test]
-	fn ffi_freeze_request_carries_selection_payload() {
+	fn ffi_click_freeze_request_carries_fixed_selection_payload() {
 		let handle = unsafe { crate::rsnap_session_create(default_config()) };
 		let mut request =
 			RsnapHostRequestValue { kind: u32::MAX, ..RsnapHostRequestValue::default() };
@@ -1653,6 +1653,94 @@ mod tests {
 		assert_eq!(request.kind, RsnapHostRequestKind::RequestFreezeSnapshot as u32);
 		assert_eq!(request.has_selection, 1);
 		assert_eq!(request.selection, RsnapRect { x: 20, y: 30, width: 60, height: 80 });
+		assert_eq!(request.selection_editable, 0);
+
+		unsafe { crate::rsnap_session_destroy(handle) };
+	}
+
+	#[test]
+	fn ffi_drag_freeze_request_carries_editable_selection_payload() {
+		let handle = unsafe { crate::rsnap_session_create(default_config()) };
+		let mut request =
+			RsnapHostRequestValue { kind: u32::MAX, ..RsnapHostRequestValue::default() };
+
+		assert_eq!(unsafe { crate::rsnap_session_enter_live(handle) }, RsnapStatus::Ok);
+
+		let _ = unsafe { crate::rsnap_session_take_next_request(handle, &mut request) };
+
+		assert_eq!(
+			unsafe {
+				crate::rsnap_session_handle_host_event(
+					handle,
+					RsnapHostEvent {
+						kind: RsnapHostEventKind::PrimaryInteractionStarted as u32,
+						point: RsnapPoint { x: 80, y: 110 },
+						has_point: 1,
+						rgb: RsnapRgb::default(),
+						has_rgb: 0,
+						active_monitor: RsnapMonitorRect {
+							id: 9,
+							origin: RsnapPoint { x: 0, y: 0 },
+							width: 1_440,
+							height: 900,
+							scale_factor_x1000: 2_000,
+						},
+						has_active_monitor: 1,
+						highlighted_window: RsnapWindowRect {
+							window_id: 42,
+							has_window_id: 1,
+							x: 20,
+							y: 30,
+							width: 60,
+							height: 80,
+						},
+						has_highlighted_window: 1,
+						toolbar_item_kind: 0,
+					},
+				)
+			},
+			RsnapStatus::Ok
+		);
+		assert_eq!(
+			unsafe {
+				crate::rsnap_session_handle_host_event(
+					handle,
+					RsnapHostEvent {
+						kind: RsnapHostEventKind::PrimaryInteractionCompleted as u32,
+						point: RsnapPoint { x: 140, y: 190 },
+						has_point: 1,
+						rgb: RsnapRgb::default(),
+						has_rgb: 0,
+						active_monitor: RsnapMonitorRect {
+							id: 9,
+							origin: RsnapPoint { x: 0, y: 0 },
+							width: 1_440,
+							height: 900,
+							scale_factor_x1000: 2_000,
+						},
+						has_active_monitor: 1,
+						highlighted_window: RsnapWindowRect {
+							window_id: 42,
+							has_window_id: 1,
+							x: 20,
+							y: 30,
+							width: 60,
+							height: 80,
+						},
+						has_highlighted_window: 1,
+						toolbar_item_kind: 0,
+					},
+				)
+			},
+			RsnapStatus::Ok
+		);
+		assert_eq!(
+			unsafe { crate::rsnap_session_take_next_request(handle, &mut request) },
+			RsnapStatus::Ok
+		);
+		assert_eq!(request.kind, RsnapHostRequestKind::RequestFreezeSnapshot as u32);
+		assert_eq!(request.has_selection, 1);
+		assert_eq!(request.selection, RsnapRect { x: 80, y: 110, width: 60, height: 80 });
 		assert_eq!(request.selection_editable, 1);
 
 		unsafe { crate::rsnap_session_destroy(handle) };

--- a/packages/rsnap-overlay/src/host_live_sampling_macos.rs
+++ b/packages/rsnap-overlay/src/host_live_sampling_macos.rs
@@ -95,6 +95,8 @@ impl HostMacLiveSampler {
 	///
 	/// This does not block on a fresh capture. When the latest frame is unavailable, the
 	/// underlying stream is primed and `None` is returned.
+	/// The returned payload intentionally does not carry frame age or sequence metadata, so it
+	/// must not be used as the first frozen screenshot frame.
 	pub fn peek_latest_monitor_rgba(&self, monitor: MonitorRect) -> Option<HostRgbaRegion> {
 		let snapshot = self.stream.peek_latest_rgba_snapshot(monitor)?;
 		let image = snapshot.image.as_ref();

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -378,10 +378,13 @@ else
 	if [[ "${RSNAP_NATIVE_HOST_SWIFT_CLEAN:-0}" == "1" ]]; then
 		swift package --package-path "$PACKAGE_DIR" clean
 	fi
-	RSNAP_HOST_FFI_LIB_DIR="$RUST_LIB_DIR" \
-		swift build --package-path "$PACKAGE_DIR" "${SWIFT_BUILD_FLAGS[@]}" --product "$EXECUTABLE_NAME"
 	BUILD_ROOT="$(RSNAP_HOST_FFI_LIB_DIR="$RUST_LIB_DIR" swift build --package-path "$PACKAGE_DIR" "${SWIFT_BUILD_FLAGS[@]}" --show-bin-path)"
 	BUILD_BINARY="$BUILD_ROOT/$EXECUTABLE_NAME"
+	# SwiftPM does not track the external Rust static library as a product input. Remove the
+	# executable before building so Rust host-FFI changes are always relinked into the app bundle.
+	rm -f "$BUILD_BINARY"
+	RSNAP_HOST_FFI_LIB_DIR="$RUST_LIB_DIR" \
+		swift build --package-path "$PACKAGE_DIR" "${SWIFT_BUILD_FLAGS[@]}" --product "$EXECUTABLE_NAME"
 
 	if [[ ! -x "$BUILD_BINARY" ]]; then
 		relink_native_host_if_missing

--- a/scripts/perf/macos.sh
+++ b/scripts/perf/macos.sh
@@ -18,4 +18,6 @@ EOF
 esac
 
 "$SCRIPT_DIR/local.sh"
-"$SCRIPT_DIR/../smoke/macos.sh"
+"$SCRIPT_DIR/../smoke/native-hud-follow-macos.sh"
+"$SCRIPT_DIR/../smoke/native-visual-contract-macos.sh"
+"$SCRIPT_DIR/../smoke/replay-scroll-capture.sh"

--- a/scripts/smoke/lib/live-hud-mouse-path.swift
+++ b/scripts/smoke/lib/live-hud-mouse-path.swift
@@ -155,6 +155,11 @@ func dragRegion(points: [CGPoint], durationMs: Int, rateHz: Int) {
 		driver.mouseEvent(.leftMouseDragged, at: point)
 		sleepUntil(dragStart + UInt64(index) * stepTicks)
 	}
+	let holdBeforeReleaseMs = readInt("PATH_HOLD_BEFORE_RELEASE_MS", default: 0)
+	if holdBeforeReleaseMs > 0 {
+		writeMaskProbePhase("holding")
+		sleepMs(useconds_t(holdBeforeReleaseMs))
+	}
 	driver.mouseEvent(.leftMouseUp, at: end)
 	writeMaskProbePhase("released")
 	if ProcessInfo.processInfo.environment["MASK_PROBE_PHASE_PATH"] != nil {

--- a/scripts/smoke/lib/live-hud.sh
+++ b/scripts/smoke/lib/live-hud.sh
@@ -18,7 +18,7 @@ live_hud_self_check() {
     return 1
   fi
 
-  for cmd in osascript swift python3; do
+  for cmd in osascript swift swiftc python3; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
       echo "missing required tool: $cmd" >&2
       return 1
@@ -45,13 +45,14 @@ APPLESCRIPT
 }
 
 live_hud_focus_rsnap_overlay() {
-  osascript <<'APPLESCRIPT'
+  local focus_settle_s="${RSNAP_FOCUS_SETTLE_S:-0.03}"
+  osascript <<APPLESCRIPT
 tell application "System Events"
     tell process "rsnap"
         set frontmost to true
     end tell
 end tell
-delay 0.15
+delay $focus_settle_s
 APPLESCRIPT
 }
 

--- a/scripts/smoke/lib/mask-probe-capture.swift
+++ b/scripts/smoke/lib/mask-probe-capture.swift
@@ -50,18 +50,22 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 	private let phasePath: String
 	private let readyPath: String?
 	private let screenshotPath: String?
+	private let releasedScreenshotPath: String?
 	private let point: CGPoint
 	private let displayFrame: CGRect
 	private let lock = NSLock()
 	private var samples: [Sample] = []
 	private var wroteReady = false
 	private var wroteScreenshot = false
+	private var wroteReleasedScreenshot = false
+	private var completedReleasedScreenshot = false
 
 	init(
 		outputPath: String,
 		phasePath: String,
 		readyPath: String?,
 		screenshotPath: String?,
+		releasedScreenshotPath: String?,
 		point: CGPoint,
 		displayFrame: CGRect
 	) {
@@ -69,6 +73,7 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 		self.phasePath = phasePath
 		self.readyPath = readyPath
 		self.screenshotPath = screenshotPath
+		self.releasedScreenshotPath = releasedScreenshotPath
 		self.point = point
 		self.displayFrame = displayFrame
 	}
@@ -86,13 +91,16 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 			return
 		}
 		let phase = currentPhase()
-		let screenshotPathToWrite: String?
+		let screenshotToWrite: (path: String, phase: String)?
 		lock.lock()
 		if phase == "holding", let screenshotPath, !wroteScreenshot {
 			wroteScreenshot = true
-			screenshotPathToWrite = screenshotPath
+			screenshotToWrite = (screenshotPath, phase)
+		} else if phase == "released", let releasedScreenshotPath, !wroteReleasedScreenshot {
+			wroteReleasedScreenshot = true
+			screenshotToWrite = (releasedScreenshotPath, phase)
 		} else {
-			screenshotPathToWrite = nil
+			screenshotToWrite = nil
 		}
 		samples.append(
 			Sample(
@@ -103,8 +111,13 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 		)
 		writeReadyIfNeeded()
 		lock.unlock()
-		if let screenshotPathToWrite {
-			writeScreenshot(pixelBuffer, to: screenshotPathToWrite)
+		if let screenshotToWrite {
+			let wroteScreenshot = writeScreenshot(pixelBuffer, to: screenshotToWrite.path)
+			if screenshotToWrite.phase == "released", wroteScreenshot {
+				lock.lock()
+				completedReleasedScreenshot = true
+				lock.unlock()
+			}
 		}
 	}
 
@@ -124,6 +137,30 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 			fputs("failed to write mask probe samples: \(error)\n", stderr)
 			exit(1)
 		}
+	}
+
+	func hasRequiredSamples(minDraggingSamples: Int, minReleasedSamples: Int) -> Bool {
+		lock.lock()
+		let samples = self.samples
+		let releasedScreenshotComplete =
+			releasedScreenshotPath == nil || completedReleasedScreenshot
+		lock.unlock()
+
+		var draggingSamples = 0
+		var releasedSamples = 0
+		for sample in samples {
+			switch sample.phase {
+			case "dragging", "holding":
+				draggingSamples += 1
+			case "released":
+				releasedSamples += 1
+			default:
+				continue
+			}
+		}
+		return draggingSamples >= minDraggingSamples
+			&& releasedSamples >= minReleasedSamples
+			&& releasedScreenshotComplete
 	}
 
 	private func currentPhase() -> String {
@@ -149,7 +186,7 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 		}
 	}
 
-	private func writeScreenshot(_ pixelBuffer: CVPixelBuffer, to path: String) {
+	private func writeScreenshot(_ pixelBuffer: CVPixelBuffer, to path: String) -> Bool {
 		let width = CVPixelBufferGetWidth(pixelBuffer)
 		let height = CVPixelBufferGetHeight(pixelBuffer)
 		let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
@@ -161,17 +198,19 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 			)
 		else {
 			fputs("failed to create drag screenshot image\n", stderr)
-			return
+			return false
 		}
 		let bitmap = NSBitmapImageRep(cgImage: cgImage)
 		guard let data = bitmap.representation(using: .png, properties: [:]) else {
 			fputs("failed to encode drag screenshot PNG\n", stderr)
-			return
+			return false
 		}
 		do {
 			try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+			return true
 		} catch {
 			fputs("failed to write drag screenshot: \(error)\n", stderr)
+			return false
 		}
 	}
 
@@ -223,9 +262,13 @@ func runMaskProbe() async throws {
 	let phasePath = readRequiredString("MASK_PROBE_PHASE_PATH")
 	let readyPath = readOptionalString("MASK_PROBE_READY_PATH")
 	let screenshotPath = readOptionalString("MASK_PROBE_SCREENSHOT_PATH")
+	let releasedScreenshotPath = readOptionalString("MASK_PROBE_RELEASED_SCREENSHOT_PATH")
 	let point = readRequiredPoint("MASK_PROBE_POINT")
 	let durationMs = readInt("MASK_PROBE_DURATION_MS", default: 1_400)
 	let rateHz = readInt("MASK_PROBE_RATE_HZ", default: 60)
+	let minPhaseSamples = readInt("MASK_PROBE_MIN_PHASE_SAMPLES", default: 3)
+	let pollMs = readInt("MASK_PROBE_POLL_MS", default: 20)
+	let stopCapture = readInt("MASK_PROBE_STOP_CAPTURE", default: 0) == 1
 
 	let content = try await SCShareableContent.current
 	guard
@@ -249,6 +292,7 @@ func runMaskProbe() async throws {
 		phasePath: phasePath,
 		readyPath: readyPath,
 		screenshotPath: screenshotPath,
+		releasedScreenshotPath: releasedScreenshotPath,
 		point: point,
 		displayFrame: display.frame
 	)
@@ -259,8 +303,19 @@ func runMaskProbe() async throws {
 		sampleHandlerQueue: DispatchQueue(label: "ink.hack.rsnap.mask-probe", qos: .userInteractive)
 	)
 	try await stream.startCapture()
-	try await Task.sleep(nanoseconds: UInt64(max(1, durationMs)) * 1_000_000)
-	try await stream.stopCapture()
+	let started = ProcessInfo.processInfo.systemUptime
+	while (ProcessInfo.processInfo.systemUptime - started) * 1_000 < Double(max(1, durationMs)) {
+		if capture.hasRequiredSamples(
+			minDraggingSamples: minPhaseSamples,
+			minReleasedSamples: minPhaseSamples
+		) {
+			break
+		}
+		try await Task.sleep(nanoseconds: UInt64(max(1, pollMs)) * 1_000_000)
+	}
+	if stopCapture {
+		try await stream.stopCapture()
+	}
 	capture.writeSamples()
 }
 

--- a/scripts/smoke/lib/mask-probe-capture.swift
+++ b/scripts/smoke/lib/mask-probe-capture.swift
@@ -1,4 +1,6 @@
+import AppKit
 import CoreGraphics
+import CoreImage
 import CoreMedia
 import CoreVideo
 import Foundation
@@ -47,22 +49,26 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 	private let outputPath: String
 	private let phasePath: String
 	private let readyPath: String?
+	private let screenshotPath: String?
 	private let point: CGPoint
 	private let displayFrame: CGRect
 	private let lock = NSLock()
 	private var samples: [Sample] = []
 	private var wroteReady = false
+	private var wroteScreenshot = false
 
 	init(
 		outputPath: String,
 		phasePath: String,
 		readyPath: String?,
+		screenshotPath: String?,
 		point: CGPoint,
 		displayFrame: CGRect
 	) {
 		self.outputPath = outputPath
 		self.phasePath = phasePath
 		self.readyPath = readyPath
+		self.screenshotPath = screenshotPath
 		self.point = point
 		self.displayFrame = displayFrame
 	}
@@ -79,16 +85,27 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 		else {
 			return
 		}
+		let phase = currentPhase()
+		let screenshotPathToWrite: String?
 		lock.lock()
+		if phase == "holding", let screenshotPath, !wroteScreenshot {
+			wroteScreenshot = true
+			screenshotPathToWrite = screenshotPath
+		} else {
+			screenshotPathToWrite = nil
+		}
 		samples.append(
 			Sample(
-				phase: currentPhase(),
+				phase: phase,
 				uptime: ProcessInfo.processInfo.systemUptime,
 				luminance: luminance
 			)
 		)
 		writeReadyIfNeeded()
 		lock.unlock()
+		if let screenshotPathToWrite {
+			writeScreenshot(pixelBuffer, to: screenshotPathToWrite)
+		}
 	}
 
 	func writeSamples() {
@@ -129,6 +146,32 @@ final class MaskProbeCapture: NSObject, SCStreamOutput {
 			try "ready\n".write(toFile: readyPath, atomically: true, encoding: .utf8)
 		} catch {
 			fputs("failed to write mask probe ready marker: \(error)\n", stderr)
+		}
+	}
+
+	private func writeScreenshot(_ pixelBuffer: CVPixelBuffer, to path: String) {
+		let width = CVPixelBufferGetWidth(pixelBuffer)
+		let height = CVPixelBufferGetHeight(pixelBuffer)
+		let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+		let context = CIContext(options: nil)
+		guard
+			let cgImage = context.createCGImage(
+				ciImage,
+				from: CGRect(x: 0, y: 0, width: width, height: height)
+			)
+		else {
+			fputs("failed to create drag screenshot image\n", stderr)
+			return
+		}
+		let bitmap = NSBitmapImageRep(cgImage: cgImage)
+		guard let data = bitmap.representation(using: .png, properties: [:]) else {
+			fputs("failed to encode drag screenshot PNG\n", stderr)
+			return
+		}
+		do {
+			try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+		} catch {
+			fputs("failed to write drag screenshot: \(error)\n", stderr)
 		}
 	}
 
@@ -179,6 +222,7 @@ func runMaskProbe() async throws {
 	let outputPath = readRequiredString("MASK_PROBE_OUTPUT")
 	let phasePath = readRequiredString("MASK_PROBE_PHASE_PATH")
 	let readyPath = readOptionalString("MASK_PROBE_READY_PATH")
+	let screenshotPath = readOptionalString("MASK_PROBE_SCREENSHOT_PATH")
 	let point = readRequiredPoint("MASK_PROBE_POINT")
 	let durationMs = readInt("MASK_PROBE_DURATION_MS", default: 1_400)
 	let rateHz = readInt("MASK_PROBE_RATE_HZ", default: 60)
@@ -204,6 +248,7 @@ func runMaskProbe() async throws {
 		outputPath: outputPath,
 		phasePath: phasePath,
 		readyPath: readyPath,
+		screenshotPath: screenshotPath,
 		point: point,
 		displayFrame: display.frame
 	)

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -190,27 +190,39 @@ def count_leaked_horizontal_seam(
         (0, max(0, min_x - margin)),
         (min(width, max_x + margin), width),
     ]
-    row_indexes = [
-        y
-        for edge_y in (min_y, max_y)
-        for y in range(max(0, edge_y - 1), min(height, edge_y + 2))
-    ]
+    edge_specs = [(min_y, -1), (max_y, 1)]
 
-    bright_pixels = 0
+    seam_pixels = 0
     sampled = 0
-    for y in row_indexes:
-        row = rows[y]
+    for edge_y, outside_direction in edge_specs:
+        seam_rows = list(range(max(0, edge_y - 1), min(height, edge_y + 2)))
+        baseline_rows = [
+            edge_y + outside_direction * distance
+            for distance in range(6, 13)
+            if 0 <= edge_y + outside_direction * distance < height
+        ]
+        if not seam_rows or not baseline_rows:
+            continue
         for span_left, span_right in spans:
             for x in range(span_left, span_right):
                 sampled += 1
-                base = x * channels
-                red, green, blue = row[base], row[base + 1], row[base + 2]
-                luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
-                if luminance >= 120:
-                    bright_pixels += 1
+                seam_luminance = max(
+                    pixel_luminance(rows[row_index], x, channels) for row_index in seam_rows
+                )
+                baseline_luminance = sum(
+                    pixel_luminance(rows[row_index], x, channels) for row_index in baseline_rows
+                ) / len(baseline_rows)
+                if seam_luminance >= 125 and seam_luminance - baseline_luminance >= 35:
+                    seam_pixels += 1
     if sampled == 0:
         return 0.0, 0
-    return bright_pixels / sampled, bright_pixels
+    return seam_pixels / sampled, seam_pixels
+
+
+def pixel_luminance(row: bytes, x: int, channels: int) -> float:
+    base = x * channels
+    red, green, blue = row[base], row[base + 1], row[base + 2]
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
 
 
 def line_epoch(line: str) -> float | None:

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -248,6 +248,14 @@ expected_min_freeze_commits = int(os.environ.get("EXPECTED_MIN_FREEZE_COMMITS", 
 expected_min_frozen_transform_commits = int(
     os.environ.get("EXPECTED_MIN_FROZEN_TRANSFORM_COMMITS", "0") or "0"
 )
+expected_max_frozen_transform_commits_raw = os.environ.get(
+    "EXPECTED_MAX_FROZEN_TRANSFORM_COMMITS", ""
+).strip()
+expected_max_frozen_transform_commits = (
+    int(expected_max_frozen_transform_commits_raw)
+    if expected_max_frozen_transform_commits_raw
+    else None
+)
 expected_freeze_editability = [
     value.strip().lower() == "true"
     for value in os.environ.get("EXPECTED_FREEZE_EDITABILITY", "").split(",")
@@ -333,6 +341,17 @@ if expected_min_frozen_transform_commits:
         failures.append(
             "frozen transform commit count too small: "
             f"{len(frozen_transform_commits)} < {expected_min_frozen_transform_commits}"
+        )
+if expected_max_frozen_transform_commits is not None:
+    print(
+        "[smoke] frozen_transform_commits "
+        f"expected<={expected_max_frozen_transform_commits} "
+        f"actual={len(frozen_transform_commits)}"
+    )
+    if len(frozen_transform_commits) > expected_max_frozen_transform_commits:
+        failures.append(
+            "frozen transform commit count too large: "
+            f"{len(frozen_transform_commits)} > {expected_max_frozen_transform_commits}"
         )
 max_latest_unchanged_frame_age_ms = threshold("MAX_LATEST_UNCHANGED_FRAME_AGE_MS", 150.0)
 max_total_ms = threshold("MAX_FREEZE_COMMIT_MS", 90.0)

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -304,6 +304,22 @@ if freeze_commit_failures:
         "freeze commit failure events observed: "
         f"{len(freeze_commit_failures)}"
     )
+max_latest_unchanged_frame_age_ms = threshold("MAX_LATEST_UNCHANGED_FRAME_AGE_MS", 150.0)
+for index, commit in enumerate(freeze_commits, start=1):
+    commit_source = commit.get("snapshotSource", "unknown")
+    commit_frame_age_ms = float_field(commit, "frameAgeMs")
+    commit_filter_complete = bool_field(commit, "selfCaptureFilterComplete")
+    if not bool_field(commit, "selfCaptureSafe"):
+        failures.append(
+            f"freeze_commit[{index}] used a frame that could contain rsnap's own capture UI"
+        )
+    if commit_source == "latest_unchanged" and not commit_filter_complete and (
+        commit_frame_age_ms > max_latest_unchanged_frame_age_ms
+    ):
+        failures.append(
+            f"freeze_commit[{index}] latest_unchanged frameAgeMs={commit_frame_age_ms:.2f} "
+            f"exceeds {max_latest_unchanged_frame_age_ms:.2f}"
+        )
 if expected_freeze_editability:
     actual_editability = [
         bool_field(handoff_event, "frozenSelectionEditable")
@@ -324,6 +340,11 @@ if freeze_commit:
     present_ms = float_field(freeze_commit, "presentMs")
     snapshot_wait_ms = float_field(freeze_commit, "snapshotWaitMs")
     base_ready = bool_field(freeze_commit, "baseReady")
+    self_capture_filter_complete = bool_field(
+        freeze_commit,
+        "selfCaptureFilterComplete",
+    )
+    self_capture_safe = bool_field(freeze_commit, "selfCaptureSafe")
     snapshot_source = freeze_commit.get("snapshotSource", "unknown")
     max_total_ms = threshold("MAX_FREEZE_COMMIT_MS", 90.0)
     max_present_ms = mode_threshold(
@@ -335,7 +356,8 @@ if freeze_commit:
         "[smoke] freeze_commit "
         f"totalMs={total_ms:.2f} presentMs={present_ms:.2f} "
         f"snapshotWaitMs={snapshot_wait_ms:.2f} snapshotSource={snapshot_source} "
-        f"baseReady={base_ready}"
+        f"selfCaptureSafe={self_capture_safe} "
+        f"selfCaptureFilterComplete={self_capture_filter_complete} baseReady={base_ready}"
     )
     if total_ms > max_total_ms:
         failures.append(f"freeze_commit totalMs={total_ms:.2f} exceeds {max_total_ms:.2f}")
@@ -491,10 +513,13 @@ if mask_probe_path:
     else:
         values: dict[str, list[float]] = {"dragging": [], "released": []}
         for row in rows[1:]:
-            if len(row) != 3 or row[0] not in values:
+            if len(row) != 3:
+                continue
+            phase = "dragging" if row[0] == "holding" else row[0]
+            if phase not in values:
                 continue
             try:
-                values[row[0]].append(float(row[2]))
+                values[phase].append(float(row[2]))
             except ValueError:
                 continue
         dragging = values["dragging"]

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -4,6 +4,7 @@ import statistics
 import struct
 import sys
 import time
+import zlib
 from datetime import datetime
 
 
@@ -52,6 +53,166 @@ def png_dimensions(path: str) -> tuple[int, int] | None:
     return struct.unpack(">II", header[16:24])
 
 
+def png_rgb_rows(path: str) -> tuple[int, int, int, list[bytes]] | None:
+    with open(path, "rb") as handle:
+        data = handle.read()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        return None
+
+    offset = 8
+    width = height = channels = 0
+    idat = bytearray()
+    while offset + 8 <= len(data):
+        length = struct.unpack(">I", data[offset : offset + 4])[0]
+        kind = data[offset + 4 : offset + 8]
+        payload = data[offset + 8 : offset + 8 + length]
+        offset += 12 + length
+        if kind == b"IHDR":
+            width, height = struct.unpack(">II", payload[:8])
+            bit_depth = payload[8]
+            color_type = payload[9]
+            interlace = payload[12]
+            if bit_depth != 8 or interlace != 0 or color_type not in {2, 6}:
+                return None
+            channels = 4 if color_type == 6 else 3
+        elif kind == b"IDAT":
+            idat.extend(payload)
+        elif kind == b"IEND":
+            break
+
+    if width <= 0 or height <= 0 or channels <= 0:
+        return None
+
+    raw = zlib.decompress(bytes(idat))
+    stride = width * channels
+    rows: list[bytes] = []
+    previous = bytearray(stride)
+    cursor = 0
+    for _ in range(height):
+        filter_type = raw[cursor]
+        cursor += 1
+        row = bytearray(raw[cursor : cursor + stride])
+        cursor += stride
+        for index in range(stride):
+            left = row[index - channels] if index >= channels else 0
+            up = previous[index]
+            up_left = previous[index - channels] if index >= channels else 0
+            if filter_type == 1:
+                row[index] = (row[index] + left) & 0xFF
+            elif filter_type == 2:
+                row[index] = (row[index] + up) & 0xFF
+            elif filter_type == 3:
+                row[index] = (row[index] + ((left + up) // 2)) & 0xFF
+            elif filter_type == 4:
+                row[index] = (row[index] + paeth(left, up, up_left)) & 0xFF
+            elif filter_type != 0:
+                return None
+        rows.append(bytes(row))
+        previous = row
+    return width, height, channels, rows
+
+
+def paeth(left: int, up: int, up_left: int) -> int:
+    estimate = left + up - up_left
+    left_distance = abs(estimate - left)
+    up_distance = abs(estimate - up)
+    up_left_distance = abs(estimate - up_left)
+    if left_distance <= up_distance and left_distance <= up_left_distance:
+        return left
+    if up_distance <= up_left_distance:
+        return up
+    return up_left
+
+
+def count_leaked_drag_border(
+    path: str, display_bounds: str, drag_points: str
+) -> tuple[float, int] | None:
+    decoded = png_rgb_rows(path)
+    if decoded is None:
+        return None
+    width, height, channels, rows = decoded
+    left, top, right, bottom = map(float, display_bounds.replace(" ", "").split(","))
+    start_raw, end_raw = drag_points.split(";")[:2]
+    sx, sy = map(float, start_raw.split(","))
+    ex, ey = map(float, end_raw.split(","))
+    scale_x = width / max(1.0, right - left)
+    scale_y = height / max(1.0, bottom - top)
+    min_x = int((min(sx, ex) - left) * scale_x)
+    max_x = int((max(sx, ex) - left) * scale_x)
+    min_y = int((min(sy, ey) - top) * scale_y)
+    max_y = int((max(sy, ey) - top) * scale_y)
+    margin = max(12, int(10 * max(scale_x, scale_y)))
+    spans = [
+        (0, max(0, min_x - margin)),
+        (min(width, max_x + margin), width),
+    ]
+    row_indexes = [
+        y
+        for edge_y in (min_y, max_y)
+        for y in range(max(0, edge_y - 2), min(height, edge_y + 3))
+    ]
+
+    border_pixels = 0
+    sampled = 0
+    for y in row_indexes:
+        row = rows[y]
+        for span_left, span_right in spans:
+            for x in range(span_left, span_right):
+                sampled += 1
+                base = x * channels
+                red, green, blue = row[base], row[base + 1], row[base + 2]
+                if blue >= 150 and green >= 140 and red >= 100 and blue - red >= 20:
+                    border_pixels += 1
+    if sampled == 0:
+        return 0.0, 0
+    return border_pixels / sampled, border_pixels
+
+
+def count_leaked_horizontal_seam(
+    path: str, display_bounds: str, drag_points: str
+) -> tuple[float, int] | None:
+    decoded = png_rgb_rows(path)
+    if decoded is None:
+        return None
+    width, height, channels, rows = decoded
+    left, top, right, bottom = map(float, display_bounds.replace(" ", "").split(","))
+    start_raw, end_raw = drag_points.split(";")[:2]
+    sx, sy = map(float, start_raw.split(","))
+    ex, ey = map(float, end_raw.split(","))
+    scale_x = width / max(1.0, right - left)
+    scale_y = height / max(1.0, bottom - top)
+    min_x = int((min(sx, ex) - left) * scale_x)
+    max_x = int((max(sx, ex) - left) * scale_x)
+    min_y = int((min(sy, ey) - top) * scale_y)
+    max_y = int((max(sy, ey) - top) * scale_y)
+    margin = max(12, int(10 * max(scale_x, scale_y)))
+    spans = [
+        (0, max(0, min_x - margin)),
+        (min(width, max_x + margin), width),
+    ]
+    row_indexes = [
+        y
+        for edge_y in (min_y, max_y)
+        for y in range(max(0, edge_y - 1), min(height, edge_y + 2))
+    ]
+
+    bright_pixels = 0
+    sampled = 0
+    for y in row_indexes:
+        row = rows[y]
+        for span_left, span_right in spans:
+            for x in range(span_left, span_right):
+                sampled += 1
+                base = x * channels
+                red, green, blue = row[base], row[base + 1], row[base + 2]
+                luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+                if luminance >= 120:
+                    bright_pixels += 1
+    if sampled == 0:
+        return 0.0, 0
+    return bright_pixels / sampled, bright_pixels
+
+
 def line_epoch(line: str) -> float | None:
     try:
         parsed = datetime.strptime(line[:23], "%Y-%m-%d %H:%M:%S.%f")
@@ -67,8 +228,16 @@ if len(sys.argv) != 2:
 log_path = sys.argv[1]
 expected_mode = os.environ.get("EXPECTED_HUD_GLASS_MODE", "liquid").strip().lower()
 screenshot_path = os.environ.get("VISUAL_SCREENSHOT_PATH", "").strip()
+drag_screenshot_path = os.environ.get("VISUAL_DRAG_SCREENSHOT_PATH", "").strip()
+visual_display_bounds = os.environ.get("VISUAL_DISPLAY_BOUNDS", "").strip()
+visual_drag_points = os.environ.get("VISUAL_DRAG_POINTS", "").strip()
 mask_probe_path = os.environ.get("MASK_PROBE_PATH", "").strip()
 expected_min_freeze_commits = int(os.environ.get("EXPECTED_MIN_FREEZE_COMMITS", "1") or "1")
+expected_freeze_editability = [
+    value.strip().lower() == "true"
+    for value in os.environ.get("EXPECTED_FREEZE_EDITABILITY", "").split(",")
+    if value.strip()
+]
 smoke_started_epoch = float(os.environ.get("SMOKE_STARTED_EPOCH", "0") or "0")
 run_id_re = re.compile(r"runID=([^ ]+)")
 event_re = re.compile(r"event=([^ ]+)")
@@ -120,7 +289,8 @@ for required_event in [
         failures.append(f"missing event {required_event}")
 
 freeze_commit = events.get("capture_timing.freeze_commit", [{}])[-1]
-handoff = events.get("capture_timing.frozen_first_display_handoff", [{}])[-1]
+handoffs = events.get("capture_timing.frozen_first_display_handoff", [])
+handoff = handoffs[-1] if handoffs else {}
 freeze_commits = events.get("capture_timing.freeze_commit", [])
 freeze_commit_failures = events.get("capture_timing.freeze_commit_failed", [])
 
@@ -134,6 +304,20 @@ if freeze_commit_failures:
         "freeze commit failure events observed: "
         f"{len(freeze_commit_failures)}"
     )
+if expected_freeze_editability:
+    actual_editability = [
+        bool_field(handoff_event, "frozenSelectionEditable")
+        for handoff_event in handoffs[-len(expected_freeze_editability) :]
+    ]
+    print(
+        "[smoke] freeze_editability "
+        f"expected={expected_freeze_editability} actual={actual_editability}"
+    )
+    if actual_editability != expected_freeze_editability:
+        failures.append(
+            "frozen editability sequence mismatch: "
+            f"expected {expected_freeze_editability}, got {actual_editability}"
+        )
 
 if freeze_commit:
     total_ms = float_field(freeze_commit, "totalMs")
@@ -221,6 +405,62 @@ if handoff:
             failures.append("Classic Glass mode unexpectedly used Liquid Glass toolbar chrome")
     elif expected_mode not in {"liquid", "classic"}:
         failures.append(f"unknown EXPECTED_HUD_GLASS_MODE={expected_mode}")
+
+if drag_screenshot_path:
+    for drag_path in [path for path in drag_screenshot_path.split(":") if path]:
+        try:
+            size = os.path.getsize(drag_path)
+            dimensions = png_dimensions(drag_path)
+        except OSError as exc:
+            failures.append(f"drag screenshot missing: {exc}")
+        else:
+            if dimensions is None:
+                failures.append(f"drag screenshot is not a PNG: {drag_path}")
+            else:
+                width, height = dimensions
+                print(
+                    "[smoke] drag_screenshot "
+                    f"path={drag_path} width={width} height={height} bytes={size}"
+                )
+                if width < 500 or height < 400:
+                    failures.append(f"drag screenshot too small: {width}x{height}")
+                if visual_display_bounds and visual_drag_points:
+                    leak = count_leaked_drag_border(
+                        drag_path, visual_display_bounds, visual_drag_points
+                    )
+                    if leak is None:
+                        failures.append("drag screenshot could not be decoded for border-leak check")
+                    else:
+                        leak_ratio, leak_pixels = leak
+                        max_leak_ratio = threshold("MAX_DRAG_BORDER_LEAK_RATIO", 0.015)
+                        max_leak_pixels = int(threshold("MAX_DRAG_BORDER_LEAK_PIXELS", 80))
+                        print(
+                            "[smoke] drag_border_leak "
+                            f"ratio={leak_ratio:.5f} pixels={leak_pixels}"
+                        )
+                        if leak_ratio > max_leak_ratio and leak_pixels > max_leak_pixels:
+                            failures.append(
+                                "live drag border leaked outside the selection "
+                                f"(ratio={leak_ratio:.5f}, pixels={leak_pixels})"
+                            )
+                    seam = count_leaked_horizontal_seam(
+                        drag_path, visual_display_bounds, visual_drag_points
+                    )
+                    if seam is None:
+                        failures.append("drag screenshot could not be decoded for seam check")
+                    else:
+                        seam_ratio, seam_pixels = seam
+                        max_seam_ratio = threshold("MAX_DRAG_HORIZONTAL_SEAM_RATIO", 0.01)
+                        max_seam_pixels = int(threshold("MAX_DRAG_HORIZONTAL_SEAM_PIXELS", 80))
+                        print(
+                            "[smoke] drag_horizontal_seam "
+                            f"ratio={seam_ratio:.5f} pixels={seam_pixels}"
+                        )
+                        if seam_ratio > max_seam_ratio and seam_pixels > max_seam_pixels:
+                            failures.append(
+                                "live drag scrim leaked a horizontal seam outside the selection "
+                                f"(ratio={seam_ratio:.5f}, pixels={seam_pixels})"
+                            )
 
 if screenshot_path:
     try:

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -309,6 +309,9 @@ handoff = handoffs[-1] if handoffs else {}
 freeze_commits = events.get("capture_timing.freeze_commit", [])
 freeze_commit_failures = events.get("capture_timing.freeze_commit_failed", [])
 frozen_transform_commits = events.get("capture.frozen_selection_transform_commit", [])
+max_window_list_below_overlay_commits = int(
+    os.environ.get("MAX_WINDOW_LIST_BELOW_OVERLAY_COMMITS", "0") or "0"
+)
 
 if len(freeze_commits) < expected_min_freeze_commits:
     failures.append(
@@ -332,14 +335,48 @@ if expected_min_frozen_transform_commits:
             f"{len(frozen_transform_commits)} < {expected_min_frozen_transform_commits}"
         )
 max_latest_unchanged_frame_age_ms = threshold("MAX_LATEST_UNCHANGED_FRAME_AGE_MS", 150.0)
+max_total_ms = threshold("MAX_FREEZE_COMMIT_MS", 90.0)
+max_present_ms = mode_threshold(
+    "MAX_FREEZE_PRESENT_MS",
+    55.0 if expected_mode == "classic" else 35.0,
+)
+max_snapshot_wait_ms = threshold("MAX_FREEZE_SNAPSHOT_WAIT_MS", 45.0)
+window_list_below_overlay_commits = 0
 for index, commit in enumerate(freeze_commits, start=1):
     commit_source = commit.get("snapshotSource", "unknown")
     commit_frame_age_ms = float_field(commit, "frameAgeMs")
     commit_filter_complete = bool_field(commit, "selfCaptureFilterComplete")
+    total_ms = float_field(commit, "totalMs")
+    present_ms = float_field(commit, "presentMs")
+    snapshot_wait_ms = float_field(commit, "snapshotWaitMs")
+    base_ready = bool_field(commit, "baseReady")
+    self_capture_safe = bool_field(commit, "selfCaptureSafe")
+    print(
+        f"[smoke] freeze_commit[{index}] "
+        f"totalMs={total_ms:.2f} presentMs={present_ms:.2f} "
+        f"snapshotWaitMs={snapshot_wait_ms:.2f} snapshotSource={commit_source} "
+        f"selfCaptureSafe={self_capture_safe} "
+        f"selfCaptureFilterComplete={commit_filter_complete} baseReady={base_ready}"
+    )
+    if total_ms > max_total_ms:
+        failures.append(
+            f"freeze_commit[{index}] totalMs={total_ms:.2f} exceeds {max_total_ms:.2f}"
+        )
+    if present_ms > max_present_ms:
+        failures.append(
+            f"freeze_commit[{index}] presentMs={present_ms:.2f} exceeds {max_present_ms:.2f}"
+        )
+    if snapshot_wait_ms > max_snapshot_wait_ms:
+        failures.append(
+            f"freeze_commit[{index}] snapshotWaitMs={snapshot_wait_ms:.2f} "
+            f"exceeds {max_snapshot_wait_ms:.2f}"
+        )
     if not bool_field(commit, "selfCaptureSafe"):
         failures.append(
             f"freeze_commit[{index}] used a frame that could contain rsnap's own capture UI"
         )
+    if commit_source == "window_list_below_overlay":
+        window_list_below_overlay_commits += 1
     if commit_source == "latest_unchanged" and not commit_filter_complete and (
         commit_frame_age_ms > max_latest_unchanged_frame_age_ms
     ):
@@ -347,6 +384,13 @@ for index, commit in enumerate(freeze_commits, start=1):
             f"freeze_commit[{index}] latest_unchanged frameAgeMs={commit_frame_age_ms:.2f} "
             f"exceeds {max_latest_unchanged_frame_age_ms:.2f}"
         )
+    if not base_ready:
+        failures.append(f"freeze_commit[{index}] did not prepare the frozen base image")
+if window_list_below_overlay_commits > max_window_list_below_overlay_commits:
+    failures.append(
+        "window-list below-overlay freeze commits exceeded limit: "
+        f"{window_list_below_overlay_commits} > {max_window_list_below_overlay_commits}"
+    )
 if expected_freeze_editability:
     actual_editability = [
         bool_field(handoff_event, "frozenSelectionEditable")
@@ -361,44 +405,6 @@ if expected_freeze_editability:
             "frozen editability sequence mismatch: "
             f"expected {expected_freeze_editability}, got {actual_editability}"
         )
-
-if freeze_commit:
-    total_ms = float_field(freeze_commit, "totalMs")
-    present_ms = float_field(freeze_commit, "presentMs")
-    snapshot_wait_ms = float_field(freeze_commit, "snapshotWaitMs")
-    base_ready = bool_field(freeze_commit, "baseReady")
-    self_capture_filter_complete = bool_field(
-        freeze_commit,
-        "selfCaptureFilterComplete",
-    )
-    self_capture_safe = bool_field(freeze_commit, "selfCaptureSafe")
-    snapshot_source = freeze_commit.get("snapshotSource", "unknown")
-    max_total_ms = threshold("MAX_FREEZE_COMMIT_MS", 90.0)
-    max_present_ms = mode_threshold(
-        "MAX_FREEZE_PRESENT_MS",
-        55.0 if expected_mode == "classic" else 35.0,
-    )
-    max_snapshot_wait_ms = threshold("MAX_FREEZE_SNAPSHOT_WAIT_MS", 45.0)
-    print(
-        "[smoke] freeze_commit "
-        f"totalMs={total_ms:.2f} presentMs={present_ms:.2f} "
-        f"snapshotWaitMs={snapshot_wait_ms:.2f} snapshotSource={snapshot_source} "
-        f"selfCaptureSafe={self_capture_safe} "
-        f"selfCaptureFilterComplete={self_capture_filter_complete} baseReady={base_ready}"
-    )
-    if total_ms > max_total_ms:
-        failures.append(f"freeze_commit totalMs={total_ms:.2f} exceeds {max_total_ms:.2f}")
-    if present_ms > max_present_ms:
-        failures.append(f"freeze_commit presentMs={present_ms:.2f} exceeds {max_present_ms:.2f}")
-    if snapshot_wait_ms > max_snapshot_wait_ms:
-        failures.append(
-            f"freeze_commit snapshotWaitMs={snapshot_wait_ms:.2f} "
-            f"exceeds {max_snapshot_wait_ms:.2f}"
-        )
-    if snapshot_source == "window_list_below_overlay":
-        failures.append("freeze_commit used synchronous window-list fallback for frozen handoff")
-    if not base_ready:
-        failures.append("freeze_commit did not prepare the frozen base image")
 
 if handoff:
     total_ms = float_field(handoff, "totalMs")

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -245,6 +245,9 @@ visual_display_bounds = os.environ.get("VISUAL_DISPLAY_BOUNDS", "").strip()
 visual_drag_points = os.environ.get("VISUAL_DRAG_POINTS", "").strip()
 mask_probe_path = os.environ.get("MASK_PROBE_PATH", "").strip()
 expected_min_freeze_commits = int(os.environ.get("EXPECTED_MIN_FREEZE_COMMITS", "1") or "1")
+expected_min_frozen_transform_commits = int(
+    os.environ.get("EXPECTED_MIN_FROZEN_TRANSFORM_COMMITS", "0") or "0"
+)
 expected_freeze_editability = [
     value.strip().lower() == "true"
     for value in os.environ.get("EXPECTED_FREEZE_EDITABILITY", "").split(",")
@@ -305,6 +308,7 @@ handoffs = events.get("capture_timing.frozen_first_display_handoff", [])
 handoff = handoffs[-1] if handoffs else {}
 freeze_commits = events.get("capture_timing.freeze_commit", [])
 freeze_commit_failures = events.get("capture_timing.freeze_commit_failed", [])
+frozen_transform_commits = events.get("capture.frozen_selection_transform_commit", [])
 
 if len(freeze_commits) < expected_min_freeze_commits:
     failures.append(
@@ -316,6 +320,17 @@ if freeze_commit_failures:
         "freeze commit failure events observed: "
         f"{len(freeze_commit_failures)}"
     )
+if expected_min_frozen_transform_commits:
+    print(
+        "[smoke] frozen_transform_commits "
+        f"expected>={expected_min_frozen_transform_commits} "
+        f"actual={len(frozen_transform_commits)}"
+    )
+    if len(frozen_transform_commits) < expected_min_frozen_transform_commits:
+        failures.append(
+            "frozen transform commit count too small: "
+            f"{len(frozen_transform_commits)} < {expected_min_frozen_transform_commits}"
+        )
 max_latest_unchanged_frame_age_ms = threshold("MAX_LATEST_UNCHANGED_FRAME_AGE_MS", 150.0)
 for index, commit in enumerate(freeze_commits, start=1):
     commit_source = commit.get("snapshotSource", "unknown")

--- a/scripts/smoke/macos.sh
+++ b/scripts/smoke/macos.sh
@@ -9,14 +9,19 @@ case "${1:-}" in
 Usage: macos.sh
 
 Runs the macOS smoke sequence:
-  1. native-host HUD-follow smoke
-  2. native-host frozen visual/behavior contract smoke
-  3. recorded live-trace replay in worker-pairwise mode
+  1. native-host visual/behavior contract smoke
+  2. recorded live-trace replay in worker-pairwise mode, or replay self-check when no trace exists
 EOF
     exit 0
     ;;
 esac
 
-"$SCRIPT_DIR/native-hud-follow-macos.sh"
 "$SCRIPT_DIR/native-visual-contract-macos.sh"
-"$SCRIPT_DIR/replay-scroll-capture.sh"
+
+TRACE_ROOT="${RSNAP_SCROLL_CAPTURE_TRACE_DIR:-$HOME/Library/Application Support/ink.hack.rsnap/scroll-capture-traces}"
+if [[ -d "$TRACE_ROOT" ]] && find "$TRACE_ROOT" -mindepth 2 -maxdepth 2 -name manifest.json -print -quit | grep -q .; then
+  "$SCRIPT_DIR/replay-scroll-capture.sh"
+else
+  echo "[smoke] no recorded scroll-capture trace found; running replay self-check"
+  "$SCRIPT_DIR/replay-scroll-capture-self-check.sh"
+fi

--- a/scripts/smoke/native-visual-contract-macos.sh
+++ b/scripts/smoke/native-visual-contract-macos.sh
@@ -10,16 +10,18 @@ usage() {
 Usage: native-visual-contract-macos.sh [--self-check] [--help]
 
 Runs the native macOS visual/behavior contract smoke:
-  1. force representative Liquid Glass and Classic Glass preferences
+  1. force a representative native-host visual mode
   2. build, sign, and launch the native host app
-  3. start capture with Option-X
-  4. drag a frozen selection and release
-  5. capture rsnap's own frozen overlay and gate toolbar/material contract telemetry
+  3. run one real click freeze and one real held-drag freeze
+  4. capture the in-drag and frozen overlays
+  5. gate click/drag editability, scrim stability, border leakage, and handoff telemetry
 
 Useful overrides:
-  VISUAL_CONTRACT_CASES=liquid,classic
-  REPEATED_CLICK_FREEZES=2
+  VISUAL_CONTRACT_CASES=liquid          optional: liquid,classic
+  REPEATED_CLICK_FREEZES=1
+  REPEATED_DRAG_FREEZES=2
   DRAG_DURATION_MS=260
+  DRAG_HOLD_BEFORE_RELEASE_MS=700
   PATH_RATE_HZ=120
   MAX_FREEZE_COMMIT_MS=90
   MAX_FREEZE_PRESENT_MS=35
@@ -52,12 +54,14 @@ ROOT_DIR="$(live_hud_repo_root)"
 live_hud_init_environment "$ROOT_DIR"
 
 DRAG_DURATION_MS="${DRAG_DURATION_MS:-260}"
+DRAG_HOLD_BEFORE_RELEASE_MS="${DRAG_HOLD_BEFORE_RELEASE_MS:-700}"
 PATH_RATE_HZ="${PATH_RATE_HZ:-120}"
-VISUAL_CONTRACT_CASES="${VISUAL_CONTRACT_CASES:-liquid,classic}"
+VISUAL_CONTRACT_CASES="${VISUAL_CONTRACT_CASES:-liquid}"
 OVERLAY_SETTLE_S="${OVERLAY_SETTLE_S:-0.25}"
 POST_FREEZE_SETTLE_S="${POST_FREEZE_SETTLE_S:-0.25}"
 POST_CLOSE_SETTLE_S="${POST_CLOSE_SETTLE_S:-0.25}"
-REPEATED_CLICK_FREEZES="${REPEATED_CLICK_FREEZES:-2}"
+REPEATED_CLICK_FREEZES="${REPEATED_CLICK_FREEZES:-1}"
+REPEATED_DRAG_FREEZES="${REPEATED_DRAG_FREEZES:-2}"
 RSNAP_TELEMETRY_LAST="${RSNAP_TELEMETRY_LAST:-3m}"
 export RSNAP_TELEMETRY_LAST
 
@@ -137,11 +141,37 @@ wait_mask_probe_ready() {
 	local ready_path="$1"
 	local attempt
 
-	for attempt in {1..80}; do
+	for attempt in {1..200}; do
 		if grep -q '^ready$' "$ready_path" >/dev/null 2>&1; then
 			return 0
 		fi
 		sleep 0.05
+	done
+	return 1
+}
+
+wait_drag_hold_ready() {
+	local phase_path="$1"
+	local attempt
+
+	for attempt in {1..120}; do
+		if grep -q '^holding$' "$phase_path" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.025
+	done
+	return 1
+}
+
+wait_file_nonempty() {
+	local path="$1"
+	local attempt
+
+	for attempt in {1..120}; do
+		if [[ -s "$path" ]]; then
+			return 0
+		fi
+		sleep 0.025
 	done
 	return 1
 }
@@ -168,7 +198,7 @@ PY
 fi
 
 echo "[smoke] display bounds: $DISPLAY_BOUNDS"
-echo "[smoke] drag points: $PATH_POINTS duration_ms=$DRAG_DURATION_MS rate_hz=$PATH_RATE_HZ"
+echo "[smoke] drag points: $PATH_POINTS duration_ms=$DRAG_DURATION_MS hold_ms=$DRAG_HOLD_BEFORE_RELEASE_MS rate_hz=$PATH_RATE_HZ"
 
 CLICK_POINTS="$(
 	python3 - "$DISPLAY_BOUNDS" <<'PY'
@@ -211,10 +241,12 @@ configure_case_preferences() {
 
 run_visual_case() {
 	local case_name="$1"
-	local case_tmp_dir screenshot_path background_ready_path case_started_epoch out_dir
+	local case_tmp_dir drag_screenshot_path drag_screenshot_paths screenshot_path background_ready_path case_started_epoch out_dir
 
 	case_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/rsnap-visual-${case_name}.XXXXXX")"
-	screenshot_path="$case_tmp_dir/frozen.png"
+	drag_screenshot_paths=""
+	drag_screenshot_path="$case_tmp_dir/dragging-1.png"
+	screenshot_path="$case_tmp_dir/frozen-1.png"
 	background_ready_path="$case_tmp_dir/background.ready"
 	case_started_epoch="$(date +%s)"
 
@@ -245,20 +277,23 @@ run_visual_case() {
 		sleep "$POST_CLOSE_SETTLE_S"
 	done
 
-	press_capture_hotkey
-	sleep 0.4
-	press_capture_hotkey
-	sleep "$OVERLAY_SETTLE_S"
-	live_hud_focus_rsnap_overlay
+	for ((drag_index = 1; drag_index <= REPEATED_DRAG_FREEZES; drag_index++)); do
+		echo "[smoke] repeated drag freeze $drag_index/$REPEATED_DRAG_FREEZES"
+		drag_screenshot_path="$case_tmp_dir/dragging-$drag_index.png"
+		screenshot_path="$case_tmp_dir/frozen-$drag_index.png"
+		press_capture_hotkey
+		sleep "$OVERLAY_SETTLE_S"
+		live_hud_focus_rsnap_overlay
 
-	local mask_probe_path mask_probe_phase_path mask_probe_ready_path mask_probe_point mask_probe_pid
-	mask_probe_path="$case_tmp_dir/mask-probe.csv"
-	mask_probe_phase_path="$case_tmp_dir/mask-probe.phase"
-	mask_probe_ready_path="$case_tmp_dir/mask-probe.ready"
-	printf 'pre' >"$mask_probe_phase_path"
-	rm -f "$mask_probe_ready_path"
-	mask_probe_point="$(
-		python3 - "$DISPLAY_BOUNDS" "$PATH_POINTS" <<'PY'
+		local mask_probe_path mask_probe_phase_path mask_probe_ready_path mask_probe_stderr_path mask_probe_point mask_probe_pid drag_pid
+		mask_probe_path="$case_tmp_dir/mask-probe-$drag_index.csv"
+		mask_probe_phase_path="$case_tmp_dir/mask-probe-$drag_index.phase"
+		mask_probe_ready_path="$case_tmp_dir/mask-probe-$drag_index.ready"
+		mask_probe_stderr_path="$case_tmp_dir/mask-probe-$drag_index.stderr"
+		printf 'pre' >"$mask_probe_phase_path"
+		rm -f "$mask_probe_ready_path"
+		mask_probe_point="$(
+			python3 - "$DISPLAY_BOUNDS" "$PATH_POINTS" <<'PY'
 import sys
 
 left, top, right, bottom = map(int, sys.argv[1].replace(" ", "").split(","))
@@ -277,58 +312,114 @@ sample_x = min(max(sample_x, left + 32), right - 32)
 sample_y = min(max(sample_y, top + 32), bottom - 32)
 print(f"{sample_x:.0f},{sample_y:.0f}")
 PY
-	)"
+		)"
 
-	MASK_PROBE_OUTPUT="$mask_probe_path" \
-	MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
-	MASK_PROBE_READY_PATH="$mask_probe_ready_path" \
-	MASK_PROBE_POINT="$mask_probe_point" \
-	MASK_PROBE_DURATION_MS="${MASK_PROBE_DURATION_MS:-2400}" \
-	MASK_PROBE_RATE_HZ="${MASK_PROBE_RATE_HZ:-60}" \
-	swift "$SCRIPT_DIR/lib/mask-probe-capture.swift" &
-	mask_probe_pid="$!"
-	if ! wait_mask_probe_ready "$mask_probe_ready_path"; then
-		kill "$mask_probe_pid" >/dev/null 2>&1 || true
-		wait "$mask_probe_pid" >/dev/null 2>&1 || true
+		MASK_PROBE_OUTPUT="$mask_probe_path" \
+		MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
+		MASK_PROBE_READY_PATH="$mask_probe_ready_path" \
+		MASK_PROBE_SCREENSHOT_PATH="$drag_screenshot_path" \
+		MASK_PROBE_POINT="$mask_probe_point" \
+		MASK_PROBE_DURATION_MS="${MASK_PROBE_DURATION_MS:-2400}" \
+		MASK_PROBE_RATE_HZ="${MASK_PROBE_RATE_HZ:-60}" \
+		swift "$SCRIPT_DIR/lib/mask-probe-capture.swift" 2>"$mask_probe_stderr_path" &
+		mask_probe_pid="$!"
+		if ! wait_mask_probe_ready "$mask_probe_ready_path"; then
+			kill "$mask_probe_pid" >/dev/null 2>&1 || true
+			wait "$mask_probe_pid" >/dev/null 2>&1 || true
+			live_hud_focus_rsnap_overlay
+			live_hud_press_escape >/dev/null 2>&1 || true
+			stop_visual_background
+			echo "[smoke] FAIL mask probe did not produce a ready sample" >&2
+			if [[ -s "$mask_probe_stderr_path" ]]; then
+				sed 's/^/[smoke] mask probe stderr: /' "$mask_probe_stderr_path" >&2
+			fi
+			return 1
+		fi
+
+		PATH_MODE=drag-region \
+		PATH_DRIVER=event \
+		PATH_POINTS="$PATH_POINTS" \
+		PATH_DURATION_MS="$DRAG_DURATION_MS" \
+		PATH_RATE_HZ="$PATH_RATE_HZ" \
+		PATH_HOLD_BEFORE_RELEASE_MS="$DRAG_HOLD_BEFORE_RELEASE_MS" \
+		MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
+		swift "$(live_hud_cursor_helper)" &
+		drag_pid="$!"
+		if ! wait_drag_hold_ready "$mask_probe_phase_path"; then
+			kill "$drag_pid" >/dev/null 2>&1 || true
+			wait "$drag_pid" >/dev/null 2>&1 || true
+			kill "$mask_probe_pid" >/dev/null 2>&1 || true
+			wait "$mask_probe_pid" >/dev/null 2>&1 || true
+			live_hud_focus_rsnap_overlay
+			live_hud_press_escape >/dev/null 2>&1 || true
+			stop_visual_background
+			echo "[smoke] FAIL drag did not reach held preview phase" >&2
+			return 1
+		fi
+		if ! wait_file_nonempty "$drag_screenshot_path"; then
+			kill "$drag_pid" >/dev/null 2>&1 || true
+			wait "$drag_pid" >/dev/null 2>&1 || true
+			kill "$mask_probe_pid" >/dev/null 2>&1 || true
+			wait "$mask_probe_pid" >/dev/null 2>&1 || true
+			live_hud_focus_rsnap_overlay
+			live_hud_press_escape >/dev/null 2>&1 || true
+			stop_visual_background
+			echo "[smoke] FAIL mask probe did not write drag screenshot: $drag_screenshot_path" >&2
+			return 1
+		fi
+		if ! wait "$drag_pid"; then
+			kill "$mask_probe_pid" >/dev/null 2>&1 || true
+			wait "$mask_probe_pid" >/dev/null 2>&1 || true
+			live_hud_focus_rsnap_overlay
+			live_hud_press_escape >/dev/null 2>&1 || true
+			stop_visual_background
+			echo "[smoke] FAIL drag cursor driver failed" >&2
+			return 1
+		fi
+		if ! wait "$mask_probe_pid"; then
+			live_hud_focus_rsnap_overlay
+			live_hud_press_escape >/dev/null 2>&1 || true
+			stop_visual_background
+			echo "[smoke] FAIL mask probe capture failed" >&2
+			if [[ -s "$mask_probe_stderr_path" ]]; then
+				sed 's/^/[smoke] mask probe stderr: /' "$mask_probe_stderr_path" >&2
+			fi
+			return 1
+		fi
+
+		sleep "$POST_FREEZE_SETTLE_S"
+		if ! capture_visual_screenshot "$screenshot_path"; then
+			live_hud_focus_rsnap_overlay
+			live_hud_press_escape >/dev/null 2>&1 || true
+			stop_visual_background
+			echo "[smoke] FAIL could not capture visual screenshot: $screenshot_path" >&2
+			return 1
+		fi
+		drag_screenshot_paths="${drag_screenshot_paths:+$drag_screenshot_paths:}$drag_screenshot_path"
 		live_hud_focus_rsnap_overlay
 		live_hud_press_escape >/dev/null 2>&1 || true
-		stop_visual_background
-		echo "[smoke] FAIL mask probe did not produce a ready sample" >&2
-		return 1
-	fi
-
-	PATH_MODE=drag-region \
-	PATH_DRIVER=event \
-	PATH_POINTS="$PATH_POINTS" \
-	PATH_DURATION_MS="$DRAG_DURATION_MS" \
-	PATH_RATE_HZ="$PATH_RATE_HZ" \
-	MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
-	swift "$(live_hud_cursor_helper)"
-	if ! wait "$mask_probe_pid"; then
-		live_hud_focus_rsnap_overlay
-		live_hud_press_escape >/dev/null 2>&1 || true
-		stop_visual_background
-		echo "[smoke] FAIL mask probe capture failed" >&2
-		return 1
-	fi
-
-	sleep "$POST_FREEZE_SETTLE_S"
-	if ! capture_visual_screenshot "$screenshot_path"; then
-		live_hud_focus_rsnap_overlay
-		live_hud_press_escape >/dev/null 2>&1 || true
-		stop_visual_background
-		echo "[smoke] FAIL could not capture visual screenshot: $screenshot_path" >&2
-		return 1
-	fi
-	live_hud_focus_rsnap_overlay
-	live_hud_press_escape >/dev/null 2>&1 || true
-	sleep "$POST_CLOSE_SETTLE_S"
+		sleep "$POST_CLOSE_SETTLE_S"
+	done
 	stop_visual_background
 
+	local expected_editability
+	expected_editability="$(
+		python3 - "$REPEATED_CLICK_FREEZES" "$REPEATED_DRAG_FREEZES" <<'PY'
+import sys
+
+click_count = int(sys.argv[1])
+drag_count = int(sys.argv[2])
+print(",".join(["true"] * (click_count + drag_count)))
+PY
+	)"
 	out_dir="$("$ROOT_DIR/scripts/telemetry/native-host.sh" collect)"
 	echo "[smoke] telemetry: $out_dir"
 	EXPECTED_HUD_GLASS_MODE="$case_name" \
-	EXPECTED_MIN_FREEZE_COMMITS="$((REPEATED_CLICK_FREEZES + 1))" \
+	EXPECTED_MIN_FREEZE_COMMITS="$((REPEATED_CLICK_FREEZES + REPEATED_DRAG_FREEZES))" \
+	EXPECTED_FREEZE_EDITABILITY="$expected_editability" \
+	VISUAL_DRAG_SCREENSHOT_PATH="$drag_screenshot_paths" \
+	VISUAL_DISPLAY_BOUNDS="$DISPLAY_BOUNDS" \
+	VISUAL_DRAG_POINTS="$PATH_POINTS" \
 	VISUAL_SCREENSHOT_PATH="$screenshot_path" \
 	MASK_PROBE_PATH="$mask_probe_path" \
 	SMOKE_STARTED_EPOCH="$case_started_epoch" \

--- a/scripts/smoke/native-visual-contract-macos.sh
+++ b/scripts/smoke/native-visual-contract-macos.sh
@@ -23,6 +23,16 @@ Useful overrides:
   DRAG_DURATION_MS=260
   DRAG_HOLD_BEFORE_RELEASE_MS=700
   PATH_RATE_HZ=120
+  VISUAL_BACKGROUND_MODE=none           optional: none,solid
+  APP_POST_VERIFY_SETTLE_S=0
+  OVERLAY_SETTLE_S=0.08
+  POST_FREEZE_SETTLE_S=0.08
+  POST_CLOSE_SETTLE_S=0.12
+  MASK_PROBE_MIN_PHASE_SAMPLES=5
+  MASK_PROBE_POLL_MS=20
+  MASK_PROBE_POST_RELEASE_MS=180
+  MASK_PROBE_STOP_CAPTURE=0
+  VISUAL_PROBE_ALL_DRAGS=0
   MAX_FREEZE_COMMIT_MS=90
   MAX_FREEZE_PRESENT_MS=35
   MAX_FREEZE_SNAPSHOT_WAIT_MS=45
@@ -53,17 +63,26 @@ live_hud_self_check
 ROOT_DIR="$(live_hud_repo_root)"
 live_hud_init_environment "$ROOT_DIR"
 
+smoke_log() {
+	printf '[smoke] +%ss %s\n' "$SECONDS" "$*"
+}
+
 DRAG_DURATION_MS="${DRAG_DURATION_MS:-260}"
 DRAG_HOLD_BEFORE_RELEASE_MS="${DRAG_HOLD_BEFORE_RELEASE_MS:-700}"
 PATH_RATE_HZ="${PATH_RATE_HZ:-120}"
 VISUAL_CONTRACT_CASES="${VISUAL_CONTRACT_CASES:-liquid}"
-OVERLAY_SETTLE_S="${OVERLAY_SETTLE_S:-0.25}"
-POST_FREEZE_SETTLE_S="${POST_FREEZE_SETTLE_S:-0.25}"
-POST_CLOSE_SETTLE_S="${POST_CLOSE_SETTLE_S:-0.25}"
+VISUAL_BACKGROUND_MODE="${VISUAL_BACKGROUND_MODE:-none}"
+APP_POST_VERIFY_SETTLE_S="${APP_POST_VERIFY_SETTLE_S:-0}"
+OVERLAY_SETTLE_S="${OVERLAY_SETTLE_S:-0.08}"
+POST_FREEZE_SETTLE_S="${POST_FREEZE_SETTLE_S:-0.08}"
+POST_CLOSE_SETTLE_S="${POST_CLOSE_SETTLE_S:-0.12}"
 REPEATED_CLICK_FREEZES="${REPEATED_CLICK_FREEZES:-1}"
 REPEATED_DRAG_FREEZES="${REPEATED_DRAG_FREEZES:-2}"
-RSNAP_TELEMETRY_LAST="${RSNAP_TELEMETRY_LAST:-3m}"
-export RSNAP_TELEMETRY_LAST
+MASK_PROBE_MIN_PHASE_SAMPLES="${MASK_PROBE_MIN_PHASE_SAMPLES:-5}"
+MASK_PROBE_POLL_MS="${MASK_PROBE_POLL_MS:-20}"
+MASK_PROBE_POST_RELEASE_MS="${MASK_PROBE_POST_RELEASE_MS:-180}"
+MASK_PROBE_STOP_CAPTURE="${MASK_PROBE_STOP_CAPTURE:-0}"
+VISUAL_PROBE_ALL_DRAGS="${VISUAL_PROBE_ALL_DRAGS:-0}"
 
 PREF_DOMAIN="${RSNAP_PREF_DOMAIN:-ink.hack.rsnap}"
 PREF_SNAPSHOT="$(mktemp "${TMPDIR:-/tmp}/rsnap-prefs.XXXXXX.plist")"
@@ -97,19 +116,6 @@ end tell
 APPLESCRIPT
 }
 
-capture_visual_screenshot() {
-	local screenshot_path="$1"
-	local attempt
-
-	for attempt in 1 2 3; do
-		if /usr/sbin/screencapture -x "$screenshot_path" >/dev/null 2>&1; then
-			return 0
-		fi
-		sleep 0.2
-	done
-	return 1
-}
-
 start_visual_background() {
 	local ready_path="$1"
 	rm -f "$ready_path"
@@ -122,6 +128,29 @@ stop_visual_background() {
 		kill "$VISUAL_BACKGROUND_PID" >/dev/null 2>&1 || true
 		VISUAL_BACKGROUND_PID=""
 	fi
+}
+
+maybe_start_visual_background() {
+	local ready_path="$1"
+
+	case "$VISUAL_BACKGROUND_MODE" in
+		none)
+			return 0
+			;;
+		solid)
+			start_visual_background "$ready_path"
+			if wait_visual_background_ready "$ready_path"; then
+				return 0
+			fi
+			stop_visual_background
+			echo "[smoke] FAIL visual background did not become ready" >&2
+			return 1
+			;;
+		*)
+			echo "[smoke] FAIL unknown VISUAL_BACKGROUND_MODE=$VISUAL_BACKGROUND_MODE" >&2
+			return 2
+			;;
+	esac
 }
 
 wait_visual_background_ready() {
@@ -197,8 +226,8 @@ PY
 	)"
 fi
 
-echo "[smoke] display bounds: $DISPLAY_BOUNDS"
-echo "[smoke] drag points: $PATH_POINTS duration_ms=$DRAG_DURATION_MS hold_ms=$DRAG_HOLD_BEFORE_RELEASE_MS rate_hz=$PATH_RATE_HZ"
+smoke_log "display bounds: $DISPLAY_BOUNDS"
+smoke_log "drag points: $PATH_POINTS duration_ms=$DRAG_DURATION_MS hold_ms=$DRAG_HOLD_BEFORE_RELEASE_MS rate_hz=$PATH_RATE_HZ"
 
 CLICK_POINTS="$(
 	python3 - "$DISPLAY_BOUNDS" <<'PY'
@@ -215,7 +244,7 @@ y = top + height * 50 // 100
 print(f"{x},{y};{x},{y}")
 PY
 )"
-echo "[smoke] click point: ${CLICK_POINTS%%;*} repeated=$REPEATED_CLICK_FREEZES"
+smoke_log "click point: ${CLICK_POINTS%%;*} repeated=$REPEATED_CLICK_FREEZES"
 
 configure_case_preferences() {
 	local case_name="$1"
@@ -242,35 +271,43 @@ configure_case_preferences() {
 run_visual_case() {
 	local case_name="$1"
 	local case_tmp_dir drag_screenshot_path drag_screenshot_paths screenshot_path background_ready_path case_started_epoch out_dir
+	local mask_probe_path
+	local cursor_helper_bin mask_probe_bin
 
 	case_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/rsnap-visual-${case_name}.XXXXXX")"
+	cursor_helper_bin="$case_tmp_dir/live-hud-mouse-path"
+	mask_probe_bin="$case_tmp_dir/mask-probe-capture"
+	smoke_log "compile visual smoke helpers"
+	swiftc "$(live_hud_cursor_helper)" -o "$cursor_helper_bin"
+	swiftc "$SCRIPT_DIR/lib/mask-probe-capture.swift" -o "$mask_probe_bin"
+	smoke_log "compiled visual smoke helpers"
 	drag_screenshot_paths=""
 	drag_screenshot_path="$case_tmp_dir/dragging-1.png"
 	screenshot_path="$case_tmp_dir/frozen-1.png"
+	mask_probe_path=""
 	background_ready_path="$case_tmp_dir/background.ready"
 	case_started_epoch="$(date +%s)"
 
 	configure_case_preferences "$case_name"
-	echo "[smoke] case: $case_name"
-	start_visual_background "$background_ready_path"
-	if ! wait_visual_background_ready "$background_ready_path"; then
-		stop_visual_background
-		echo "[smoke] FAIL visual background did not become ready" >&2
+	smoke_log "case: $case_name"
+	if ! maybe_start_visual_background "$background_ready_path"; then
 		return 1
 	fi
+	smoke_log "build and verify native host"
 	"$ROOT_DIR/scripts/build_and_run.sh" verify >/tmp/rsnap-native-visual-contract-build.out
-	sleep 1.0
+	smoke_log "native host verified"
+	sleep "$APP_POST_VERIFY_SETTLE_S"
 	live_hud_press_escape >/dev/null 2>&1 || true
 
 	for ((click_index = 1; click_index <= REPEATED_CLICK_FREEZES; click_index++)); do
-		echo "[smoke] repeated click freeze $click_index/$REPEATED_CLICK_FREEZES"
+		smoke_log "repeated click freeze $click_index/$REPEATED_CLICK_FREEZES"
 		press_capture_hotkey
 		sleep "$OVERLAY_SETTLE_S"
 		live_hud_focus_rsnap_overlay
 		PATH_MODE=click-point \
 		PATH_DRIVER=event \
 		PATH_POINTS="$CLICK_POINTS" \
-		swift "$(live_hud_cursor_helper)"
+		"$cursor_helper_bin"
 		sleep "$POST_FREEZE_SETTLE_S"
 		live_hud_focus_rsnap_overlay
 		live_hud_press_escape >/dev/null 2>&1 || true
@@ -278,22 +315,34 @@ run_visual_case() {
 	done
 
 	for ((drag_index = 1; drag_index <= REPEATED_DRAG_FREEZES; drag_index++)); do
-		echo "[smoke] repeated drag freeze $drag_index/$REPEATED_DRAG_FREEZES"
+		smoke_log "repeated drag freeze $drag_index/$REPEATED_DRAG_FREEZES"
 		drag_screenshot_path="$case_tmp_dir/dragging-$drag_index.png"
 		screenshot_path="$case_tmp_dir/frozen-$drag_index.png"
-		press_capture_hotkey
-		sleep "$OVERLAY_SETTLE_S"
-		live_hud_focus_rsnap_overlay
 
-		local mask_probe_path mask_probe_phase_path mask_probe_ready_path mask_probe_stderr_path mask_probe_point mask_probe_pid drag_pid
-		mask_probe_path="$case_tmp_dir/mask-probe-$drag_index.csv"
-		mask_probe_phase_path="$case_tmp_dir/mask-probe-$drag_index.phase"
-		mask_probe_ready_path="$case_tmp_dir/mask-probe-$drag_index.ready"
-		mask_probe_stderr_path="$case_tmp_dir/mask-probe-$drag_index.stderr"
-		printf 'pre' >"$mask_probe_phase_path"
-		rm -f "$mask_probe_ready_path"
-		mask_probe_point="$(
-			python3 - "$DISPLAY_BOUNDS" "$PATH_POINTS" <<'PY'
+		local should_probe_drag mask_probe_path mask_probe_phase_path mask_probe_ready_path mask_probe_stderr_path mask_probe_point mask_probe_duration_ms mask_probe_pid drag_pid
+		should_probe_drag=0
+		mask_probe_path=""
+		mask_probe_phase_path=""
+		mask_probe_ready_path=""
+		mask_probe_stderr_path=""
+		mask_probe_point=""
+		mask_probe_duration_ms=""
+		mask_probe_pid=""
+		drag_pid=""
+		if [[ "$VISUAL_PROBE_ALL_DRAGS" == "1" || "$drag_index" -eq "$REPEATED_DRAG_FREEZES" ]]; then
+			should_probe_drag=1
+		fi
+
+		if [[ "$should_probe_drag" == "1" ]]; then
+			mask_probe_path="$case_tmp_dir/mask-probe-$drag_index.csv"
+			mask_probe_phase_path="$case_tmp_dir/mask-probe-$drag_index.phase"
+			mask_probe_ready_path="$case_tmp_dir/mask-probe-$drag_index.ready"
+			mask_probe_stderr_path="$case_tmp_dir/mask-probe-$drag_index.stderr"
+			mask_probe_duration_ms="${MASK_PROBE_DURATION_MS:-$((DRAG_DURATION_MS + DRAG_HOLD_BEFORE_RELEASE_MS + 1400))}"
+			printf 'pre' >"$mask_probe_phase_path"
+			rm -f "$mask_probe_ready_path"
+			mask_probe_point="$(
+				python3 - "$DISPLAY_BOUNDS" "$PATH_POINTS" <<'PY'
 import sys
 
 left, top, right, bottom = map(int, sys.argv[1].replace(" ", "").split(","))
@@ -312,28 +361,53 @@ sample_x = min(max(sample_x, left + 32), right - 32)
 sample_y = min(max(sample_y, top + 32), bottom - 32)
 print(f"{sample_x:.0f},{sample_y:.0f}")
 PY
-		)"
+			)"
 
-		MASK_PROBE_OUTPUT="$mask_probe_path" \
-		MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
-		MASK_PROBE_READY_PATH="$mask_probe_ready_path" \
-		MASK_PROBE_SCREENSHOT_PATH="$drag_screenshot_path" \
-		MASK_PROBE_POINT="$mask_probe_point" \
-		MASK_PROBE_DURATION_MS="${MASK_PROBE_DURATION_MS:-2400}" \
-		MASK_PROBE_RATE_HZ="${MASK_PROBE_RATE_HZ:-60}" \
-		swift "$SCRIPT_DIR/lib/mask-probe-capture.swift" 2>"$mask_probe_stderr_path" &
-		mask_probe_pid="$!"
-		if ! wait_mask_probe_ready "$mask_probe_ready_path"; then
-			kill "$mask_probe_pid" >/dev/null 2>&1 || true
-			wait "$mask_probe_pid" >/dev/null 2>&1 || true
+			MASK_PROBE_OUTPUT="$mask_probe_path" \
+			MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
+			MASK_PROBE_READY_PATH="$mask_probe_ready_path" \
+			MASK_PROBE_SCREENSHOT_PATH="$drag_screenshot_path" \
+			MASK_PROBE_RELEASED_SCREENSHOT_PATH="$screenshot_path" \
+			MASK_PROBE_POINT="$mask_probe_point" \
+			MASK_PROBE_DURATION_MS="$mask_probe_duration_ms" \
+			MASK_PROBE_RATE_HZ="${MASK_PROBE_RATE_HZ:-60}" \
+			MASK_PROBE_MIN_PHASE_SAMPLES="$MASK_PROBE_MIN_PHASE_SAMPLES" \
+			MASK_PROBE_POLL_MS="$MASK_PROBE_POLL_MS" \
+			MASK_PROBE_STOP_CAPTURE="$MASK_PROBE_STOP_CAPTURE" \
+			"$mask_probe_bin" 2>"$mask_probe_stderr_path" &
+			mask_probe_pid="$!"
+			if ! wait_mask_probe_ready "$mask_probe_ready_path"; then
+				kill "$mask_probe_pid" >/dev/null 2>&1 || true
+				wait "$mask_probe_pid" >/dev/null 2>&1 || true
+				stop_visual_background
+				echo "[smoke] FAIL mask probe did not produce a ready sample" >&2
+				if [[ -s "$mask_probe_stderr_path" ]]; then
+					sed 's/^/[smoke] mask probe stderr: /' "$mask_probe_stderr_path" >&2
+				fi
+				return 1
+			fi
+			smoke_log "drag $drag_index mask probe ready"
+		fi
+
+		press_capture_hotkey
+		sleep "$OVERLAY_SETTLE_S"
+		live_hud_focus_rsnap_overlay
+		smoke_log "drag $drag_index overlay focused"
+
+		if [[ "$should_probe_drag" != "1" ]]; then
+			PATH_MODE=drag-region \
+			PATH_DRIVER=event \
+			PATH_POINTS="$PATH_POINTS" \
+			PATH_DURATION_MS="$DRAG_DURATION_MS" \
+			PATH_RATE_HZ="$PATH_RATE_HZ" \
+			PATH_HOLD_BEFORE_RELEASE_MS="$DRAG_HOLD_BEFORE_RELEASE_MS" \
+			"$cursor_helper_bin"
+			sleep "$POST_FREEZE_SETTLE_S"
 			live_hud_focus_rsnap_overlay
 			live_hud_press_escape >/dev/null 2>&1 || true
-			stop_visual_background
-			echo "[smoke] FAIL mask probe did not produce a ready sample" >&2
-			if [[ -s "$mask_probe_stderr_path" ]]; then
-				sed 's/^/[smoke] mask probe stderr: /' "$mask_probe_stderr_path" >&2
-			fi
-			return 1
+			sleep "$POST_CLOSE_SETTLE_S"
+			smoke_log "drag $drag_index closed overlay"
+			continue
 		fi
 
 		PATH_MODE=drag-region \
@@ -343,7 +417,8 @@ PY
 		PATH_RATE_HZ="$PATH_RATE_HZ" \
 		PATH_HOLD_BEFORE_RELEASE_MS="$DRAG_HOLD_BEFORE_RELEASE_MS" \
 		MASK_PROBE_PHASE_PATH="$mask_probe_phase_path" \
-		swift "$(live_hud_cursor_helper)" &
+		MASK_PROBE_POST_RELEASE_MS="$MASK_PROBE_POST_RELEASE_MS" \
+		"$cursor_helper_bin" &
 		drag_pid="$!"
 		if ! wait_drag_hold_ready "$mask_probe_phase_path"; then
 			kill "$drag_pid" >/dev/null 2>&1 || true
@@ -356,6 +431,7 @@ PY
 			echo "[smoke] FAIL drag did not reach held preview phase" >&2
 			return 1
 		fi
+		smoke_log "drag $drag_index reached held preview"
 		if ! wait_file_nonempty "$drag_screenshot_path"; then
 			kill "$drag_pid" >/dev/null 2>&1 || true
 			wait "$drag_pid" >/dev/null 2>&1 || true
@@ -367,6 +443,7 @@ PY
 			echo "[smoke] FAIL mask probe did not write drag screenshot: $drag_screenshot_path" >&2
 			return 1
 		fi
+		smoke_log "drag $drag_index wrote in-drag screenshot"
 		if ! wait "$drag_pid"; then
 			kill "$mask_probe_pid" >/dev/null 2>&1 || true
 			wait "$mask_probe_pid" >/dev/null 2>&1 || true
@@ -376,6 +453,7 @@ PY
 			echo "[smoke] FAIL drag cursor driver failed" >&2
 			return 1
 		fi
+		smoke_log "drag $drag_index cursor driver finished"
 		if ! wait "$mask_probe_pid"; then
 			live_hud_focus_rsnap_overlay
 			live_hud_press_escape >/dev/null 2>&1 || true
@@ -386,19 +464,22 @@ PY
 			fi
 			return 1
 		fi
+		smoke_log "drag $drag_index mask probe finished"
 
 		sleep "$POST_FREEZE_SETTLE_S"
-		if ! capture_visual_screenshot "$screenshot_path"; then
+		if ! wait_file_nonempty "$screenshot_path"; then
 			live_hud_focus_rsnap_overlay
 			live_hud_press_escape >/dev/null 2>&1 || true
 			stop_visual_background
-			echo "[smoke] FAIL could not capture visual screenshot: $screenshot_path" >&2
+			echo "[smoke] FAIL mask probe did not write frozen screenshot: $screenshot_path" >&2
 			return 1
 		fi
+		smoke_log "drag $drag_index captured frozen screenshot"
 		drag_screenshot_paths="${drag_screenshot_paths:+$drag_screenshot_paths:}$drag_screenshot_path"
 		live_hud_focus_rsnap_overlay
 		live_hud_press_escape >/dev/null 2>&1 || true
 		sleep "$POST_CLOSE_SETTLE_S"
+		smoke_log "drag $drag_index closed overlay"
 	done
 	stop_visual_background
 
@@ -412,8 +493,19 @@ drag_count = int(sys.argv[2])
 print(",".join(["true"] * (click_count + drag_count)))
 PY
 	)"
-	out_dir="$("$ROOT_DIR/scripts/telemetry/native-host.sh" collect)"
-	echo "[smoke] telemetry: $out_dir"
+	local telemetry_last
+	telemetry_last="${RSNAP_TELEMETRY_LAST:-}"
+	if [[ -z "$telemetry_last" ]]; then
+		local elapsed_seconds
+		elapsed_seconds="$(($(date +%s) - case_started_epoch + 10))"
+		if ((elapsed_seconds < 20)); then
+			elapsed_seconds=20
+		fi
+		telemetry_last="${elapsed_seconds}s"
+	fi
+	smoke_log "collect telemetry last=$telemetry_last"
+	out_dir="$(RSNAP_TELEMETRY_LAST="$telemetry_last" "$ROOT_DIR/scripts/telemetry/native-host.sh" collect)"
+	smoke_log "telemetry: $out_dir"
 	EXPECTED_HUD_GLASS_MODE="$case_name" \
 	EXPECTED_MIN_FREEZE_COMMITS="$((REPEATED_CLICK_FREEZES + REPEATED_DRAG_FREEZES))" \
 	EXPECTED_FREEZE_EDITABILITY="$expected_editability" \

--- a/scripts/smoke/native-visual-contract-macos.sh
+++ b/scripts/smoke/native-visual-contract-macos.sh
@@ -19,7 +19,7 @@ Runs the native macOS visual/behavior contract smoke:
 Useful overrides:
   VISUAL_CONTRACT_CASES=liquid          optional: liquid,classic
   REPEATED_CLICK_FREEZES=1
-  VERIFY_CLICK_FROZEN_MOVE=1
+  VERIFY_CLICK_FROZEN_MOVE=1       attempts a forbidden fixed-selection frozen move
   REPEATED_DRAG_FREEZES=2
   DRAG_DURATION_MS=260
   DRAG_HOLD_BEFORE_RELEASE_MS=700
@@ -336,7 +336,7 @@ run_visual_case() {
 			"$cursor_helper_bin"
 			sleep "$POST_FREEZE_SETTLE_S"
 			live_hud_focus_rsnap_overlay
-			smoke_log "click $click_index moved frozen selection"
+			smoke_log "click $click_index attempted forbidden frozen move"
 		fi
 		live_hud_press_escape >/dev/null 2>&1 || true
 		sleep "$POST_CLOSE_SETTLE_S"
@@ -513,19 +513,21 @@ PY
 
 	local expected_editability
 	local expected_transform_commits
+	local max_transform_commits
 	expected_editability="$(
 		python3 - "$REPEATED_CLICK_FREEZES" "$REPEATED_DRAG_FREEZES" <<'PY'
 import sys
 
 click_count = int(sys.argv[1])
 drag_count = int(sys.argv[2])
-print(",".join(["true"] * (click_count + drag_count)))
+print(",".join((["false"] * click_count) + (["true"] * drag_count)))
 PY
 	)"
+	expected_transform_commits=0
 	if [[ "$VERIFY_CLICK_FROZEN_MOVE" == "1" ]]; then
-		expected_transform_commits="$REPEATED_CLICK_FREEZES"
+		max_transform_commits=0
 	else
-		expected_transform_commits=0
+		max_transform_commits=""
 	fi
 	local telemetry_last
 	telemetry_last="${RSNAP_TELEMETRY_LAST:-}"
@@ -537,17 +539,23 @@ PY
 		fi
 		telemetry_last="${elapsed_seconds}s"
 	fi
+	local summary_screenshot_path
+	summary_screenshot_path="$screenshot_path"
+	if ((REPEATED_DRAG_FREEZES == 0)); then
+		summary_screenshot_path=""
+	fi
 	smoke_log "collect telemetry last=$telemetry_last"
 	out_dir="$(RSNAP_TELEMETRY_LAST="$telemetry_last" "$ROOT_DIR/scripts/telemetry/native-host.sh" collect)"
 	smoke_log "telemetry: $out_dir"
 	EXPECTED_HUD_GLASS_MODE="$case_name" \
 	EXPECTED_MIN_FREEZE_COMMITS="$((REPEATED_CLICK_FREEZES + REPEATED_DRAG_FREEZES))" \
 	EXPECTED_MIN_FROZEN_TRANSFORM_COMMITS="$expected_transform_commits" \
+	EXPECTED_MAX_FROZEN_TRANSFORM_COMMITS="$max_transform_commits" \
 	EXPECTED_FREEZE_EDITABILITY="$expected_editability" \
 	VISUAL_DRAG_SCREENSHOT_PATH="$drag_screenshot_paths" \
 	VISUAL_DISPLAY_BOUNDS="$DISPLAY_BOUNDS" \
 	VISUAL_DRAG_POINTS="$PATH_POINTS" \
-	VISUAL_SCREENSHOT_PATH="$screenshot_path" \
+	VISUAL_SCREENSHOT_PATH="$summary_screenshot_path" \
 	MASK_PROBE_PATH="$mask_probe_path" \
 	SMOKE_STARTED_EPOCH="$case_started_epoch" \
 	python3 "$SCRIPT_DIR/lib/native-visual-contract-summary.py" "$out_dir/all.log"

--- a/scripts/smoke/native-visual-contract-macos.sh
+++ b/scripts/smoke/native-visual-contract-macos.sh
@@ -19,6 +19,7 @@ Runs the native macOS visual/behavior contract smoke:
 Useful overrides:
   VISUAL_CONTRACT_CASES=liquid          optional: liquid,classic
   REPEATED_CLICK_FREEZES=1
+  VERIFY_CLICK_FROZEN_MOVE=1
   REPEATED_DRAG_FREEZES=2
   DRAG_DURATION_MS=260
   DRAG_HOLD_BEFORE_RELEASE_MS=700
@@ -77,6 +78,7 @@ OVERLAY_SETTLE_S="${OVERLAY_SETTLE_S:-0.08}"
 POST_FREEZE_SETTLE_S="${POST_FREEZE_SETTLE_S:-0.08}"
 POST_CLOSE_SETTLE_S="${POST_CLOSE_SETTLE_S:-0.12}"
 REPEATED_CLICK_FREEZES="${REPEATED_CLICK_FREEZES:-1}"
+VERIFY_CLICK_FROZEN_MOVE="${VERIFY_CLICK_FROZEN_MOVE:-1}"
 REPEATED_DRAG_FREEZES="${REPEATED_DRAG_FREEZES:-2}"
 MASK_PROBE_MIN_PHASE_SAMPLES="${MASK_PROBE_MIN_PHASE_SAMPLES:-5}"
 MASK_PROBE_POLL_MS="${MASK_PROBE_POLL_MS:-20}"
@@ -245,6 +247,20 @@ print(f"{x},{y};{x},{y}")
 PY
 )"
 smoke_log "click point: ${CLICK_POINTS%%;*} repeated=$REPEATED_CLICK_FREEZES"
+CLICK_FROZEN_MOVE_POINTS="$(
+	python3 - "$DISPLAY_BOUNDS" "$CLICK_POINTS" <<'PY'
+import sys
+
+left, top, right, bottom = map(int, sys.argv[1].replace(" ", "").split(","))
+start_raw = sys.argv[2].split(";")[0]
+x, y = map(int, start_raw.split(","))
+dx = max(48, min(120, (right - left) // 18))
+dy = max(36, min(90, (bottom - top) // 20))
+end_x = min(max(x + dx, left + 24), right - 24)
+end_y = min(max(y + dy, top + 24), bottom - 24)
+print(f"{x},{y};{end_x},{end_y}")
+PY
+)"
 
 configure_case_preferences() {
 	local case_name="$1"
@@ -310,6 +326,18 @@ run_visual_case() {
 		"$cursor_helper_bin"
 		sleep "$POST_FREEZE_SETTLE_S"
 		live_hud_focus_rsnap_overlay
+		if [[ "$VERIFY_CLICK_FROZEN_MOVE" == "1" ]]; then
+			PATH_MODE=drag-region \
+			PATH_DRIVER=event \
+			PATH_POINTS="$CLICK_FROZEN_MOVE_POINTS" \
+			PATH_DURATION_MS=90 \
+			PATH_RATE_HZ=120 \
+			PATH_HOLD_BEFORE_RELEASE_MS=0 \
+			"$cursor_helper_bin"
+			sleep "$POST_FREEZE_SETTLE_S"
+			live_hud_focus_rsnap_overlay
+			smoke_log "click $click_index moved frozen selection"
+		fi
 		live_hud_press_escape >/dev/null 2>&1 || true
 		sleep "$POST_CLOSE_SETTLE_S"
 	done
@@ -484,6 +512,7 @@ PY
 	stop_visual_background
 
 	local expected_editability
+	local expected_transform_commits
 	expected_editability="$(
 		python3 - "$REPEATED_CLICK_FREEZES" "$REPEATED_DRAG_FREEZES" <<'PY'
 import sys
@@ -493,6 +522,11 @@ drag_count = int(sys.argv[2])
 print(",".join(["true"] * (click_count + drag_count)))
 PY
 	)"
+	if [[ "$VERIFY_CLICK_FROZEN_MOVE" == "1" ]]; then
+		expected_transform_commits="$REPEATED_CLICK_FREEZES"
+	else
+		expected_transform_commits=0
+	fi
 	local telemetry_last
 	telemetry_last="${RSNAP_TELEMETRY_LAST:-}"
 	if [[ -z "$telemetry_last" ]]; then
@@ -508,6 +542,7 @@ PY
 	smoke_log "telemetry: $out_dir"
 	EXPECTED_HUD_GLASS_MODE="$case_name" \
 	EXPECTED_MIN_FREEZE_COMMITS="$((REPEATED_CLICK_FREEZES + REPEATED_DRAG_FREEZES))" \
+	EXPECTED_MIN_FROZEN_TRANSFORM_COMMITS="$expected_transform_commits" \
 	EXPECTED_FREEZE_EDITABILITY="$expected_editability" \
 	VISUAL_DRAG_SCREENSHOT_PATH="$drag_screenshot_paths" \
 	VISUAL_DISPLAY_BOUNDS="$DISPLAY_BOUNDS" \


### PR DESCRIPTION
## Summary
- Lock Frozen editability to drag-created region selections only; window-click and fullscreen fallback captures stay fixed and cannot commit transform moves.
- Harden the native host gate and first-frame cursor state so fixed selections do not expose grab/resize behavior.
- Update docs, bridge probe, and visual smoke assertions to prevent this regression from coming back.

## Validation
- `cargo test -p rsnap-capture-core --lib`
- `cargo make build-swift-strict`
- `cargo make test-macos-native-host`
- `VISUAL_CONTRACT_CASES=liquid REPEATED_CLICK_FREEZES=3 VERIFY_CLICK_FROZEN_MOVE=1 REPEATED_DRAG_FREEZES=0 ./scripts/smoke/native-visual-contract-macos.sh`