### PR TITLE
Restore native-host OCR action

### DIFF
--- a/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
+++ b/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
@@ -145,6 +145,12 @@ enum RsnapHostBridgeProbe {
 		guard try session.takeNextRequest() == .recognizeText else {
 			fatalError("expected a recognize-text host request")
 		}
+		try session.send(report: .hostEffectCompleted(.recognizeText))
+		scene = try session.currentScene()
+		guard scene.statusMessage == "Recognized text." else {
+			fatalError(
+				"unexpected status message after OCR: \(String(describing: scene.statusMessage))")
+		}
 
 		try session.send(event: .toolbarItemInvoked(.copy))
 		guard try session.takeNextRequest() == .copyCapture else {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -957,7 +957,7 @@ final class CaptureSessionController: NSObject {
 
 	func recognizeText() {
 		let _ = chromeState.frozenOverlay.commitTextEdit()
-		sendFrozenAction(.recognizeTextRequested)
+		sendFrozenAction(.recognizeTextRequested, exitAfter: .recognizeText)
 	}
 
 	func startScrollCapture() {
@@ -984,6 +984,8 @@ final class CaptureSessionController: NSObject {
 			sendFrozenAction(.toolbarItemInvoked(item), exitAfter: .copyCapture)
 		case .save:
 			sendFrozenAction(.toolbarItemInvoked(item), exitAfter: .saveCapture)
+		case .ocr:
+			sendFrozenAction(.toolbarItemInvoked(item), exitAfter: .recognizeText)
 		case .scroll:
 			startScrollCapture()
 		default:
@@ -1727,16 +1729,30 @@ final class CaptureSessionController: NSObject {
 
 		let request = VNRecognizeTextRequest()
 		request.recognitionLevel = .accurate
+		request.usesLanguageCorrection = true
+		request.automaticallyDetectsLanguage = true
 		let handler = VNImageRequestHandler(cgImage: cgImage)
 		try handler.perform([request])
 
 		let text = (request.results ?? [])
-			.compactMap { $0.topCandidates(1).first?.string }
+			.compactMap { observation -> String? in
+				guard let line = observation.topCandidates(1).first?.string,
+					!line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+				else {
+					return nil
+				}
+				return line
+			}
 			.joined(separator: "\n")
 
-		let pasteboard = NSPasteboard.general
-		pasteboard.clearContents()
-		pasteboard.setString(text, forType: .string)
+		if !text.isEmpty {
+			let pasteboard = NSPasteboard.general
+			pasteboard.clearContents()
+			guard pasteboard.setString(text, forType: .string) else {
+				try sendHostStatusMessage("Could not copy recognized text.")
+				return
+			}
+		}
 
 		try session.send(report: .hostEffectCompleted(.recognizeText))
 		let message =
@@ -1744,6 +1760,7 @@ final class CaptureSessionController: NSObject {
 			? "No text was recognized."
 			: "Recognized text copied to clipboard."
 		try session.send(report: .statusMessage(message))
+		completedHostEffect = .recognizeText
 	}
 
 	private func captureFrozenSelectionImage() throws -> CGImage? {


### PR DESCRIPTION
## Summary
- wire the native-host OCR action through the same completed-effect path as copy/save
- run Vision OCR with quality-preserving accurate recognition, language correction, and automatic language detection
- copy non-empty recognized text to the pasteboard and exit the frozen capture after OCR completes
- extend the host bridge probe to cover OCR completion status

## Validation
- cargo make lint-swift
- cargo make test-macos-native-host
- cargo make test-macos-native-host-stage
- git diff --check
- ./scripts/build_and_run.sh run

## Follow-up
- OCR performance telemetry is tracked separately in XY-452: https://linear.app/hack-ink/issue/XY-452/rsnap-add-quality-preserving-ocr-performance-telemetry