### PR TITLE
Improve frozen auto-center margin balancing

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -459,6 +459,7 @@ final class CaptureSessionController: NSObject {
 		let desktopFrame: CGRect
 	}
 
+	private static let autoCenterMaxIterations = 6
 	private static let displayFirstFrameWait: TimeInterval = 0.025
 	private static let coldSelfCaptureRecoveryWait: TimeInterval = 3.5
 
@@ -1268,38 +1269,57 @@ final class CaptureSessionController: NSObject {
 		if chromeState.frozenOverlay.keepsFrozenSelectionFixed {
 			return
 		}
-		if chromeState.frozenSelectionSnapshot != selection || chromeState.frozenBaseImage == nil {
-			chromeState.frozenSelectionSnapshot = selection
-			chromeState.frozenBaseImage = frozenBaseImageFromDisplay(for: selection)
-		}
-		guard
-			let baseImage = chromeState.frozenBaseImage,
-			let contentBounds = Self.detectAutoCenterContentBounds(in: baseImage),
-			let screen = screen(containing: CGPoint(x: selection.midX, y: selection.midY))
-		else {
+		guard let screen = screen(containing: CGPoint(x: selection.midX, y: selection.midY)) else {
 			return
 		}
 
-		let deltaX = Self.autoCenterShiftPoints(
-			contentOriginPx: contentBounds.minX,
-			contentSizePx: contentBounds.width,
-			cropSizePx: CGFloat(baseImage.width),
-			captureSizePoints: selection.width
-		)
-		let deltaY = Self.autoCenterShiftPoints(
-			contentOriginPx: contentBounds.minY,
-			contentSizePx: contentBounds.height,
-			cropSizePx: CGFloat(baseImage.height),
-			captureSizePoints: selection.height
-		)
-		let nextSelection = Self.clampedSelectionRect(
-			width: selection.width,
-			height: selection.height,
-			x: selection.minX + deltaX,
-			// Content bounds are in top-down CGImage coordinates; AppKit screen coordinates are bottom-up.
-			y: selection.minY - deltaY,
-			monitorFrame: screen.frame
-		)
+		var nextSelection = selection
+		var nextBaseImage =
+			(chromeState.frozenSelectionSnapshot == selection) ? chromeState.frozenBaseImage : nil
+		if nextBaseImage == nil {
+			nextBaseImage = frozenBaseImageFromDisplay(for: selection)
+		}
+
+		for _ in 0..<Self.autoCenterMaxIterations {
+			guard
+				let baseImage = nextBaseImage,
+				let contentBounds = Self.detectAutoCenterContentBounds(in: baseImage)
+			else {
+				break
+			}
+
+			let deltaX = Self.autoCenterMarginBalanceShiftPoints(
+				contentOriginPx: contentBounds.minX,
+				contentSizePx: contentBounds.width,
+				cropSizePx: CGFloat(baseImage.width),
+				captureSizePoints: nextSelection.width
+			)
+			let deltaY = Self.autoCenterMarginBalanceShiftPoints(
+				contentOriginPx: contentBounds.minY,
+				contentSizePx: contentBounds.height,
+				cropSizePx: CGFloat(baseImage.height),
+				captureSizePoints: nextSelection.height
+			)
+			guard deltaX != 0 || deltaY != 0 else {
+				break
+			}
+
+			let candidateSelection = Self.clampedSelectionRect(
+				width: nextSelection.width,
+				height: nextSelection.height,
+				x: nextSelection.minX + deltaX,
+				// Content bounds are in top-down CGImage coordinates; AppKit screen coordinates are bottom-up.
+				y: nextSelection.minY - deltaY,
+				monitorFrame: screen.frame
+			)
+			guard candidateSelection != nextSelection else {
+				break
+			}
+
+			nextSelection = candidateSelection
+			nextBaseImage = frozenBaseImageFromDisplay(for: nextSelection)
+		}
+
 		guard nextSelection != selection else {
 			return
 		}
@@ -1307,7 +1327,8 @@ final class CaptureSessionController: NSObject {
 		do {
 			frozenSnapshotGeneration &+= 1
 			chromeState.frozenSelectionSnapshot = nextSelection
-			chromeState.frozenBaseImage = frozenBaseImageFromDisplay(for: nextSelection)
+			chromeState.frozenBaseImage =
+				nextBaseImage ?? frozenBaseImageFromDisplay(for: nextSelection)
 			try session?.send(report: .freezeSnapshotCommitted(selection: nextSelection))
 			try syncCore()
 		} catch {
@@ -2223,7 +2244,7 @@ final class CaptureSessionController: NSObject {
 		)
 	}
 
-	private static func autoCenterShiftPoints(
+	private static func autoCenterMarginBalanceShiftPoints(
 		contentOriginPx: CGFloat,
 		contentSizePx: CGFloat,
 		cropSizePx: CGFloat,
@@ -2232,9 +2253,9 @@ final class CaptureSessionController: NSObject {
 		guard cropSizePx > 0, captureSizePoints > 0 else {
 			return 0
 		}
-		let contentCenterPx = contentOriginPx + (contentSizePx * 0.5)
-		let cropCenterPx = cropSizePx * 0.5
-		let deltaPx = contentCenterPx - cropCenterPx
+		let leadingMarginPx = contentOriginPx
+		let trailingMarginPx = cropSizePx - (contentOriginPx + contentSizePx)
+		let deltaPx = (leadingMarginPx - trailingMarginPx) * 0.5
 		return (deltaPx * captureSizePoints / cropSizePx).rounded()
 	}
 

--- a/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
@@ -32,6 +32,7 @@ impl OverlaySession {
 			.state
 			.frozen_capture_rect
 			.unwrap_or_else(|| RectPoints::new(0, 0, monitor.width, monitor.height));
+
 		self.cropped_frozen_capture_image_for_rect(monitor, capture_rect)
 	}
 

--- a/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_export_runtime.rs
@@ -32,6 +32,15 @@ impl OverlaySession {
 			.state
 			.frozen_capture_rect
 			.unwrap_or_else(|| RectPoints::new(0, 0, monitor.width, monitor.height));
+		self.cropped_frozen_capture_image_for_rect(monitor, capture_rect)
+	}
+
+	pub(super) fn cropped_frozen_capture_image_for_rect(
+		&self,
+		monitor: MonitorRect,
+		capture_rect: RectPoints,
+	) -> Option<RgbaImage> {
+		let export_image = self.state.frozen_export_image.as_ref()?;
 		let capture_rect = monitor.local_rect_to_pixels(capture_rect);
 		let x = capture_rect.x.min(export_image.width());
 		let y = capture_rect.y.min(export_image.height());

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -1156,36 +1156,60 @@ impl OverlaySession {
 		let Some((monitor, capture_rect)) = self.frozen_capture_rect_drag_target() else {
 			return false;
 		};
-		let Some(capture_image) = self.cropped_frozen_capture_image() else {
+		let mut next_rect = capture_rect;
+
+		for _ in 0..Self::AUTO_CENTER_MAX_ITERATIONS {
+			let Some(capture_image) =
+				self.cropped_frozen_capture_image_for_rect(monitor, next_rect)
+			else {
+				break;
+			};
+			let Some(content_bounds) = Self::detect_auto_center_content_bounds(&capture_image)
+			else {
+				break;
+			};
+			let delta_x_points = Self::auto_center_margin_balance_shift_points(
+				content_bounds.x,
+				content_bounds.width,
+				capture_image.width(),
+				next_rect.width,
+			);
+			let delta_y_points = Self::auto_center_margin_balance_shift_points(
+				content_bounds.y,
+				content_bounds.height,
+				capture_image.height(),
+				next_rect.height,
+			);
+
+			if delta_x_points == 0 && delta_y_points == 0 {
+				break;
+			}
+
+			let candidate_rect = Self::clamp_frozen_capture_rect_to_monitor(
+				monitor,
+				next_rect.width,
+				next_rect.height,
+				i64::from(next_rect.x) + delta_x_points,
+				i64::from(next_rect.y) + delta_y_points,
+			);
+
+			if candidate_rect == next_rect {
+				break;
+			}
+
+			next_rect = candidate_rect;
+		}
+
+		if next_rect == capture_rect {
 			return false;
-		};
-		let Some(content_bounds) = Self::detect_auto_center_content_bounds(&capture_image) else {
-			return false;
-		};
-		let delta_x_points = Self::auto_center_shift_points(
-			content_bounds.x,
-			content_bounds.width,
-			capture_image.width(),
-			capture_rect.width,
-		);
-		let delta_y_points = Self::auto_center_shift_points(
-			content_bounds.y,
-			content_bounds.height,
-			capture_image.height(),
-			capture_rect.height,
-		);
-		let next_rect = Self::clamp_frozen_capture_rect_to_monitor(
-			monitor,
-			capture_rect.width,
-			capture_rect.height,
-			i64::from(capture_rect.x) + delta_x_points,
-			i64::from(capture_rect.y) + delta_y_points,
-		);
+		}
 
 		self.apply_frozen_capture_rect_update(monitor, next_rect)
 	}
 
-	fn auto_center_shift_points(
+	const AUTO_CENTER_MAX_ITERATIONS: usize = 6;
+
+	fn auto_center_margin_balance_shift_points(
 		content_origin_px: u32,
 		content_size_px: u32,
 		crop_size_px: u32,
@@ -1195,9 +1219,10 @@ impl OverlaySession {
 			return 0;
 		}
 
-		let content_center_px = content_origin_px as f32 + (content_size_px as f32 * 0.5);
-		let crop_center_px = crop_size_px as f32 * 0.5;
-		let delta_px = content_center_px - crop_center_px;
+		let leading_margin_px = content_origin_px as f32;
+		let trailing_margin_px =
+			crop_size_px.saturating_sub(content_origin_px.saturating_add(content_size_px)) as f32;
+		let delta_px = (leading_margin_px - trailing_margin_px) * 0.5;
 
 		((delta_px * capture_size_points as f32) / crop_size_px as f32).round() as i64
 	}

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/selection_runtime.rs
@@ -437,6 +437,30 @@ fn auto_center_frozen_capture_rect_recenters_detected_content_across_tools() {
 }
 
 #[test]
+fn auto_center_frozen_capture_rect_repeats_until_content_margins_balance() {
+	let monitor = tests::test_monitor_with_scale(80, 60, 1_000);
+	let capture_rect = RectPoints::new(20, 16, 40, 24);
+	let mut image = RgbaImage::from_pixel(80, 60, Rgba([14, 16, 20, 255]));
+	let mut session = OverlaySession::new();
+
+	for y in 24..36 {
+		for x in 38..68 {
+			image.put_pixel(x, y, Rgba([228, 232, 240, 255]));
+		}
+	}
+
+	session.state.begin_freeze(monitor);
+
+	tests::finish_frozen_ready_state(&mut session, monitor, image);
+
+	session.state.frozen_capture_rect = Some(capture_rect);
+	session.frozen_capture_source = FrozenCaptureSource::DragRegion;
+
+	assert!(session.auto_center_frozen_capture_rect());
+	assert_eq!(session.state.frozen_capture_rect, Some(RectPoints::new(33, 18, 40, 24)));
+}
+
+#[test]
 fn frozen_selection_resize_hit_test_prefers_corner_handles() {
 	let capture_rect = RectPoints::new(100, 120, 8, 8);
 


### PR DESCRIPTION
## Summary
- Rework frozen Auto-center to iteratively balance detected-content margins instead of stopping after one shift.
- Keep Swift native-host behavior and Rust transitional overlay behavior aligned.
- Add a regression test for the case where repeated recropping is needed to balance margins.

## Validation
- cargo test -p rsnap-overlay auto_center_frozen_capture_rect
- cargo make build-swift-strict
- cargo make fmt-check
- cargo make lint-swift
- cargo make lint-rust
- cargo make test-macos-native-host
- git diff --check
- ./scripts/build_and_run.sh --verify