### PR TITLE
Polish live Tab toggle and Settings defaults

### DIFF
--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -56,6 +56,24 @@ Defines:
 - Raw event spellings such as `alt+KeyX` must not appear in user-facing shortcut fields,
   summaries, or menu shortcut labels.
 - The default capture shortcut is `Option-X`.
+- In live capture, plain `Tab` toggles the loupe on and off. Hold-to-show Tab behavior is not a
+  supported setting.
+
+## Default Configuration
+
+- Capture shortcut: `Option-X`.
+- Output directory: `~/Desktop`.
+- Output filename prefix: `rsnap`.
+- Output naming: timestamp.
+- Frozen toolbar placement: bottom.
+- Frozen resize handles: outward.
+- Live HUD hint keycap: enabled.
+- HUD glass: enabled, `liquid_glass`, `clear`.
+- HUD opacity: `0.4999747693194925`.
+- HUD blur: `0.5032628676470589`.
+- HUD tint: `0.4990234375`.
+- HUD tint hue: `0.6074879184861536`.
+- Loupe sample size: small.
 
 ## Permission Settings
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1652,10 +1652,13 @@ final class LiveOverlayRenderer {
 		glassLayer.opacity = hasInlineGlass ? CaptureChrome.glassOpacity(settings: settings) : 0
 		glassLayer.isHidden = !hasInlineGlass
 
+		let usesNativeLiquidGlass = settings.usesLiquidHudGlass
 		fillLayer.frame = frame
 		fillLayer.cornerRadius = cornerRadius
 		fillLayer.backgroundColor =
-			CaptureChrome.effectiveBodyFill(
+			usesNativeLiquidGlass
+			? NSColor.clear.cgColor
+			: CaptureChrome.effectiveBodyFill(
 				palette: palette,
 				settings: settings,
 				hasGlass: hasGlass

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -1388,7 +1388,12 @@ final class CaptureSessionController: NSObject {
 
 	func toggleLoupe() {
 		do {
+			let shouldPrimeLoupePatch = scene.mode == .live && !scene.loupeVisible
+			let loupePoint = scene.pointer ?? NSEvent.mouseLocation
 			try session?.send(event: .toggleLoupe)
+			if shouldPrimeLoupePatch {
+				primeLoupePatchForToggle(at: loupePoint)
+			}
 			try syncCore()
 		} catch {
 			NativeHostTelemetry.captureWarning(
@@ -1397,6 +1402,20 @@ final class CaptureSessionController: NSObject {
 				stage: "send_or_sync",
 				error: String(describing: error)
 			)
+		}
+	}
+
+	private func primeLoupePatchForToggle(at point: CGPoint) {
+		let sample = overlayController?.immediateLiveChromeSample(
+			point: point,
+			settings: currentSettings,
+			includeLoupePatch: true
+		)
+		if let rgbSample = sample?.rgbSample {
+			chromeState.rgbSample = rgbSample
+		}
+		if let loupePatch = sample?.loupePatch {
+			chromeState.loupePatch = loupePatch
 		}
 	}
 
@@ -2745,6 +2764,16 @@ final class CaptureOverlayController {
 			return LiveChromeSample(rgbSample: latestSample.rgbSample, loupePatch: nil)
 		}
 		return latestSample
+	}
+
+	fileprivate func immediateLiveChromeSample(
+		point: CGPoint,
+		settings: NativeHostSettings,
+		includeLoupePatch: Bool
+	) -> LiveChromeSample? {
+		let samplePixels = includeLoupePatch ? settings.loupeSampleSize.sidePixels : 1
+		return liveFrameStream.sample(at: point, sidePixels: samplePixels)
+			?? chromeSampleFeed.snapshot(for: point)
 	}
 
 	fileprivate func updateLiveChromeBackdrops(
@@ -5734,17 +5763,23 @@ final class CaptureHostView: NSView {
 	}
 
 	private func currentLiveChromeSample(at point: CGPoint?) -> LiveChromeSample? {
+		let wantsLoupePatch = scene.loupeVisible && !liveHoverChromeSuppressed
 		let sample = controller?.liveChromeSnapshot(
 			point: point,
 			settings: settings,
-			includeLoupePatch: scene.loupeVisible && !liveHoverChromeSuppressed
+			includeLoupePatch: wantsLoupePatch
 		)
 		if let sample {
-			seedLiveChromeSampleCache(sample, point: point)
-			if let rgbSample = sample.rgbSample {
+			let resolvedSample = sampleWithCachedLoupePatch(
+				sample,
+				point: point,
+				wantsLoupePatch: wantsLoupePatch
+			)
+			seedLiveChromeSampleCache(resolvedSample, point: point)
+			if let rgbSample = resolvedSample.rgbSample {
 				seedLiveRgbSampleCache(rgbSample, point: point)
 			}
-			return sample
+			return resolvedSample
 		}
 		if let cachedSample = cachedLiveChromeSample(matching: point) {
 			return cachedSample
@@ -5756,6 +5791,31 @@ final class CaptureHostView: NSView {
 			return cachedLiveChromeSample(matching: point)
 		}
 		return nil
+	}
+
+	private func sampleWithCachedLoupePatch(
+		_ sample: LiveChromeSample,
+		point: CGPoint?,
+		wantsLoupePatch: Bool
+	) -> LiveChromeSample {
+		guard wantsLoupePatch, sample.loupePatch == nil else {
+			return sample
+		}
+		if let cachedSample = cachedLiveChromeSample(matching: point),
+			let cachedPatch = cachedSample.loupePatch
+		{
+			return LiveChromeSample(
+				rgbSample: sample.rgbSample ?? cachedSample.rgbSample,
+				loupePatch: cachedPatch
+			)
+		}
+		if liveSamplePoint(scene.pointer, matches: point), let chromePatch = chrome.loupePatch {
+			return LiveChromeSample(
+				rgbSample: sample.rgbSample ?? chrome.rgbSample,
+				loupePatch: chromePatch
+			)
+		}
+		return sample
 	}
 
 	private func liveRgbSample(from sample: LiveChromeSample?, at point: CGPoint?) -> RGBSample? {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
@@ -60,7 +60,12 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 		self.viewModel = NativeHostSettingsViewModel(settingsStore: settingsStore)
 		self.onClose = onClose
 
-		let contentRect = NSRect(x: 0, y: 0, width: 620, height: 320)
+		let contentRect = NSRect(
+			x: 0,
+			y: 0,
+			width: NativeHostSettingsWindowMetrics.width,
+			height: NativeHostSettingsWindowMetrics.idealHeight
+		)
 		let window = SettingsWindow(
 			contentRect: contentRect,
 			styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
@@ -77,7 +82,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 			window.titlebarSeparatorStyle = .none
 		}
 		window.isReleasedWhenClosed = false
-		window.contentMinSize = NSSize(width: 620, height: 300)
+		window.contentMinSize = NSSize(
+			width: NativeHostSettingsWindowMetrics.width,
+			height: NativeHostSettingsWindowMetrics.minHeight
+		)
 		window.collectionBehavior.insert(.moveToActiveSpace)
 		super.init(window: window)
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -135,14 +135,14 @@ struct NativeHostSettings: Equatable {
 			outputFilenamePrefix: "rsnap",
 			outputNaming: .timestamp,
 			toolbarPlacement: .bottom,
-			frozenResizeHandleOrientation: .inward,
+			frozenResizeHandleOrientation: .outward,
 			showAltHintKeycap: true,
 			hudGlassEnabled: true,
-			hudGlassMode: HudGlassModePreference.defaultForCurrentSystem,
-			hudOpacity: 0.5,
-			hudBlur: 0.5,
-			hudTint: 0.5,
-			hudTintHue: 215.0 / 360.0,
+			hudGlassMode: .liquidGlass,
+			hudOpacity: 0.4999747693194925,
+			hudBlur: 0.5032628676470589,
+			hudTint: 0.4990234375,
+			hudTintHue: 0.6074879184861536,
 			liquidGlassStyle: .clear,
 			loupeSampleSize: .small
 		)
@@ -313,10 +313,6 @@ enum FrozenResizeHandleOrientationPreference: String, CaseIterable {
 enum HudGlassModePreference: String, CaseIterable {
 	case classicGlass = "classic_glass"
 	case liquidGlass = "liquid_glass"
-
-	static var defaultForCurrentSystem: Self {
-		.classicGlass
-	}
 
 	var title: String {
 		switch self {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -2,6 +2,12 @@ import AppKit
 import RsnapHostBridge
 import SwiftUI
 
+enum NativeHostSettingsWindowMetrics {
+	static let width: CGFloat = 620
+	static let minHeight: CGFloat = 348
+	static let idealHeight: CGFloat = 360
+}
+
 @MainActor
 final class NativeHostSettingsViewModel: ObservableObject {
 	@Published private(set) var settings: NativeHostSettings
@@ -65,8 +71,12 @@ struct NativeHostSettingsView: View {
 		}
 		.ignoresSafeArea(.container, edges: .top)
 		.controlSize(.small)
-		.animation(.spring(response: 0.34, dampingFraction: 0.86), value: selectedSection)
-		.frame(minWidth: 620, idealWidth: 620, minHeight: 306, idealHeight: 318)
+		.frame(
+			minWidth: NativeHostSettingsWindowMetrics.width,
+			idealWidth: NativeHostSettingsWindowMetrics.width,
+			minHeight: NativeHostSettingsWindowMetrics.minHeight,
+			idealHeight: NativeHostSettingsWindowMetrics.idealHeight
+		)
 	}
 }
 
@@ -149,9 +159,7 @@ private struct SettingsRail: View {
 						section: section,
 						isSelected: selectedSection == section
 					) {
-						withAnimation(.easeOut(duration: 0.16)) {
-							selectedSection = section
-						}
+						selectedSection = section
 					}
 				}
 			}
@@ -275,8 +283,9 @@ private struct SettingsDashboard: View {
 					.padding(.trailing, 8)
 					.padding(.bottom, 6)
 			}
-			.scrollIndicators(.automatic)
+			.scrollIndicators(.hidden)
 			.frame(maxWidth: .infinity, alignment: .topLeading)
+			.animation(.spring(response: 0.34, dampingFraction: 0.86), value: section)
 		}
 		.padding(.horizontal, 13)
 		.padding(.vertical, 9)
@@ -1169,32 +1178,76 @@ private struct FlatColorSwatch: View {
 	@State private var isHovered = false
 
 	var body: some View {
-		ZStack {
-			RoundedRectangle(cornerRadius: 6, style: .continuous)
-				.fill(selection)
-				.frame(width: 30, height: 18)
-				.overlay {
-					RoundedRectangle(cornerRadius: 6, style: .continuous)
-						.stroke(borderColor, lineWidth: 1)
-				}
-
-			ColorPicker("", selection: $selection, supportsOpacity: false)
-				.labelsHidden()
-				.frame(width: 30, height: 18)
-				.opacity(0.02)
-		}
-		.frame(width: 30, height: 18)
-		.opacity(isEnabled ? 1 : 0.45)
-		.scaleEffect(isHovered && isEnabled ? 1.04 : 1)
-		.animation(.easeOut(duration: 0.12), value: isHovered)
-		.onHover { hovering in
-			isHovered = hovering
-		}
-		.disabled(!isEnabled)
+		SettingsColorWell(selection: $selection, isEnabled: isEnabled)
+			.clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+			.overlay {
+				RoundedRectangle(cornerRadius: 6, style: .continuous)
+					.stroke(borderColor, lineWidth: 1)
+					.allowsHitTesting(false)
+			}
+			.frame(width: 30, height: 18)
+			.opacity(isEnabled ? 1 : 0.45)
+			.scaleEffect(isHovered && isEnabled ? 1.04 : 1)
+			.animation(.easeOut(duration: 0.12), value: isHovered)
+			.onHover { hovering in
+				isHovered = hovering
+			}
+			.disabled(!isEnabled)
 	}
 
 	private var borderColor: Color {
 		colorScheme == .light ? Color.black.opacity(0.12) : Color.white.opacity(0.18)
+	}
+}
+
+private struct SettingsColorWell: NSViewRepresentable {
+	@Binding var selection: Color
+	let isEnabled: Bool
+
+	func makeNSView(context: Context) -> NSColorWell {
+		let colorWell = NSColorWell(frame: .zero)
+		colorWell.isBordered = false
+		colorWell.supportsAlpha = false
+		colorWell.target = context.coordinator
+		colorWell.action = #selector(Coordinator.colorChanged(_:))
+		return colorWell
+	}
+
+	func updateNSView(_ colorWell: NSColorWell, context: Context) {
+		context.coordinator.selection = $selection
+		colorWell.isEnabled = isEnabled
+		let nextColor = NSColor(selection).usingColorSpace(.deviceRGB) ?? NSColor(selection)
+		if !Self.matches(colorWell.color, nextColor) {
+			colorWell.color = nextColor
+		}
+	}
+
+	func makeCoordinator() -> Coordinator {
+		Coordinator(selection: $selection)
+	}
+
+	private static func matches(_ lhs: NSColor, _ rhs: NSColor) -> Bool {
+		let left = lhs.usingColorSpace(.deviceRGB) ?? lhs
+		let right = rhs.usingColorSpace(.deviceRGB) ?? rhs
+		return abs(left.redComponent - right.redComponent) < 0.001
+			&& abs(left.greenComponent - right.greenComponent) < 0.001
+			&& abs(left.blueComponent - right.blueComponent) < 0.001
+			&& abs(left.alphaComponent - right.alphaComponent) < 0.001
+	}
+
+	final class Coordinator: NSObject {
+		var selection: Binding<Color>
+
+		init(selection: Binding<Color>) {
+			self.selection = selection
+		}
+
+		@MainActor
+		@objc
+		func colorChanged(_ sender: NSColorWell) {
+			NSColorPanel.shared.showsAlpha = false
+			selection.wrappedValue = Color(nsColor: sender.color)
+		}
 	}
 }
 

--- a/packages/rsnap-overlay/src/lib.rs
+++ b/packages/rsnap-overlay/src/lib.rs
@@ -26,8 +26,8 @@ pub mod session {
 	//! Rust-core session, protocol, and shared state exports consumed by the native app host.
 
 	pub use crate::overlay::{
-		AltActivationMode, FrozenGlobalHotkey, HudAnchor, OverlayConfig, OverlayControl,
-		OverlayExit, OverlayKeyboardInputEvent, OverlaySession, ThemeMode, ToolbarPlacement,
+		FrozenGlobalHotkey, HudAnchor, OverlayConfig, OverlayControl, OverlayExit,
+		OverlayKeyboardInputEvent, OverlaySession, ThemeMode, ToolbarPlacement,
 		WindowCaptureAlphaMode,
 	};
 	#[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -501,17 +501,6 @@ pub enum OverlayControl {
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-/// Controls how the Tab-triggered loupe interaction is activated.
-pub enum AltActivationMode {
-	#[default]
-	/// Enable the loupe only while Tab is held.
-	Hold,
-	/// Toggle the loupe on and off with Tab presses.
-	Toggle,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
 /// Chooses where the frozen toolbar is anchored relative to the capture.
 pub enum ToolbarPlacement {
 	/// Render the toolbar above the frozen capture.
@@ -974,8 +963,6 @@ pub struct OverlayConfig {
 	pub hud_milk_amount: f32,
 	/// Hue value for tint, 0..=1.
 	pub hud_tint_hue: f32,
-	/// Selects whether Tab must be held or can toggle the loupe.
-	pub alt_activation: AltActivationMode,
 	/// Chooses where the frozen toolbar is placed.
 	pub toolbar_placement: ToolbarPlacement,
 	/// Sets the loupe sample size in source pixels.
@@ -1006,7 +993,6 @@ impl Default for OverlayConfig {
 			hud_fog_amount: 0.16,
 			hud_milk_amount: 0.0,
 			hud_tint_hue: 0.585,
-			alt_activation: AltActivationMode::Hold,
 			toolbar_placement: ToolbarPlacement::Bottom,
 			loupe_sample_side_px: 21,
 			theme_mode: ThemeMode::System,

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -9,8 +9,8 @@ use winit::keyboard::ModifiersState;
 #[cfg(target_os = "macos")]
 use crate::overlay::FrozenGlobalHotkey;
 use crate::overlay::{
-	AltActivationMode, CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource,
-	ElementState, FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
+	CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource, ElementState,
+	FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
 	FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction, LiveClickCaptureTarget,
 	Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
 	OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId,
@@ -263,7 +263,7 @@ impl OverlaySession {
 			return;
 		}
 
-		let Some((monitor, cursor)) = self.alt_activation_cursor_context() else {
+		let Some((monitor, cursor)) = self.loupe_activation_cursor_context() else {
 			return;
 		};
 
@@ -279,13 +279,8 @@ impl OverlaySession {
 	pub(super) fn apply_loupe_activation_input(&mut self, pressed: bool, repeat: bool) -> bool {
 		let previous_alt_held = self.state.alt_held;
 
-		match self.config.alt_activation {
-			AltActivationMode::Hold => self.set_alt_held(pressed),
-			AltActivationMode::Toggle => {
-				if pressed && !repeat {
-					self.set_alt_held(!self.state.alt_held);
-				}
-			},
+		if pressed && !repeat {
+			self.set_alt_held(!self.state.alt_held);
 		}
 
 		previous_alt_held != self.state.alt_held
@@ -314,19 +309,11 @@ impl OverlaySession {
 	}
 
 	pub(super) fn clear_loupe_activation_on_focus_loss(&mut self) {
-		let should_reset = self.loupe_activation_key_down
-			|| (matches!(self.config.alt_activation, AltActivationMode::Hold)
-				&& self.state.alt_held);
-
-		if !should_reset {
+		if !self.loupe_activation_key_down {
 			return;
 		}
 
 		self.loupe_activation_key_down = false;
-
-		if self.apply_loupe_activation_input(false, false) {
-			let _ = self.request_redraw_for_alt_state_change();
-		}
 	}
 
 	pub(super) fn maybe_clear_loupe_activation_after_focus_loss(&mut self) {
@@ -353,9 +340,9 @@ impl OverlaySession {
 		OverlayControl::Continue
 	}
 
-	pub(super) fn alt_activation_cursor_context(&mut self) -> Option<(MonitorRect, GlobalPoint)> {
+	pub(super) fn loupe_activation_cursor_context(&mut self) -> Option<(MonitorRect, GlobalPoint)> {
 		if let Some((monitor, cursor)) = self.last_fresh_event_cursor() {
-			self.seed_alt_activation_cursor_context(monitor, cursor);
+			self.seed_loupe_activation_cursor_context(monitor, cursor);
 
 			return Some((monitor, cursor));
 		}
@@ -369,12 +356,12 @@ impl OverlaySession {
 			return self.active_cursor_monitor().zip(self.state.cursor);
 		};
 
-		self.seed_alt_activation_cursor_context(monitor, cursor);
+		self.seed_loupe_activation_cursor_context(monitor, cursor);
 
 		Some((monitor, cursor))
 	}
 
-	pub(super) fn seed_alt_activation_cursor_context(
+	pub(super) fn seed_loupe_activation_cursor_context(
 		&mut self,
 		monitor: MonitorRect,
 		cursor: GlobalPoint,

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -61,13 +61,12 @@ use crate::overlay::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
-	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry,
-	InflightScrollCaptureObservation, KCG_SCROLL_EVENT_UNIT_PIXEL, LiveSampleApplyResult,
-	LiveStreamStaleGrace, MacOSScrollPixelResidual, OverlayExit,
-	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW, SCROLL_CAPTURE_INPUT_FRESHNESS,
-	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES, SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
-	ScrollCaptureFrameSource, ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
-	StartupLiveRgbPlan,
+	HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, InflightScrollCaptureObservation,
+	KCG_SCROLL_EVENT_UNIT_PIXEL, LiveSampleApplyResult, LiveStreamStaleGrace,
+	MacOSScrollPixelResidual, OverlayExit, SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
+	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES,
+	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE, ScrollCaptureFrameSource,
+	ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError, StartupLiveRgbPlan,
 };
 use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -27,16 +27,16 @@ use crate::overlay::PENDING_CLICK_HIT_TEST_TIMEOUT;
 use crate::overlay::tests;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::WorkerResponse;
-#[cfg(target_os = "macos")]
-use crate::overlay::tests::{
-	AltActivationMode, HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, Ime, Key, LiveCursorSample,
-	LiveSampleApplyResult, ModifiersState, NamedKey, OverlayExit, StartupLiveRgbPlan, WindowId,
-	WindowListSnapshot,
-};
 use crate::overlay::tests::{
 	Duration, GlobalPoint, HudRedrawSummary, Instant, LoupeSample, MonitorRect, MonitorRectPoints,
 	OverlayMode, OverlaySession, OverlayState, Pos2, Rect, RectPoints, Rgb, Vec2, WindowRenderer,
 	hud_helpers,
+};
+#[cfg(target_os = "macos")]
+use crate::overlay::tests::{
+	HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, Ime, Key, LiveCursorSample,
+	LiveSampleApplyResult, ModifiersState, NamedKey, OverlayExit, StartupLiveRgbPlan, WindowId,
+	WindowListSnapshot,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{FrozenGlobalHotkey, PngAction};
@@ -551,8 +551,6 @@ fn live_sample_request_redraw_intent_only_redraws_immediate_hover_changes() {
 fn apply_loupe_activation_input_toggle_ignores_release_and_repeat() {
 	let mut session = OverlaySession::new();
 
-	session.config.alt_activation = AltActivationMode::Toggle;
-
 	assert!(session.apply_loupe_activation_input(true, false));
 	assert!(session.state.alt_held);
 	assert!(!session.apply_loupe_activation_input(true, true));
@@ -565,16 +563,14 @@ fn apply_loupe_activation_input_toggle_ignores_release_and_repeat() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn apply_loupe_activation_input_hold_tracks_pressed_state() {
+fn apply_loupe_activation_input_next_press_toggles_loupe_off() {
 	let mut session = OverlaySession::new();
-
-	session.config.alt_activation = AltActivationMode::Hold;
 
 	assert!(session.apply_loupe_activation_input(true, false));
 	assert!(session.state.alt_held);
-	assert!(!session.apply_loupe_activation_input(true, false));
+	assert!(!session.apply_loupe_activation_input(false, false));
 	assert!(session.state.alt_held);
-	assert!(session.apply_loupe_activation_input(false, false));
+	assert!(session.apply_loupe_activation_input(true, false));
 	assert!(!session.state.alt_held);
 }
 
@@ -582,8 +578,6 @@ fn apply_loupe_activation_input_hold_tracks_pressed_state() {
 #[test]
 fn plain_character_shortcut_available_blocks_loupe_activation_key_while_pressed() {
 	let mut session = OverlaySession::new();
-
-	session.config.alt_activation = AltActivationMode::Toggle;
 
 	assert!(session.plain_character_shortcut_available());
 	assert!(session.apply_loupe_activation_key_event(true, false));
@@ -595,10 +589,8 @@ fn plain_character_shortcut_available_blocks_loupe_activation_key_while_pressed(
 
 #[cfg(target_os = "macos")]
 #[test]
-fn clear_loupe_activation_on_focus_loss_releases_hold_mode_state() {
+fn clear_loupe_activation_on_focus_loss_releases_toggle_press_without_toggling_off() {
 	let mut session = OverlaySession::new();
-
-	session.config.alt_activation = AltActivationMode::Hold;
 
 	assert!(session.apply_loupe_activation_key_event(true, false));
 	assert!(session.state.alt_held);
@@ -606,21 +598,20 @@ fn clear_loupe_activation_on_focus_loss_releases_hold_mode_state() {
 
 	session.clear_loupe_activation_on_focus_loss();
 
-	assert!(!session.state.alt_held);
+	assert!(session.state.alt_held);
 	assert!(!session.loupe_activation_key_down);
 	assert!(session.plain_character_shortcut_available());
 }
 
 #[cfg(target_os = "macos")]
 #[test]
-fn clear_loupe_activation_on_focus_loss_releases_toggle_press_without_toggling_off() {
+fn clear_loupe_activation_on_focus_loss_ignores_released_toggle_state() {
 	let mut session = OverlaySession::new();
-
-	session.config.alt_activation = AltActivationMode::Toggle;
 
 	assert!(session.apply_loupe_activation_key_event(true, false));
 	assert!(session.state.alt_held);
-	assert!(session.loupe_activation_key_down);
+	assert!(!session.apply_loupe_activation_key_event(false, false));
+	assert!(!session.loupe_activation_key_down);
 
 	session.clear_loupe_activation_on_focus_loss();
 
@@ -647,7 +638,6 @@ fn duplicate_loupe_activation_key_events_do_not_double_toggle() {
 	let mut session = OverlaySession::new();
 
 	session.state.mode = OverlayMode::Live;
-	session.config.alt_activation = AltActivationMode::Toggle;
 
 	assert!(session.apply_loupe_activation_key_event(true, false));
 	assert!(session.state.alt_held);
@@ -664,7 +654,7 @@ fn duplicate_loupe_activation_key_events_do_not_double_toggle() {
 }
 
 #[test]
-fn live_drag_alt_activation_does_not_reopen_loupe() {
+fn live_drag_loupe_toggle_does_not_reopen_loupe() {
 	let mut session = OverlaySession::new();
 
 	session.state.mode = OverlayMode::Live;
@@ -729,8 +719,6 @@ fn pending_focus_loss_cleanup_does_not_clear_loupe_during_internal_focus_transfe
 	let toolbar_window_id = WindowId::from(2);
 	let mut session = OverlaySession::new();
 
-	session.config.alt_activation = AltActivationMode::Hold;
-
 	session.note_window_focus_change(overlay_window_id, true);
 
 	assert!(session.apply_loupe_activation_key_event(true, false));
@@ -746,11 +734,9 @@ fn pending_focus_loss_cleanup_does_not_clear_loupe_during_internal_focus_transfe
 
 #[cfg(target_os = "macos")]
 #[test]
-fn pending_focus_loss_cleanup_clears_loupe_after_all_overlay_windows_blur() {
+fn pending_focus_loss_cleanup_releases_toggle_press_after_all_overlay_windows_blur() {
 	let overlay_window_id = WindowId::from(1);
 	let mut session = OverlaySession::new();
-
-	session.config.alt_activation = AltActivationMode::Hold;
 
 	session.note_window_focus_change(overlay_window_id, true);
 
@@ -760,7 +746,7 @@ fn pending_focus_loss_cleanup_clears_loupe_after_all_overlay_windows_blur() {
 	session.note_window_focus_change(overlay_window_id, false);
 	session.maybe_clear_loupe_activation_after_focus_loss();
 
-	assert!(!session.state.alt_held);
+	assert!(session.state.alt_held);
 	assert!(!session.loupe_activation_key_down);
 	assert!(session.plain_character_shortcut_available());
 }
@@ -772,7 +758,6 @@ fn initial_unfocused_window_blur_does_not_cancel_first_global_loupe_press() {
 	let mut session = OverlaySession::new();
 
 	session.state.mode = OverlayMode::Live;
-	session.config.alt_activation = AltActivationMode::Hold;
 
 	session.note_window_focus_change(overlay_window_id, false);
 
@@ -1772,14 +1757,19 @@ fn global_escape_hotkey_cancels_active_capture_modes() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn global_loupe_hotkey_tracks_live_hold_state() {
+fn global_loupe_hotkey_toggles_live_loupe_on_press() {
 	let mut session = OverlaySession::new();
 
 	session.state.mode = OverlayMode::Live;
-	session.config.alt_activation = AltActivationMode::Hold;
 
 	assert!(matches!(session.handle_global_loupe_hotkey(true), OverlayControl::Continue));
 	assert!(session.state.alt_held);
+	assert!(session.loupe_activation_key_down);
+	assert!(matches!(session.handle_global_loupe_hotkey(false), OverlayControl::Continue));
+	assert!(session.state.alt_held);
+	assert!(!session.loupe_activation_key_down);
+	assert!(matches!(session.handle_global_loupe_hotkey(true), OverlayControl::Continue));
+	assert!(!session.state.alt_held);
 	assert!(session.loupe_activation_key_down);
 	assert!(matches!(session.handle_global_loupe_hotkey(false), OverlayControl::Continue));
 	assert!(!session.state.alt_held);

--- a/scripts/smoke/native-hud-follow-macos.sh
+++ b/scripts/smoke/native-hud-follow-macos.sh
@@ -108,8 +108,6 @@ run_hud_follow_case() {
 			echo "[smoke] case: loupe"
 			live_hud_focus_rsnap_overlay
 			live_hud_press_tab
-			# Let the loupe patch populate once before testing expanded HUD rendering.
-			sleep 0.2
 			live_hud_run_mouse_path
 			;;
 		"")


### PR DESCRIPTION
## Summary
- make live Tab loupe activation toggle-only and remove the old hold/toggle config surface
- align native Settings defaults with current desired HUD/glass values while keeping default save location at ~/Desktop
- fix Settings polish issues: tint color well interaction, default window height, subtitle animation, and capture page scroll behavior
- prime the live loupe patch on first toggle and avoid dark Liquid Glass fallback fill on first live frames

## Validation
- cargo make fmt-rust
- cargo make fmt-swift
- cargo make lint-rust
- cargo make lint-swift
- cargo make test-rust (571 passed)
- cargo make test-macos-native-host-stage
- HUD_FOLLOW_CASES=hud,loupe PATH_DURATION_MS=800 PATH_CYCLES=1 RSNAP_TELEMETRY_LAST=6s scripts/smoke/native-hud-follow-macos.sh
- ./scripts/build_and_run.sh run
- codesign --verify --deep --strict target/rsnap-native-host/rsnap.app
- git diff --check