### PR TITLE
Fix frozen annotation export y-axis mapping

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -259,6 +259,8 @@ script = '''
 swift package --package-path native/macos-host clean
 RSNAP_HOST_FFI_LIB_DIR="$PWD/target/debug" \
 swift run --package-path native/macos-host RsnapHostBridgeProbe
+RSNAP_HOST_FFI_LIB_DIR="$PWD/target/debug" \
+swift run --package-path native/macos-host RsnapNativeHostKitProbe
 '''
 
 [tasks.test-macos-native-host-stage]

--- a/native/macos-host/Package.swift
+++ b/native/macos-host/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
 		.library(name: "RsnapHostBridge", targets: ["RsnapHostBridge"]),
 		.library(name: "RsnapNativeHostKit", targets: ["RsnapNativeHostKit"]),
 		.executable(name: "RsnapHostBridgeProbe", targets: ["RsnapHostBridgeProbe"]),
+		.executable(name: "RsnapNativeHostKitProbe", targets: ["RsnapNativeHostKitProbe"]),
 		.executable(name: "RsnapNativeHost", targets: ["RsnapNativeHost"]),
 	],
 	dependencies: [
@@ -65,6 +66,10 @@ let package = Package(
 		.executableTarget(
 			name: "RsnapHostBridgeProbe",
 			dependencies: ["RsnapHostBridge"]
+		),
+		.executableTarget(
+			name: "RsnapNativeHostKitProbe",
+			dependencies: ["RsnapNativeHostKit"]
 		),
 		.executableTarget(
 			name: "RsnapNativeHost",

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -74,6 +74,49 @@ private enum CaptureSuccessSound {
 
 private let frozenMosaicBlockSizePixels: CGFloat = 10.0
 
+package func frozenExportOverlayPoint(
+	_ point: CGPoint,
+	selection: CGRect,
+	imageSize: CGSize
+) -> CGPoint {
+	let scaleX = imageSize.width / max(selection.width, 1)
+	let scaleY = imageSize.height / max(selection.height, 1)
+	return CGPoint(
+		x: (point.x - selection.minX) * scaleX,
+		y: (point.y - selection.minY) * scaleY
+	)
+}
+
+package func frozenExportOverlayRect(
+	_ rect: CGRect,
+	selection: CGRect,
+	imageSize: CGSize
+) -> CGRect {
+	let scaleX = imageSize.width / max(selection.width, 1)
+	let scaleY = imageSize.height / max(selection.height, 1)
+	return CGRect(
+		x: (rect.minX - selection.minX) * scaleX,
+		y: (rect.minY - selection.minY) * scaleY,
+		width: rect.width * scaleX,
+		height: rect.height * scaleY
+	)
+}
+
+package func frozenExportSourceImageRect(
+	_ rect: CGRect,
+	selection: CGRect,
+	imageSize: CGSize
+) -> CGRect {
+	let scaleX = imageSize.width / max(selection.width, 1)
+	let scaleY = imageSize.height / max(selection.height, 1)
+	return CGRect(
+		x: (rect.minX - selection.minX) * scaleX,
+		y: (selection.maxY - rect.maxY) * scaleY,
+		width: rect.width * scaleX,
+		height: rect.height * scaleY
+	)
+}
+
 private func makeFrozenMosaicPatch(from image: CGImage, sourceRect: CGRect) -> CGImage? {
 	let imageRect = CGRect(x: 0, y: 0, width: image.width, height: image.height)
 	let cropRect = sourceRect.integral.intersection(imageRect)
@@ -2025,32 +2068,42 @@ final class CaptureSessionController: NSObject {
 		}
 
 		let imageRect = CGRect(x: 0, y: 0, width: width, height: height)
+		let imageSize = CGSize(width: CGFloat(width), height: CGFloat(height))
+		let scaleX = imageSize.width / max(selection.width, 1)
+		let scaleY = imageSize.height / max(selection.height, 1)
 		context.draw(image, in: imageRect)
 
-		let scaleX = CGFloat(width) / max(selection.width, 1)
-		let scaleY = CGFloat(height) / max(selection.height, 1)
 		func mapPoint(_ point: CGPoint) -> CGPoint {
-			CGPoint(
-				x: (point.x - selection.minX) * scaleX,
-				y: (point.y - selection.minY) * scaleY
+			frozenExportOverlayPoint(
+				point,
+				selection: selection,
+				imageSize: imageSize
 			)
 		}
 		func mapRect(_ rect: CGRect) -> CGRect {
-			CGRect(
-				x: (rect.minX - selection.minX) * scaleX,
-				y: (selection.maxY - rect.maxY) * scaleY,
-				width: rect.width * scaleX,
-				height: rect.height * scaleY
+			frozenExportOverlayRect(
+				rect,
+				selection: selection,
+				imageSize: imageSize
+			)
+		}
+		func sourceImageRect(_ rect: CGRect) -> CGRect {
+			frozenExportSourceImageRect(
+				rect,
+				selection: selection,
+				imageSize: imageSize
 			)
 		}
 
-		let mosaicRects = chromeState.frozenOverlay.mosaicRects.map(mapRect)
+		let mosaicRects = chromeState.frozenOverlay.mosaicRects.map {
+			(source: sourceImageRect($0), destination: mapRect($0))
+		}
 		if !mosaicRects.isEmpty {
 			context.saveGState()
 			context.interpolationQuality = .high
 			for rect in mosaicRects {
-				if let mosaicPatch = makeFrozenMosaicPatch(from: image, sourceRect: rect) {
-					context.draw(mosaicPatch, in: rect.integral.intersection(imageRect))
+				if let mosaicPatch = makeFrozenMosaicPatch(from: image, sourceRect: rect.source) {
+					context.draw(mosaicPatch, in: rect.destination.integral.intersection(imageRect))
 				}
 			}
 			context.restoreGState()

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -1,0 +1,123 @@
+import CoreGraphics
+import RsnapNativeHostKit
+
+@main
+enum RsnapNativeHostKitProbe {
+	static func main() {
+		let selection = CGRect(x: 100, y: 200, width: 50, height: 100)
+		let imageSize = CGSize(width: 100, height: 200)
+		let rectNearTop = CGRect(x: 110, y: 270, width: 20, height: 20)
+
+		assertRectEqual(
+			frozenExportOverlayRect(
+				rectNearTop,
+				selection: selection,
+				imageSize: imageSize
+			),
+			CGRect(x: 20, y: 140, width: 40, height: 40),
+			"rect overlay export must stay in bottom-left drawing coordinates"
+		)
+		assertRectEqual(
+			frozenExportSourceImageRect(
+				rectNearTop,
+				selection: selection,
+				imageSize: imageSize
+			),
+			CGRect(x: 20, y: 20, width: 40, height: 40),
+			"source image rect must stay in top-down CGImage coordinates"
+		)
+		assertPointEqual(
+			frozenExportOverlayPoint(
+				CGPoint(x: 125, y: 280),
+				selection: selection,
+				imageSize: imageSize
+			),
+			CGPoint(x: 50, y: 160),
+			"point annotation export must match bottom-left drawing coordinates"
+		)
+		assertRectOverlayDrawsAtVisualTop(
+			rectNearTop,
+			selection: selection,
+			imageSize: imageSize
+		)
+	}
+
+	private static func assertRectEqual(_ actual: CGRect, _ expected: CGRect, _ message: String) {
+		guard nearlyEqual(actual.origin.x, expected.origin.x),
+			nearlyEqual(actual.origin.y, expected.origin.y),
+			nearlyEqual(actual.width, expected.width),
+			nearlyEqual(actual.height, expected.height)
+		else {
+			fatalError("\(message): expected \(expected), got \(actual)")
+		}
+	}
+
+	private static func assertPointEqual(_ actual: CGPoint, _ expected: CGPoint, _ message: String)
+	{
+		guard nearlyEqual(actual.x, expected.x), nearlyEqual(actual.y, expected.y) else {
+			fatalError("\(message): expected \(expected), got \(actual)")
+		}
+	}
+
+	private static func nearlyEqual(_ actual: CGFloat, _ expected: CGFloat) -> Bool {
+		abs(actual - expected) <= 0.000_1
+	}
+
+	private static func assertRectOverlayDrawsAtVisualTop(
+		_ rect: CGRect,
+		selection: CGRect,
+		imageSize: CGSize
+	) {
+		let width = Int(imageSize.width)
+		let height = Int(imageSize.height)
+		let byteCount = width * height * 4
+		let data = UnsafeMutablePointer<UInt8>.allocate(capacity: byteCount)
+		data.initialize(repeating: 0, count: byteCount)
+		defer {
+			data.deinitialize(count: byteCount)
+			data.deallocate()
+		}
+		guard
+			let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+			let context = CGContext(
+				data: data,
+				width: width,
+				height: height,
+				bitsPerComponent: 8,
+				bytesPerRow: width * 4,
+				space: colorSpace,
+				bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+			)
+		else {
+			fatalError("could not create geometry probe context")
+		}
+
+		context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+		context.fill(
+			frozenExportOverlayRect(
+				rect,
+				selection: selection,
+				imageSize: imageSize
+			))
+
+		guard redPixel(in: data, width: width, x: 25, yFromTop: 30) else {
+			fatalError("rect overlay export did not mark the visual top rows")
+		}
+		guard !redPixel(in: data, width: width, x: 25, yFromTop: 170) else {
+			fatalError("rect overlay export marked the mirrored bottom rows")
+		}
+	}
+
+	private static func redPixel(
+		in data: UnsafePointer<UInt8>,
+		width: Int,
+		x: Int,
+		yFromTop: Int
+	) -> Bool {
+		let offset = (yFromTop * width + x) * 4
+		return data[offset] > 200
+			&& data[offset + 1] < 80
+			&& data[offset + 2] < 20
+			&& data[offset + 3] > 200
+	}
+}


### PR DESCRIPTION
## Summary
- keep frozen rect annotations in overlay drawing coordinates during export
- keep mosaic source sampling in top-down CGImage coordinates
- add a native-host probe covering rect, source-image, and point export geometry

## Validation
- cargo make lint-swift
- cargo make test-macos-native-host
- cargo make fmt-toml-check
- git diff --check
- cargo make test-macos-native-host-stage