### PR TITLE
Polish Screen Recording permission onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cargo run -p rsnap
 - macOS may phrase the Input Monitoring prompt as receiving keystrokes from any application even though rsnap only listens for scroll-wheel input in this path.
 - macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when rsnap bypasses the system picker.
 - The native menubar host exposes `Permissions…`, which shows Screen Recording, Accessibility, and Input Monitoring status. It marks Accessibility and Input Monitoring as not needed until native scroll automation is enabled.
-- Normal native capture depends on Screen Recording; if access is missing, rsnap reports it in the host status message and the Permissions window is the canonical repair surface.
+- Normal native capture depends on Screen Recording; if access is missing, rsnap opens the Screen Recording page in System Settings and shows a floating drag-to-grant guide.
 - You can reopen `Permissions…` from the tray or menubar menu at any time.
 - Base capture path: `System Settings` -> `Privacy & Security` -> `Screen Recording`.
 - Scroll capture paths: `System Settings` -> `Privacy & Security` -> `Accessibility` and `Input Monitoring`.

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -79,10 +79,13 @@ Defines:
 
 - Settings must include a Permissions section.
 - Screen Recording permission is required for the current native macOS capture host.
+- When Screen Recording is missing at launch or at capture start, rsnap must open the macOS Screen
+  Recording privacy page and present a small rsnap-owned floating drag guide near System Settings.
 - Accessibility and Input Monitoring may be displayed as diagnostic permissions, but they must not
   be presented as required when the current native host does not need them.
-- Permission recovery should provide a drag-the-app affordance for adding rsnap to System Settings
-  where macOS allows that workflow, plus an Open System Settings fallback.
+- Permission recovery should provide a visible drag-the-app affordance for adding rsnap to System
+  Settings where macOS allows that workflow, including a directional guide from the floating window
+  toward System Settings and an Open System Settings fallback.
 - Permission status refresh must be available without restarting rsnap.
 
 ## Default-Size Usability

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -215,6 +215,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	private var liveSamplingPrewarmWorkItem: DispatchWorkItem?
 	private var selfCaptureRegistrationWindow: NSWindow?
 	private var didBootstrap = false
+	private var didPresentLaunchPermissionOnboarding = false
 	@objc public dynamic var window: NSWindow?
 	private lazy var sessionController: CaptureSessionController = {
 		let controller = CaptureSessionController(settingsStore: settingsStore)
@@ -228,6 +229,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	}()
 	private var statusItem: NSStatusItem?
 	private weak var captureMenuItem: NSMenuItem?
+	private lazy var permissionRecoveryWindowController = PermissionRecoveryGuideWindowController()
 	private lazy var settingsWindowController = SettingsWindowController(
 		settingsStore: settingsStore,
 		onClose: { [weak self] in
@@ -260,6 +262,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
 		refreshStatusMenuState()
 		scheduleLiveSamplingPrewarm()
+		scheduleLaunchPermissionOnboardingIfNeeded()
 		NativeHostTelemetry.lifecycleEvent(
 			"native_host.finish_launching_end",
 			detail: "statusItemPresent=\(statusItem != nil)"
@@ -313,6 +316,9 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 
 	@objc
 	private func startCapture(_ sender: Any?) {
+		if presentPermissionRecoveryIfNeeded(source: "start_capture") {
+			return
+		}
 		sessionController.startCapture(
 			capturableOwnWindowIDs: settingsWindowController.captureExceptionWindowIDs)
 	}
@@ -325,6 +331,38 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	@objc
 	private func openSettings(_ sender: Any?) {
 		settingsWindowController.present()
+	}
+
+	private func scheduleLaunchPermissionOnboardingIfNeeded() {
+		DispatchQueue.main.async { [weak self] in
+			_ = self?.presentPermissionRecoveryIfNeeded(
+				source: "launch",
+				oncePerLaunch: true
+			)
+		}
+	}
+
+	@discardableResult
+	private func presentPermissionRecoveryIfNeeded(
+		source: String,
+		oncePerLaunch: Bool = false
+	) -> Bool {
+		guard !NativePermissions.status(for: .screenRecording) else {
+			permissionRecoveryWindowController.close()
+			return false
+		}
+		if oncePerLaunch {
+			guard !didPresentLaunchPermissionOnboarding else {
+				return true
+			}
+			didPresentLaunchPermissionOnboarding = true
+		}
+		permissionRecoveryWindowController.present(kind: .screenRecording)
+		NativeHostTelemetry.lifecycleEvent(
+			"native_host.permission_recovery_presented",
+			detail: "source=\(source)"
+		)
+		return true
 	}
 
 	private func settingsWindowDidClose() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -1532,14 +1532,14 @@ private struct PermissionGrantCard: View {
 	}
 
 	private var title: String {
-		isGranted ? "Screen Recording ready" : "Drag rsnap into Screen Recording"
+		isGranted ? "Screen Recording ready" : "Screen Recording access needed"
 	}
 
 	private var subtitle: String {
 		if isGranted {
 			return "The native capture host can see the screen."
 		}
-		return "Open System Settings, then drop the app chip into the allowed apps list."
+		return "Open System Settings, then drag rsnap into the Screen Recording app list."
 	}
 
 	private var iconBackgroundColor: Color {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 
 enum NativeHostSettingsWindowMetrics {
 	static let width: CGFloat = 620
-	static let minHeight: CGFloat = 348
-	static let idealHeight: CGFloat = 360
+	static let minHeight: CGFloat = 320
+	static let idealHeight: CGFloat = 336
 }
 
 @MainActor
@@ -1378,7 +1378,7 @@ private struct PermissionsSettingsPanel: View {
 	private let primaryKind = PermissionKind.screenRecording
 
 	var body: some View {
-		VStack(spacing: 8) {
+		VStack(spacing: 6) {
 			PermissionGrantCard(
 				kind: primaryKind,
 				refreshID: refreshID,
@@ -1392,7 +1392,7 @@ private struct PermissionsSettingsPanel: View {
 				}
 			)
 
-			VStack(spacing: 8) {
+			VStack(spacing: 6) {
 				VStack(spacing: 0) {
 					ForEach(Self.rows.prefix(2)) { row in
 						PermissionStatusTile(
@@ -1463,67 +1463,72 @@ private struct PermissionGrantCard: View {
 	let openSettings: () -> Void
 	let refresh: () -> Void
 	@Environment(\.colorScheme) private var colorScheme
+	@State private var didRefresh = false
 
 	var body: some View {
-		HStack(alignment: .center, spacing: 12) {
-			ZStack {
-				Circle()
-					.fill(iconBackgroundColor)
-				Image(systemName: isGranted ? "checkmark.seal.fill" : "hand.draw.fill")
-					.symbolRenderingMode(.hierarchical)
-					.font(.system(size: 17, weight: .semibold))
-					.foregroundStyle(isGranted ? Color.green : Color.accentColor)
-			}
-			.frame(width: 34, height: 34)
-
-			VStack(alignment: .leading, spacing: 5) {
-				HStack(spacing: 7) {
-					Text(title)
-						.font(.system(size: 12.5, weight: .semibold))
-						.lineLimit(2)
-					PermissionStateBadge(
-						title: isGranted ? "Granted" : "Required",
-						style: isGranted ? .granted : .required
-					)
+		VStack(alignment: .leading, spacing: 7) {
+			HStack(alignment: .top, spacing: 11) {
+				ZStack {
+					Circle()
+						.fill(iconBackgroundColor)
+					Image(systemName: isGranted ? "checkmark.seal.fill" : "hand.draw.fill")
+						.symbolRenderingMode(.hierarchical)
+						.font(.system(size: 17, weight: .semibold))
+						.foregroundStyle(isGranted ? Color.green : Color.accentColor)
 				}
-				Text(subtitle)
-					.font(.system(size: 10, weight: .medium))
-					.foregroundStyle(.secondary)
-					.lineLimit(2)
-					.fixedSize(horizontal: false, vertical: true)
+				.frame(width: 34, height: 34)
+
+				VStack(alignment: .leading, spacing: 5) {
+					HStack(alignment: .firstTextBaseline, spacing: 7) {
+						Text(title)
+							.font(.system(size: 12.5, weight: .semibold))
+							.lineLimit(2)
+							.fixedSize(horizontal: false, vertical: true)
+							.layoutPriority(1)
+						PermissionStateBadge(
+							title: isGranted ? "Granted" : "Required",
+							style: isGranted ? .granted : .required
+						)
+					}
+					Text(subtitle)
+						.font(.system(size: 10.5, weight: .medium))
+						.foregroundStyle(.secondary)
+						.lineLimit(2)
+						.fixedSize(horizontal: false, vertical: true)
+				}
 			}
-			.layoutPriority(1)
 
-			Spacer(minLength: 8)
-
-			VStack(alignment: .trailing, spacing: 7) {
+			HStack(alignment: .center, spacing: 8) {
 				PermissionAppDragSource(bundleURL: bundleURL, icon: appIcon, label: "rsnap")
-					.frame(width: 112, height: 34)
+					.frame(width: 108, height: 31)
 					.opacity(isGranted ? 0.76 : 1)
 
-				HStack(spacing: 6) {
-					Button {
-						openSettings()
-					} label: {
-						Label("Open", systemImage: "gearshape")
-							.labelStyle(.titleAndIcon)
-					}
-					.rsnapGlassButton(prominent: false)
-					.controlSize(.small)
+				Spacer(minLength: 6)
 
-					Button(action: refresh) {
-						Image(systemName: "arrow.clockwise")
-							.frame(width: 13, height: 13)
-					}
-					.rsnapGlassButton(prominent: false)
-					.controlSize(.small)
-					.help("Refresh status")
+				Button {
+					openSettings()
+				} label: {
+					Label("Settings", systemImage: "gearshape")
+						.labelStyle(.titleAndIcon)
 				}
+				.rsnapGlassButton(prominent: false)
+				.controlSize(.small)
+				.help("Open Screen Recording settings")
+
+				Button(action: refreshStatus) {
+					Label(
+						didRefresh ? "Updated" : "Refresh",
+						systemImage: didRefresh ? "checkmark" : "arrow.clockwise"
+					)
+					.labelStyle(.titleAndIcon)
+				}
+				.rsnapGlassButton(prominent: false)
+				.controlSize(.small)
+				.help("Refresh permission status")
 			}
-			.frame(width: SettingsControlLayout.controlColumnWidth, alignment: .trailing)
 		}
-		.padding(.vertical, 8)
-		.frame(maxWidth: .infinity, minHeight: 82, alignment: .leading)
+		.padding(.vertical, 7)
+		.frame(maxWidth: .infinity, minHeight: 98, alignment: .leading)
 	}
 
 	private var isGranted: Bool {
@@ -1549,6 +1554,14 @@ private struct PermissionGrantCard: View {
 		return Color.accentColor.opacity(colorScheme == .light ? 0.12 : 0.20)
 	}
 
+	private func refreshStatus() {
+		refresh()
+		didRefresh = true
+		DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
+			didRefresh = false
+		}
+	}
+
 }
 
 private struct PermissionStatusTile: View {
@@ -1557,11 +1570,21 @@ private struct PermissionStatusTile: View {
 	let openSettings: (PermissionKind) -> Void
 
 	var body: some View {
-		SettingsControlTile(
-			symbolName: row.symbolName,
-			title: row.title,
-			subtitle: subtitle
-		) {
+		HStack(alignment: .center, spacing: 10) {
+			SettingsTileIcon(symbolName: row.symbolName, size: 19)
+			VStack(alignment: .leading, spacing: 2) {
+				Text(row.title)
+					.font(.system(size: 13, weight: .semibold))
+					.lineLimit(1)
+					.minimumScaleFactor(0.9)
+				Text(subtitle)
+					.font(.system(size: 10.5, weight: .medium))
+					.foregroundStyle(.secondary)
+					.lineLimit(2)
+					.fixedSize(horizontal: false, vertical: true)
+			}
+			.layoutPriority(1)
+			Spacer(minLength: 8)
 			HStack(spacing: 7) {
 				PermissionStateBadge(title: badgeTitle, style: badgeStyle)
 				if canOpen {
@@ -1577,6 +1600,8 @@ private struct PermissionStatusTile: View {
 				}
 			}
 		}
+		.padding(.vertical, 4)
+		.frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
 	}
 
 	private var isGranted: Bool {
@@ -1629,6 +1654,7 @@ private struct PermissionStateBadge: View {
 		Text(title)
 			.font(.system(size: 9.2, weight: .semibold))
 			.lineLimit(1)
+			.fixedSize(horizontal: true, vertical: false)
 			.padding(.horizontal, 7)
 			.padding(.vertical, 4)
 			.foregroundStyle(foregroundColor)

--- a/native/macos-host/Sources/RsnapNativeHostKit/PermissionRecoveryGuideWindow.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/PermissionRecoveryGuideWindow.swift
@@ -19,12 +19,15 @@ final class PermissionRecoveryGuideWindowController: NSWindowController {
 		}
 	}
 
-	private static let windowSize = NSSize(width: 314, height: 118)
+	private static let windowSize = NSSize(width: 318, height: 50)
+	private static let cornerRadius: CGFloat = 17
 	private static let windowGap: CGFloat = 14
 	private var kind: PermissionKind = .screenRecording
 	private var positionWorkItem: DispatchWorkItem?
 	private var statusPollWorkItem: DispatchWorkItem?
 	private var guideDirection: GuideDirection = .left
+	private let materialView = NSVisualEffectView()
+	private var hostingController: NSHostingController<PermissionRecoveryGuideView>?
 
 	init() {
 		let panel = NSPanel(
@@ -43,6 +46,7 @@ final class PermissionRecoveryGuideWindowController: NSWindowController {
 		panel.isReleasedWhenClosed = false
 		panel.level = .floating
 		super.init(window: panel)
+		configureMaterialView()
 		updateRootView()
 	}
 
@@ -55,9 +59,7 @@ final class PermissionRecoveryGuideWindowController: NSWindowController {
 		self.kind = kind
 		NativePermissions.openSystemSettings(for: kind)
 		updateRootView()
-		positionAtFallbackLocation()
-		showWindow(nil)
-		window?.orderFrontRegardless()
+		window?.orderOut(nil)
 		scheduleSystemSettingsPositioning()
 		schedulePermissionStatusPolling()
 	}
@@ -73,25 +75,68 @@ final class PermissionRecoveryGuideWindowController: NSWindowController {
 	private func updateRootView() {
 		let bundleURL = Bundle.main.bundleURL
 		let appIcon = NSWorkspace.shared.icon(forFile: bundleURL.path)
-		window?.contentViewController = NSHostingController(
-			rootView: PermissionRecoveryGuideView(
-				directionSymbolName: guideDirection.symbolName,
-				bundleURL: bundleURL,
-				appIcon: appIcon,
-				openSettings: { [weak self] in
-					guard let self else {
-						return
-					}
-					NativePermissions.openSystemSettings(for: self.kind)
-					self.scheduleSystemSettingsPositioning()
-				},
-				close: { [weak self] in
-					self?.close()
+		let rootView = PermissionRecoveryGuideView(
+			directionSymbolName: guideDirection.symbolName,
+			bundleURL: bundleURL,
+			appIcon: appIcon,
+			openSettings: { [weak self] in
+				guard let self else {
+					return
 				}
-			)
+				NativePermissions.openSystemSettings(for: self.kind)
+				self.scheduleSystemSettingsPositioning()
+			}
 		)
-		window?.contentViewController?.view.wantsLayer = true
-		window?.contentViewController?.view.layer?.backgroundColor = NSColor.clear.cgColor
+		if let hostingController {
+			hostingController.rootView = rootView
+			return
+		}
+
+		let hostingController = NSHostingController(rootView: rootView)
+		hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+		hostingController.view.wantsLayer = true
+		hostingController.view.layer?.backgroundColor = NSColor.clear.cgColor
+		materialView.addSubview(hostingController.view)
+		NSLayoutConstraint.activate([
+			hostingController.view.leadingAnchor.constraint(equalTo: materialView.leadingAnchor),
+			hostingController.view.trailingAnchor.constraint(equalTo: materialView.trailingAnchor),
+			hostingController.view.topAnchor.constraint(equalTo: materialView.topAnchor),
+			hostingController.view.bottomAnchor.constraint(equalTo: materialView.bottomAnchor),
+		])
+		self.hostingController = hostingController
+	}
+
+	private func configureMaterialView() {
+		materialView.frame = NSRect(origin: .zero, size: Self.windowSize)
+		materialView.autoresizingMask = [.width, .height]
+		materialView.blendingMode = .withinWindow
+		materialView.material = .popover
+		materialView.state = .active
+		materialView.wantsLayer = true
+		materialView.layer?.cornerRadius = Self.cornerRadius
+		if #available(macOS 10.15, *) {
+			materialView.layer?.cornerCurve = .continuous
+		}
+		materialView.layer?.masksToBounds = true
+		materialView.maskImage = Self.roundedMaskImage(
+			size: Self.windowSize,
+			cornerRadius: Self.cornerRadius
+		)
+		window?.contentView = materialView
+	}
+
+	private static func roundedMaskImage(size: NSSize, cornerRadius: CGFloat) -> NSImage {
+		let image = NSImage(size: size)
+		image.lockFocus()
+		NSColor.black.setFill()
+		NSBezierPath(
+			roundedRect: NSRect(origin: .zero, size: size),
+			xRadius: cornerRadius,
+			yRadius: cornerRadius
+		)
+		.fill()
+		image.unlockFocus()
+		return image
 	}
 
 	private func scheduleSystemSettingsPositioning() {
@@ -106,12 +151,17 @@ final class PermissionRecoveryGuideWindowController: NSWindowController {
 				guideDirection = direction
 				updateRootView()
 			}
-			window?.orderFrontRegardless()
+			revealGuideWindow()
 			return
 		}
 
 		guard remainingAttempts > 0 else {
-			window?.orderFrontRegardless()
+			positionAtFallbackLocation()
+			if guideDirection != .left {
+				guideDirection = .left
+				updateRootView()
+			}
+			revealGuideWindow()
 			return
 		}
 		let workItem = DispatchWorkItem { [weak self] in
@@ -127,9 +177,6 @@ final class PermissionRecoveryGuideWindowController: NSWindowController {
 	}
 
 	private func pollPermissionStatus(remainingAttempts: Int) {
-		guard window?.isVisible == true else {
-			return
-		}
 		if NativePermissions.status(for: kind) {
 			close()
 			return
@@ -142,6 +189,11 @@ final class PermissionRecoveryGuideWindowController: NSWindowController {
 		}
 		statusPollWorkItem = workItem
 		DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: workItem)
+	}
+
+	private func revealGuideWindow() {
+		showWindow(nil)
+		window?.orderFrontRegardless()
 	}
 
 	private func positionAtFallbackLocation() {
@@ -266,74 +318,26 @@ private struct PermissionRecoveryGuideView: View {
 	let bundleURL: URL
 	let appIcon: NSImage
 	let openSettings: () -> Void
-	let close: () -> Void
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var pulse = false
 
 	var body: some View {
-		HStack(spacing: 12) {
-			PermissionGuideArrow(symbolName: directionSymbolName, pulse: pulse)
-				.frame(width: 38, height: 52)
-
-			VStack(alignment: .leading, spacing: 8) {
-				HStack(alignment: .center, spacing: 8) {
-					Text("Drag rsnap here")
-						.font(.system(size: 12.5, weight: .semibold))
-						.lineLimit(1)
-					Spacer(minLength: 6)
-					Button(action: close) {
-						Image(systemName: "xmark")
-							.font(.system(size: 9.5, weight: .bold))
-							.frame(width: 18, height: 18)
-					}
-					.buttonStyle(.plain)
-					.foregroundStyle(.secondary)
-					.help("Close")
-				}
-
-				HStack(spacing: 9) {
-					PermissionAppDragSource(bundleURL: bundleURL, icon: appIcon, label: "rsnap")
-						.frame(width: 116, height: 36)
-						.overlay {
-							Capsule()
-								.stroke(
-									Color.accentColor.opacity(pulse ? 0.58 : 0.20), lineWidth: 1.2
-								)
-								.scaleEffect(reduceMotion ? 1 : (pulse ? 1.06 : 1))
-								.allowsHitTesting(false)
-						}
-					Button(action: openSettings) {
-						Image(systemName: "gearshape")
-							.font(.system(size: 12.5, weight: .semibold))
-							.frame(width: 30, height: 30)
-					}
-					.buttonStyle(.plain)
-					.foregroundStyle(Color.accentColor)
-					.background(
-						Color.accentColor.opacity(colorScheme == .light ? 0.075 : 0.13),
-						in: RoundedRectangle(cornerRadius: 8, style: .continuous)
-					)
-					.help("Open Screen Recording settings")
-				}
-
-				Text("Drop it into Screen Recording, then turn it on.")
-					.font(.system(size: 10, weight: .medium))
-					.foregroundStyle(.secondary)
-					.lineLimit(1)
-					.minimumScaleFactor(0.9)
+		HStack(alignment: .center, spacing: 8) {
+			if pointsLeft {
+				arrowGuide
+				appDragChip
+				instructionText
+				openSettingsButton
+			} else {
+				openSettingsButton
+				instructionText
+				appDragChip
+				arrowGuide
 			}
 		}
-		.padding(.horizontal, 13)
-		.padding(.vertical, 11)
-		.frame(width: 314, height: 118)
-		.background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-		.background(panelFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-		.overlay {
-			RoundedRectangle(cornerRadius: 18, style: .continuous)
-				.stroke(panelBorder, lineWidth: 1)
-		}
-		.shadow(color: .black.opacity(colorScheme == .light ? 0.16 : 0.34), radius: 18, y: 8)
+		.padding(.horizontal, 11)
+		.frame(width: 318, height: 50)
 		.onAppear {
 			guard !reduceMotion else {
 				return
@@ -344,12 +348,58 @@ private struct PermissionRecoveryGuideView: View {
 		}
 	}
 
-	private var panelFill: Color {
-		colorScheme == .light ? Color.white.opacity(0.42) : Color.black.opacity(0.20)
+	private var pointsLeft: Bool {
+		directionSymbolName == "arrow.left"
 	}
 
-	private var panelBorder: Color {
-		colorScheme == .light ? Color.black.opacity(0.10) : Color.white.opacity(0.16)
+	private var guideTextFont: Font {
+		.system(size: 11.2, weight: .semibold)
+	}
+
+	private var guideTextColor: Color {
+		Color.primary.opacity(colorScheme == .light ? 0.78 : 0.86)
+	}
+
+	private var arrowGuide: some View {
+		PermissionGuideArrow(symbolName: directionSymbolName, pulse: pulse)
+			.frame(width: 40, height: 31)
+	}
+
+	private var appDragChip: some View {
+		PermissionAppDragSource(bundleURL: bundleURL, icon: appIcon, label: "rsnap")
+			.frame(width: 114, height: 31)
+			.overlay {
+				Capsule()
+					.stroke(Color.accentColor.opacity(pulse ? 0.58 : 0.20), lineWidth: 1.2)
+					.scaleEffect(reduceMotion ? 1 : (pulse ? 1.055 : 1))
+					.allowsHitTesting(false)
+			}
+	}
+
+	private var instructionText: some View {
+		Text("Drop in, turn on")
+			.font(guideTextFont)
+			.foregroundStyle(guideTextColor)
+			.lineLimit(1)
+			.minimumScaleFactor(0.88)
+			.frame(maxWidth: .infinity, alignment: .leading)
+			.layoutPriority(1)
+	}
+
+	private var openSettingsButton: some View {
+		Button(action: openSettings) {
+			Image(systemName: "arrow.up.forward.app")
+				.font(.system(size: 11.4, weight: .semibold))
+				.frame(width: 24, height: 24)
+		}
+		.buttonStyle(.plain)
+		.foregroundStyle(Color.accentColor)
+		.background(
+			Color.accentColor.opacity(colorScheme == .light ? 0.075 : 0.13),
+			in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+		)
+		.frame(width: 28, height: 31)
+		.help("Open Screen Recording settings")
 	}
 }
 
@@ -359,16 +409,31 @@ private struct PermissionGuideArrow: View {
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 
 	var body: some View {
-		VStack(spacing: 4) {
+		HStack(spacing: 3) {
+			if pointsLeft {
+				arrow
+				dots
+			} else {
+				dots
+				arrow
+			}
+		}
+	}
+
+	private var arrow: some View {
+		Image(systemName: symbolName)
+			.font(.system(size: 19, weight: .bold))
+			.foregroundStyle(Color.accentColor)
+			.offset(x: arrowOffset)
+	}
+
+	private var dots: some View {
+		HStack(spacing: 3) {
 			ForEach(0..<3) { index in
 				Circle()
 					.fill(Color.accentColor.opacity(dotOpacity(index: index)))
-					.frame(width: 4.5, height: 4.5)
+					.frame(width: 3.8, height: 3.8)
 			}
-			Image(systemName: symbolName)
-				.font(.system(size: 22, weight: .bold))
-				.foregroundStyle(Color.accentColor)
-				.offset(x: arrowOffset)
 		}
 	}
 
@@ -392,5 +457,9 @@ private struct PermissionGuideArrow: View {
 		default:
 			return 0
 		}
+	}
+
+	private var pointsLeft: Bool {
+		symbolName == "arrow.left"
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/PermissionRecoveryGuideWindow.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/PermissionRecoveryGuideWindow.swift
@@ -1,0 +1,396 @@
+import AppKit
+import CoreGraphics
+import RsnapHostBridge
+import SwiftUI
+
+@MainActor
+final class PermissionRecoveryGuideWindowController: NSWindowController {
+	private enum GuideDirection: Equatable {
+		case left
+		case right
+
+		var symbolName: String {
+			switch self {
+			case .left:
+				return "arrow.left"
+			case .right:
+				return "arrow.right"
+			}
+		}
+	}
+
+	private static let windowSize = NSSize(width: 314, height: 118)
+	private static let windowGap: CGFloat = 14
+	private var kind: PermissionKind = .screenRecording
+	private var positionWorkItem: DispatchWorkItem?
+	private var statusPollWorkItem: DispatchWorkItem?
+	private var guideDirection: GuideDirection = .left
+
+	init() {
+		let panel = NSPanel(
+			contentRect: NSRect(origin: .zero, size: Self.windowSize),
+			styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
+			backing: .buffered,
+			defer: false
+		)
+		panel.backgroundColor = .clear
+		panel.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
+		panel.hasShadow = true
+		panel.hidesOnDeactivate = false
+		panel.isFloatingPanel = true
+		panel.isMovable = false
+		panel.isOpaque = false
+		panel.isReleasedWhenClosed = false
+		panel.level = .floating
+		super.init(window: panel)
+		updateRootView()
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	func present(kind: PermissionKind) {
+		self.kind = kind
+		NativePermissions.openSystemSettings(for: kind)
+		updateRootView()
+		positionAtFallbackLocation()
+		showWindow(nil)
+		window?.orderFrontRegardless()
+		scheduleSystemSettingsPositioning()
+		schedulePermissionStatusPolling()
+	}
+
+	override func close() {
+		positionWorkItem?.cancel()
+		statusPollWorkItem?.cancel()
+		positionWorkItem = nil
+		statusPollWorkItem = nil
+		super.close()
+	}
+
+	private func updateRootView() {
+		let bundleURL = Bundle.main.bundleURL
+		let appIcon = NSWorkspace.shared.icon(forFile: bundleURL.path)
+		window?.contentViewController = NSHostingController(
+			rootView: PermissionRecoveryGuideView(
+				directionSymbolName: guideDirection.symbolName,
+				bundleURL: bundleURL,
+				appIcon: appIcon,
+				openSettings: { [weak self] in
+					guard let self else {
+						return
+					}
+					NativePermissions.openSystemSettings(for: self.kind)
+					self.scheduleSystemSettingsPositioning()
+				},
+				close: { [weak self] in
+					self?.close()
+				}
+			)
+		)
+		window?.contentViewController?.view.wantsLayer = true
+		window?.contentViewController?.view.layer?.backgroundColor = NSColor.clear.cgColor
+	}
+
+	private func scheduleSystemSettingsPositioning() {
+		positionWorkItem?.cancel()
+		positionNearSystemSettings(remainingAttempts: 8)
+	}
+
+	private func positionNearSystemSettings(remainingAttempts: Int) {
+		if let settingsFrame = Self.systemSettingsWindowFrame() {
+			let direction = positionBesideSystemSettings(frame: settingsFrame)
+			if guideDirection != direction {
+				guideDirection = direction
+				updateRootView()
+			}
+			window?.orderFrontRegardless()
+			return
+		}
+
+		guard remainingAttempts > 0 else {
+			window?.orderFrontRegardless()
+			return
+		}
+		let workItem = DispatchWorkItem { [weak self] in
+			self?.positionNearSystemSettings(remainingAttempts: remainingAttempts - 1)
+		}
+		positionWorkItem = workItem
+		DispatchQueue.main.asyncAfter(deadline: .now() + 0.45, execute: workItem)
+	}
+
+	private func schedulePermissionStatusPolling() {
+		statusPollWorkItem?.cancel()
+		pollPermissionStatus(remainingAttempts: 90)
+	}
+
+	private func pollPermissionStatus(remainingAttempts: Int) {
+		guard window?.isVisible == true else {
+			return
+		}
+		if NativePermissions.status(for: kind) {
+			close()
+			return
+		}
+		guard remainingAttempts > 0 else {
+			return
+		}
+		let workItem = DispatchWorkItem { [weak self] in
+			self?.pollPermissionStatus(remainingAttempts: remainingAttempts - 1)
+		}
+		statusPollWorkItem = workItem
+		DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: workItem)
+	}
+
+	private func positionAtFallbackLocation() {
+		guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+			return
+		}
+		let visibleFrame = screen.visibleFrame
+		let origin = NSPoint(
+			x: visibleFrame.maxX - Self.windowSize.width - 30,
+			y: visibleFrame.maxY - Self.windowSize.height - 86
+		)
+		window?.setFrame(NSRect(origin: origin, size: Self.windowSize), display: true)
+		guideDirection = .left
+	}
+
+	@discardableResult
+	private func positionBesideSystemSettings(frame settingsFrame: CGRect) -> GuideDirection {
+		guard let screen = Self.screen(containing: settingsFrame) ?? NSScreen.main else {
+			return .left
+		}
+		let visibleFrame = screen.visibleFrame
+		let y = min(
+			max(settingsFrame.midY - Self.windowSize.height / 2, visibleFrame.minY + 12),
+			visibleFrame.maxY - Self.windowSize.height - 12
+		)
+		let rightOrigin = NSPoint(
+			x: settingsFrame.maxX + Self.windowGap,
+			y: y
+		)
+		if rightOrigin.x + Self.windowSize.width <= visibleFrame.maxX - 8 {
+			window?.setFrame(NSRect(origin: rightOrigin, size: Self.windowSize), display: true)
+			return .left
+		}
+
+		let leftOrigin = NSPoint(
+			x: settingsFrame.minX - Self.windowGap - Self.windowSize.width,
+			y: y
+		)
+		if leftOrigin.x >= visibleFrame.minX + 8 {
+			window?.setFrame(NSRect(origin: leftOrigin, size: Self.windowSize), display: true)
+			return .right
+		}
+
+		let fallbackOrigin = NSPoint(
+			x: min(
+				max(settingsFrame.maxX - Self.windowSize.width - 18, visibleFrame.minX + 8),
+				visibleFrame.maxX - Self.windowSize.width - 8
+			),
+			y: min(settingsFrame.maxY + 12, visibleFrame.maxY - Self.windowSize.height - 8)
+		)
+		window?.setFrame(NSRect(origin: fallbackOrigin, size: Self.windowSize), display: true)
+		return .left
+	}
+
+	private static func systemSettingsWindowFrame() -> CGRect? {
+		guard
+			let windowInfos = CGWindowListCopyWindowInfo(
+				[.optionOnScreenOnly, .excludeDesktopElements],
+				kCGNullWindowID
+			) as? [[String: Any]]
+		else {
+			return nil
+		}
+
+		return windowInfos.compactMap { info -> CGRect? in
+			guard
+				let ownerName = info[kCGWindowOwnerName as String] as? String,
+				ownerName == "System Settings" || ownerName == "System Preferences",
+				(info[kCGWindowLayer as String] as? Int) == 0,
+				let bounds = info[kCGWindowBounds as String] as? [String: Any],
+				let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary)
+			else {
+				return nil
+			}
+			return convertCGWindowFrameToAppKit(frame)
+		}
+		.max { lhs, rhs in
+			lhs.width * lhs.height < rhs.width * rhs.height
+		}
+	}
+
+	private static func convertCGWindowFrameToAppKit(_ cgFrame: CGRect) -> CGRect {
+		for screen in NSScreen.screens {
+			let candidate = CGRect(
+				x: cgFrame.minX,
+				y: screen.frame.maxY - cgFrame.maxY,
+				width: cgFrame.width,
+				height: cgFrame.height
+			)
+			if candidate.intersects(screen.frame.insetBy(dx: -40, dy: -40)) {
+				return candidate
+			}
+		}
+		guard let mainScreen = NSScreen.main else {
+			return cgFrame
+		}
+		return CGRect(
+			x: cgFrame.minX,
+			y: mainScreen.frame.maxY - cgFrame.maxY,
+			width: cgFrame.width,
+			height: cgFrame.height
+		)
+	}
+
+	private static func screen(containing frame: CGRect) -> NSScreen? {
+		NSScreen.screens.max { lhs, rhs in
+			intersectionArea(lhs.frame, frame) < intersectionArea(rhs.frame, frame)
+		}
+	}
+
+	private static func intersectionArea(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+		let intersection = lhs.intersection(rhs)
+		guard !intersection.isNull, !intersection.isInfinite else {
+			return 0
+		}
+		return max(0, intersection.width) * max(0, intersection.height)
+	}
+}
+
+private struct PermissionRecoveryGuideView: View {
+	let directionSymbolName: String
+	let bundleURL: URL
+	let appIcon: NSImage
+	let openSettings: () -> Void
+	let close: () -> Void
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
+	@Environment(\.colorScheme) private var colorScheme
+	@State private var pulse = false
+
+	var body: some View {
+		HStack(spacing: 12) {
+			PermissionGuideArrow(symbolName: directionSymbolName, pulse: pulse)
+				.frame(width: 38, height: 52)
+
+			VStack(alignment: .leading, spacing: 8) {
+				HStack(alignment: .center, spacing: 8) {
+					Text("Drag rsnap here")
+						.font(.system(size: 12.5, weight: .semibold))
+						.lineLimit(1)
+					Spacer(minLength: 6)
+					Button(action: close) {
+						Image(systemName: "xmark")
+							.font(.system(size: 9.5, weight: .bold))
+							.frame(width: 18, height: 18)
+					}
+					.buttonStyle(.plain)
+					.foregroundStyle(.secondary)
+					.help("Close")
+				}
+
+				HStack(spacing: 9) {
+					PermissionAppDragSource(bundleURL: bundleURL, icon: appIcon, label: "rsnap")
+						.frame(width: 116, height: 36)
+						.overlay {
+							Capsule()
+								.stroke(
+									Color.accentColor.opacity(pulse ? 0.58 : 0.20), lineWidth: 1.2
+								)
+								.scaleEffect(reduceMotion ? 1 : (pulse ? 1.06 : 1))
+								.allowsHitTesting(false)
+						}
+					Button(action: openSettings) {
+						Image(systemName: "gearshape")
+							.font(.system(size: 12.5, weight: .semibold))
+							.frame(width: 30, height: 30)
+					}
+					.buttonStyle(.plain)
+					.foregroundStyle(Color.accentColor)
+					.background(
+						Color.accentColor.opacity(colorScheme == .light ? 0.075 : 0.13),
+						in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+					)
+					.help("Open Screen Recording settings")
+				}
+
+				Text("Drop it into Screen Recording, then turn it on.")
+					.font(.system(size: 10, weight: .medium))
+					.foregroundStyle(.secondary)
+					.lineLimit(1)
+					.minimumScaleFactor(0.9)
+			}
+		}
+		.padding(.horizontal, 13)
+		.padding(.vertical, 11)
+		.frame(width: 314, height: 118)
+		.background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+		.background(panelFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+		.overlay {
+			RoundedRectangle(cornerRadius: 18, style: .continuous)
+				.stroke(panelBorder, lineWidth: 1)
+		}
+		.shadow(color: .black.opacity(colorScheme == .light ? 0.16 : 0.34), radius: 18, y: 8)
+		.onAppear {
+			guard !reduceMotion else {
+				return
+			}
+			withAnimation(.easeInOut(duration: 0.78).repeatForever(autoreverses: true)) {
+				pulse = true
+			}
+		}
+	}
+
+	private var panelFill: Color {
+		colorScheme == .light ? Color.white.opacity(0.42) : Color.black.opacity(0.20)
+	}
+
+	private var panelBorder: Color {
+		colorScheme == .light ? Color.black.opacity(0.10) : Color.white.opacity(0.16)
+	}
+}
+
+private struct PermissionGuideArrow: View {
+	let symbolName: String
+	let pulse: Bool
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+	var body: some View {
+		VStack(spacing: 4) {
+			ForEach(0..<3) { index in
+				Circle()
+					.fill(Color.accentColor.opacity(dotOpacity(index: index)))
+					.frame(width: 4.5, height: 4.5)
+			}
+			Image(systemName: symbolName)
+				.font(.system(size: 22, weight: .bold))
+				.foregroundStyle(Color.accentColor)
+				.offset(x: arrowOffset)
+		}
+	}
+
+	private func dotOpacity(index: Int) -> Double {
+		guard !reduceMotion else {
+			return 0.34
+		}
+		let activeIndex = pulse ? 2 : 0
+		return index == activeIndex ? 0.80 : 0.26
+	}
+
+	private var arrowOffset: CGFloat {
+		guard !reduceMotion else {
+			return 0
+		}
+		switch symbolName {
+		case "arrow.left":
+			return pulse ? -3 : 1
+		case "arrow.right":
+			return pulse ? 3 : -1
+		default:
+			return 0
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- open Screen Recording settings before revealing the floating permission guide
- add the drag-to-grant rsnap floating guide and refine it into a compact horizontal coach mark
- tighten the Settings permissions page and reduce Settings window height without showing a scrollbar

## Validation
- cargo make fmt-swift
- cargo make lint-swift-format
- cargo make build-swift-strict
- cargo make lint-swiftlint
- cargo make test-macos-native-host-stage
- git diff --check
- installed and verified /Applications/rsnap.app codesign