### PR TITLE
Rename macOS app branding to Rsnap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,11 +120,16 @@ jobs:
           RSNAP_NATIVE_HOST_SKIP_SIGN=1 \
           ./scripts/build_and_run.sh stage
 
-          APP_PATH="target/rsnap-native-host/rsnap.app"
+          APP_PATH="target/rsnap-native-host/Rsnap.app"
           if [[ ! -d "${APP_PATH}" ]]; then
             echo "Failed to find staged native host app at ${APP_PATH}" >&2
             exit 1
           fi
+          ACTUAL_APP_BUNDLE="$(find "target/rsnap-native-host" -maxdepth 1 -type d -iname 'Rsnap.app' -print -quit)"
+          test -n "${ACTUAL_APP_BUNDLE}"
+          test "$(basename "${ACTUAL_APP_BUNDLE}")" = "Rsnap.app"
+          test "$(plutil -extract CFBundleName raw "${APP_PATH}/Contents/Info.plist")" = "Rsnap"
+          test "$(plutil -extract CFBundleDisplayName raw "${APP_PATH}/Contents/Info.plist")" = "Rsnap"
 
           codesign \
             --force \
@@ -134,7 +139,7 @@ jobs:
             "${APP_PATH}"
           codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
 
-          NOTARY_ZIP="${RUNNER_TEMP}/rsnap-notary.zip"
+          NOTARY_ZIP="${RUNNER_TEMP}/Rsnap-notary.zip"
           ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${NOTARY_ZIP}"
 
           NOTARY_ARGS=(

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 authors     = ["Xavier Lau <x@acg.box>"]
-description = "Xnip-style screenshot utility scaffolding (Rust-only workspace)"
+description = "Rsnap macOS-first screenshot utility scaffolding"
 edition     = "2024"
 homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -268,12 +268,18 @@ workspace = false
 script = '''
 ./scripts/build_and_run.sh stage
 COMMON_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
-APP_PATH="${RSNAP_NATIVE_HOST_STAGE_DIR:-$COMMON_ROOT/target/rsnap-native-host}/rsnap.app"
+STAGE_DIR="${RSNAP_NATIVE_HOST_STAGE_DIR:-$COMMON_ROOT/target/rsnap-native-host}"
+APP_PATH="$STAGE_DIR/Rsnap.app"
+ACTUAL_APP_BUNDLE="$(find "$STAGE_DIR" -maxdepth 1 -type d -iname 'Rsnap.app' -print -quit)"
+test -n "$ACTUAL_APP_BUNDLE"
+test "$(basename "$ACTUAL_APP_BUNDLE")" = 'Rsnap.app'
 codesign --verify --deep --strict "$APP_PATH"
 codesign -dv --verbose=4 "$APP_PATH" 2>&1 | grep -q '^TeamIdentifier='
 test -x "$APP_PATH/Contents/MacOS/RsnapNativeHost"
 test -f "$APP_PATH/Contents/Info.plist"
 test -f "$APP_PATH/Contents/Resources/AppIcon.icns"
+plutil -extract CFBundleName raw "$APP_PATH/Contents/Info.plist" | grep -qx 'Rsnap'
+plutil -extract CFBundleDisplayName raw "$APP_PATH/Contents/Info.plist" | grep -qx 'Rsnap'
 plutil -extract CFBundleIdentifier raw "$APP_PATH/Contents/Info.plist" | grep -qx 'ink.hack.rsnap'
 if plutil -extract LSUIElement raw "$APP_PATH/Contents/Info.plist" >/dev/null 2>&1; then
   echo "LSUIElement must stay unset so Settings is a normal foreground window" >&2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# rsnap
+# Rsnap
 
 macOS-first screenshot prototype in native-host / Rust-core reset.
 
@@ -20,7 +20,7 @@ macOS-first screenshot prototype in native-host / Rust-core reset.
 - Transparent capture-session overlay that blocks desktop interaction.
 - HUD near the cursor showing global `x,y` and `rgb(r,g,b)`.
 - Left click + drag freezes a selected region; a single left click freezes the hovered window or falls back to the active monitor fullscreen.
-- On macOS, entering Frozen mode restores the pre-capture target after selection completes instead of leaving rsnap focused; exiting capture restores the original frontmost app.
+- On macOS, entering Frozen mode restores the pre-capture target after selection completes instead of leaving Rsnap focused; exiting capture restores the original frontmost app.
 - In Frozen mode, a dragged-region capture can be dragged from inside the bright selection area to reposition it without resizing.
 - In Frozen mode, `Space` copies the current frozen PNG to the clipboard and exits.
 - In Frozen mode, Cmd+S (macOS) / Ctrl+S saves the current PNG to disk and exits.
@@ -35,6 +35,14 @@ macOS-first screenshot prototype in native-host / Rust-core reset.
 ## Status
 
 Prototype / in active development.
+
+## App identity
+
+- Product display name: **Rsnap**.
+- macOS app bundle name: **Rsnap.app**.
+- Lower-case `rsnap` remains only for stable technical identifiers such as the repository slug,
+  Cargo package names, crate paths, environment variables, bundle identifiers, telemetry schemas,
+  and C ABI symbols. See `docs/spec/app-identity.md`.
 
 ## Reset posture
 
@@ -79,20 +87,20 @@ cargo run -p rsnap
 
 ### macOS permissions
 
-`rsnap` currently relies on **Screen Recording** permission to capture other apps/windows.
+Rsnap currently relies on **Screen Recording** permission to capture other apps/windows.
 - ScreenCaptureKit live sampling on macOS requires macOS 12.3+ and Screen Recording permission.
 - Normal region/window/monitor capture does not require Accessibility or Input Monitoring.
-- Scroll capture currently requires **Accessibility** because rsnap forwards scroll into the target app.
-- Scroll capture currently requires **Input Monitoring** because rsnap listens for global scroll-wheel input via a native macOS listen-event tap.
+- Scroll capture currently requires **Accessibility** because Rsnap forwards scroll into the target app.
+- Scroll capture currently requires **Input Monitoring** because Rsnap listens for global scroll-wheel input via a native macOS listen-event tap.
 - The native host currently disables scroll capture, so the active native feature set only requests Screen Recording.
-- macOS may phrase the Input Monitoring prompt as receiving keystrokes from any application even though rsnap only listens for scroll-wheel input in this path.
-- macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when rsnap bypasses the system picker.
+- macOS may phrase the Input Monitoring prompt as receiving keystrokes from any application even though Rsnap only listens for scroll-wheel input in this path.
+- macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when Rsnap bypasses the system picker.
 - The native menubar host exposes `Permissions…`, which shows Screen Recording, Accessibility, and Input Monitoring status. It marks Accessibility and Input Monitoring as not needed until native scroll automation is enabled.
-- Normal native capture depends on Screen Recording; if access is missing, rsnap opens the Screen Recording page in System Settings and shows a floating drag-to-grant guide.
+- Normal native capture depends on Screen Recording; if access is missing, Rsnap opens the Screen Recording page in System Settings and shows a floating drag-to-grant guide.
 - You can reopen `Permissions…` from the tray or menubar menu at any time.
 - Base capture path: `System Settings` -> `Privacy & Security` -> `Screen Recording`.
 - Scroll capture paths: `System Settings` -> `Privacy & Security` -> `Accessibility` and `Input Monitoring`.
-- Enable `rsnap` (the built `.app`), then retry capture. If macOS still keeps capture blocked after changing a permission, relaunch the app.
+- Enable `Rsnap.app`, then retry capture. If macOS still keeps capture blocked after changing a permission, relaunch the app.
 
 ### HUD settings behavior
 
@@ -119,7 +127,7 @@ cargo run -p rsnap
   returns to the original Frozen capture without exiting.
 - Output is configured in the native `Settings…` window:
   - `output directory` (default: Desktop)
-  - `filename prefix` (default: `rsnap`, sanitized to `[A-Za-z0-9_-]`)
+  - `filename prefix` (default: `Rsnap`, sanitized to `[A-Za-z0-9_-]`)
   - `output naming` (`timestamp` or `sequence`)
 
 ## Development
@@ -136,7 +144,7 @@ cargo make test-macos-native-host-stage
 Native-host local loop:
 
 - `scripts/build_and_run.sh` builds `rsnap-host-ffi`, builds `native/macos-host/`, stages
-  `target/rsnap-native-host/rsnap.app`, and launches it as a real `.app` bundle.
+  `target/rsnap-native-host/Rsnap.app`, and launches it as a real `.app` bundle.
 - On macOS, `cargo run -p rsnap` now delegates to that staged native host bundle instead of
   starting a legacy Rust-owned capture runtime.
 - `.codex/environments/environment.toml` points the Codex app Run button at that script.

--- a/apps/rsnap/src/lib.rs
+++ b/apps/rsnap/src/lib.rs
@@ -1,4 +1,4 @@
-//! Library surface for the `rsnap` native host crate.
+//! Library surface for the Rsnap native host crate.
 
 #![allow(unused_crate_dependencies)]
 

--- a/apps/rsnap/src/main.rs
+++ b/apps/rsnap/src/main.rs
@@ -1,4 +1,4 @@
-//! Desktop binary entrypoint for the `rsnap` application.
+//! Desktop binary entrypoint for the Rsnap application.
 
 #![allow(unused_crate_dependencies)]
 
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
 		op = "rsnap.starting",
 		version = build_info.version,
 		git_commit = build_info.git_commit,
-		"Starting rsnap."
+		"Starting Rsnap."
 	);
 
 	rsnap::run()

--- a/apps/rsnap/src/native_launcher_macos.rs
+++ b/apps/rsnap/src/native_launcher_macos.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use color_eyre::eyre::{self, Context as _, Result};
 
-const APP_NAME: &str = "rsnap.app";
+const APP_NAME: &str = "Rsnap.app";
 const STAGE_DIR_NAME: &str = "rsnap-native-host";
 
 /// Launches the staged native macOS host bundle for the current worktree.
@@ -105,5 +105,10 @@ mod tests {
 			.expect("worktree root should resolve");
 
 		assert_eq!(worktree_root, Path::new("/tmp/rsnap/.worktrees/native"));
+	}
+
+	#[test]
+	fn staged_native_host_bundle_uses_product_case() {
+		assert_eq!(native_launcher_macos::APP_NAME, "Rsnap.app");
 	}
 }

--- a/apps/rsnap/src/startup.rs
+++ b/apps/rsnap/src/startup.rs
@@ -66,7 +66,7 @@ pub fn init_logging() -> Option<WorkerGuard> {
 
 	let appender = match RollingFileAppender::builder()
 		.rotation(Rotation::DAILY)
-		.filename_prefix("rsnap")
+		.filename_prefix("Rsnap")
 		.filename_suffix("log")
 		.max_log_files(15)
 		.build(&log_dir)

--- a/apps/rsnap/src/unsupported_platform.rs
+++ b/apps/rsnap/src/unsupported_platform.rs
@@ -2,5 +2,5 @@ use color_eyre::eyre::{self, Result};
 
 /// Returns an explicit unsupported-platform error for non-macOS builds.
 pub fn run() -> Result<()> {
-	eyre::bail!("rsnap currently ships only the native macOS host")
+	eyre::bail!("Rsnap currently ships only the native macOS host")
 }

--- a/docs/decisions/annotation-pen-style.md
+++ b/docs/decisions/annotation-pen-style.md
@@ -4,7 +4,7 @@ Status: accepted
 Date: 2026-04-07
 Context:
 
-- `rsnap` uses the pen tool for screenshot annotation, not for professional drawing.
+- Rsnap uses the pen tool for screenshot annotation, not for professional drawing.
 - Users prefer a polished handwritten annotation look over faithful reproduction of every mouse
   wobble.
 - The governing behavior contract for this decision is `docs/spec/annotation-pen.md`.

--- a/docs/decisions/native-host-rust-core-reset.md
+++ b/docs/decisions/native-host-rust-core-reset.md
@@ -5,7 +5,7 @@ Date: 2026-04-18
 
 Context:
 
-- The existing rsnap implementation accumulated repeated ownership conflicts across platform
+- The existing Rsnap implementation accumulated repeated ownership conflicts across platform
   windows, focus/activation, cursor handling, IME, wheel routing, and fallback-heavy capture
   lifecycle behavior.
 - Earlier work attempted to repair those problems with mixed ownership, including passive shells,
@@ -13,12 +13,12 @@ Context:
   for more of the capture-window lifecycle than it should have.
 - That path did not produce a durable architecture for macOS, and it would make future platforms
   harder rather than easier.
-- At the same time, rsnap still benefits from keeping cross-platform product semantics, replay,
+- At the same time, Rsnap still benefits from keeping cross-platform product semantics, replay,
   geometry, annotation logic, stitching, and export composition in Rust.
 
 Decision:
 
-- rsnap will be reset around native platform hosts plus a Rust core.
+- Rsnap will be reset around native platform hosts plus a Rust core.
 - Native platform hosts own operating-system semantics:
   - capture-window lifecycle
   - focus/activation

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ The active split below is by question type, not by human-versus-agent audience.
   `docs/spec/host-core-protocol.md`
 - Need the product-level capture contract independent from implementation history ->
   `docs/spec/capture-session.md`
+- Need product display name, macOS app bundle identity, or lower-case identifier exceptions ->
+  `docs/spec/app-identity.md`
 - Need Settings, status-menu shortcut display, permission placement, Dock behavior, or Settings
   window semantics -> `docs/spec/settings.md`
 - Need telemetry fields, event names, metric names, or log correlation identifiers ->

--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -1,6 +1,6 @@
 # Host/Core Reset Reference
 
-Purpose: Describe the active target architecture for the rsnap reset lane and how new work should
+Purpose: Describe the active target architecture for the Rsnap reset lane and how new work should
 behave while the checked-in codebase is still transitional.
 
 Read this when: You are planning architecture work, deciding whether a change deepens the right

--- a/docs/reference/live-sampling.md
+++ b/docs/reference/live-sampling.md
@@ -1,6 +1,6 @@
 # Live Sampling Reference
 
-Purpose: Describe the current stream-first live RGB/loupe sampling path and why rsnap uses it.
+Purpose: Describe the current stream-first live RGB/loupe sampling path and why Rsnap uses it.
 
 Read this when: You are working on live HUD updates, loupe behavior, cursor-path performance, or
 hovered-window outline responsiveness.
@@ -27,7 +27,7 @@ architecture. For the reset architecture route, start with `docs/reference/host-
 
 ## Why this doc exists
 
-rsnap current UX requires instant updates on cursor movement:
+Rsnap current UX requires instant updates on cursor movement:
 
 - RGB under cursor
 - Loupe patch under cursor
@@ -43,7 +43,7 @@ This reference records the current stream-first implementation and why it is use
 Even after moving hover outline + sampling to overlay-local caches, fast cursor movement could
 still stall the HUD/Loupe UI (for example, circling quickly across window corners).
 
-Key observation: system cursor tracking remains smooth while rsnap updates lag, indicating
+Key observation: system cursor tracking remains smooth while Rsnap updates lag, indicating
 app-side stalls in the live path.
 
 ## Root causes that were observed
@@ -62,7 +62,7 @@ Window refresh and sampling work in the same high-frequency path increases jitte
 
 ## Implemented stream path
 
-rsnap now uses the following live model on macOS:
+Rsnap now uses the following live model on macOS:
 
 - Keep a per-monitor `SCStream` alive while in live mode.
 - Store the latest frame in shared state.
@@ -127,7 +127,7 @@ Frozen commit must use `FrozenFrameAuthority` or another source with equivalent 
   self-capture-excluding stream alive until the replacement stream is configured so fast click
   selection cannot fail with `no_fresh_frame` solely because content-filter lookup is still
   running. Once the replacement stream is ready, the first Frozen display frame must come from a
-  self-capture-excluding filter, not from a pre-overlay filter that can see rsnap's own live mask,
+  self-capture-excluding filter, not from a pre-overlay filter that can see Rsnap's own live mask,
   border, badge, or toolbar.
 - If no freshness-proven frame is available, fail the freeze with `no_fresh_frame` instead of
   showing a screenshot from seconds earlier.

--- a/docs/reference/window-hit-testing.md
+++ b/docs/reference/window-hit-testing.md
@@ -1,7 +1,7 @@
 # Window Hit-Testing Reference
 
 Purpose: Describe the current live-mode window hit-testing strategy and the default choice used by
-rsnap.
+Rsnap.
 
 Read this when: You are changing hovered-window outline behavior, evaluating live hit-test
 latency, or comparing candidate hit-testing strategies.
@@ -24,7 +24,7 @@ boundary for the reset lane. For the active target architecture, start with
 
 ## Current Strategy Scope
 
-This reference describes the current window-outline strategy used by rsnap live mode as of March
+This reference describes the current window-outline strategy used by Rsnap live mode as of March
 2026.
 
 ## Strategy A (current, default)

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -1,6 +1,6 @@
 # Workspace Layout Reference
 
-Purpose: Explain the current rsnap workspace layout, which crate owns which behavior today, and
+Purpose: Explain the current Rsnap workspace layout, which crate owns which behavior today, and
 which directories are source versus generated or runtime-local.
 
 Read this when: You are deciding where a change belongs in the current tree, checking whether the
@@ -162,7 +162,7 @@ Rust core.
 These paths are intentionally ignored and should not be treated as tracked repository structure:
 
 - `target/`: Rust build products, benchmark outputs, and local analysis artifacts
-- `target/rsnap-native-host/`: locally staged native-host `.app` bundles from
+- `target/rsnap-native-host/`: locally staged native-host `Rsnap.app` bundles from
   `scripts/build_and_run.sh`
 - `.worktrees/`: local git worktree lanes
 - `.workspaces/`: local clone-backed workspace lanes from older workflows

--- a/docs/runbook/architecture-reset-validation.md
+++ b/docs/runbook/architecture-reset-validation.md
@@ -6,7 +6,7 @@ assumptions.
 Read this when: You changed docs, boundaries, native-host code, or Rust-core code under the host /
 core reset and need a bounded validation sequence.
 
-Inputs: A build of `rsnap`, the touched change set, and the governing specs:
+Inputs: A build of Rsnap, the touched change set, and the governing specs:
 `docs/spec/capture-session.md`, `docs/spec/platform-host-boundary.md`, and
 `docs/spec/performance.md`.
 

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -150,7 +150,7 @@ Dedicated macOS smoke:
   suspect live overlay cadence, desktop-session conditions, or smoke-harness environment drift.
 - `scripts/smoke/native-visual-contract-macos.sh` failures:
   treat them as native-host visual or behavior contract regressions. The smoke runs Liquid Glass and
-  Classic Glass cases, screenshots rsnap's own frozen overlay, and verifies frozen handoff timing,
+  Classic Glass cases, screenshots Rsnap's own frozen overlay, and verifies frozen handoff timing,
   toolbar visibility, Liquid toolbar content draw, material selection, and that live-to-frozen did
   not display a pending half-frame before the complete frozen UI. It also samples outside the
   selection during release so a disappearing/reappearing scrim fails even if the final screenshot

--- a/docs/runbook/telemetry-debugging.md
+++ b/docs/runbook/telemetry-debugging.md
@@ -1,6 +1,6 @@
 # Telemetry Debugging
 
-Goal: Collect and summarize rsnap native-host and Rust telemetry for screenshot,
+Goal: Collect and summarize Rsnap native-host and Rust telemetry for screenshot,
 ScreenCaptureKit, live chrome, and capture-output debugging.
 
 Read this when: A local run has a performance, startup, frozen-frame, pasteboard, live

--- a/docs/spec/annotation-pen.md
+++ b/docs/spec/annotation-pen.md
@@ -1,4 +1,4 @@
-# rsnap Annotation Pen Contract
+# Rsnap Annotation Pen Contract
 
 Purpose: Define the normative behavior contract for the Frozen-mode pen tool used for screenshot
 annotation.

--- a/docs/spec/app-identity.md
+++ b/docs/spec/app-identity.md
@@ -1,0 +1,57 @@
+# Rsnap App Identity Contract
+
+Purpose: Define the product display name, macOS app bundle name, and allowed stable technical
+identifiers for Rsnap.
+
+Status: normative
+
+Read this when:
+
+- Changing user-visible app names, Settings text, permission guidance, release packaging, or
+  local macOS bundle staging.
+- Auditing whether a lower-case `rsnap` occurrence is a branding miss or an intentional technical
+  identifier.
+
+Not this document:
+
+- Use `docs/reference/workspace-layout.md` for crate and directory ownership.
+- Use `docs/spec/telemetry.md` for telemetry schema names and log predicates.
+
+Defines:
+
+- Product display name.
+- macOS `.app` bundle name.
+- Stable lower-case technical identifiers that must not be title-cased.
+
+## Required user-visible names
+
+- The product display name is `Rsnap`.
+- The macOS app bundle is `Rsnap.app`.
+- `CFBundleName` and `CFBundleDisplayName` must resolve to `Rsnap` for the staged native host
+  bundle.
+- Permission recovery drag chips and other UI affordances that represent the dragged bundle must
+  show `Rsnap.app`.
+- User-facing Settings, permission, onboarding, README, and runtime error text should use
+  `Rsnap` when referring to the app or product.
+- The default saved-capture filename prefix is `Rsnap`.
+
+## Stable technical identifiers
+
+Keep these identifiers lower-case unless a separate migration explicitly changes their technical
+contract:
+
+- Repository slug and URLs: `hack-ink/rsnap`.
+- Cargo package names, crate names, binary package selectors, and source paths such as
+  `rsnap`, `rsnap-overlay`, `rsnap-capture-core`, `rsnap-host-ffi`, and `apps/rsnap/`.
+- Environment variables and build-time constants such as `RSNAP_NATIVE_HOST_STAGE_DIR`.
+- Bundle identifier and preference domain: `ink.hack.rsnap`.
+- Telemetry schemas and log predicates such as `rsnap.native_host.telemetry/1` and
+  `rsnap.rust.telemetry/1`.
+- C ABI symbols, headers, and Swift module bridge names containing `rsnap` or `Rsnap`.
+- Local build directories such as `target/rsnap-native-host/`.
+
+## Packaging invariant
+
+Local staging, release packaging, and launcher fallback lookup must all use
+`target/rsnap-native-host/Rsnap.app` unless `RSNAP_NATIVE_HOST_STAGE_DIR` overrides only the stage
+directory. The override must still contain `Rsnap.app`, not `rsnap.app`.

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -1,6 +1,6 @@
-# rsnap Capture Session Contract
+# Rsnap Capture Session Contract
 
-Purpose: Define the product-level normative contract for rsnap capture flow, Frozen-mode
+Purpose: Define the product-level normative contract for Rsnap capture flow, Frozen-mode
 behavior, export readiness, and macOS-first scroll capture.
 
 Status: normative
@@ -26,7 +26,7 @@ product level rather than binding itself to a particular window toolkit or shell
 
 ## Architecture posture
 
-- rsnap product behavior must remain valid independently from any specific capture-window
+- Rsnap product behavior must remain valid independently from any specific capture-window
   implementation strategy.
 - Platform-native ownership of windows, focus, activation, cursor, IME, permissions, clipboard,
   save panels, OCR, and native capture capabilities is governed by
@@ -38,7 +38,7 @@ product level rather than binding itself to a particular window toolkit or shell
 
 1. Background app shell on macOS: no Dock icon while Settings is closed and no other ordinary app
    window is visible. Opening Settings may temporarily use a normal app/window activation policy;
-   closing Settings must return rsnap to the background menubar shell.
+   closing Settings must return Rsnap to the background menubar shell.
 2. Global hotkey starts capture session (default `Alt+X`, macOS: Option+X) and can be customized
    from Settings.
 3. The status menu's New Capture item must use the configured capture shortcut. Shortcut display
@@ -49,12 +49,12 @@ product level rather than binding itself to a particular window toolkit or shell
    Settings.
 5. When the capture session UI is visible, underlying desktop content MUST NOT be interactive.
 6. The visible capture UI should be transparent and non-dimming by default.
-7. On macOS, rsnap overlay, HUD, loupe, frozen toolbar, and scroll preview surfaces MUST remain
+7. On macOS, Rsnap overlay, HUD, loupe, frozen toolbar, and scroll preview surfaces MUST remain
    externally capturable by system screenshot and screen-recording tools. Internal self-capture
-   correctness comes from rsnap's own capture filters and handoff logic, not window content
+   correctness comes from Rsnap's own capture filters and handoff logic, not window content
    protection.
-   External tools being allowed to capture rsnap UI is only a debugging/export affordance. rsnap's
-   own Frozen first frame MUST NOT capture rsnap's live mask, dashed selection border, size badge,
+   External tools being allowed to capture Rsnap UI is only a debugging/export affordance. Rsnap's
+   own Frozen first frame MUST NOT capture Rsnap's live mask, dashed selection border, size badge,
    toolbar, loupe, or transitional Frozen UI into the frozen display image.
 8. The product contract does not require any specific platform window implementation. Focus,
    cursor, keyboard, and IME correctness are mandatory outcomes, regardless of how the native host
@@ -105,7 +105,7 @@ product level rather than binding itself to a particular window toolkit or shell
 - Entering capture MUST NOT leave the target app permanently deactivated after the selection
   completes.
 - On macOS, live drag and window-click entry into Frozen mode must restore the pre-capture target
-  after selection instead of leaving rsnap focused.
+  after selection instead of leaving Rsnap focused.
 - Exiting capture must restore the originally captured frontmost application where the platform
   allows that behavior.
 - Normal interaction must not require a visible Dock activation or an implementation artifact such
@@ -141,7 +141,7 @@ product level rather than binding itself to a particular window toolkit or shell
   single visible handoff instead of waiting on a later visible capture swap.
 - The live-to-Frozen handoff MUST NOT flash through a blank surface, a mask/scrim-only state, or
   any other intermediate mode-switch artifact.
-- The live-to-Frozen handoff MUST NOT show a doubled mask/scrim caused by capturing rsnap's own
+- The live-to-Frozen handoff MUST NOT show a doubled mask/scrim caused by capturing Rsnap's own
   capture UI into the frozen display image. Frozen-frame streams that were created before capture
   overlay windows became visible must be rebuilt or invalidated before their frames can be used for
   the first Frozen display image.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -56,6 +56,8 @@ Then keep the body explicit:
 
 - `docs/spec/capture-session.md` for the product-level capture-flow, Frozen-mode, and
   scroll-capture contract
+- `docs/spec/app-identity.md` for the Rsnap product display name, macOS `Rsnap.app` bundle
+  identity, and stable lower-case technical identifiers
 - `docs/spec/settings.md` for Settings, status-menu, shortcut, permission, Dock, and Settings
   window behavior
 - `docs/spec/platform-host-boundary.md` for the normative ownership boundary between native hosts

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -1,6 +1,6 @@
-# rsnap Performance Contract
+# Rsnap Performance Contract
 
-Purpose: Define the normative performance-tracking contract for rsnap so render cadence,
+Purpose: Define the normative performance-tracking contract for Rsnap so render cadence,
 measurement surfaces, thresholds, and known contract gaps are explicit and shared across code,
 benchmarks, smoke harnesses, and tracker issues.
 
@@ -19,14 +19,14 @@ Primary procedures:
   use
 
 Defines:
-- the active render cadence contract for rsnap UI and overlay paths
+- the active render cadence contract for Rsnap UI and overlay paths
 - the tracked performance scenarios and their primary metrics
 - the distinction between target cadence, diagnostic thresholds, and coarse smoke gates
 - the current cadence implementation status and any known gap against the agreed contract
 
 ## Scope
 
-This contract applies to performance tracking for actively rendered rsnap surfaces:
+This contract applies to performance tracking for actively rendered Rsnap surfaces:
 
 - live overlay redraw
 - HUD and loupe movement while live
@@ -40,7 +40,7 @@ or animation.
 
 ## Cadence classes
 
-rsnap tracks two different cadence classes. They must not be collapsed into one number during
+Rsnap tracks two different cadence classes. They must not be collapsed into one number during
 implementation, telemetry review, or smoke interpretation.
 
 ### Display-bound presentation cadence
@@ -54,7 +54,7 @@ Practical meaning:
 
 - On a `120 Hz` or faster display, the target frame budget is `8.33 ms`.
 - On a `60 Hz` display, the target frame budget is `16.67 ms`.
-- If the display refresh rate is unavailable, rsnap uses the conservative `60 Hz` fallback.
+- If the display refresh rate is unavailable, Rsnap uses the conservative `60 Hz` fallback.
 - A `60 Hz` panel cannot physically display `120` distinct visual updates per second. On that
   hardware, the visual contract is one responsive update per display frame, not impossible
   `8.33 ms` presentation.
@@ -254,7 +254,7 @@ metrics before claiming contract compliance.
 
 ## Minimum artifact set for contract compliance
 
-The rsnap performance-tracking project should maintain all of the following:
+The Rsnap performance-tracking project should maintain all of the following:
 
 - one normative spec for cadence, scenarios, metrics, and known gaps
 - one or more direct benchmark surfaces for render-heavy components

--- a/docs/spec/platform-host-boundary.md
+++ b/docs/spec/platform-host-boundary.md
@@ -1,7 +1,7 @@
 # Platform Host Boundary
 
 Purpose: Define the normative ownership boundary between native platform hosts and the Rust core
-for the rsnap architecture reset.
+for the Rsnap architecture reset.
 
 Status: normative
 
@@ -21,7 +21,7 @@ Defines:
 
 ## Architecture rule
 
-rsnap must be organized around:
+Rsnap must be organized around:
 
 - native platform hosts that own operating-system semantics
 - a Rust core that owns cross-platform product semantics

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -1,7 +1,7 @@
 # Settings and App Shell Contract
 
 Purpose: Define the normative Settings, status-menu, shortcut, permission, and macOS app-shell
-behavior for rsnap.
+behavior for Rsnap.
 
 Status: normative
 
@@ -21,11 +21,11 @@ Defines:
 
 ## App Shell
 
-- rsnap is a background menubar app while Settings is closed: it must not keep a Dock icon visible
+- Rsnap is a background menubar app while Settings is closed: it must not keep a Dock icon visible
   in the idle menubar state.
-- Opening Settings may temporarily promote rsnap to an ordinary app-window activation state so the
+- Opening Settings may temporarily promote Rsnap to an ordinary app-window activation state so the
   Settings window participates in normal macOS focus, keyboard, and window management.
-- Closing Settings must return rsnap to the background menubar state when no other ordinary app
+- Closing Settings must return Rsnap to the background menubar state when no other ordinary app
   window is visible.
 - Capture sessions must not require visible Dock activation artifacts to begin, complete, cancel,
   copy, save, or restore focus.
@@ -42,10 +42,10 @@ Defines:
 ## Settings Window
 
 - Settings must be an ordinary top-level platform window, not only an overlay surface.
-- Settings must be selectable by system screenshot/window-picking tools and by rsnap's own window
+- Settings must be selectable by system screenshot/window-picking tools and by Rsnap's own window
   selector so normal selection effects can apply to it.
 - Settings must support standard macOS shortcuts: `Command-W` closes the Settings window and
-  `Command-Q` quits rsnap.
+  `Command-Q` quits Rsnap.
 - The Settings window background must not globally hijack drag gestures. Draggable controls and
   component hit testing must receive their own pointer gestures.
 
@@ -63,7 +63,7 @@ Defines:
 
 - Capture shortcut: `Option-X`.
 - Output directory: `~/Desktop`.
-- Output filename prefix: `rsnap`.
+- Output filename prefix: `Rsnap`.
 - Output naming: timestamp.
 - Frozen toolbar placement: bottom.
 - Frozen resize handles: outward.
@@ -79,14 +79,14 @@ Defines:
 
 - Settings must include a Permissions section.
 - Screen Recording permission is required for the current native macOS capture host.
-- When Screen Recording is missing at launch or at capture start, rsnap must open the macOS Screen
-  Recording privacy page and present a small rsnap-owned floating drag guide near System Settings.
+- When Screen Recording is missing at launch or at capture start, Rsnap must open the macOS Screen
+  Recording privacy page and present a small Rsnap-owned floating drag guide near System Settings.
 - Accessibility and Input Monitoring may be displayed as diagnostic permissions, but they must not
   be presented as required when the current native host does not need them.
-- Permission recovery should provide a visible drag-the-app affordance for adding rsnap to System
+- Permission recovery should provide a visible drag-the-app affordance for adding Rsnap to System
   Settings where macOS allows that workflow, including a directional guide from the floating window
   toward System Settings and an Open System Settings fallback.
-- Permission status refresh must be available without restarting rsnap.
+- Permission status refresh must be available without restarting Rsnap.
 
 ## Default-Size Usability
 

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -1,7 +1,7 @@
 # Telemetry Schema
 
 Purpose: Define the required telemetry fields, source boundaries, and naming rules for
-rsnap runtime debugging.
+Rsnap runtime debugging.
 
 Status: normative
 
@@ -15,7 +15,7 @@ metric names, and correlation identifiers.
 
 ## Sources
 
-rsnap has two active telemetry sources.
+Rsnap has two active telemetry sources.
 
 | Source | Transport | Schema | Primary file |
 | --- | --- | --- | --- |

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -243,11 +243,11 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		didBootstrap = true
 		NativeHostTelemetry.lifecycleEvent("native_host.finish_launching_begin")
 		NSApp.setActivationPolicy(.accessory)
-		ProcessInfo.processInfo.disableAutomaticTermination("rsnap menubar host")
+		ProcessInfo.processInfo.disableAutomaticTermination("Rsnap menubar host")
 		ProcessInfo.processInfo.disableSuddenTermination()
 		lifecycleActivity = ProcessInfo.processInfo.beginActivity(
 			options: [.automaticTerminationDisabled, .suddenTerminationDisabled],
-			reason: "rsnap menubar host"
+			reason: "Rsnap menubar host"
 		)
 		Self.applyApplicationIcon()
 		configureStatusItem()
@@ -405,7 +405,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 			}
 		}
 
-		let menu = NSMenu(title: "Rsnap Native Host")
+		let menu = NSMenu(title: NativeHostBrand.displayName)
 		let captureItem = menu.addItem(
 			withTitle: "New Capture",
 			action: #selector(startCapture(_:)),

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostBrand.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostBrand.swift
@@ -1,0 +1,5 @@
+enum NativeHostBrand {
+	static let displayName = "Rsnap"
+	static let appBundleName = "Rsnap.app"
+	static let defaultFilenamePrefix = "Rsnap"
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -132,7 +132,7 @@ struct NativeHostSettings: Equatable {
 			captureHotkey: "Option-X",
 			outputDirectory: FileManager.default.homeDirectoryForCurrentUser
 				.appendingPathComponent("Desktop", isDirectory: true),
-			outputFilenamePrefix: "rsnap",
+			outputFilenamePrefix: NativeHostBrand.defaultFilenamePrefix,
 			outputNaming: .timestamp,
 			toolbarPlacement: .bottom,
 			frozenResizeHandleOrientation: .outward,
@@ -174,7 +174,7 @@ struct NativeHostSettings: Equatable {
 			return "_"
 		}
 		let collapsed = String(sanitized).trimmingCharacters(in: CharacterSet(charactersIn: "_"))
-		return collapsed.isEmpty ? "rsnap" : collapsed
+		return collapsed.isEmpty ? NativeHostBrand.defaultFilenamePrefix : collapsed
 	}
 
 	private static func sanitizeCaptureHotkey(_ raw: String) -> String {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -144,7 +144,7 @@ private struct SettingsRail: View {
 			HStack(spacing: 8) {
 				SettingsBrandIcon()
 				VStack(alignment: .leading, spacing: 2) {
-					Text("rsnap")
+					Text(NativeHostBrand.displayName)
 						.font(.system(size: 17, weight: .semibold, design: .rounded))
 					Text("Settings")
 						.font(.system(size: 10.5, weight: .medium))
@@ -1392,21 +1392,8 @@ private struct PermissionsSettingsPanel: View {
 				}
 			)
 
-			VStack(spacing: 6) {
-				VStack(spacing: 0) {
-					ForEach(Self.rows.prefix(2)) { row in
-						PermissionStatusTile(
-							row: row,
-							refreshID: refreshID,
-							openSettings: { kind in
-								NativePermissions.openSystemSettings(for: kind)
-								refreshID += 1
-							}
-						)
-					}
-				}
-
-				ForEach(Self.rows.dropFirst(2)) { row in
+			VStack(spacing: 0) {
+				ForEach(Self.rows) { row in
 					PermissionStatusTile(
 						row: row,
 						refreshID: refreshID,
@@ -1429,11 +1416,6 @@ private struct PermissionsSettingsPanel: View {
 	}
 
 	private static let rows: [PermissionSettingsRow] = [
-		PermissionSettingsRow(
-			kind: .screenRecording,
-			title: "Screen Recording",
-			symbolName: "rectangle.on.rectangle"
-		),
 		PermissionSettingsRow(
 			kind: .accessibility,
 			title: "Accessibility",
@@ -1499,9 +1481,13 @@ private struct PermissionGrantCard: View {
 			}
 
 			HStack(alignment: .center, spacing: 8) {
-				PermissionAppDragSource(bundleURL: bundleURL, icon: appIcon, label: "rsnap")
-					.frame(width: 108, height: 31)
-					.opacity(isGranted ? 0.76 : 1)
+				PermissionAppDragSource(
+					bundleURL: bundleURL,
+					icon: appIcon,
+					label: NativeHostBrand.appBundleName
+				)
+				.frame(width: 108, height: 31)
+				.opacity(isGranted ? 0.76 : 1)
 
 				Spacer(minLength: 6)
 
@@ -1544,7 +1530,7 @@ private struct PermissionGrantCard: View {
 		if isGranted {
 			return "The native capture host can see the screen."
 		}
-		return "Open System Settings, then drag rsnap into the Screen Recording app list."
+		return "Open System Settings, then drag Rsnap.app into the Screen Recording app list."
 	}
 
 	private var iconBackgroundColor: Color {
@@ -1724,7 +1710,7 @@ private struct OutputSettingsPanel: View {
 					subtitle: "Safe text."
 				) {
 					TextField(
-						"rsnap",
+						NativeHostBrand.defaultFilenamePrefix,
 						text: Binding(
 							get: { model.settings.outputFilenamePrefix },
 							set: { value in model.update { $0.outputFilenamePrefix = value } }

--- a/native/macos-host/Sources/RsnapNativeHostKit/PermissionAppDragSource.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/PermissionAppDragSource.swift
@@ -28,7 +28,7 @@ final class PermissionAppDragSourceView: NSView, NSDraggingSource {
 		super.init(frame: .zero)
 		wantsLayer = true
 		layer?.cornerCurve = .continuous
-		toolTip = "Drag rsnap to System Settings"
+		toolTip = "Drag \(label) to System Settings"
 	}
 
 	@available(*, unavailable)
@@ -48,6 +48,7 @@ final class PermissionAppDragSourceView: NSView, NSDraggingSource {
 		self.bundleURL = bundleURL
 		self.icon = icon
 		self.label = label
+		toolTip = "Drag \(label) to System Settings"
 		needsDisplay = true
 		invalidateIntrinsicContentSize()
 	}
@@ -125,32 +126,41 @@ final class PermissionAppDragSourceView: NSView, NSDraggingSource {
 		path.lineWidth = 1
 		path.stroke()
 
+		let paragraph = NSMutableParagraphStyle()
+		paragraph.lineBreakMode = .byTruncatingTail
+		let labelAttributes: [NSAttributedString.Key: Any] = [
+			.font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+			.foregroundColor: isDark
+				? NSColor.white.withAlphaComponent(0.92)
+				: NSColor.black.withAlphaComponent(0.78),
+			.paragraphStyle: paragraph,
+		]
 		let iconSize: CGFloat = 20
+		let iconLabelGap: CGFloat = 7
+		let horizontalPadding: CGFloat = 12
+		let maxLabelWidth = max(0, chipRect.width - horizontalPadding * 2 - iconSize - iconLabelGap)
+		let measuredLabelSize = (label as NSString).size(withAttributes: labelAttributes)
+		let labelWidth = min(ceil(measuredLabelSize.width), maxLabelWidth)
+		let labelHeight = ceil(measuredLabelSize.height)
+		let contentWidth = iconSize + iconLabelGap + labelWidth
+		let contentOriginX = chipRect.midX - contentWidth / 2
 		let iconRect = NSRect(
-			x: 8,
-			y: (rect.height - iconSize) / 2,
+			x: contentOriginX,
+			y: chipRect.midY - iconSize / 2,
 			width: iconSize,
 			height: iconSize
 		)
 		icon.draw(in: iconRect, from: .zero, operation: .sourceOver, fraction: 1)
 
-		let paragraph = NSMutableParagraphStyle()
-		paragraph.lineBreakMode = .byTruncatingTail
 		let labelRect = NSRect(
-			x: iconRect.maxX + 6,
-			y: (rect.height - 16) / 2,
-			width: max(0, rect.width - iconRect.maxX - 16),
-			height: 17
+			x: iconRect.maxX + iconLabelGap,
+			y: chipRect.midY - labelHeight / 2,
+			width: labelWidth,
+			height: labelHeight
 		)
 		(label as NSString).draw(
 			in: labelRect,
-			withAttributes: [
-				.font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-				.foregroundColor: isDark
-					? NSColor.white.withAlphaComponent(0.92)
-					: NSColor.black.withAlphaComponent(0.78),
-				.paragraphStyle: paragraph,
-			]
+			withAttributes: labelAttributes
 		)
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/PermissionRecoveryGuideWindow.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/PermissionRecoveryGuideWindow.swift
@@ -366,14 +366,16 @@ private struct PermissionRecoveryGuideView: View {
 	}
 
 	private var appDragChip: some View {
-		PermissionAppDragSource(bundleURL: bundleURL, icon: appIcon, label: "rsnap")
-			.frame(width: 114, height: 31)
-			.overlay {
-				Capsule()
-					.stroke(Color.accentColor.opacity(pulse ? 0.58 : 0.20), lineWidth: 1.2)
-					.scaleEffect(reduceMotion ? 1 : (pulse ? 1.055 : 1))
-					.allowsHitTesting(false)
-			}
+		PermissionAppDragSource(
+			bundleURL: bundleURL, icon: appIcon, label: NativeHostBrand.appBundleName
+		)
+		.frame(width: 114, height: 31)
+		.overlay {
+			Capsule()
+				.stroke(Color.accentColor.opacity(pulse ? 0.58 : 0.20), lineWidth: 1.2)
+				.scaleEffect(reduceMotion ? 1 : (pulse ? 1.055 : 1))
+				.allowsHitTesting(false)
+		}
 	}
 
 	private var instructionText: some View {

--- a/packages/rsnap-capture-core/Cargo.toml
+++ b/packages/rsnap-capture-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace    = true
-description          = "Platform-neutral capture-session semantics and host/core protocol models for rsnap"
+description          = "Platform-neutral capture-session semantics and host/core protocol models for Rsnap"
 edition.workspace    = true
 homepage.workspace   = true
 license.workspace    = true

--- a/packages/rsnap-host-ffi/Cargo.toml
+++ b/packages/rsnap-host-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace    = true
-description          = "Thin C ABI bridge for the rsnap native host reset"
+description          = "Thin C ABI bridge for the Rsnap native host reset"
 edition.workspace    = true
 homepage.workspace   = true
 license.workspace    = true

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -2494,7 +2494,7 @@ fn build_stream_content_filter(
 					monitor_id,
 					pid = process::id(),
 					excepting_window_count,
-					"Configured ScreenCaptureKit to exclude rsnap windows from the live stream."
+					"Configured ScreenCaptureKit to exclude Rsnap windows from the live stream."
 				);
 
 				PreparedStreamFilter {
@@ -2567,7 +2567,7 @@ fn build_shareable_window_filter(
 			excepting_window_count,
 			fallback_excluded_window_count,
 			missing_window_ids = ?missing_window_ids,
-			"ScreenCaptureKit omitted at least one requested self-capture exception window; falling back to excluding only rsnap's currently shareable windows."
+			"ScreenCaptureKit omitted at least one requested self-capture exception window; falling back to excluding only Rsnap's currently shareable windows."
 		);
 	}
 
@@ -2603,7 +2603,7 @@ fn log_missing_current_process_fallback(
 		pid = process::id(),
 		excepting_window_count,
 		fallback_excluded_window_count,
-		"ScreenCaptureKit omitted rsnap's running application during stream setup; falling back to excluding only rsnap's currently shareable windows."
+		"ScreenCaptureKit omitted Rsnap's running application during stream setup; falling back to excluding only Rsnap's currently shareable windows."
 	);
 }
 

--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -977,7 +977,7 @@ pub struct OverlayConfig {
 	pub output_naming: OutputNaming,
 	/// Selects how transparent window captures are flattened.
 	pub window_capture_alpha_mode: WindowCaptureAlphaMode,
-	/// Current-process windows that should remain capturable while the rest of rsnap stays excluded.
+	/// Current-process windows that should remain capturable while the rest of Rsnap stays excluded.
 	pub self_capture_exception_window_ids: Vec<u32>,
 }
 impl Default for OverlayConfig {
@@ -997,7 +997,7 @@ impl Default for OverlayConfig {
 			loupe_sample_side_px: 21,
 			theme_mode: ThemeMode::System,
 			output_dir: PathBuf::from("."),
-			output_filename_prefix: String::from("rsnap"),
+			output_filename_prefix: String::from("Rsnap"),
 			output_naming: OutputNaming::Timestamp,
 			window_capture_alpha_mode: WindowCaptureAlphaMode::Background,
 			self_capture_exception_window_ids: Vec::new(),
@@ -2773,7 +2773,7 @@ impl OverlaySession {
 		self.skip_toolbar_focus_on_next_show = true;
 		#[cfg(target_os = "macos")]
 		{
-			// Keep rsnap active for the entire overlay session so AppKit continues to honor native
+			// Keep Rsnap active for the entire overlay session so AppKit continues to honor native
 			// crosshair / grab / resize cursors. The pre-capture frontmost app is restored on exit.
 			self.preserve_frontmost_on_next_toolbar_show = false;
 		}

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -192,8 +192,8 @@ impl MacOSCaptureHost {
 		self.frontmost_application_before_start = super::macos_frontmost_application();
 		self.last_synced_frozen_mode = false;
 
-		// AppKit only keeps native cursor ownership stable while rsnap is the active app. Capture
-		// the prior frontmost app for teardown restore, then activate rsnap for the overlay session.
+		// AppKit only keeps native cursor ownership stable while Rsnap is the active app. Capture
+		// the prior frontmost app for teardown restore, then activate Rsnap for the overlay session.
 		super::macos_activate_app();
 
 		tracing::info!(
@@ -362,7 +362,7 @@ impl MacOSCaptureHost {
 	fn maybe_preserve_frontmost_application(&mut self, _state: &MacOSCaptureHostSyncState) {
 		// Do not hand focus back during an active overlay session. Live crosshair and frozen hover
 		// cursors are native AppKit cursors; restoring the previous frontmost app during capture
-		// hands visible cursor ownership back to that app and leaves rsnap showing an arrow until
+		// hands visible cursor ownership back to that app and leaves Rsnap showing an arrow until
 		// the next direct interaction. The original app is restored when the session exits.
 	}
 

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 MODE="${1:-run}"
-APP_NAME="rsnap"
+APP_NAME="Rsnap"
 EXECUTABLE_NAME="RsnapNativeHost"
 BUNDLE_ID="ink.hack.rsnap"
 MIN_SYSTEM_VERSION="14.0"
@@ -153,7 +153,30 @@ write_if_changed() {
 	return 0
 }
 
+canonicalize_app_bundle_name() {
+	local desired_name="$APP_NAME.app"
+	local existing_bundle existing_name tmp_bundle
+
+	mkdir -p "$STAGE_DIR"
+	while IFS= read -r existing_bundle; do
+		[[ -n "$existing_bundle" ]] || continue
+		existing_name="$(basename "$existing_bundle")"
+		[[ "$existing_name" == "$desired_name" ]] && continue
+
+		if [[ -e "$APP_BUNDLE" ]]; then
+			rm -rf "$existing_bundle"
+		else
+			tmp_bundle="$STAGE_DIR/.$desired_name.rename.$$"
+			rm -rf "$tmp_bundle"
+			mv "$existing_bundle" "$tmp_bundle"
+			mv "$tmp_bundle" "$APP_BUNDLE"
+		fi
+		STAGED_APP_DIRTY=1
+	done < <(find "$STAGE_DIR" -maxdepth 1 -type d -iname "$desired_name" -print)
+}
+
 stage_app_bundle() {
+	canonicalize_app_bundle_name
 	mkdir -p "$APP_MACOS" "$APP_RESOURCES"
 	if [[ ! -x "$APP_BINARY" ]] || copy_if_changed "$BUILD_BINARY" "$APP_SOURCE_BINARY_CACHE"; then
 		mkdir -p "$(dirname "$APP_SOURCE_BINARY_CACHE")"
@@ -285,7 +308,7 @@ sign_staged_app_bundle() {
 
 	echo "error: no valid macOS codesigning identity matching \"$requested_identity\" was found." >&2
 	echo "error: import the real signing certificate or set RSNAP_NATIVE_HOST_SIGN_IDENTITY to a valid identity." >&2
-	echo "error: rsnap native host staging requires a stable codesigning identity." >&2
+	echo "error: Rsnap native host staging requires a stable codesigning identity." >&2
 	exit 1
 }
 
@@ -376,6 +399,7 @@ if [[ "$MODE" != "stage" ]]; then
 	terminate_running_host
 fi
 
+canonicalize_app_bundle_name
 if [[ "${RSNAP_NATIVE_HOST_FORCE_REBUILD:-0}" != "1" ]] && staged_bundle_is_current; then
 	BUILD_ROOT=""
 	BUILD_BINARY="$APP_BINARY"

--- a/scripts/smoke/lib/live-hud.sh
+++ b/scripts/smoke/lib/live-hud.sh
@@ -48,7 +48,7 @@ live_hud_focus_rsnap_overlay() {
   local focus_settle_s="${RSNAP_FOCUS_SETTLE_S:-0.03}"
   osascript <<APPLESCRIPT
 tell application "System Events"
-    tell process "rsnap"
+    tell process "Rsnap"
         set frontmost to true
     end tell
 end tell

--- a/scripts/smoke/lib/native-visual-contract-summary.py
+++ b/scripts/smoke/lib/native-visual-contract-summary.py
@@ -393,7 +393,7 @@ for index, commit in enumerate(freeze_commits, start=1):
         )
     if not bool_field(commit, "selfCaptureSafe"):
         failures.append(
-            f"freeze_commit[{index}] used a frame that could contain rsnap's own capture UI"
+            f"freeze_commit[{index}] used a frame that could contain Rsnap's own capture UI"
         )
     if commit_source == "window_list_below_overlay":
         window_list_below_overlay_commits += 1


### PR DESCRIPTION
Summary:
- Rename the visible macOS product branding from rsnap to Rsnap and stage/install the app as Rsnap.app.
- Add a canonical app identity spec while preserving stable lowercase technical identifiers such as crate names, bundle id, env vars, and build directory names.
- Update Screen Recording onboarding to show Rsnap.app, center the drag chip content, and remove the duplicate lower Screen Recording status row.

Validation:
- cargo make fmt
- cargo make fmt-check
- cargo test -p rsnap staged_native_host_bundle_uses_product_case
- cargo make lint-swift
- cargo make test-macos-native-host-stage
- cargo make lint-rust
- cargo make test-rust
- git diff --check
- codesign --verify --deep --strict /Applications/Rsnap.app
