### PR TITLE
Fix native scroll capture stitching

### DIFF
--- a/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
+++ b/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
@@ -58,6 +58,35 @@ public struct RGBARegionSnapshot: Equatable, Sendable {
 	}
 }
 
+public enum ScrollObserveOutcome: UInt32, Equatable, Sendable {
+	case noChange = 0
+	case previewUpdated = 1
+	case committed = 2
+	case unsupportedDirection = 3
+}
+
+public struct ScrollObserveResult: Equatable, Sendable {
+	public var outcome: ScrollObserveOutcome
+	public var growthRows: Int
+	public var exportWidth: Int
+	public var exportHeight: Int
+	public var currentViewportTopY: Int
+
+	public init(
+		outcome: ScrollObserveOutcome,
+		growthRows: Int,
+		exportWidth: Int,
+		exportHeight: Int,
+		currentViewportTopY: Int
+	) {
+		self.outcome = outcome
+		self.growthRows = growthRows
+		self.exportWidth = exportWidth
+		self.exportHeight = exportHeight
+		self.currentViewportTopY = currentViewportTopY
+	}
+}
+
 public struct MonitorSnapshot: Equatable, Sendable {
 	public var id: UInt32
 	public var frame: CGRect
@@ -183,6 +212,7 @@ public enum HostRequest: Equatable, Sendable {
 	case startLiveCapture
 	case stopLiveCapture
 	case requestFreezeSnapshot(selection: CGRect, selectionEditable: Bool)
+	case startScrollCapture
 	case copyCapture
 	case saveCapture
 	case recognizeText
@@ -563,6 +593,8 @@ public final class RsnapHostSession {
 			return .requestAccessibilityPermission
 		case RSNAP_HOST_REQUEST_REQUEST_INPUT_MONITORING_PERMISSION.rawValue:
 			return .requestInputMonitoringPermission
+		case RSNAP_HOST_REQUEST_START_SCROLL_CAPTURE.rawValue:
+			return .startScrollCapture
 		default:
 			throw HostBridgeError.invalidRequestKind(request.kind)
 		}
@@ -663,6 +695,124 @@ public final class RsnapHostSession {
 				width: Int(window.width),
 				height: Int(window.height)
 			)
+		)
+	}
+}
+
+public final class RsnapScrollCaptureSession: @unchecked Sendable {
+	private let handle: OpaquePointer
+	private let stateLock = NSLock()
+
+	public init(baseImage: RGBARegionSnapshot, previewWidthPixels: Int) throws {
+		let actualAbi = rsnap_host_ffi_abi_version()
+		if actualAbi != RSNAP_HOST_FFI_ABI_VERSION {
+			throw HostBridgeError.abiVersionMismatch(
+				expected: RSNAP_HOST_FFI_ABI_VERSION,
+				actual: actualAbi
+			)
+		}
+
+		let width = UInt32(max(baseImage.width, 0))
+		let height = UInt32(max(baseImage.height, 0))
+		let previewWidth = UInt32(max(previewWidthPixels, 1))
+		let maybeHandle = baseImage.rgba.withUnsafeBytes { buffer -> OpaquePointer? in
+			guard let baseAddress = buffer.bindMemory(to: UInt8.self).baseAddress else {
+				return nil
+			}
+			return rsnap_scroll_session_create(
+				width,
+				height,
+				baseAddress,
+				baseImage.rgba.count,
+				previewWidth
+			)
+		}
+		guard let handle = maybeHandle else {
+			throw HostBridgeError.sessionCreationFailed
+		}
+		self.handle = handle
+	}
+
+	deinit {
+		rsnap_scroll_session_destroy(handle)
+	}
+
+	public func observeDownwardFrame(_ frame: RGBARegionSnapshot) throws -> ScrollObserveResult {
+		stateLock.lock()
+		defer { stateLock.unlock() }
+
+		var outResult = RsnapScrollObserveResult()
+		let status = frame.rgba.withUnsafeBytes { buffer -> RsnapStatus in
+			guard let baseAddress = buffer.bindMemory(to: UInt8.self).baseAddress else {
+				return RSNAP_STATUS_INVALID_INPUT
+			}
+			return rsnap_scroll_session_observe_downward_frame(
+				handle,
+				UInt32(max(frame.width, 0)),
+				UInt32(max(frame.height, 0)),
+				baseAddress,
+				frame.rgba.count,
+				&outResult
+			)
+		}
+		try requireOk(status, context: "observing scroll-capture frame")
+
+		return try decode(result: outResult)
+	}
+
+	public func exportImage() throws -> RGBARegionSnapshot? {
+		stateLock.lock()
+		defer { stateLock.unlock() }
+
+		var outRegion = RsnapOwnedRgbaRegion()
+		let status = rsnap_scroll_session_take_export_rgba(handle, &outRegion)
+		let code = rsnap_status_code(status)
+		if code == 3 {
+			return nil
+		}
+		if code != 0 {
+			throw HostBridgeError.ffiStatus(
+				context: "taking scroll-capture export RGBA", code: code)
+		}
+		guard outRegion.len > 0, let rgba = outRegion.rgba else {
+			return nil
+		}
+		let ownedRegion = UnsafeMutablePointer<RsnapOwnedRgbaRegion>.allocate(capacity: 1)
+		ownedRegion.initialize(to: outRegion)
+		let data = Data(
+			bytesNoCopy: rgba,
+			count: outRegion.len,
+			deallocator: .custom { _, _ in
+				rsnap_owned_rgba_region_release(ownedRegion)
+				ownedRegion.deinitialize(count: 1)
+				ownedRegion.deallocate()
+			}
+		)
+		return RGBARegionSnapshot(
+			width: Int(outRegion.width),
+			height: Int(outRegion.height),
+			rgba: data
+		)
+	}
+
+	private func requireOk(_ status: RsnapStatus, context: String) throws {
+		let code = rsnap_status_code(status)
+		if code != 0 {
+			throw HostBridgeError.ffiStatus(context: context, code: code)
+		}
+	}
+
+	private func decode(result: RsnapScrollObserveResult) throws -> ScrollObserveResult {
+		guard let outcome = ScrollObserveOutcome(rawValue: result.kind) else {
+			throw HostBridgeError.ffiStatus(
+				context: "decoding scroll observation", code: result.kind)
+		}
+		return ScrollObserveResult(
+			outcome: outcome,
+			growthRows: Int(result.growth_rows),
+			exportWidth: Int(result.export_width),
+			exportHeight: Int(result.export_height),
+			currentViewportTopY: Int(result.current_viewport_top_y)
 		)
 	}
 }

--- a/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
+++ b/native/macos-host/Sources/RsnapHostBridgeProbe/main.swift
@@ -104,10 +104,15 @@ enum RsnapHostBridgeProbe {
 			scene.statusMessage == nil,
 			scene.toolbarItems.contains(where: { $0.kind == .pointer && $0.selected }),
 			scene.toolbarItems.contains(where: { $0.kind == .ocr && $0.enabled }),
+			scene.toolbarItems.contains(where: { $0.kind == .scroll && $0.enabled }),
 			scene.toolbarItems.contains(where: { $0.kind == .copy && $0.enabled }),
 			scene.toolbarItems.contains(where: { $0.kind == .save && $0.enabled })
 		else {
 			fatalError("unexpected frozen scene: \(scene)")
+		}
+		try session.send(event: .toolbarItemInvoked(.scroll))
+		guard try session.takeNextRequest() == .startScrollCapture else {
+			fatalError("expected a start-scroll-capture host request")
 		}
 
 		try session.send(
@@ -306,6 +311,45 @@ enum RsnapHostBridgeProbe {
 			fatalError("stale live highlighted window was not cleared: \(scene)")
 		}
 
+		let baseScrollFrame = makeScrollFrame(width: 16, height: 96, topRow: 0)
+		let movedScrollFrame = makeScrollFrame(width: 16, height: 96, topRow: 24)
+		let scrollSession = try RsnapScrollCaptureSession(
+			baseImage: baseScrollFrame,
+			previewWidthPixels: baseScrollFrame.width
+		)
+		let scrollResult = try scrollSession.observeDownwardFrame(movedScrollFrame)
+		guard
+			scrollResult.outcome == .committed,
+			scrollResult.growthRows == 24,
+			scrollResult.exportWidth == 16,
+			scrollResult.exportHeight == 120,
+			scrollResult.currentViewportTopY == 24
+		else {
+			fatalError("unexpected scroll observe result: \(scrollResult)")
+		}
+		guard let scrollExport = try scrollSession.exportImage(), scrollExport.height == 120 else {
+			fatalError("unexpected scroll export image")
+		}
+
 		print("rsnap-host-bridge probe ok")
+	}
+
+	private static func makeScrollFrame(
+		width: Int,
+		height: Int,
+		topRow: Int
+	) -> RGBARegionSnapshot {
+		var rgba = Data()
+		rgba.reserveCapacity(width * height * 4)
+		for y in 0..<height {
+			let documentRow = topRow + y
+			for x in 0..<width {
+				rgba.append(UInt8((documentRow * 17 + x * 13) % 251))
+				rgba.append(UInt8((documentRow * 29 + x * 7) % 251))
+				rgba.append(UInt8((documentRow * 5 + x * 31) % 251))
+				rgba.append(255)
+			}
+		}
+		return RGBARegionSnapshot(width: width, height: height, rgba: rgba)
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -117,6 +117,51 @@ package func frozenExportSourceImageRect(
 	)
 }
 
+package func scrollCaptureMinimapFrame(
+	for selection: CGRect,
+	exportSize: CGSize,
+	in bounds: CGRect,
+	preferredWidth: CGFloat,
+	minimumWidth: CGFloat,
+	gap: CGFloat,
+	margin: CGFloat
+) -> CGRect? {
+	guard exportSize.width > 0, exportSize.height > 0, bounds.width > margin * 2,
+		bounds.height > margin * 2
+	else {
+		return nil
+	}
+
+	let rightSpace = bounds.maxX - selection.maxX - gap - margin
+	let leftSpace = selection.minX - bounds.minX - gap - margin
+	let useRight: Bool
+	let sideSpace: CGFloat
+	if rightSpace >= minimumWidth {
+		useRight = true
+		sideSpace = rightSpace
+	} else if leftSpace >= minimumWidth {
+		useRight = false
+		sideSpace = leftSpace
+	} else {
+		useRight = rightSpace >= leftSpace
+		sideSpace = max(rightSpace, leftSpace)
+	}
+
+	let maxHeight = bounds.height - margin * 2
+	let aspectHeightPerWidth = exportSize.height / exportSize.width
+	let heightLimitedWidth = maxHeight / max(aspectHeightPerWidth, .leastNonzeroMagnitude)
+	let width = min(preferredWidth, sideSpace, heightLimitedWidth)
+	guard width >= min(minimumWidth, preferredWidth) * 0.55 else {
+		return nil
+	}
+
+	let height = width * aspectHeightPerWidth
+	let maxY = max(margin, bounds.maxY - margin - height)
+	let y = (selection.midY - height / 2).clamped(to: margin...maxY)
+	let x = useRight ? selection.maxX + gap : selection.minX - gap - width
+	return CGRect(x: x, y: y, width: width, height: height)
+}
+
 private func makeFrozenMosaicPatch(from image: CGImage, sourceRect: CGRect) -> CGImage? {
 	let imageRect = CGRect(x: 0, y: 0, width: image.width, height: image.height)
 	let cropRect = sourceRect.integral.intersection(imageRect)
@@ -544,6 +589,8 @@ final class CaptureSessionController: NSObject {
 	private static let autoCenterMaxIterations = 6
 	private static let displayFirstFrameWait: TimeInterval = 0.025
 	private static let coldSelfCaptureRecoveryWait: TimeInterval = 3.5
+	private static let scrollCaptureForwardingPassthrough: TimeInterval = 0.055
+	private static let scrollCaptureSampleDelay: TimeInterval = 0.04
 
 	private let settingsStore: NativeHostSettingsStore
 	private let liveFrameStream = LiveFrameStreamBroker()
@@ -554,6 +601,8 @@ final class CaptureSessionController: NSObject {
 	private var frozenFrameLatchToken: FrozenFrameLatchToken?
 	private var frozenSnapshotGeneration: UInt64 = 0
 	private var completedHostEffect: HostEffectKind?
+	private var scrollCaptureState: NativeScrollCaptureState?
+	private var scrollCaptureGlobalMonitor: Any?
 	private var liveStreamPrimedByStartupPrewarm = false
 	private var nextCaptureTelemetryID: UInt64 = 1
 	private var activeCaptureTelemetryID: UInt64?
@@ -1054,17 +1103,7 @@ final class CaptureSessionController: NSObject {
 	func startScrollCapture() {
 		let _ = chromeState.frozenOverlay.commitTextEdit(
 			style: chromeState.annotationStyle.textStyle)
-		do {
-			try sendHostStatusMessage("Scroll capture is not available in the native host yet.")
-			try syncCore()
-		} catch {
-			NativeHostTelemetry.captureWarning(
-				"capture.scroll_unavailable_report_failed",
-				captureID: currentCaptureTelemetryID,
-				stage: "send_or_sync",
-				error: String(describing: error)
-			)
-		}
+		sendFrozenAction(.toolbarItemInvoked(.scroll))
 	}
 
 	func invokeToolbarItem(_ item: ToolbarItemKind) {
@@ -1586,6 +1625,8 @@ final class CaptureSessionController: NSObject {
 				selection,
 				editable: selectionEditable
 			)
+		case .startScrollCapture:
+			try beginNativeScrollCapture()
 		case .copyCapture:
 			try performCopy()
 		case .saveCapture:
@@ -1747,12 +1788,12 @@ final class CaptureSessionController: NSObject {
 			frozenSelection: selection,
 			rgb: scene.rgb,
 			loupeVisible: false,
-			toolbarItems: hostOwnedFrozenToolbarItems(),
+			toolbarItems: hostOwnedFrozenToolbarItems(scrollEnabled: editable),
 			statusMessage: nil
 		)
 	}
 
-	private func hostOwnedFrozenToolbarItems() -> [ToolbarItem] {
+	private func hostOwnedFrozenToolbarItems(scrollEnabled: Bool) -> [ToolbarItem] {
 		let allowTextInput =
 			session?.configuration.allowTextInput
 			?? settingsStore.sessionConfiguration.allowTextInput
@@ -1766,7 +1807,7 @@ final class CaptureSessionController: NSObject {
 			ToolbarItem(kind: .undo, enabled: false, selected: false),
 			ToolbarItem(kind: .redo, enabled: false, selected: false),
 			ToolbarItem(kind: .autoCenter, enabled: true, selected: false),
-			ToolbarItem(kind: .scroll, enabled: false, selected: false),
+			ToolbarItem(kind: .scroll, enabled: scrollEnabled, selected: false),
 		]
 		if allowTextInput {
 			items.append(ToolbarItem(kind: .ocr, enabled: true, selected: false))
@@ -1774,6 +1815,214 @@ final class CaptureSessionController: NSObject {
 		items.append(ToolbarItem(kind: .copy, enabled: true, selected: false))
 		items.append(ToolbarItem(kind: .save, enabled: true, selected: false))
 		return items
+	}
+
+	var scrollCaptureToolbarEnabled: Bool {
+		scene.mode == .frozen
+			&& scrollCaptureState == nil
+			&& currentFrozenSelection() != nil
+	}
+
+	func handleScrollCaptureWheel(_ event: NSEvent, at point: CGPoint) -> Bool {
+		guard var state = scrollCaptureState else {
+			return false
+		}
+		guard state.viewportRect.contains(point) else {
+			return false
+		}
+
+		let targetPoint = CGPoint(
+			x: point.x.clamped(to: state.viewportRect.minX...state.viewportRect.maxX),
+			y: point.y.clamped(to: state.viewportRect.minY...state.viewportRect.maxY)
+		)
+		let posted =
+			overlayController?.withPrimaryMousePassthrough(
+				duration: Self.scrollCaptureForwardingPassthrough
+			) {
+				Self.postScrollWheelEvent(matching: event, at: targetPoint)
+			} ?? Self.postScrollWheelEvent(matching: event, at: targetPoint)
+
+		guard posted else {
+			try? setHostStatusMessage("Could not forward scroll input.")
+			refreshOverlay()
+			return true
+		}
+
+		state.sampleGeneration &+= 1
+		let generation = state.sampleGeneration
+		scrollCaptureState = state
+		DispatchQueue.main.asyncAfter(deadline: .now() + Self.scrollCaptureSampleDelay) {
+			[weak self] in
+			self?.observeNativeScrollCaptureFrame(generation: generation)
+		}
+
+		return true
+	}
+
+	private func installNativeScrollCaptureMonitor() {
+		removeNativeScrollCaptureMonitor()
+		scrollCaptureGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .scrollWheel) {
+			[weak self] _ in
+			DispatchQueue.main.async { [weak self] in
+				self?.scheduleNativeScrollCaptureSampleIfPointerIsInViewport()
+			}
+		}
+	}
+
+	private func removeNativeScrollCaptureMonitor() {
+		if let monitor = scrollCaptureGlobalMonitor {
+			NSEvent.removeMonitor(monitor)
+			scrollCaptureGlobalMonitor = nil
+		}
+		overlayController?.setScrollCaptureMousePassthroughActive(false)
+	}
+
+	private func scheduleNativeScrollCaptureSampleIfPointerIsInViewport() {
+		guard let state = scrollCaptureState else {
+			return
+		}
+		guard state.viewportRect.contains(NSEvent.mouseLocation) else {
+			return
+		}
+		scheduleNativeScrollCaptureSample()
+	}
+
+	private func scheduleNativeScrollCaptureSample() {
+		guard var state = scrollCaptureState else {
+			return
+		}
+		state.sampleGeneration &+= 1
+		let generation = state.sampleGeneration
+		scrollCaptureState = state
+		DispatchQueue.main.asyncAfter(deadline: .now() + Self.scrollCaptureSampleDelay) {
+			[weak self] in
+			self?.observeNativeScrollCaptureFrame(generation: generation)
+		}
+	}
+
+	private func beginNativeScrollCapture() throws {
+		guard scrollCaptureState == nil else {
+			try setHostStatusMessage("Scroll capture is already active.")
+			refreshOverlay()
+			return
+		}
+		guard scene.mode == .frozen, let selection = currentFrozenSelection() else {
+			try setHostStatusMessage("Scroll capture requires a frozen selection.")
+			refreshOverlay()
+			return
+		}
+		guard chromeState.frozenSelectionEditable else {
+			try setHostStatusMessage("Scroll capture requires a dragged region selection.")
+			refreshOverlay()
+			return
+		}
+
+		ensureFrozenBaseImageFromDisplayIfNeeded(for: selection)
+		let baseImage = chromeState.frozenBaseImage ?? frozenBaseImageFromDisplay(for: selection)
+		guard let baseImage, let baseSnapshot = Self.rgbaSnapshot(from: baseImage) else {
+			try setHostStatusMessage("Scroll capture could not read the selected region.")
+			refreshOverlay()
+			return
+		}
+
+		let stitcher = try RsnapScrollCaptureSession(
+			baseImage: baseSnapshot,
+			previewWidthPixels: baseSnapshot.width
+		)
+		scrollCaptureState = NativeScrollCaptureState(
+			stitcher: stitcher,
+			viewportRect: selection
+		)
+		installNativeScrollCaptureMonitor()
+		overlayController?.setScrollCaptureMousePassthroughActive(true)
+		chromeState.frozenOverlay.reset()
+		chromeState.frozenSelectionEditable = false
+		chromeState.frozenSelectionInteraction = nil
+		chromeState.frozenSelectionSnapshot = selection
+		chromeState.frozenDisplayFrame = nil
+		chromeState.frozenDisplayImage = nil
+		chromeState.frozenBaseImage = baseImage
+		chromeState.scrollMinimapPreview = ScrollCaptureMinimapSnapshot(
+			image: baseImage,
+			exportSizePixels: CGSize(
+				width: CGFloat(baseSnapshot.width),
+				height: CGFloat(baseSnapshot.height)
+			),
+			viewportTopYPixels: 0,
+			viewportHeightPixels: CGFloat(baseSnapshot.height)
+		)
+		try setHostStatusMessage(
+			"Scroll capture started. Scroll inside the selection, then copy or save.")
+		refreshOverlay()
+	}
+
+	private func observeNativeScrollCaptureFrame(generation: UInt64) {
+		guard let state = scrollCaptureState, generation <= state.sampleGeneration else {
+			return
+		}
+		guard
+			let sampleImage = overlayController?.backgroundPatch(in: state.viewportRect),
+			let sample = Self.rgbaSnapshot(from: sampleImage)
+		else {
+			try? setHostStatusMessage("Scroll capture could not sample the scrolled region.")
+			refreshOverlay()
+			return
+		}
+
+		do {
+			let result = try state.stitcher.observeDownwardFrame(sample)
+			try refreshNativeScrollCapturePreview(
+				result: result,
+				currentViewportSnapshot: sample
+			)
+		} catch {
+			NativeHostTelemetry.captureWarning(
+				"capture.scroll_observe_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: "observe_frame",
+				error: String(describing: error)
+			)
+			try? setHostStatusMessage("Scroll capture could not stitch that frame.")
+			refreshOverlay()
+		}
+	}
+
+	private func refreshNativeScrollCapturePreview(
+		result: ScrollObserveResult,
+		currentViewportSnapshot: RGBARegionSnapshot
+	) throws {
+		guard let state = scrollCaptureState else {
+			return
+		}
+		guard
+			let export = try state.stitcher.exportImage(),
+			let exportImage = Self.cgImage(from: export)
+		else {
+			try setHostStatusMessage("Scroll capture could not render the stitched image.")
+			refreshOverlay()
+			return
+		}
+
+		chromeState.frozenSelectionSnapshot = state.viewportRect
+		chromeState.frozenSelectionEditable = false
+		chromeState.frozenSelectionInteraction = nil
+		chromeState.frozenDisplayFrame = nil
+		chromeState.frozenDisplayImage = nil
+		chromeState.scrollMinimapPreview = ScrollCaptureMinimapSnapshot(
+			image: exportImage,
+			exportSizePixels: CGSize(width: CGFloat(export.width), height: CGFloat(export.height)),
+			viewportTopYPixels: CGFloat(result.currentViewportTopY),
+			viewportHeightPixels: CGFloat(currentViewportSnapshot.height)
+		)
+
+		if result.outcome == .committed {
+			try setHostStatusMessage(
+				"Scroll capture appended \(result.growthRows) px. Copy or save exports the stitched image."
+			)
+		} else if result.outcome == .unsupportedDirection {
+			try setHostStatusMessage("Scroll capture only appends downward motion.")
+		}
+		refreshOverlay()
 	}
 
 	private func performCopy() throws {
@@ -1919,6 +2168,19 @@ final class CaptureSessionController: NSObject {
 		completedHostEffect = .recognizeText
 	}
 
+	private func activeScrollCaptureExportImage() throws -> CGImage? {
+		guard let state = scrollCaptureState else {
+			return nil
+		}
+		guard
+			let export = try state.stitcher.exportImage(),
+			let exportImage = Self.cgImage(from: export)
+		else {
+			return nil
+		}
+		return exportImage
+	}
+
 	private func captureFrozenSelectionImage() throws -> CGImage? {
 		let captureStartedAt = ProcessInfo.processInfo.systemUptime
 		guard let selection = currentFrozenSelection() else {
@@ -1935,6 +2197,22 @@ final class CaptureSessionController: NSObject {
 				hasOverlayEdits: false
 			)
 			return nil
+		}
+
+		if let scrollExport = try activeScrollCaptureExportImage() {
+			NativeHostTelemetry.frozenSelectionImageTiming(
+				captureID: currentCaptureTelemetryID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+				ensureMilliseconds: 0,
+				refreshMilliseconds: 0,
+				compositeMilliseconds: 0,
+				source: "scroll_capture_export",
+				success: true,
+				width: scrollExport.width,
+				height: scrollExport.height,
+				hasOverlayEdits: false
+			)
+			return scrollExport
 		}
 
 		let snapshotMatchedBefore = chromeState.frozenSelectionSnapshot == selection
@@ -2046,6 +2324,101 @@ final class CaptureSessionController: NSObject {
 		return image.cropping(to: cropRect)
 	}
 
+	private static func rgbaSnapshot(from image: CGImage) -> RGBARegionSnapshot? {
+		let width = image.width
+		let height = image.height
+		guard width > 0, height > 0 else {
+			return nil
+		}
+
+		let bytesPerPixel = 4
+		let bytesPerRow = width * bytesPerPixel
+		var rgba = Data(count: bytesPerRow * height)
+		let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+		let bitmapInfo =
+			CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
+		let rendered = rgba.withUnsafeMutableBytes { buffer -> Bool in
+			guard
+				let baseAddress = buffer.baseAddress,
+				let context = CGContext(
+					data: baseAddress,
+					width: width,
+					height: height,
+					bitsPerComponent: 8,
+					bytesPerRow: bytesPerRow,
+					space: colorSpace,
+					bitmapInfo: bitmapInfo
+				)
+			else {
+				return false
+			}
+			context.interpolationQuality = .none
+			context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+			return true
+		}
+		guard rendered else {
+			return nil
+		}
+
+		return RGBARegionSnapshot(width: width, height: height, rgba: rgba)
+	}
+
+	private static func cgImage(from snapshot: RGBARegionSnapshot) -> CGImage? {
+		guard snapshot.width > 0, snapshot.height > 0 else {
+			return nil
+		}
+		let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+		let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue)
+		guard
+			let provider = CGDataProvider(data: snapshot.rgba as CFData),
+			let image = CGImage(
+				width: snapshot.width,
+				height: snapshot.height,
+				bitsPerComponent: 8,
+				bitsPerPixel: 32,
+				bytesPerRow: snapshot.width * 4,
+				space: colorSpace,
+				bitmapInfo: bitmapInfo,
+				provider: provider,
+				decode: nil,
+				shouldInterpolate: false,
+				intent: .defaultIntent
+			)
+		else {
+			return nil
+		}
+
+		return image
+	}
+
+	private static func postScrollWheelEvent(matching event: NSEvent, at point: CGPoint) -> Bool {
+		let deltaX = Int32(event.scrollingDeltaX.rounded())
+		let deltaY = Int32(event.scrollingDeltaY.rounded())
+		guard deltaX != 0 || deltaY != 0 else {
+			return false
+		}
+
+		let units: CGScrollEventUnit = event.hasPreciseScrollingDeltas ? .pixel : .line
+		let wheelCount: UInt32 = deltaX == 0 ? 1 : 2
+		guard
+			let source = CGEventSource(stateID: .hidSystemState),
+			let scrollEvent = CGEvent(
+				scrollWheelEvent2Source: source,
+				units: units,
+				wheelCount: wheelCount,
+				wheel1: deltaY,
+				wheel2: deltaX,
+				wheel3: 0
+			)
+		else {
+			return false
+		}
+
+		scrollEvent.location = point
+		scrollEvent.post(tap: .cghidEventTap)
+		return true
+	}
+
 	private func screen(containing point: CGPoint) -> NSScreen? {
 		NSScreen.screens.first(where: { $0.frame.contains(point) })
 	}
@@ -2098,6 +2471,11 @@ final class CaptureSessionController: NSObject {
 			return
 		}
 		try session.send(report: .statusMessage(message))
+	}
+
+	private func setHostStatusMessage(_ message: String) throws {
+		try sendHostStatusMessage(message)
+		scene.statusMessage = message
 	}
 
 	private func compositeFrozenOverlay(on image: CGImage, selection: CGRect) -> CGImage? {
@@ -2270,6 +2648,8 @@ final class CaptureSessionController: NSObject {
 		frozenFrameLatchToken = nil
 		frozenSnapshotGeneration &+= 1
 		completedHostEffect = nil
+		removeNativeScrollCaptureMonitor()
+		scrollCaptureState = nil
 		chromeState = CaptureChromeState()
 		overlayController?.close()
 		overlayController = nil
@@ -2756,6 +3136,25 @@ final class CaptureOverlayController {
 		liveChromeBackdrops.hideAll()
 		targetWindow.hostView.refreshLivePresentationNow()
 		targetWindow.displayIfNeeded()
+	}
+
+	func withPrimaryMousePassthrough<T>(duration: TimeInterval, perform: () -> T) -> T {
+		guard let window = primaryWindow as? CaptureOverlayWindow else {
+			return perform()
+		}
+		let previousIgnoresMouseEvents = window.ignoresMouseEvents
+		window.ignoresMouseEvents = true
+		let result = perform()
+		DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak window] in
+			window?.ignoresMouseEvents = previousIgnoresMouseEvents
+		}
+		return result
+	}
+
+	func setScrollCaptureMousePassthroughActive(_ active: Bool) {
+		for window in windows {
+			window.ignoresMouseEvents = active
+		}
 	}
 
 	func close() {
@@ -3427,6 +3826,16 @@ final class CaptureHostView: NSView {
 	override var acceptsFirstResponder: Bool { true }
 	override var isOpaque: Bool { false }
 
+	override func hitTest(_ point: NSPoint) -> NSView? {
+		guard scene.mode == .frozen, chrome.scrollMinimapPreview != nil,
+			let selection = localFrozenSelectionRect(), selection.contains(point),
+			!toolbarFrameContains(point), annotationStyleAction(at: point) == nil
+		else {
+			return super.hitTest(point)
+		}
+		return nil
+	}
+
 	override init(frame frameRect: NSRect) {
 		super.init(frame: frameRect)
 		wantsLayer = true
@@ -3853,6 +4262,10 @@ final class CaptureHostView: NSView {
 			super.scrollWheel(with: event)
 			return
 		}
+		if controller?.handleScrollCaptureWheel(event, at: globalPoint(from: event)) == true {
+			resetAnnotationStyleWheelGate()
+			return
+		}
 		let localPoint = event.locationInWindow
 		guard annotationStyleSizeControlContains(localPoint) else {
 			resetAnnotationStyleWheelGate()
@@ -4019,6 +4432,7 @@ final class CaptureHostView: NSView {
 					drawFrozenResizeHandles(for: selection, in: context)
 				}
 				drawFrozenOverlays(for: selection, in: context)
+				drawScrollCaptureMinimap(for: selection, in: context)
 				drawSelectionSizeBadge(for: selection, in: context)
 				drawFrozenToolbar(for: selection, in: context)
 			}
@@ -4064,6 +4478,94 @@ final class CaptureHostView: NSView {
 		context.clip(to: bounds)
 		context.draw(image, in: frame)
 		context.restoreGState()
+	}
+
+	private func drawScrollCaptureMinimap(for selection: CGRect, in context: CGContext) {
+		guard let preview = chrome.scrollMinimapPreview else {
+			return
+		}
+		guard
+			let frame = scrollCaptureMinimapFrame(
+				for: selection,
+				exportSize: preview.exportSizePixels,
+				in: bounds,
+				preferredWidth: CaptureChrome.scrollMinimapPreferredWidth,
+				minimumWidth: CaptureChrome.scrollMinimapMinimumWidth,
+				gap: CaptureChrome.scrollMinimapGap,
+				margin: CaptureChrome.scrollMinimapScreenMargin
+			)
+		else {
+			return
+		}
+
+		let theme = chromeTheme()
+		let palette = CaptureChrome.palette(for: theme, settings: settings)
+		let imageFrame = frame.insetBy(
+			dx: CaptureChrome.scrollMinimapImageInset,
+			dy: CaptureChrome.scrollMinimapImageInset
+		)
+		let backgroundPath = NSBezierPath(
+			roundedRect: frame,
+			xRadius: CaptureChrome.scrollMinimapCornerRadius,
+			yRadius: CaptureChrome.scrollMinimapCornerRadius
+		)
+
+		context.saveGState()
+		context.setShadow(
+			offset: CGSize(width: 0, height: -2),
+			blur: 12,
+			color: NSColor.black.withAlphaComponent(0.32).cgColor
+		)
+		context.setFillColor(NSColor.black.withAlphaComponent(0.72).cgColor)
+		backgroundPath.fill()
+		context.restoreGState()
+
+		context.saveGState()
+		let imageClipPath = NSBezierPath(
+			roundedRect: imageFrame,
+			xRadius: max(CaptureChrome.scrollMinimapCornerRadius - 3, 1),
+			yRadius: max(CaptureChrome.scrollMinimapCornerRadius - 3, 1)
+		)
+		imageClipPath.addClip()
+		context.interpolationQuality = .high
+		context.draw(preview.image, in: imageFrame)
+		context.restoreGState()
+
+		if let viewportFrame = scrollCaptureMinimapViewportFrame(
+			for: preview,
+			in: imageFrame
+		) {
+			context.setFillColor(NSColor.white.withAlphaComponent(0.13).cgColor)
+			context.fill(viewportFrame)
+			context.setStrokeColor(NSColor.white.withAlphaComponent(0.88).cgColor)
+			context.setLineWidth(1)
+			context.stroke(viewportFrame)
+		}
+
+		context.setStrokeColor(palette.keycapStroke.withAlphaComponent(0.88).cgColor)
+		context.setLineWidth(1)
+		backgroundPath.stroke()
+	}
+
+	private func scrollCaptureMinimapViewportFrame(
+		for preview: ScrollCaptureMinimapSnapshot,
+		in frame: CGRect
+	) -> CGRect? {
+		let exportHeight = max(preview.exportSizePixels.height, 1)
+		let viewportHeight = preview.viewportHeightPixels.clamped(to: 1...exportHeight)
+		let maxTop = max(exportHeight - viewportHeight, 0)
+		let viewportTop = preview.viewportTopYPixels.clamped(to: 0...maxTop)
+		let markerHeight = max(2, frame.height * viewportHeight / exportHeight)
+		let markerY =
+			frame.maxY - frame.height * (viewportTop + viewportHeight) / exportHeight
+		let marker = CGRect(
+			x: frame.minX,
+			y: markerY,
+			width: frame.width,
+			height: markerHeight
+		)
+		let clippedMarker = marker.intersection(frame)
+		return clippedMarker.isNull ? nil : clippedMarker
 	}
 
 	private func drawHud(in context: CGContext) {
@@ -5226,7 +5728,7 @@ final class CaptureHostView: NSView {
 					scene.frozenSelection != nil
 					&& !chrome.frozenOverlay.keepsFrozenSelectionFixed
 			case .scroll:
-				item.enabled = false
+				item.enabled = controller?.scrollCaptureToolbarEnabled ?? false
 			default:
 				break
 			}
@@ -6979,6 +7481,7 @@ private struct CaptureChromeState {
 	var frozenDisplayFrame: CGRect?
 	var frozenDisplayImage: CGImage?
 	var frozenBaseImage: CGImage?
+	var scrollMinimapPreview: ScrollCaptureMinimapSnapshot?
 	var frozenOverlay = FrozenOverlayState()
 	var annotationStyle = FrozenAnnotationStyleState()
 
@@ -6998,6 +7501,7 @@ private struct CaptureChromeState {
 		frozenDisplayFrame = nil
 		frozenDisplayImage = nil
 		frozenBaseImage = nil
+		scrollMinimapPreview = nil
 		frozenOverlay.reset()
 		annotationStyle = FrozenAnnotationStyleState()
 	}
@@ -7014,9 +7518,23 @@ private struct CaptureChromeState {
 		frozenDisplayFrame = nil
 		frozenDisplayImage = nil
 		frozenBaseImage = nil
+		scrollMinimapPreview = nil
 		frozenOverlay.reset()
 		annotationStyle = FrozenAnnotationStyleState()
 	}
+}
+
+private struct NativeScrollCaptureState {
+	let stitcher: RsnapScrollCaptureSession
+	let viewportRect: CGRect
+	var sampleGeneration: UInt64 = 0
+}
+
+private struct ScrollCaptureMinimapSnapshot {
+	let image: CGImage
+	let exportSizePixels: CGSize
+	let viewportTopYPixels: CGFloat
+	let viewportHeightPixels: CGFloat
 }
 
 private struct FrozenOverlayState {
@@ -7588,6 +8106,12 @@ enum CaptureChrome {
 	static let toolbarVerticalPadding: CGFloat = 5
 	static let toolbarGap: CGFloat = 10
 	static let toolbarScreenMargin: CGFloat = 10
+	static let scrollMinimapPreferredWidth: CGFloat = 96
+	static let scrollMinimapMinimumWidth: CGFloat = 44
+	static let scrollMinimapGap: CGFloat = 10
+	static let scrollMinimapScreenMargin: CGFloat = 10
+	static let scrollMinimapImageInset: CGFloat = 3
+	static let scrollMinimapCornerRadius: CGFloat = 9
 	static let annotationStyleRowGap: CGFloat = 4
 	static let annotationStyleRowHeight: CGFloat = 24
 	static let annotationStyleControlGap: CGFloat = 4

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -40,6 +40,43 @@ enum RsnapNativeHostKitProbe {
 			selection: selection,
 			imageSize: imageSize
 		)
+		let minimapExportSize = CGSize(width: 100, height: 200)
+		guard
+			let rightMinimap = scrollCaptureMinimapFrame(
+				for: CGRect(x: 100, y: 100, width: 100, height: 100),
+				exportSize: minimapExportSize,
+				in: CGRect(x: 0, y: 0, width: 500, height: 500),
+				preferredWidth: 96,
+				minimumWidth: 44,
+				gap: 10,
+				margin: 10
+			)
+		else {
+			fatalError("expected right-side scroll minimap frame")
+		}
+		assertRectEqual(
+			rightMinimap,
+			CGRect(x: 210, y: 54, width: 96, height: 192),
+			"scroll minimap should prefer the right side when space is available"
+		)
+		guard
+			let leftMinimap = scrollCaptureMinimapFrame(
+				for: CGRect(x: 130, y: 100, width: 100, height: 100),
+				exportSize: minimapExportSize,
+				in: CGRect(x: 0, y: 0, width: 250, height: 500),
+				preferredWidth: 96,
+				minimumWidth: 44,
+				gap: 10,
+				margin: 10
+			)
+		else {
+			fatalError("expected left-side scroll minimap frame")
+		}
+		assertRectEqual(
+			leftMinimap,
+			CGRect(x: 24, y: 54, width: 96, height: 192),
+			"scroll minimap should fall back to the left when the right side is constrained"
+		)
 	}
 
 	private static func assertRectEqual(_ actual: CGRect, _ expected: CGRect, _ message: String) {

--- a/packages/rsnap-capture-core/src/protocol.rs
+++ b/packages/rsnap-capture-core/src/protocol.rs
@@ -214,6 +214,8 @@ pub enum HostRequest {
 		/// Whether the frozen selection may be moved or resized after commit.
 		selection_editable: bool,
 	},
+	/// Start a native scroll-capture session for the current dragged-region freeze.
+	StartScrollCapture,
 	/// Perform a host-owned effect.
 	PerformHostEffect(HostEffectKind),
 	/// Request a host-owned permission flow.

--- a/packages/rsnap-capture-core/src/session.rs
+++ b/packages/rsnap-capture-core/src/session.rs
@@ -216,10 +216,10 @@ impl CaptureSessionCore {
 				self.selected_toolbar_item = item;
 				self.scene.status_message = None;
 			},
-			ToolbarItemKind::Undo
-			| ToolbarItemKind::Redo
-			| ToolbarItemKind::AutoCenter
-			| ToolbarItemKind::Scroll => {},
+			ToolbarItemKind::Undo | ToolbarItemKind::Redo | ToolbarItemKind::AutoCenter => {},
+			ToolbarItemKind::Scroll => {
+				self.pending_requests.push_back(HostRequest::StartScrollCapture);
+			},
 			ToolbarItemKind::Ocr => {
 				if self.config.allow_text_input {
 					self.pending_requests
@@ -252,7 +252,7 @@ impl CaptureSessionCore {
 				self.toolbar_item(ToolbarItemKind::Undo, false),
 				self.toolbar_item(ToolbarItemKind::Redo, false),
 				self.toolbar_item(ToolbarItemKind::AutoCenter, true),
-				self.toolbar_item(ToolbarItemKind::Scroll, false),
+				self.toolbar_item(ToolbarItemKind::Scroll, self.frozen_selection_editable),
 			];
 
 			if self.config.allow_text_input {
@@ -565,6 +565,13 @@ mod tests {
 		assert_eq!(session.scene_model().mode, CaptureMode::Frozen);
 		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Grab);
 		assert_eq!(session.scene_model().toolbar_items.len(), 13);
+		assert!(
+			session
+				.scene_model()
+				.toolbar_items
+				.iter()
+				.any(|item| item.kind == ToolbarItemKind::Scroll && item.enabled)
+		);
 	}
 
 	#[test]
@@ -870,6 +877,39 @@ mod tests {
 			session.pop_host_request(),
 			Some(HostRequest::PerformHostEffect(HostEffectKind::CopyCapture))
 		);
+	}
+
+	#[test]
+	fn scroll_toolbar_invocation_requests_native_scroll_capture_for_drag_region() {
+		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
+		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
+
+		session.handle_host_event(HostEvent::ToolbarItemInvoked { item: ToolbarItemKind::Scroll });
+
+		assert_eq!(session.pop_host_request(), Some(HostRequest::StartScrollCapture));
+	}
+
+	#[test]
+	fn scroll_toolbar_requests_native_host_feedback_for_non_editable_frozen_selection() {
+		let selection = GlobalRect::new(10, 20, 100, 50);
+		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
+		session.enter_live();
+
+		let _ = session.pop_host_request();
+
+		session.handle_host_report(HostReport::FreezeSnapshotCommitted { selection });
+		session.handle_host_event(HostEvent::ToolbarItemInvoked { item: ToolbarItemKind::Scroll });
+
+		assert!(
+			session
+				.scene_model()
+				.toolbar_items
+				.iter()
+				.any(|item| item.kind == ToolbarItemKind::Scroll && !item.enabled)
+		);
+		assert_eq!(session.pop_host_request(), Some(HostRequest::StartScrollCapture));
 	}
 
 	#[test]

--- a/packages/rsnap-host-ffi/include/rsnap_host_ffi.h
+++ b/packages/rsnap-host-ffi/include/rsnap_host_ffi.h
@@ -8,19 +8,21 @@
 extern "C" {
 #endif
 
-#define RSNAP_HOST_FFI_ABI_VERSION 15u
+#define RSNAP_HOST_FFI_ABI_VERSION 16u
 #define RSNAP_TOOLBAR_ITEM_CAPACITY 16u
 #define RSNAP_STATUS_MESSAGE_CAPACITY 256u
 #define RSNAP_LIVE_SAMPLE_PATCH_CAPACITY 4096u
 
 typedef struct RsnapSessionHandle RsnapSessionHandle;
 typedef struct RsnapLiveSamplerHandle RsnapLiveSamplerHandle;
+typedef struct RsnapScrollSessionHandle RsnapScrollSessionHandle;
 
 typedef enum RsnapStatus {
 	RSNAP_STATUS_OK = 0,
 	RSNAP_STATUS_NULL_HANDLE = 1,
 	RSNAP_STATUS_NULL_OUTPUT = 2,
 	RSNAP_STATUS_EMPTY = 3,
+	RSNAP_STATUS_INVALID_INPUT = 4,
 } RsnapStatus;
 
 typedef enum RsnapPlatformTag {
@@ -205,6 +207,7 @@ typedef enum RsnapHostRequestKind {
 	RSNAP_HOST_REQUEST_REQUEST_SCREEN_RECORDING_PERMISSION = 6,
 	RSNAP_HOST_REQUEST_REQUEST_ACCESSIBILITY_PERMISSION = 7,
 	RSNAP_HOST_REQUEST_REQUEST_INPUT_MONITORING_PERMISSION = 8,
+	RSNAP_HOST_REQUEST_START_SCROLL_CAPTURE = 9,
 } RsnapHostRequestKind;
 
 typedef struct RsnapHostRequestValue {
@@ -239,8 +242,30 @@ typedef struct RsnapOwnedRgbaRegion {
 	uint8_t *rgba;
 } RsnapOwnedRgbaRegion;
 
+typedef enum RsnapScrollObserveOutcomeKind {
+	RSNAP_SCROLL_OBSERVE_NO_CHANGE = 0,
+	RSNAP_SCROLL_OBSERVE_PREVIEW_UPDATED = 1,
+	RSNAP_SCROLL_OBSERVE_COMMITTED = 2,
+	RSNAP_SCROLL_OBSERVE_UNSUPPORTED_DIRECTION = 3,
+} RsnapScrollObserveOutcomeKind;
+
+typedef struct RsnapScrollObserveResult {
+	uint32_t kind;
+	uint32_t growth_rows;
+	uint32_t export_width;
+	uint32_t export_height;
+	int32_t current_viewport_top_y;
+} RsnapScrollObserveResult;
+
 uint32_t rsnap_host_ffi_abi_version(void);
 RsnapSessionHandle *rsnap_session_create(struct RsnapSessionConfig config);
+RsnapScrollSessionHandle *rsnap_scroll_session_create(
+	uint32_t width,
+	uint32_t height,
+	const uint8_t *rgba,
+	size_t rgba_len,
+	uint32_t preview_width_px
+);
 RsnapLiveSamplerHandle *rsnap_live_sampler_create(void);
 RsnapLiveSamplerHandle *rsnap_live_sampler_create_with_self_capture_exception_window_ids(
 	const uint32_t *window_ids,
@@ -254,7 +279,24 @@ enum RsnapStatus rsnap_live_sampler_reset(
 	RsnapLiveSamplerHandle *handle
 );
 void rsnap_session_destroy(RsnapSessionHandle *handle);
+void rsnap_scroll_session_destroy(RsnapScrollSessionHandle *handle);
 void rsnap_live_sampler_destroy(RsnapLiveSamplerHandle *handle);
+enum RsnapStatus rsnap_scroll_session_observe_downward_frame(
+	RsnapScrollSessionHandle *handle,
+	uint32_t width,
+	uint32_t height,
+	const uint8_t *rgba,
+	size_t rgba_len,
+	struct RsnapScrollObserveResult *out_result
+);
+enum RsnapStatus rsnap_scroll_session_take_export_rgba(
+	RsnapScrollSessionHandle *handle,
+	struct RsnapOwnedRgbaRegion *out_region
+);
+enum RsnapStatus rsnap_scroll_session_undo_last_append(
+	RsnapScrollSessionHandle *handle,
+	struct RsnapScrollObserveResult *out_result
+);
 enum RsnapStatus rsnap_session_enter_live(RsnapSessionHandle *handle);
 enum RsnapStatus rsnap_session_handle_host_event(
 	RsnapSessionHandle *handle,

--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -4,10 +4,8 @@
 //! new host/core direction with an opaque session handle, FFI-safe config/event
 //! structs, and copy-out scene/request snapshots.
 
-#[cfg(target_os = "macos")]
 use std::mem;
 use std::ptr::{self, NonNull};
-#[cfg(target_os = "macos")]
 use std::slice;
 
 #[cfg(not(target_os = "macos"))]
@@ -21,9 +19,12 @@ use rsnap_capture_core::{
 };
 #[cfg(target_os = "macos")]
 use rsnap_overlay::host_live_sampling_macos::HostMacLiveSampler;
+use rsnap_overlay::scroll_stitching::{
+	ScrollStitchImage, ScrollStitchObserveOutcome, ScrollStitchSession,
+};
 
 /// ABI version exported by the thin C host bridge.
-pub const RSNAP_HOST_FFI_ABI_VERSION: u32 = 15;
+pub const RSNAP_HOST_FFI_ABI_VERSION: u32 = 16;
 
 const RSNAP_TOOLBAR_ITEM_CAPACITY: usize = 16;
 const RSNAP_STATUS_MESSAGE_CAPACITY: usize = 256;
@@ -32,6 +33,11 @@ const RSNAP_LIVE_SAMPLE_PATCH_CAPACITY: usize = 4_096;
 /// Opaque session handle owned by the native host through the C ABI.
 pub struct RsnapSessionHandle {
 	session: CaptureSessionCore,
+}
+
+/// Opaque scroll-capture stitching handle owned by the native host through the C ABI.
+pub struct RsnapScrollSessionHandle {
+	session: ScrollStitchSession,
 }
 
 #[cfg(target_os = "macos")]
@@ -52,6 +58,8 @@ pub enum RsnapStatus {
 	NullOutput = 2,
 	/// No queued value was available.
 	Empty = 3,
+	/// The provided input payload was invalid.
+	InvalidInput = 4,
 }
 
 /// FFI-safe live cursor sample copied out of the native Rust sampler.
@@ -123,6 +131,47 @@ pub struct RsnapOwnedRgbaRegion {
 impl Default for RsnapOwnedRgbaRegion {
 	fn default() -> Self {
 		Self { width: 0, height: 0, len: 0, capacity: 0, rgba: ptr::null_mut() }
+	}
+}
+
+/// FFI-safe scroll-capture observation discriminator.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RsnapScrollObserveOutcomeKind {
+	/// The candidate did not change committed output.
+	NoChange = 0,
+	/// Preview-only state changed.
+	PreviewUpdated = 1,
+	/// Downward growth was committed.
+	Committed = 2,
+	/// The candidate proved motion in a direction not appended by this wrapper.
+	UnsupportedDirection = 3,
+}
+
+/// FFI-safe result for one scroll-capture frame observation.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RsnapScrollObserveResult {
+	/// Observation outcome.
+	pub kind: u32,
+	/// Appended row count when `kind` is committed.
+	pub growth_rows: u32,
+	/// Current committed export width in pixels.
+	pub export_width: u32,
+	/// Current committed export height in pixels.
+	pub export_height: u32,
+	/// Current committed viewport top in pixels.
+	pub current_viewport_top_y: i32,
+}
+impl Default for RsnapScrollObserveResult {
+	fn default() -> Self {
+		Self {
+			kind: RsnapScrollObserveOutcomeKind::NoChange as u32,
+			growth_rows: 0,
+			export_width: 0,
+			export_height: 0,
+			current_viewport_top_y: 0,
+		}
 	}
 }
 
@@ -517,6 +566,8 @@ pub enum RsnapHostRequestKind {
 	RequestAccessibilityPermission = 7,
 	/// Request input monitoring permission.
 	RequestInputMonitoringPermission = 8,
+	/// Start native scroll capture.
+	StartScrollCapture = 9,
 }
 
 /// FFI-safe queued host request.
@@ -545,6 +596,152 @@ pub unsafe extern "C" fn rsnap_session_create(
 	let session = CaptureSessionCore::with_config(decode_session_config(config));
 
 	Box::into_raw(Box::new(RsnapSessionHandle { session }))
+}
+
+/// Creates a scroll-capture stitcher from the first frozen viewport frame.
+///
+/// # Safety
+///
+/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
+/// row-major RGBA data. The returned pointer must be released by calling
+/// `rsnap_scroll_session_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_create(
+	width: u32,
+	height: u32,
+	rgba: *const u8,
+	rgba_len: usize,
+	preview_width_px: u32,
+) -> *mut RsnapScrollSessionHandle {
+	let Some(bytes) = (unsafe { rgba_bytes(rgba, rgba_len) }) else {
+		return ptr::null_mut();
+	};
+	let Ok(session) = ScrollStitchSession::new_from_rgba(width, height, bytes, preview_width_px)
+	else {
+		return ptr::null_mut();
+	};
+
+	Box::into_raw(Box::new(RsnapScrollSessionHandle { session }))
+}
+
+/// Destroys a scroll-capture stitcher returned by `rsnap_scroll_session_create`.
+///
+/// # Safety
+///
+/// The pointer must either be null or a pointer returned by
+/// `rsnap_scroll_session_create` that has not already been destroyed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_destroy(handle: *mut RsnapScrollSessionHandle) {
+	if handle.is_null() {
+		return;
+	}
+
+	unsafe {
+		drop(Box::from_raw(handle));
+	}
+}
+
+/// Observes one discrete viewport screenshot for downward scroll-capture stitching.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`.
+/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
+/// row-major RGBA data, and `out_result` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_observe_downward_frame(
+	handle: *mut RsnapScrollSessionHandle,
+	width: u32,
+	height: u32,
+	rgba: *const u8,
+	rgba_len: usize,
+	out_result: *mut RsnapScrollObserveResult,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_result.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let Some(bytes) = (unsafe { rgba_bytes(rgba, rgba_len) }) else {
+		return RsnapStatus::InvalidInput;
+	};
+	let outcome = match handle.session.observe_worker_pairwise_rgba(width, height, bytes) {
+		Ok(outcome) => outcome,
+		Err(_err) => return RsnapStatus::InvalidInput,
+	};
+	let export = handle.session.export_image();
+
+	unsafe {
+		ptr::write(out_result, encode_scroll_observe_result(outcome, &export, &handle.session));
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Copies the current committed scroll-capture export into a Rust-owned RGBA buffer.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
+/// `out_region` must be writable. The returned buffer must be released with
+/// `rsnap_owned_rgba_region_release`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_take_export_rgba(
+	handle: *mut RsnapScrollSessionHandle,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let export = handle.session.export_image();
+
+	unsafe {
+		ptr::write(out_region, owned_region_from_scroll_image(export));
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Reverts the most recent committed scroll-capture append when possible.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
+/// `out_result` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_undo_last_append(
+	handle: *mut RsnapScrollSessionHandle,
+	out_result: *mut RsnapScrollObserveResult,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_result.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let did_undo = handle.session.undo_last_append();
+	let export = handle.session.export_image();
+	let kind = if did_undo {
+		ScrollStitchObserveOutcome::PreviewUpdated
+	} else {
+		ScrollStitchObserveOutcome::NoChange
+	};
+
+	unsafe {
+		ptr::write(out_result, encode_scroll_observe_result(kind, &export, &handle.session));
+	}
+
+	RsnapStatus::Ok
 }
 
 /// Returns the current C ABI version for the native host bridge.
@@ -1054,13 +1251,12 @@ pub unsafe extern "C" fn rsnap_live_sampler_take_latest_monitor_rgba(
 	RsnapStatus::Ok
 }
 
-/// Releases a buffer previously returned by `rsnap_live_sampler_take_latest_monitor_rgba`.
+/// Releases a buffer previously returned by an RGBA export function.
 ///
 /// # Safety
 ///
-/// `region` must point to a struct returned by `rsnap_live_sampler_take_latest_monitor_rgba`
-/// that has not already been released.
-#[cfg(target_os = "macos")]
+/// `region` must point to a struct returned by a `*_take_*_rgba` function that has not already
+/// been released.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rsnap_owned_rgba_region_release(region: *mut RsnapOwnedRgbaRegion) {
 	let Some(region) = (unsafe { region.as_mut() }) else {
@@ -1082,11 +1278,25 @@ unsafe fn handle_ref<'a>(handle: *const RsnapSessionHandle) -> Option<&'a RsnapS
 	unsafe { handle.as_ref() }
 }
 
+unsafe fn scroll_session_handle_mut<'a>(
+	handle: *mut RsnapScrollSessionHandle,
+) -> Option<&'a mut RsnapScrollSessionHandle> {
+	unsafe { handle.as_mut() }
+}
+
 #[cfg(target_os = "macos")]
 unsafe fn live_sampler_handle_mut<'a>(
 	handle: *mut RsnapLiveSamplerHandle,
 ) -> Option<&'a mut RsnapLiveSamplerHandle> {
 	unsafe { handle.as_mut() }
+}
+
+unsafe fn rgba_bytes<'a>(rgba: *const u8, rgba_len: usize) -> Option<&'a [u8]> {
+	if rgba.is_null() || rgba_len == 0 {
+		return None;
+	}
+
+	Some(unsafe { slice::from_raw_parts(rgba, rgba_len) })
 }
 
 fn decode_session_config(config: RsnapSessionConfig) -> SessionConfig {
@@ -1349,6 +1559,10 @@ fn encode_host_request(request: HostRequest) -> RsnapHostRequestValue {
 				selection_editable: u8::from(selection_editable),
 			}
 		},
+		HostRequest::StartScrollCapture => RsnapHostRequestValue {
+			kind: RsnapHostRequestKind::StartScrollCapture as u32,
+			..RsnapHostRequestValue::default()
+		},
 		HostRequest::PerformHostEffect(effect) => RsnapHostRequestValue {
 			kind: match effect {
 				HostEffectKind::CopyCapture => RsnapHostRequestKind::CopyCapture,
@@ -1372,6 +1586,48 @@ fn encode_host_request(request: HostRequest) -> RsnapHostRequestValue {
 			..RsnapHostRequestValue::default()
 		},
 	}
+}
+
+fn encode_scroll_observe_result(
+	outcome: ScrollStitchObserveOutcome,
+	export: &ScrollStitchImage,
+	session: &ScrollStitchSession,
+) -> RsnapScrollObserveResult {
+	let (kind, growth_rows) = match outcome {
+		ScrollStitchObserveOutcome::NoChange => (RsnapScrollObserveOutcomeKind::NoChange, 0),
+		ScrollStitchObserveOutcome::PreviewUpdated => {
+			(RsnapScrollObserveOutcomeKind::PreviewUpdated, 0)
+		},
+		ScrollStitchObserveOutcome::Committed { growth_rows } => {
+			(RsnapScrollObserveOutcomeKind::Committed, growth_rows)
+		},
+		ScrollStitchObserveOutcome::UnsupportedDirection => {
+			(RsnapScrollObserveOutcomeKind::UnsupportedDirection, 0)
+		},
+	};
+
+	RsnapScrollObserveResult {
+		kind: kind as u32,
+		growth_rows,
+		export_width: export.width,
+		export_height: export.height,
+		current_viewport_top_y: session.current_viewport_top_y(),
+	}
+}
+
+fn owned_region_from_scroll_image(image: ScrollStitchImage) -> RsnapOwnedRgbaRegion {
+	let mut rgba = image.rgba;
+	let out = RsnapOwnedRgbaRegion {
+		width: image.width,
+		height: image.height,
+		len: rgba.len(),
+		capacity: rgba.capacity(),
+		rgba: rgba.as_mut_ptr(),
+	};
+
+	mem::forget(rgba);
+
+	out
 }
 
 fn decode_effect_kind(effect_kind: u32) -> HostEffectKind {
@@ -1498,6 +1754,8 @@ mod tests {
 		RsnapPoint, RsnapRect, RsnapRgb, RsnapSceneKind, RsnapSceneModel, RsnapSessionConfig,
 		RsnapSessionHandle, RsnapStatus, RsnapWindowRect,
 	};
+	#[cfg(target_os = "macos")]
+	use crate::{RsnapOwnedRgbaRegion, RsnapScrollObserveOutcomeKind, RsnapScrollObserveResult};
 
 	fn default_config() -> RsnapSessionConfig {
 		RsnapSessionConfig {
@@ -1505,6 +1763,24 @@ mod tests {
 			allow_text_input: 1,
 			prefers_toolbar_above_selection: 0,
 		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn scroll_frame(width: u32, height: u32, top_row: u32) -> Vec<u8> {
+		let mut rgba = Vec::with_capacity((width * height * 4) as usize);
+
+		for y in 0..height {
+			let document_row = top_row + y;
+
+			for x in 0..width {
+				rgba.push(((document_row * 17 + x * 13) % 251) as u8);
+				rgba.push(((document_row * 29 + x * 7) % 251) as u8);
+				rgba.push(((document_row * 5 + x * 31) % 251) as u8);
+				rgba.push(255);
+			}
+		}
+
+		rgba
 	}
 
 	#[test]
@@ -1631,6 +1907,51 @@ mod tests {
 		let handle: *mut RsnapSessionHandle = ptr::null_mut();
 
 		unsafe { crate::rsnap_session_destroy(handle) };
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn ffi_scroll_session_observes_downward_frame_and_exports() {
+		let base = scroll_frame(16, 96, 0);
+		let moved = scroll_frame(16, 96, 24);
+		let handle =
+			unsafe { crate::rsnap_scroll_session_create(16, 96, base.as_ptr(), base.len(), 16) };
+
+		assert!(!handle.is_null());
+
+		let mut result = RsnapScrollObserveResult::default();
+		let observe_status = unsafe {
+			crate::rsnap_scroll_session_observe_downward_frame(
+				handle,
+				16,
+				96,
+				moved.as_ptr(),
+				moved.len(),
+				&mut result,
+			)
+		};
+
+		assert_eq!(observe_status, RsnapStatus::Ok);
+		assert_eq!(result.kind, RsnapScrollObserveOutcomeKind::Committed as u32);
+		assert_eq!(result.growth_rows, 24);
+		assert_eq!(result.export_width, 16);
+		assert_eq!(result.export_height, 120);
+		assert_eq!(result.current_viewport_top_y, 24);
+
+		let mut export = RsnapOwnedRgbaRegion::default();
+
+		assert_eq!(
+			unsafe { crate::rsnap_scroll_session_take_export_rgba(handle, &mut export) },
+			RsnapStatus::Ok
+		);
+		assert_eq!(export.width, 16);
+		assert_eq!(export.height, 120);
+		assert_eq!(export.len, 16 * 120 * 4);
+
+		unsafe {
+			crate::rsnap_owned_rgba_region_release(&mut export);
+			crate::rsnap_scroll_session_destroy(handle);
+		}
 	}
 
 	#[test]

--- a/packages/rsnap-host-ffi/tests/header_smoke.c
+++ b/packages/rsnap-host-ffi/tests/header_smoke.c
@@ -8,35 +8,70 @@ int main(void) {
 	};
 	RsnapHostRequestValue request = {0};
 	RsnapSceneModel scene = {0};
+	RsnapScrollObserveResult scroll_result = {0};
+	RsnapOwnedRgbaRegion scroll_export = {0};
+	uint8_t rgba[4 * 4 * 4] = {0};
 	RsnapSessionHandle *handle = rsnap_session_create(config);
+	RsnapScrollSessionHandle *scroll_handle =
+		rsnap_scroll_session_create(4, 4, rgba, sizeof(rgba), 4);
 
 	if (handle == 0) {
 		return 1;
 	}
+	if (scroll_handle == 0) {
+		rsnap_session_destroy(handle);
+		return 8;
+	}
 	if (rsnap_host_ffi_abi_version() != RSNAP_HOST_FFI_ABI_VERSION) {
+		rsnap_scroll_session_destroy(scroll_handle);
+		rsnap_session_destroy(handle);
 		return 2;
 	}
+	if (rsnap_scroll_session_observe_downward_frame(
+			scroll_handle,
+			4,
+			4,
+			rgba,
+			sizeof(rgba),
+			&scroll_result
+		) != RSNAP_STATUS_OK) {
+		rsnap_scroll_session_destroy(scroll_handle);
+		rsnap_session_destroy(handle);
+		return 9;
+	}
+	if (rsnap_scroll_session_take_export_rgba(scroll_handle, &scroll_export) != RSNAP_STATUS_OK) {
+		rsnap_scroll_session_destroy(scroll_handle);
+		rsnap_session_destroy(handle);
+		return 10;
+	}
+	rsnap_owned_rgba_region_release(&scroll_export);
 	if (rsnap_session_enter_live(handle) != RSNAP_STATUS_OK) {
+		rsnap_scroll_session_destroy(scroll_handle);
 		rsnap_session_destroy(handle);
 		return 3;
 	}
 	if (rsnap_session_take_next_request(handle, &request) != RSNAP_STATUS_OK) {
+		rsnap_scroll_session_destroy(scroll_handle);
 		rsnap_session_destroy(handle);
 		return 4;
 	}
 	if (request.kind != RSNAP_HOST_REQUEST_START_LIVE_CAPTURE) {
+		rsnap_scroll_session_destroy(scroll_handle);
 		rsnap_session_destroy(handle);
 		return 5;
 	}
 	if (rsnap_session_copy_scene_model(handle, &scene) != RSNAP_STATUS_OK) {
+		rsnap_scroll_session_destroy(scroll_handle);
 		rsnap_session_destroy(handle);
 		return 6;
 	}
 	if (scene.scene_kind != RSNAP_SCENE_LIVE) {
+		rsnap_scroll_session_destroy(scroll_handle);
 		rsnap_session_destroy(handle);
 		return 7;
 	}
 
+	rsnap_scroll_session_destroy(scroll_handle);
 	rsnap_session_destroy(handle);
 	return 0;
 }

--- a/packages/rsnap-overlay/src/lib.rs
+++ b/packages/rsnap-overlay/src/lib.rs
@@ -22,6 +22,134 @@ pub mod replay_support {
 		replay_recorded_scroll_capture_trace, replay_recorded_scroll_capture_trace_with_mode,
 	};
 }
+pub mod scroll_stitching {
+	//! Narrow native-host wrapper around the existing scroll-capture stitching engine.
+
+	use color_eyre::eyre::{self, Result};
+	use image::RgbaImage;
+
+	use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
+
+	/// RGBA image payload used by native-host FFI wrappers.
+	#[derive(Clone, Debug, Eq, PartialEq)]
+	pub struct ScrollStitchImage {
+		/// Image width in pixels.
+		pub width: u32,
+		/// Image height in pixels.
+		pub height: u32,
+		/// Row-major RGBA bytes.
+		pub rgba: Vec<u8>,
+	}
+
+	/// Result of observing one candidate scroll-capture frame.
+	#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+	pub enum ScrollStitchObserveOutcome {
+		/// The candidate did not change the committed stitched image.
+		NoChange,
+		/// Only preview state changed.
+		PreviewUpdated,
+		/// Downward growth was committed.
+		Committed {
+			/// Number of appended pixel rows.
+			growth_rows: u32,
+		},
+		/// The candidate proved motion in a direction that this wrapper does not append.
+		UnsupportedDirection,
+	}
+
+	/// Native-host scroll stitcher that preserves the proven pairwise registration logic.
+	pub struct ScrollStitchSession {
+		inner: ScrollSession,
+	}
+	impl ScrollStitchSession {
+		/// Creates a stitcher from the first frozen viewport frame.
+		pub fn new_from_rgba(
+			width: u32,
+			height: u32,
+			rgba: &[u8],
+			preview_width_px: u32,
+		) -> Result<Self> {
+			let frame = rgba_image_from_bytes(width, height, rgba)?;
+			let inner = ScrollSession::new(frame, preview_width_px)?;
+
+			Ok(Self { inner })
+		}
+
+		/// Observes a discrete native screenshot using the macOS worker pairwise path.
+		pub fn observe_worker_pairwise_rgba(
+			&mut self,
+			width: u32,
+			height: u32,
+			rgba: &[u8],
+		) -> Result<ScrollStitchObserveOutcome> {
+			let frame = rgba_image_from_bytes(width, height, rgba)?;
+
+			self.inner
+				.observe_worker_pairwise_vision_frame(frame)
+				.map(scroll_stitch_observe_outcome_from)
+		}
+
+		/// Returns the committed stitched export image.
+		#[must_use]
+		pub fn export_image(&self) -> ScrollStitchImage {
+			let image = self.inner.export_image();
+
+			ScrollStitchImage {
+				width: image.width(),
+				height: image.height(),
+				rgba: image.as_raw().clone(),
+			}
+		}
+
+		/// Returns the current committed viewport top offset in pixels.
+		#[must_use]
+		pub fn current_viewport_top_y(&self) -> i32 {
+			self.inner.current_viewport_top_y()
+		}
+
+		/// Reverts the last committed append, when one exists.
+		#[must_use]
+		pub fn undo_last_append(&mut self) -> bool {
+			self.inner.undo_last_append()
+		}
+	}
+
+	fn scroll_stitch_observe_outcome_from(
+		value: ScrollObserveOutcome,
+	) -> ScrollStitchObserveOutcome {
+		match value {
+			ScrollObserveOutcome::NoChange => ScrollStitchObserveOutcome::NoChange,
+			ScrollObserveOutcome::PreviewUpdated => ScrollStitchObserveOutcome::PreviewUpdated,
+			ScrollObserveOutcome::Committed { direction: ScrollDirection::Down, growth_rows } => {
+				ScrollStitchObserveOutcome::Committed { growth_rows }
+			},
+			ScrollObserveOutcome::Committed { direction: ScrollDirection::Up, .. }
+			| ScrollObserveOutcome::UnsupportedDirection { .. } => {
+				ScrollStitchObserveOutcome::UnsupportedDirection
+			},
+		}
+	}
+
+	fn rgba_image_from_bytes(width: u32, height: u32, rgba: &[u8]) -> Result<RgbaImage> {
+		let expected_len = usize::try_from(width)
+			.ok()
+			.and_then(|width| usize::try_from(height).ok().map(|height| (width, height)))
+			.and_then(|(width, height)| width.checked_mul(height))
+			.and_then(|pixels| pixels.checked_mul(4))
+			.ok_or_else(|| eyre::eyre!("scroll-capture frame dimensions overflow"))?;
+
+		if rgba.len() != expected_len {
+			return Err(eyre::eyre!(
+				"scroll-capture frame byte length mismatch: expected {} got {}",
+				expected_len,
+				rgba.len()
+			));
+		}
+
+		RgbaImage::from_raw(width, height, rgba.to_vec())
+			.ok_or_else(|| eyre::eyre!("scroll-capture frame could not be decoded as RGBA"))
+	}
+}
 pub mod session {
 	//! Rust-core session, protocol, and shared state exports consumed by the native app host.
 

--- a/packages/rsnap-overlay/src/scroll_capture.rs
+++ b/packages/rsnap-overlay/src/scroll_capture.rs
@@ -9,7 +9,7 @@ pub(crate) use self::support::{
 
 use std::ops::RangeInclusive;
 
-use color_eyre::eyre::{self, Result};
+use color_eyre::eyre::{self};
 use image::RgbaImage;
 
 #[cfg(test)]
@@ -44,7 +44,6 @@ const FALLBACK_DOWNWARD_GROWTH_MIN_ROWS: u32 = 8;
 const FALLBACK_DOWNWARD_GROWTH_MAX_ROWS: u32 = 16;
 const TRANSIENT_MOTION_HINT_MAX_MULTIPLIER: u32 = 3;
 const TRANSIENT_MOTION_HINT_MIN_CAP_ROWS: u32 = 12;
-const WORKER_PAIRWISE_CORROBORATION_MIN_ROWS: u32 = 32;
 const WORKER_PAIRWISE_CORROBORATION_TOLERANCE_ROWS: u32 = 24;
 const DIRECTION_WARNING_MARGIN_X100: u32 = 90;
 const RESUME_DIRECT_PROOF_MAX_MEAN_ABS_DIFF_X100: u32 = 320;
@@ -252,7 +251,10 @@ pub(crate) struct ScrollSession {
 	preview_width_px: u32,
 }
 impl ScrollSession {
-	pub(crate) fn new(base_frame: RgbaImage, preview_width_px: u32) -> Result<Self> {
+	pub(crate) fn new(
+		base_frame: RgbaImage,
+		preview_width_px: u32,
+	) -> color_eyre::eyre::Result<Self> {
 		let fingerprint = scroll_capture_fingerprint(&base_frame);
 		let anchor_preview =
 			self::support::resize_strip_to_preview_width(&base_frame, preview_width_px.max(1));
@@ -320,7 +322,7 @@ impl ScrollSession {
 	pub(crate) fn observe_downward_sample(
 		&mut self,
 		frame: RgbaImage,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.observe_downward_sample_with_motion_hint(frame, None)
 	}
 
@@ -328,7 +330,7 @@ impl ScrollSession {
 		&mut self,
 		frame: RgbaImage,
 		motion_rows_hint: Option<u32>,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.observe_downward_sample_with_motion_hint_and_burst(frame, motion_rows_hint, false)
 	}
 
@@ -337,7 +339,7 @@ impl ScrollSession {
 		frame: RgbaImage,
 		motion_rows_hint: Option<u32>,
 		allow_burst_search: bool,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.observe_sample_with_motion_context(
 			frame,
 			ScrollDirection::Down,
@@ -350,14 +352,14 @@ impl ScrollSession {
 	pub(crate) fn observe_upward_sample(
 		&mut self,
 		frame: RgbaImage,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.observe_sample_with_motion_context(frame, ScrollDirection::Up, None, false)
 	}
 
 	pub(crate) fn observe_worker_pairwise_vision_frame(
 		&mut self,
 		frame: RgbaImage,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.clear_last_downward_sample_registration();
 
 		if frame.width() != self.anchor_frame.width() {
@@ -372,81 +374,83 @@ impl ScrollSession {
 		let previous_worker_frame = self.worker_pairwise_previous_frame.clone();
 
 		if frame == previous_worker_frame {
-			self.update_worker_pairwise_reference_frame(frame, fingerprint);
-			self.log_decision(
-				"scroll_capture.worker_pairwise_no_change",
-				ScrollDirection::Down,
-				None,
-				Some(self.observed_viewport_top_y),
-				Some(0),
-				Some("frame_matches_last_committed_frame"),
-			);
-
-			return Ok(ScrollObserveOutcome::NoChange);
+			return Ok(self.observe_worker_pairwise_no_change(
+				frame,
+				fingerprint,
+				"frame_matches_last_committed_frame",
+			));
 		}
 
 		let Some(matched) = self::support::classify_vision_downward_sample_motion_against(
 			&previous_worker_frame,
 			&frame,
 		) else {
-			self.update_worker_pairwise_reference_frame(frame, fingerprint);
-			self.log_decision(
-				"scroll_capture.worker_pairwise_no_change",
-				ScrollDirection::Down,
-				None,
-				Some(self.observed_viewport_top_y),
-				Some(0),
-				Some("worker_pairwise_vision_no_downward_offset"),
-			);
-
-			return Ok(ScrollObserveOutcome::NoChange);
+			return Ok(self.observe_worker_pairwise_no_change(
+				frame,
+				fingerprint,
+				"worker_pairwise_vision_no_downward_offset",
+			));
 		};
 		let corroborated_shift_rows =
-			self::support::estimate_pairwise_downward_shift_rows(&previous_worker_frame, &frame);
-
-		if matched.motion_rows >= WORKER_PAIRWISE_CORROBORATION_MIN_ROWS
-			&& corroborated_shift_rows.is_none_or(|estimated| {
-				estimated == 0
-					|| matched.motion_rows.abs_diff(estimated)
-						> WORKER_PAIRWISE_CORROBORATION_TOLERANCE_ROWS
-			}) {
-			self.update_worker_pairwise_reference_frame(frame, fingerprint);
-			self.log_decision(
-				"scroll_capture.worker_pairwise_growth_blocked",
-				ScrollDirection::Down,
-				Some(MotionObservation {
-					direction: ScrollDirection::Down,
-					motion_rows: matched.motion_rows,
-				}),
-				Some(self.current_viewport_top_y),
-				Some(0),
-				Some("worker_pairwise_large_growth_missing_corroboration"),
+			self::support::trusted_pairwise_downward_shift_rows_near_motion(
+				&previous_worker_frame,
+				&frame,
+				matched.motion_rows,
+				WORKER_PAIRWISE_CORROBORATION_TOLERANCE_ROWS,
 			);
+		let effective_motion_rows = match Self::resolve_worker_pairwise_motion_rows(
+			matched.motion_rows,
+			corroborated_shift_rows,
+		) {
+			Ok(motion_rows) => motion_rows,
+			Err(block_reason) => {
+				return Ok(self.block_worker_pairwise_growth(
+					frame,
+					fingerprint,
+					matched.motion_rows,
+					self.current_viewport_top_y,
+					0,
+					block_reason,
+				));
+			},
+		};
 
-			return Ok(ScrollObserveOutcome::NoChange);
+		tracing::debug!(
+			op = "scroll_capture.worker_pairwise_motion_resolved",
+			vision_motion_rows = matched.motion_rows,
+			corroborated_motion_rows = corroborated_shift_rows,
+			effective_motion_rows,
+			current_viewport_top_y = self.current_viewport_top_y,
+			observed_viewport_top_y = self.observed_viewport_top_y,
+			"Scroll-capture worker pairwise motion resolved against pixel overlap."
+		);
+
+		if effective_motion_rows == 0 {
+			return Ok(self.block_worker_pairwise_growth(
+				frame,
+				fingerprint,
+				effective_motion_rows,
+				self.current_viewport_top_y,
+				0,
+				"worker_pairwise_zero_effective_motion",
+			));
 		}
 
 		let candidate_viewport_top_y = self
 			.current_viewport_top_y
-			.saturating_add(i32::try_from(matched.motion_rows).unwrap_or_default());
+			.saturating_add(i32::try_from(effective_motion_rows).unwrap_or_default());
 		let growth_rows = self.growth_rows_for_candidate_viewport_top_y(candidate_viewport_top_y);
 		let frame_max_growth_rows = frame.height().saturating_sub(1).max(1);
 
 		if growth_rows == 0 || growth_rows > frame_max_growth_rows {
-			self.update_worker_pairwise_reference_frame(frame, fingerprint);
-			self.log_decision(
-				"scroll_capture.worker_pairwise_growth_blocked",
-				ScrollDirection::Down,
-				Some(MotionObservation {
-					direction: ScrollDirection::Down,
-					motion_rows: matched.motion_rows,
-				}),
-				Some(candidate_viewport_top_y),
-				Some(growth_rows),
-				Some("worker_pairwise_growth_exceeded_frame_bounds"),
-			);
-
-			return Ok(ScrollObserveOutcome::NoChange);
+			return Ok(self.block_worker_pairwise_growth(
+				frame,
+				fingerprint,
+				effective_motion_rows,
+				candidate_viewport_top_y,
+				growth_rows,
+				"worker_pairwise_growth_exceeded_frame_bounds",
+			));
 		}
 
 		self.log_decision(
@@ -454,7 +458,7 @@ impl ScrollSession {
 			ScrollDirection::Down,
 			Some(MotionObservation {
 				direction: ScrollDirection::Down,
-				motion_rows: matched.motion_rows,
+				motion_rows: effective_motion_rows,
 			}),
 			Some(candidate_viewport_top_y),
 			Some(growth_rows),
@@ -471,9 +475,70 @@ impl ScrollSession {
 			candidate_viewport_top_y,
 			"worker_pairwise_vision",
 			Some(matched.motion_rows),
-			None,
+			Some(effective_motion_rows),
 			None,
 		)
+	}
+
+	fn observe_worker_pairwise_no_change(
+		&mut self,
+		frame: RgbaImage,
+		fingerprint: Vec<u8>,
+		reason: &'static str,
+	) -> ScrollObserveOutcome {
+		self.update_worker_pairwise_reference_frame(frame, fingerprint);
+		self.log_decision(
+			"scroll_capture.worker_pairwise_no_change",
+			ScrollDirection::Down,
+			None,
+			Some(self.observed_viewport_top_y),
+			Some(0),
+			Some(reason),
+		);
+
+		ScrollObserveOutcome::NoChange
+	}
+
+	fn block_worker_pairwise_growth(
+		&mut self,
+		frame: RgbaImage,
+		fingerprint: Vec<u8>,
+		motion_rows: u32,
+		candidate_viewport_top_y: i32,
+		growth_rows: u32,
+		reason: &'static str,
+	) -> ScrollObserveOutcome {
+		self.update_worker_pairwise_reference_frame(frame, fingerprint);
+		self.log_decision(
+			"scroll_capture.worker_pairwise_growth_blocked",
+			ScrollDirection::Down,
+			Some(MotionObservation { direction: ScrollDirection::Down, motion_rows }),
+			Some(candidate_viewport_top_y),
+			Some(growth_rows),
+			Some(reason),
+		);
+
+		ScrollObserveOutcome::NoChange
+	}
+
+	fn resolve_worker_pairwise_motion_rows(
+		vision_motion_rows: u32,
+		corroborated_shift_rows: Option<u32>,
+	) -> std::result::Result<u32, &'static str> {
+		let Some(corroborated_shift_rows) = corroborated_shift_rows else {
+			return Err("worker_pairwise_missing_or_ambiguous_overlap_corroboration");
+		};
+
+		if corroborated_shift_rows == 0 {
+			return Err("worker_pairwise_zero_overlap_corroboration");
+		}
+		if vision_motion_rows.abs_diff(corroborated_shift_rows)
+			> WORKER_PAIRWISE_CORROBORATION_TOLERANCE_ROWS
+		{
+			return Err("worker_pairwise_vision_overlap_motion_mismatch");
+		}
+
+		Ok(corroborated_shift_rows)
 	}
 
 	fn update_worker_pairwise_reference_frame(&mut self, frame: RgbaImage, fingerprint: Vec<u8>) {
@@ -491,7 +556,7 @@ impl ScrollSession {
 		input_direction: ScrollDirection,
 		motion_rows_hint: Option<u32>,
 		allow_burst_search: bool,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let previous_hint = self.transient_motion_rows_hint;
 		let previous_burst = self.transient_burst_search_enabled;
 
@@ -512,7 +577,7 @@ impl ScrollSession {
 		&mut self,
 		frame: RgbaImage,
 		input_direction: ScrollDirection,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.clear_last_downward_sample_registration();
 
 		if frame.width() != self.anchor_frame.width() {
@@ -724,7 +789,7 @@ impl ScrollSession {
 		sample_motion: Option<MotionObservation>,
 		downward_sample_match: Option<DownwardSampleMatch>,
 		preview_changed: bool,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.last_unconfirmed_upward_fingerprint = None;
 
 		if let Some(motion) = sample_motion {
@@ -797,7 +862,7 @@ impl ScrollSession {
 		sample_delta: Option<u32>,
 		sample_motion: Option<MotionObservation>,
 		_preview_changed: bool,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let diagnostics = self.diagnose_upward_input(&frame);
 
 		self.log_upward_input_diagnostics(&diagnostics, sample_delta, sample_motion, &frame);
@@ -1416,7 +1481,7 @@ impl ScrollSession {
 		frame: RgbaImage,
 		observed_match: DownwardSampleMatch,
 		preview_changed: bool,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let motion_rows = observed_match.matched.motion_rows;
 
 		if self.resume_frontier_top_y.is_some() {
@@ -1543,7 +1608,7 @@ impl ScrollSession {
 		observed_match: DownwardSampleMatch,
 		motion_rows: u32,
 		preview_changed: bool,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let reset_preview_only_local_baseline =
 			self.should_reset_preview_only_local_baseline_after_huge_far_committed_block();
 		let preview_only_local_viewport_top_y = if self
@@ -1623,7 +1688,7 @@ impl ScrollSession {
 		candidate: DownwardViewportCandidate,
 		preview_changed: bool,
 		block_reason: &'static str,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		self.consecutive_transient_burst_missing_downward_candidate_frames = 0;
 
 		self.refresh_local_downward_sample(frame);
@@ -1790,7 +1855,7 @@ impl ScrollSession {
 		frame: RgbaImage,
 		motion_rows: u32,
 		preview_changed: bool,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let candidate_observed_viewport_top_y = self
 			.observed_viewport_top_y
 			.saturating_add(i32::try_from(motion_rows).unwrap_or_default());
@@ -1963,7 +2028,7 @@ impl ScrollSession {
 		preview_changed: bool,
 		frame_reacquires_last_committed_viewport: bool,
 		context: ResumeFrontierDirectMatchContext,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let direct_match_hint_rows = Some(self.resume_frontier_direct_match_hint_rows(context));
 		let raw_committed_down_match = self.evaluate_reference_overlap_direction_preferred_only(
 			&self.last_committed_frame,
@@ -2151,7 +2216,7 @@ impl ScrollSession {
 		preview_changed: bool,
 		down: DirectionMatch,
 		context: ResumeFrontierDirectMatchContext,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let candidate_viewport_top_y = if self.resume_frontier_requires_reacquire {
 			let resume_frontier_top_y =
 				self.resume_frontier_top_y.unwrap_or(self.current_viewport_top_y);
@@ -2204,7 +2269,7 @@ impl ScrollSession {
 		preview_changed: bool,
 		detected_motion: Option<MotionObservation>,
 		decision_source: &'static str,
-	) -> Result<ScrollObserveOutcome> {
+	) -> color_eyre::eyre::Result<ScrollObserveOutcome> {
 		let growth_rows = self.growth_rows_for_candidate_viewport_top_y(candidate_viewport_top_y);
 		let effective_motion_rows_hint = self.effective_motion_rows_hint();
 

--- a/packages/rsnap-overlay/src/scroll_capture/downward_resolution.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/downward_resolution.rs
@@ -1,3 +1,5 @@
+use color_eyre::eyre::Result;
+
 use crate::scroll_capture::support;
 use crate::scroll_capture::{
 	BlockedPreviewOnlyLocalCandidate, CommittedDownwardViewportCandidateMode,
@@ -12,7 +14,7 @@ use crate::scroll_capture::{
 	LOCAL_DOWNWARD_SEARCH_MOTION_TOLERANCE_ROWS, MotionObservation, OverlapSearchConfig,
 	OverlapSearchRange, PREVIEW_ONLY_LOCAL_NEAR_CONTINUITY_ROWS,
 	PREVIEW_ONLY_LOCAL_RECOVERY_MAX_MOTION_ROWS, PREVIEW_ONLY_LOCAL_RECOVERY_MAX_TOLERANCE_ROWS,
-	REPEATED_PREVIEW_ONLY_LOCAL_RECOVERY_MAX_MOTION_ROWS, RangeInclusive, Result, RgbaImage,
+	REPEATED_PREVIEW_ONLY_LOCAL_RECOVERY_MAX_MOTION_ROWS, RangeInclusive, RgbaImage,
 	ScrollDirection, ScrollObserveOutcome, ScrollSession,
 	TINY_PREVIEW_ONLY_LOCAL_BURST_RECOVERY_MAX_MOTION_ROWS,
 	UNDERCONSUMED_OBSERVED_BURST_RECOVERY_GAP_ROWS, eyre,

--- a/packages/rsnap-overlay/src/scroll_capture/support.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/support.rs
@@ -177,6 +177,7 @@ pub(super) fn classify_vision_downward_sample_motion_against(
 	None
 }
 
+#[cfg(test)]
 pub(super) fn estimate_pairwise_downward_shift_rows(
 	previous: &RgbaImage,
 	current: &RgbaImage,
@@ -201,6 +202,23 @@ pub(super) fn estimate_pairwise_downward_shift_rows(
 		worker_pairwise_overlap_search_config(),
 	)
 	.map(|matched| matched.motion_rows)
+}
+
+pub(super) fn trusted_pairwise_downward_shift_rows_near_motion(
+	previous: &RgbaImage,
+	current: &RgbaImage,
+	motion_rows: u32,
+	tolerance_rows: u32,
+) -> Option<u32> {
+	match classify_pairwise_downward_shift_near_motion(
+		previous,
+		current,
+		motion_rows,
+		tolerance_rows,
+	) {
+		DownwardRegistration::Matched(matched) => Some(matched.motion_rows),
+		DownwardRegistration::Ambiguous { .. } | DownwardRegistration::NoMatch => None,
+	}
 }
 
 pub(super) fn select_downward_viewport_candidate(
@@ -693,6 +711,36 @@ pub(super) fn evenly_spaced_sample(start: u32, end_exclusive: u32, index: u32, c
 		(u64::from(index) * u64::from(span.saturating_sub(1))) / u64::from(count.saturating_sub(1));
 
 	start.saturating_add(numerator as u32).min(end_exclusive.saturating_sub(1))
+}
+
+fn classify_pairwise_downward_shift_near_motion(
+	previous: &RgbaImage,
+	current: &RgbaImage,
+	motion_rows: u32,
+	tolerance_rows: u32,
+) -> DownwardRegistration {
+	if previous.dimensions() != current.dimensions() {
+		return DownwardRegistration::NoMatch;
+	}
+
+	let (_width, height) = previous.dimensions();
+
+	if height < 3 {
+		return DownwardRegistration::NoMatch;
+	}
+
+	let max_shift = height.saturating_sub(1);
+	let start = motion_rows.saturating_sub(tolerance_rows).max(1);
+	let end = motion_rows.saturating_add(tolerance_rows).min(max_shift).max(start);
+	let candidates = collect_overlap_direction_matches(
+		previous,
+		current,
+		ScrollDirection::Down,
+		start..=end,
+		worker_pairwise_overlap_search_config(),
+	);
+
+	classify_downward_registration_candidates(&candidates)
 }
 
 fn worker_pairwise_overlap_search_config() -> OverlapSearchConfig {

--- a/packages/rsnap-overlay/src/scroll_capture/tests.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/tests.rs
@@ -275,6 +275,51 @@ fn pairwise_downward_shift_estimate_tracks_successive_browser_like_steps() {
 	}
 }
 
+#[test]
+fn trusted_pairwise_downward_shift_blocks_periodic_ambiguity_near_vision_motion() {
+	let document: Vec<[u8; 4]> = (0..256)
+		.map(|row| {
+			let bucket = (row % 24) as u8;
+
+			[
+				bucket.saturating_mul(7),
+				255_u8.saturating_sub(bucket.saturating_mul(3)),
+				bucket.saturating_mul(5),
+				255,
+			]
+		})
+		.collect();
+	let base = make_window(&document, 8, 0, 96);
+	let moved = make_window(&document, 8, 24, 96);
+
+	assert!(support::estimate_pairwise_downward_shift_rows(&base, &moved).is_some());
+	assert_eq!(
+		support::trusted_pairwise_downward_shift_rows_near_motion(&base, &moved, 24, 24),
+		None
+	);
+}
+
+#[test]
+fn worker_pairwise_motion_resolution_prefers_overlap_rows_for_stitch_boundary() {
+	assert_eq!(ScrollSession::resolve_worker_pairwise_motion_rows(180, Some(168)), Ok(168));
+}
+
+#[test]
+fn worker_pairwise_motion_resolution_blocks_uncorroborated_or_conflicting_motion() {
+	assert_eq!(
+		ScrollSession::resolve_worker_pairwise_motion_rows(20, None),
+		Err("worker_pairwise_missing_or_ambiguous_overlap_corroboration")
+	);
+	assert_eq!(
+		ScrollSession::resolve_worker_pairwise_motion_rows(20, Some(0)),
+		Err("worker_pairwise_zero_overlap_corroboration")
+	);
+	assert_eq!(
+		ScrollSession::resolve_worker_pairwise_motion_rows(180, Some(220)),
+		Err("worker_pairwise_vision_overlap_motion_mismatch")
+	);
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn worker_pairwise_vision_uses_latest_committed_live_frame_for_followup_growth() {


### PR DESCRIPTION
Summary:
- route scroll capture into the native host and keep the selected viewport live while stitching
- add fixed-area minimap preview and stitched-image copy/save/OCR export
- harden pairwise stitching so ambiguous or mismatched overlap does not append a broken seam

Validation:
- cargo test -p rsnap-overlay worker_pairwise_vision
- cargo make fmt-check
- cargo make test-host-reset
- cargo make test-macos-native-host
- git diff --check