### PR TITLE
Fix live loupe background refresh

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -499,6 +499,22 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		)
 	}
 
+	func loupePatch(containing point: CGPoint, sidePixels: Int) -> CGImage? {
+		stateLock.lock()
+		let displayID = displayTargets.first(where: { $0.value.frame.contains(point) })?.key
+		let record = displayID.flatMap { latestFrames[$0] }.flatMap(snapshotEligibleRecordLocked)
+		stateLock.unlock()
+		guard let record else {
+			return nil
+		}
+		return Self.loupePatch(
+			from: record.pixelBuffer,
+			point: point,
+			displayFrame: record.displayFrame,
+			sidePixels: sidePixels
+		)
+	}
+
 	func snapshot(
 		containing point: CGPoint,
 		after token: FrozenFrameLatchToken?,
@@ -1044,6 +1060,87 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let bytes = baseAddress.assumingMemoryBound(to: UInt8.self)
 		let offset = y * bytesPerRow + x * 4
 		return RGBSample(r: bytes[offset + 2], g: bytes[offset + 1], b: bytes[offset])
+	}
+
+	private static func loupePatch(
+		from pixelBuffer: CVPixelBuffer,
+		point: CGPoint,
+		displayFrame: CGRect,
+		sidePixels: Int
+	) -> CGImage? {
+		guard displayFrame.width > 0, displayFrame.height > 0, displayFrame.contains(point) else {
+			return nil
+		}
+		let width = CVPixelBufferGetWidth(pixelBuffer)
+		let height = CVPixelBufferGetHeight(pixelBuffer)
+		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+		let side = max(sidePixels, 1)
+		guard width > 0, height > 0, bytesPerRow >= width * 4 else {
+			return nil
+		}
+		let xRatio = (point.x - displayFrame.minX) / displayFrame.width
+		let yRatio = (displayFrame.maxY - point.y) / displayFrame.height
+		let centerX = min(max(Int((xRatio * CGFloat(width)).rounded(.down)), 0), width - 1)
+		let centerY = min(max(Int((yRatio * CGFloat(height)).rounded(.down)), 0), height - 1)
+		guard CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly) == kCVReturnSuccess else {
+			return nil
+		}
+		defer {
+			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
+		}
+		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+			return nil
+		}
+		let sourceBytes = baseAddress.assumingMemoryBound(to: UInt8.self)
+		let outputBytesPerPixel = 4
+		let outputBytesPerRow = side * outputBytesPerPixel
+		let half = side / 2
+		var rgba = [UInt8](repeating: 0, count: outputBytesPerRow * side)
+		for outputY in 0..<side {
+			let sourceY = min(max(centerY - half + outputY, 0), height - 1)
+			for outputX in 0..<side {
+				let sourceX = min(max(centerX - half + outputX, 0), width - 1)
+				let sourceOffset = sourceY * bytesPerRow + sourceX * 4
+				let outputOffset = outputY * outputBytesPerRow + outputX * outputBytesPerPixel
+				rgba[outputOffset] = sourceBytes[sourceOffset + 2]
+				rgba[outputOffset + 1] = sourceBytes[sourceOffset + 1]
+				rgba[outputOffset + 2] = sourceBytes[sourceOffset]
+				rgba[outputOffset + 3] = sourceBytes[sourceOffset + 3]
+			}
+		}
+		return rgbaImage(width: side, height: side, rgba: rgba)
+	}
+
+	private static func rgbaImage(width: Int, height: Int, rgba: [UInt8]) -> CGImage? {
+		guard width > 0, height > 0 else {
+			return nil
+		}
+		let bytesPerRow = width * 4
+		let expectedByteCount = bytesPerRow * height
+		guard rgba.count >= expectedByteCount else {
+			return nil
+		}
+		let data = Data(rgba.prefix(expectedByteCount))
+		let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue)
+		guard
+			let provider = CGDataProvider(data: data as CFData),
+			let image = CGImage(
+				width: width,
+				height: height,
+				bitsPerComponent: 8,
+				bitsPerPixel: 32,
+				bytesPerRow: bytesPerRow,
+				space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+				bitmapInfo: bitmapInfo,
+				provider: provider,
+				decode: nil,
+				shouldInterpolate: false,
+				intent: .defaultIntent
+			)
+		else {
+			return nil
+		}
+		return image
 	}
 }
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -152,12 +152,15 @@ final class WindowSnapshotFeed {
 }
 
 final class ChromeSampleFeed: @unchecked Sendable {
-	typealias BackgroundSampler = @Sendable (CGPoint, LiveColorSampleSource) -> RGBSample?
 	typealias FrameRgbSampler = @Sendable (CGPoint) -> RGBSample?
+	typealias FramePatchSampler = @Sendable (CGPoint, Int) -> CGImage?
+	typealias BackgroundSampler =
+		@Sendable (CGPoint, LiveColorSampleSource, Int, Bool) -> LiveChromeSample?
 	typealias SampleUpdated = () -> Void
 
 	private let broker: LiveFrameStreamBroker
 	private let frameRgbSampler: FrameRgbSampler
+	private let framePatchSampler: FramePatchSampler
 	private let backgroundSampler: BackgroundSampler
 	private let sampleUpdated: SampleUpdated
 	private let queue = DispatchQueue(
@@ -203,11 +206,13 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	init(
 		broker: LiveFrameStreamBroker,
 		frameRgbSampler: @escaping FrameRgbSampler = { _ in nil },
+		framePatchSampler: @escaping FramePatchSampler = { _, _ in nil },
 		backgroundSampler: @escaping BackgroundSampler,
 		sampleUpdated: @escaping SampleUpdated = {}
 	) {
 		self.broker = broker
 		self.frameRgbSampler = frameRgbSampler
+		self.framePatchSampler = framePatchSampler
 		self.backgroundSampler = backgroundSampler
 		self.sampleUpdated = sampleUpdated
 	}
@@ -358,12 +363,19 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			stateLock.unlock()
 			return
 		}
-		let streamSample =
+		let frameRgbSample = frameRgbSampler(point)
+		let framePatchSample =
 			includeLoupePatch
+			? framePatchSampler(point, sidePixels)
+			: nil
+		let streamSample =
+			includeLoupePatch && framePatchSample == nil
 			? broker.sample(at: point, sidePixels: sidePixels)
 			: nil
-		let frameRgbSample = frameRgbSampler(point)
-		let streamRgbSample = streamSample?.rgbSample ?? broker.rgbSample(at: point)
+		let streamRgbSample =
+			frameRgbSample == nil
+			? (streamSample?.rgbSample ?? broker.rgbSample(at: point))
+			: nil
 		let rgbSample =
 			frameRgbSample
 			?? streamRgbSample
@@ -373,12 +385,15 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			enqueueBackgroundSampleIfNeeded(
 				point: point,
 				source: source,
+				sidePixels: sidePixels,
+				includeLoupePatch: includeLoupePatch,
 				streamRgbSample: streamRgbSample,
 				pointIdleDuration: pointIdleDuration
 			)
 		}
 		let patchSample =
-			streamSample
+			Self.sampleWithUpdatedPatch(rgbSample: nil, loupePatch: framePatchSample)
+			?? streamSample
 			?? Self.reusablePatchSample(
 				previousSample: previousSample,
 				previousPoint: previousPoint,
@@ -438,6 +453,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private func enqueueBackgroundSampleIfNeeded(
 		point: CGPoint,
 		source: LiveColorSampleSource,
+		sidePixels: Int,
+		includeLoupePatch: Bool,
 		streamRgbSample: RGBSample?,
 		pointIdleDuration: TimeInterval
 	) {
@@ -482,6 +499,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			self?.refreshBackgroundSample(
 				point: point,
 				source: source,
+				sidePixels: sidePixels,
+				includeLoupePatch: includeLoupePatch,
 				shouldProbeForCorrection: shouldProbe
 			)
 		}
@@ -490,25 +509,27 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private func refreshBackgroundSample(
 		point: CGPoint,
 		source: LiveColorSampleSource,
+		sidePixels: Int,
+		includeLoupePatch: Bool,
 		shouldProbeForCorrection: Bool
 	) {
 		let startedAt = ProcessInfo.processInfo.systemUptime
-		let rgbSample = backgroundSampler(point, source)
+		let sample = backgroundSampler(point, source, sidePixels, includeLoupePatch)
 		backgroundSampleDurationMetric.recordMillisecondsSince(startedAt)
 		let shouldNotify: Bool
 		stateLock.lock()
 		backgroundRefreshQueued = false
 		if let desiredPoint,
-			let rgbSample,
+			let sample,
 			desiredSource == source,
 			Self.pointsEquivalent(desiredPoint, point)
 		{
-			if shouldProbeForCorrection {
+			if shouldProbeForCorrection, let rgbSample = sample.rgbSample {
 				backgroundCorrectionMode = !Self.isLikelyOverlayWhite(rgbSample)
 			}
 			latestSample = LiveChromeSample(
-				rgbSample: rgbSample,
-				loupePatch: latestSample?.loupePatch
+				rgbSample: sample.rgbSample ?? latestSample?.rgbSample,
+				loupePatch: sample.loupePatch ?? latestSample?.loupePatch
 			)
 			latestSamplePoint = point
 			shouldNotify = Self.shouldNotifySampleUpdated(
@@ -539,12 +560,19 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		rgbSample: RGBSample?,
 		patchSample: LiveChromeSample?
 	) -> LiveChromeSample? {
-		guard rgbSample != nil || patchSample != nil else {
+		sampleWithUpdatedPatch(rgbSample: rgbSample, loupePatch: patchSample?.loupePatch)
+	}
+
+	private static func sampleWithUpdatedPatch(
+		rgbSample: RGBSample?,
+		loupePatch: CGImage?
+	) -> LiveChromeSample? {
+		guard rgbSample != nil || loupePatch != nil else {
 			return nil
 		}
 		return LiveChromeSample(
 			rgbSample: rgbSample,
-			loupePatch: patchSample?.loupePatch
+			loupePatch: loupePatch
 		)
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -798,6 +798,9 @@ final class CaptureSessionController: NSObject {
 				liveFrameStream: liveFrameStream,
 				frameRgbSampler: { [frozenFrameAuthority] point in
 					frozenFrameAuthority.rgbSample(containing: point)
+				},
+				framePatchSampler: { [frozenFrameAuthority] point, sidePixels in
+					frozenFrameAuthority.loupePatch(containing: point, sidePixels: sidePixels)
 				}
 			)
 			self.overlayController = overlayController
@@ -2953,11 +2956,13 @@ final class CaptureOverlayController {
 	private var collapsedForFrozen = false
 	private let liveFrameStream: LiveFrameStreamBroker
 	private let frameRgbSampler: ChromeSampleFeed.FrameRgbSampler
+	private let framePatchSampler: ChromeSampleFeed.FramePatchSampler
 	private lazy var windowSnapshotFeed = WindowSnapshotFeed()
 	private lazy var chromeSampleFeed = ChromeSampleFeed(
 		broker: liveFrameStream,
 		frameRgbSampler: frameRgbSampler,
-		backgroundSampler: Self.rgbSampleAtDisplayPoint,
+		framePatchSampler: framePatchSampler,
+		backgroundSampler: Self.chromeSampleAtDisplayPoint,
 		sampleUpdated: { [weak self] in
 			DispatchQueue.main.async { [weak self] in
 				(self?.primaryWindow as? CaptureOverlayWindow)?.hostView
@@ -2970,11 +2975,13 @@ final class CaptureOverlayController {
 	init(
 		controller: CaptureSessionController,
 		liveFrameStream: LiveFrameStreamBroker,
-		frameRgbSampler: @escaping ChromeSampleFeed.FrameRgbSampler
+		frameRgbSampler: @escaping ChromeSampleFeed.FrameRgbSampler,
+		framePatchSampler: @escaping ChromeSampleFeed.FramePatchSampler
 	) {
 		self.controller = controller
 		self.liveFrameStream = liveFrameStream
 		self.frameRgbSampler = frameRgbSampler
+		self.framePatchSampler = framePatchSampler
 	}
 
 	var primaryWindow: NSWindow? {
@@ -3325,6 +3332,25 @@ final class CaptureOverlayController {
 		)
 	}
 
+	nonisolated private static func chromeSampleAtDisplayPoint(
+		_ point: CGPoint,
+		source: LiveColorSampleSource,
+		sidePixels: Int,
+		includeLoupePatch: Bool
+	) -> LiveChromeSample? {
+		let loupePatch =
+			includeLoupePatch
+			? loupePatchAtDisplayPoint(point, source: source, sidePixels: sidePixels)
+			: nil
+		let rgbSample =
+			loupePatch.flatMap(rgbSample(from:))
+			?? rgbSampleAtDisplayPoint(point, source: source)
+		guard rgbSample != nil || loupePatch != nil else {
+			return nil
+		}
+		return LiveChromeSample(rgbSample: rgbSample, loupePatch: loupePatch)
+	}
+
 	nonisolated private static func rgbSampleAtDisplayPoint(
 		_ point: CGPoint,
 		source: LiveColorSampleSource
@@ -3346,6 +3372,29 @@ final class CaptureOverlayController {
 			return sample
 		}
 		return nil
+	}
+
+	nonisolated private static func loupePatchAtDisplayPoint(
+		_ point: CGPoint,
+		source: LiveColorSampleSource,
+		sidePixels: Int
+	) -> CGImage? {
+		let scaleFactor = max(source.scaleFactor, 1)
+		let sidePixels = max(sidePixels, 1)
+		let sampleSide = max(CGFloat(sidePixels) / scaleFactor, 1 / scaleFactor)
+		let sampleRect = CGRect(
+			x: point.x - sampleSide / 2,
+			y: point.y - sampleSide / 2,
+			width: sampleSide,
+			height: sampleSide
+		).intersection(source.screenFrame)
+		guard !sampleRect.isNull, sampleRect.width > 0, sampleRect.height > 0 else {
+			return nil
+		}
+		guard let image = captureImageBelowOverlay(in: sampleRect, source: source) else {
+			return nil
+		}
+		return normalizedPatchImage(image, sidePixels: sidePixels)
 	}
 
 	nonisolated private static func captureImageBelowOverlay(
@@ -3394,6 +3443,44 @@ final class CaptureOverlayController {
 				g: bytes[centerOffset + 1],
 				b: bytes[centerOffset + 2]
 			)
+		}
+	}
+
+	nonisolated private static func normalizedPatchImage(
+		_ image: CGImage,
+		sidePixels: Int
+	) -> CGImage? {
+		let sidePixels = max(sidePixels, 1)
+		if image.width == sidePixels, image.height == sidePixels {
+			return image
+		}
+		let bytesPerPixel = 4
+		let bytesPerRow = sidePixels * bytesPerPixel
+		var pixels = [UInt8](repeating: 0, count: bytesPerRow * sidePixels)
+		let colorSpace = CGColorSpaceCreateDeviceRGB()
+		let bitmapInfo =
+			CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
+		return pixels.withUnsafeMutableBytes { buffer -> CGImage? in
+			guard
+				let baseAddress = buffer.baseAddress,
+				let context = CGContext(
+					data: baseAddress,
+					width: sidePixels,
+					height: sidePixels,
+					bitsPerComponent: 8,
+					bytesPerRow: bytesPerRow,
+					space: colorSpace,
+					bitmapInfo: bitmapInfo
+				)
+			else {
+				return nil
+			}
+			context.interpolationQuality = .none
+			context.draw(
+				image,
+				in: CGRect(x: 0, y: 0, width: sidePixels, height: sidePixels)
+			)
+			return context.makeImage()
 		}
 	}
 


### PR DESCRIPTION
## Summary
- sample live loupe patches from the same latest frame authority used for RGB sampling
- keep stream/window-list sampling as fallbacks so stationary background changes update without widening hot-path capture cost
- preserve the existing fast HUD/loupe render path and sample cache behavior

## Validation
- cargo make lint-swift
- cargo make test-macos-native-host
- cargo make test-macos-native-host-stage
- HUD_FOLLOW_CASES=loupe PATH_DURATION_MS=800 PATH_CYCLES=1 POST_PATH_SETTLE_S=0.25 OVERLAY_SETTLE_S=0.2 POST_CLOSE_SETTLE_S=0.12 RSNAP_TELEMETRY_LAST=8s scripts/smoke/native-hud-follow-macos.sh
  - PASS; sample_refresh_gap p95=8.89ms against 120Hz sample budget 9.33ms
  - active_layer_chrome_render_gap p95=14.28ms against 60Hz budget 16.67ms