### PR TITLE
Serialize crates publish after release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,7 @@ jobs:
   publish-on-crates-io:
     name: Publish on crates.io
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- make the crates.io publish job wait for the release build matrix
- ensure tag-triggered crate publication cannot race ahead of macOS signing/notarization/package build failures

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release-yaml-ok"'`
- `git diff --check`
