### PR TITLE
Document release validation and native scroll permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,13 @@ cargo run -p rsnap
 Rsnap currently relies on **Screen Recording** permission to capture other apps/windows.
 - ScreenCaptureKit live sampling on macOS requires macOS 12.3+ and Screen Recording permission.
 - Normal region/window/monitor capture does not require Accessibility or Input Monitoring.
-- Scroll capture currently requires **Accessibility** because Rsnap forwards scroll into the target app.
-- Scroll capture currently requires **Input Monitoring** because Rsnap listens for global scroll-wheel input via a native macOS listen-event tap.
-- The native host currently disables scroll capture, so the active native feature set only requests Screen Recording.
-- macOS may phrase the Input Monitoring prompt as receiving keystrokes from any application even though Rsnap only listens for scroll-wheel input in this path.
+- Scroll capture is available from dragged-region freezes on the current native host and uses
+  Screen Recording-backed screenshots plus forwarded wheel input.
 - macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when Rsnap bypasses the system picker.
-- The native menubar host exposes `Permissions…`, which shows Screen Recording, Accessibility, and Input Monitoring status. It marks Accessibility and Input Monitoring as not needed until native scroll automation is enabled.
+- The native menubar host exposes `Permissions…`, which shows Screen Recording, Accessibility, and Input Monitoring status. It marks Accessibility and Input Monitoring as diagnostic/not required for the current native host.
 - Normal native capture depends on Screen Recording; if access is missing, Rsnap opens the Screen Recording page in System Settings and shows a floating drag-to-grant guide.
 - You can reopen `Permissions…` from the tray or menubar menu at any time.
 - Base capture path: `System Settings` -> `Privacy & Security` -> `Screen Recording`.
-- Scroll capture paths: `System Settings` -> `Privacy & Security` -> `Accessibility` and `Input Monitoring`.
 - Enable `Rsnap.app`, then retry capture. If macOS still keeps capture blocked after changing a permission, relaunch the app.
 
 ### HUD settings behavior

--- a/docs/runbook/index.md
+++ b/docs/runbook/index.md
@@ -67,6 +67,8 @@ Then structure the body for execution:
 - `docs/runbook/scroll-capture-benchmarks.md` for deterministic scroll-capture benchmark usage
 - `docs/runbook/telemetry-debugging.md` for collecting and summarizing native-host OSLog plus
   Rust rolling logs during runtime debugging
+- `docs/runbook/validate-release.md` for the formal release-candidate and published-artifact
+  validation sequence
 
 Historical validation material is archived outside the active runbook lane and should not be used
 as the default validation route for reset work.

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -1,0 +1,92 @@
+# Validate Release
+
+Goal: Execute the final release-candidate checks before publishing a tagged Rsnap release.
+
+Read this when: You are preparing a formal Rsnap release tag or verifying the published release
+artifacts immediately after the tag workflow completes.
+
+Preconditions: `main` is clean and synced, the intended release version is committed in
+`Cargo.toml`, GitHub Actions release secrets are configured, and a logged-in macOS desktop session
+is available for native-host smoke and manual checks.
+
+Depends on: `docs/spec/app-identity.md`; `docs/spec/settings.md`; `docs/spec/telemetry.md`;
+`docs/runbook/performance-validation.md`; `.github/workflows/release.yml`
+
+Verification: Local checks, dedicated macOS smoke/perf evidence, release workflow success, signed
+and notarized macOS artifact acceptance, and manual first-run/user-flow validation.
+
+## Before Tagging
+
+1. Confirm the release version:
+   - `Cargo.toml` `workspace.package.version` matches the intended tag without a leading `v`.
+   - No existing local or remote tag already uses `v<version>`.
+2. Confirm release credentials:
+   - Apple signing certificate and notary credentials are available to the Release workflow.
+   - `CARGO_REGISTRY_TOKEN` is available if the crates.io publish job should run.
+3. Confirm local gates:
+   - `cargo make checks`
+   - `cargo make test-host-reset`
+   - `cargo make test-macos-native-host-stage`
+4. Confirm dedicated desktop validation:
+   - `scripts/smoke/macos.sh`
+   - `scripts/perf/macos.sh`
+   - If scroll-capture correctness changed, follow the recorded-trace flow in
+     `docs/runbook/performance-validation.md`.
+
+## Manual RC Smoke
+
+Launch the staged signed app path:
+
+```sh
+RSNAP_NATIVE_HOST_FORCE_REBUILD=1 ./scripts/build_and_run.sh run
+```
+
+Validate these user-visible flows:
+
+- First launch and missing Screen Recording recovery.
+- Menubar app identity, no Dock icon during capture, Settings open/close behavior.
+- Option-X capture start, cancel, and frontmost-app restoration.
+- Live HUD, Tab loupe sampling, window outline, dragged-region freeze, click-window freeze, and
+  fullscreen fallback.
+- Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
+  scroll capture, Recognize Text, copy, and save.
+- Light and dark appearance; Classic Glass and Liquid Glass where the OS supports Liquid Glass.
+- Output directory, filename prefix, sequence/timestamp naming, clipboard copy, and save failure
+  handling where practical.
+
+Collect telemetry after any surprising behavior:
+
+```sh
+scripts/telemetry/native-host.sh collect
+```
+
+Telemetry artifacts must not include captured image contents, OCR text, clipboard contents, or
+user-entered annotation text.
+
+## Tag And Publish
+
+1. Push the annotated release tag only after local and manual RC validation pass.
+2. Watch the Release workflow for the exact tag.
+3. Treat a build, signing, notarization, or packaging failure as a release blocker.
+4. Treat crates.io publishing as dependent on successful build/package jobs; do not publish crates
+   manually unless the workflow failure has been diagnosed and the already-published state is clear.
+
+## Published Artifact Check
+
+After the Release workflow succeeds:
+
+1. Download the macOS zip from the GitHub release.
+2. Unzip it and verify identity:
+   - The app bundle is `Rsnap.app`.
+   - `CFBundleName` and `CFBundleDisplayName` are `Rsnap`.
+   - `CFBundleIdentifier` is `ink.hack.rsnap`.
+3. Verify signature and Gatekeeper acceptance:
+
+```sh
+codesign --verify --deep --strict /path/to/Rsnap.app
+spctl -a -vvv --type exec /path/to/Rsnap.app
+```
+
+4. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, save, and scroll
+   capture check.
+5. Confirm release notes and checksums were published with the artifacts.


### PR DESCRIPTION
## Summary

- remove stale README text that said the native host disables scroll capture
- align the permission guidance with the current native host, where Screen Recording is required and Accessibility/Input Monitoring are diagnostic/not required
- add `docs/runbook/validate-release.md` as a compact release-candidate and published-artifact checklist
- route the new runbook from `docs/runbook/index.md`

## Validation

- `git diff --check`
- checked local runbook/spec links referenced by `docs/runbook/validate-release.md`
