### PR TITLE
Add quality-preserving OCR telemetry

### DIFF
--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -85,6 +85,7 @@ Use dotted lowercase names:
 - `capture_timing.start_capture`
 - `capture_timing.freeze_commit`
 - `capture_timing.copy_capture`
+- `capture_timing.recognize_text`
 - `frozen_authority.stream_start_failed`
 - `live_chrome.refresh_target`
 - `logging.file_initialized`
@@ -125,6 +126,9 @@ Expected capture-session chain:
 5. `capture_timing.copy_capture`
 6. `capture.teardown`
 
+Optional host-effect timing events include `capture_timing.recognize_text` when the user requests
+OCR from a frozen capture.
+
 Missing events in the chain are evidence of the next failing phase and should be treated as
 debug signal, not as logging noise.
 
@@ -148,3 +152,7 @@ rendering path can change without `targetHz` changing.
 Native-host telemetry can mark diagnostic fields public when they are needed for debugging.
 Do not log captured image contents, OCR text, clipboard contents, or user-entered annotation
 text. Paths may be logged only when they identify app resources or log artifacts.
+
+OCR telemetry may log timing, image dimensions, Vision request configuration, observation counts,
+non-empty line counts, character counts, and final outcome labels. It must not log recognized text,
+candidate strings, image contents, clipboard contents, or annotation text.

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -2130,19 +2130,78 @@ final class CaptureSessionController: NSObject {
 		guard let session else {
 			return
 		}
+		let captureID = currentCaptureTelemetryID
+		let recognizeStartedAt = ProcessInfo.processInfo.systemUptime
+		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
+		let recognitionLevel = "accurate"
+		let usesLanguageCorrection = true
+		let automaticallyDetectsLanguage = true
 		guard let cgImage = try captureFrozenSelectionImage() else {
+			NativeHostTelemetry.recognizeTextTiming(
+				captureID: captureID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: recognizeStartedAt),
+				captureImageMilliseconds: NativeHostTelemetry.milliseconds(
+					since: captureImageStartedAt),
+				visionRequestMilliseconds: 0,
+				resultProcessingMilliseconds: 0,
+				clearPasteboardMilliseconds: 0,
+				writePasteboardMilliseconds: 0,
+				success: false,
+				outcome: "recognize_error",
+				failureStage: "capture_image",
+				width: 0,
+				height: 0,
+				observationCount: 0,
+				recognizedLines: 0,
+				recognizedCharacters: 0,
+				recognitionLevel: recognitionLevel,
+				languageCorrection: usesLanguageCorrection,
+				automaticLanguageDetection: automaticallyDetectsLanguage
+			)
 			try sendHostStatusMessage("Could not capture the frozen selection.")
 			return
 		}
+		let captureImageMilliseconds =
+			NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
 
 		let request = VNRecognizeTextRequest()
 		request.recognitionLevel = .accurate
-		request.usesLanguageCorrection = true
-		request.automaticallyDetectsLanguage = true
+		request.usesLanguageCorrection = usesLanguageCorrection
+		request.automaticallyDetectsLanguage = automaticallyDetectsLanguage
 		let handler = VNImageRequestHandler(cgImage: cgImage)
-		try handler.perform([request])
+		let visionStartedAt = ProcessInfo.processInfo.systemUptime
+		do {
+			try handler.perform([request])
+		} catch {
+			NativeHostTelemetry.recognizeTextTiming(
+				captureID: captureID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: recognizeStartedAt),
+				captureImageMilliseconds: captureImageMilliseconds,
+				visionRequestMilliseconds: NativeHostTelemetry.milliseconds(
+					since: visionStartedAt),
+				resultProcessingMilliseconds: 0,
+				clearPasteboardMilliseconds: 0,
+				writePasteboardMilliseconds: 0,
+				success: false,
+				outcome: "recognize_error",
+				failureStage: "vision_request",
+				width: cgImage.width,
+				height: cgImage.height,
+				observationCount: 0,
+				recognizedLines: 0,
+				recognizedCharacters: 0,
+				recognitionLevel: recognitionLevel,
+				languageCorrection: usesLanguageCorrection,
+				automaticLanguageDetection: automaticallyDetectsLanguage
+			)
+			throw error
+		}
+		let visionRequestMilliseconds = NativeHostTelemetry.milliseconds(since: visionStartedAt)
 
-		let text = (request.results ?? [])
+		let resultProcessingStartedAt = ProcessInfo.processInfo.systemUptime
+		let observations = request.results ?? []
+		let recognizedLines =
+			observations
 			.compactMap { observation -> String? in
 				guard let line = observation.topCandidates(1).first?.string,
 					!line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -2151,16 +2210,70 @@ final class CaptureSessionController: NSObject {
 				}
 				return line
 			}
-			.joined(separator: "\n")
+		let text = recognizedLines.joined(separator: "\n")
+		let resultProcessingMilliseconds =
+			NativeHostTelemetry.milliseconds(since: resultProcessingStartedAt)
 
+		var clearPasteboardMilliseconds = 0.0
+		var writePasteboardMilliseconds = 0.0
 		if !text.isEmpty {
 			let pasteboard = NSPasteboard.general
+			let clearPasteboardStartedAt = ProcessInfo.processInfo.systemUptime
 			pasteboard.clearContents()
+			clearPasteboardMilliseconds =
+				NativeHostTelemetry.milliseconds(since: clearPasteboardStartedAt)
+			let writePasteboardStartedAt = ProcessInfo.processInfo.systemUptime
 			guard pasteboard.setString(text, forType: .string) else {
+				writePasteboardMilliseconds =
+					NativeHostTelemetry.milliseconds(since: writePasteboardStartedAt)
+				NativeHostTelemetry.recognizeTextTiming(
+					captureID: captureID,
+					totalMilliseconds: NativeHostTelemetry.milliseconds(
+						since: recognizeStartedAt),
+					captureImageMilliseconds: captureImageMilliseconds,
+					visionRequestMilliseconds: visionRequestMilliseconds,
+					resultProcessingMilliseconds: resultProcessingMilliseconds,
+					clearPasteboardMilliseconds: clearPasteboardMilliseconds,
+					writePasteboardMilliseconds: writePasteboardMilliseconds,
+					success: false,
+					outcome: "recognize_error",
+					failureStage: "pasteboard_write",
+					width: cgImage.width,
+					height: cgImage.height,
+					observationCount: observations.count,
+					recognizedLines: recognizedLines.count,
+					recognizedCharacters: text.count,
+					recognitionLevel: recognitionLevel,
+					languageCorrection: usesLanguageCorrection,
+					automaticLanguageDetection: automaticallyDetectsLanguage
+				)
 				try sendHostStatusMessage("Could not copy recognized text.")
 				return
 			}
+			writePasteboardMilliseconds =
+				NativeHostTelemetry.milliseconds(since: writePasteboardStartedAt)
 		}
+
+		NativeHostTelemetry.recognizeTextTiming(
+			captureID: captureID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: recognizeStartedAt),
+			captureImageMilliseconds: captureImageMilliseconds,
+			visionRequestMilliseconds: visionRequestMilliseconds,
+			resultProcessingMilliseconds: resultProcessingMilliseconds,
+			clearPasteboardMilliseconds: clearPasteboardMilliseconds,
+			writePasteboardMilliseconds: writePasteboardMilliseconds,
+			success: true,
+			outcome: text.isEmpty ? "no_text" : "text_ready",
+			failureStage: "none",
+			width: cgImage.width,
+			height: cgImage.height,
+			observationCount: observations.count,
+			recognizedLines: recognizedLines.count,
+			recognizedCharacters: text.count,
+			recognitionLevel: recognitionLevel,
+			languageCorrection: usesLanguageCorrection,
+			automaticLanguageDetection: automaticallyDetectsLanguage
+		)
 
 		try session.send(report: .hostEffectCompleted(.recognizeText))
 		let message =

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -291,6 +291,31 @@ enum NativeHostTelemetry {
 		)
 	}
 
+	static func recognizeTextTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		captureImageMilliseconds: Double,
+		visionRequestMilliseconds: Double,
+		resultProcessingMilliseconds: Double,
+		clearPasteboardMilliseconds: Double,
+		writePasteboardMilliseconds: Double,
+		success: Bool,
+		outcome: String,
+		failureStage: String,
+		width: Int,
+		height: Int,
+		observationCount: Int,
+		recognizedLines: Int,
+		recognizedCharacters: Int,
+		recognitionLevel: String,
+		languageCorrection: Bool,
+		automaticLanguageDetection: Bool
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.recognize_text totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) captureImageMs=\(captureImageMilliseconds, format: .fixed(precision: 2), privacy: .public) visionRequestMs=\(visionRequestMilliseconds, format: .fixed(precision: 2), privacy: .public) resultProcessingMs=\(resultProcessingMilliseconds, format: .fixed(precision: 2), privacy: .public) clearPasteboardMs=\(clearPasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) writePasteboardMs=\(writePasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) success=\(success, privacy: .public) outcome=\(outcome, privacy: .public) failureStage=\(failureStage, privacy: .public) width=\(width, privacy: .public) height=\(height, privacy: .public) observationCount=\(observationCount, privacy: .public) recognizedLines=\(recognizedLines, privacy: .public) recognizedCharacters=\(recognizedCharacters, privacy: .public) recognitionLevel=\(recognitionLevel, privacy: .public) languageCorrection=\(languageCorrection, privacy: .public) automaticLanguageDetection=\(automaticLanguageDetection, privacy: .public)"
+		)
+	}
+
 	final class DistributionMetric: @unchecked Sendable {
 		private let name: String
 		private let unit: String


### PR DESCRIPTION
## Summary

- emit `capture_timing.recognize_text` telemetry for OCR timing, dimensions, Vision request configuration, result counts, and outcome labels
- keep OCR quality settings unchanged: `.accurate`, language correction enabled, automatic language detection enabled
- document the new OCR telemetry event and privacy boundary

## Privacy / quality boundary

The telemetry does not log captured image contents, OCR text, Vision candidate strings, clipboard contents, or annotation text. It records only timing, dimensions, counts, config labels, and outcome/failure-stage labels.

## Validation

- `cargo make fmt-swift`
- `cargo make lint-swift`
- `cargo make test-macos-native-host`
- `git diff --check`

Refs XY-452.
