### PR TITLE
Improve on-demand capture color startup

### DIFF
--- a/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
+++ b/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
@@ -29,17 +29,29 @@ public struct RGBSample: Equatable, Sendable {
 
 public struct LiveSampleSnapshot: Equatable, Sendable {
 	public var rgb: RGBSample?
+	public var capturedAtUptime: TimeInterval?
+	public var frameAgeMicroseconds: UInt64?
+	public var frameSequence: UInt64?
+	public var streamGeneration: UInt64?
 	public var patchWidth: Int
 	public var patchHeight: Int
 	public var patchRGBA: Data?
 
 	public init(
 		rgb: RGBSample?,
+		capturedAtUptime: TimeInterval? = nil,
+		frameAgeMicroseconds: UInt64? = nil,
+		frameSequence: UInt64? = nil,
+		streamGeneration: UInt64? = nil,
 		patchWidth: Int = 0,
 		patchHeight: Int = 0,
 		patchRGBA: Data? = nil
 	) {
 		self.rgb = rgb
+		self.capturedAtUptime = capturedAtUptime
+		self.frameAgeMicroseconds = frameAgeMicroseconds
+		self.frameSequence = frameSequence
+		self.streamGeneration = streamGeneration
 		self.patchWidth = patchWidth
 		self.patchHeight = patchHeight
 		self.patchRGBA = patchRGBA
@@ -892,9 +904,21 @@ public final class RsnapLiveSampler: @unchecked Sendable {
 			return Data(rawBuffer.prefix(count))
 		}
 
+		let frameAgeMicroseconds =
+			outSample.has_frame_metadata == 0 ? nil : UInt64(outSample.frame_age_micros)
+		let capturedAtUptime = frameAgeMicroseconds.map {
+			ProcessInfo.processInfo.systemUptime - (Double($0) / 1_000_000.0)
+		}
+
 		return LiveSampleSnapshot(
 			rgb: outSample.has_rgb == 0
 				? nil : RGBSample(r: outSample.rgb.r, g: outSample.rgb.g, b: outSample.rgb.b),
+			capturedAtUptime: capturedAtUptime,
+			frameAgeMicroseconds: frameAgeMicroseconds,
+			frameSequence: outSample.has_frame_metadata == 0
+				? nil : UInt64(outSample.frame_seq),
+			streamGeneration: outSample.has_frame_metadata == 0
+				? nil : UInt64(outSample.stream_generation),
 			patchWidth: Int(outSample.patch_width),
 			patchHeight: Int(outSample.patch_height),
 			patchRGBA: patchData

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -38,6 +38,7 @@ struct FrozenFrameSnapshot: @unchecked Sendable {
 /// screenshots just because a pixel buffer happens to exist.
 final class FrozenFrameAuthority: @unchecked Sendable {
 	private static let maximumSnapshotAgeMilliseconds = 150.0
+	private static let maximumLiveRgbAgeMilliseconds = 100.0
 	private static let selfCaptureFilterRetryInterval: TimeInterval = 0.035
 	private static let selfCaptureFilterRetryWindow: TimeInterval = 2.5
 
@@ -638,7 +639,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		guard let record else {
 			return nil
 		}
-		guard record.ageMilliseconds() <= LiveRgbSample.maximumDisplayAge * 1_000 else {
+		guard record.ageMilliseconds() <= Self.maximumLiveRgbAgeMilliseconds else {
 			return nil
 		}
 		guard

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -7,14 +7,14 @@ import Foundation
 import RsnapHostBridge
 import ScreenCaptureKit
 
-struct FrozenFrameLatchToken {
+struct FrozenFrameLatchToken: Sendable {
 	let displayID: CGDirectDisplayID
 	let generation: UInt64
 	let minSequence: UInt64
 	let startedAtUptime: TimeInterval
 }
 
-struct FrozenFrameSnapshot {
+struct FrozenFrameSnapshot: @unchecked Sendable {
 	let displayID: CGDirectDisplayID
 	let displayFrame: CGRect
 	let image: CGImage
@@ -485,6 +485,10 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	}
 
 	func rgbSample(containing point: CGPoint) -> RGBSample? {
+		liveRgbSample(containing: point)?.rgb
+	}
+
+	func liveRgbSample(containing point: CGPoint) -> LiveRgbSample? {
 		stateLock.lock()
 		let displayID = displayTargets.first(where: { $0.value.frame.contains(point) })?.key
 		let record = displayID.flatMap { latestFrames[$0] }.flatMap(snapshotEligibleRecordLocked)
@@ -492,10 +496,22 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		guard let record else {
 			return nil
 		}
-		return Self.rgbSample(
-			from: record.pixelBuffer,
-			point: point,
-			displayFrame: record.displayFrame
+		guard record.ageMilliseconds() <= LiveRgbSample.maximumDisplayAge * 1_000 else {
+			return nil
+		}
+		guard
+			let rgb = Self.rgbSample(
+				from: record.pixelBuffer,
+				point: point,
+				displayFrame: record.displayFrame
+			)
+		else {
+			return nil
+		}
+		return LiveRgbSample(
+			rgb: rgb,
+			capturedAtUptime: record.capturedAtUptime,
+			source: "frame_authority"
 		)
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -30,6 +30,12 @@ struct FrozenFrameSnapshot: @unchecked Sendable {
 	}
 }
 
+/// Owns the screenshot consistency protocol around ScreenCaptureKit's asynchronous frame stream.
+///
+/// The controller asks this type to prepare an overlay-safe filter, latch a commit point, and
+/// resolve that latch into either a fresh frame, a pending self-capture-safe frame, or failure.
+/// Keeping those states here prevents cached stream frames from being treated as authoritative
+/// screenshots just because a pixel buffer happens to exist.
 final class FrozenFrameAuthority: @unchecked Sendable {
 	private static let maximumSnapshotAgeMilliseconds = 150.0
 	private static let selfCaptureFilterRetryInterval: TimeInterval = 0.035
@@ -55,6 +61,12 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		func ageMilliseconds(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Double {
 			max(0, now - capturedAtUptime) * 1_000
 		}
+	}
+
+	enum SnapshotResolution: Sendable {
+		case resolved(FrozenFrameSnapshot)
+		case pendingSelfCaptureFrame
+		case noFreshFrame
 	}
 
 	private final class DisplayStream: @unchecked Sendable {
@@ -114,11 +126,34 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let matchedWindowCount: Int
 	}
 
+	private final class ShareableContentCache: @unchecked Sendable {
+		private let lock = NSLock()
+		private var content: SCShareableContent?
+		private var cachedAtUptime: TimeInterval = 0
+
+		func store(_ content: SCShareableContent) {
+			lock.lock()
+			self.content = content
+			cachedAtUptime = ProcessInfo.processInfo.systemUptime
+			lock.unlock()
+		}
+
+		func fresh(maxAge: TimeInterval) -> SCShareableContent? {
+			let now = ProcessInfo.processInfo.systemUptime
+			lock.lock()
+			let content = now - cachedAtUptime <= maxAge ? self.content : nil
+			lock.unlock()
+			return content
+		}
+	}
+
 	private let stateLock = NSCondition()
 	private let outputQueue = DispatchQueue(
 		label: "ink.hack.rsnap.native-host.frozen-frame-authority-output",
 		qos: .userInteractive
 	)
+	private static let shareableContentCacheMaxAge: TimeInterval = 3_600
+	private static let shareableContentCache = ShareableContentCache()
 	private var generation: UInt64 = 0
 	private var setupRequestID: UInt64 = 0
 	private var setupDisplayIDs: Set<CGDirectDisplayID>?
@@ -132,6 +167,40 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	private var firstFrameLoggedDisplayIDs: Set<CGDirectDisplayID> = []
 	private var telemetryContext = TelemetryContext(
 		captureID: 0, source: "capture", startedAtUptime: 0)
+
+	func refreshShareableContentCache(captureID: UInt64 = 0, source: String = "cache") {
+		let startedAtUptime = ProcessInfo.processInfo.systemUptime
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
+			content, error in
+			guard let content else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_cache_refresh_failed",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: String(describing: error)
+				)
+				return
+			}
+			Self.shareableContentCache.store(content)
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: true,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+		}
+	}
+
+	private static func cachedShareableContent() -> SCShareableContent? {
+		shareableContentCache.fresh(maxAge: shareableContentCacheMaxAge)
+	}
+
+	func hasFreshShareableContentCache() -> Bool {
+		Self.cachedShareableContent() != nil
+	}
 
 	func start(
 		for screens: [NSScreen],
@@ -243,6 +312,55 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		retryUntilUptime: TimeInterval,
 		requestID: UInt64
 	) {
+		if let content = Self.cachedShareableContent() {
+			let preparedFilters = Self.contentFilters(
+				for: targets,
+				in: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+			)
+			if Self.filtersAreComplete(preparedFilters, for: targets) {
+				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+					captureID: captureID,
+					source: source,
+					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+					success: true,
+					displayCount: content.displays.count,
+					windowCount: content.windows.count
+				)
+				stateLock.lock()
+				guard setupRequestID == requestID, activeDisplayIDs == targetIDs else {
+					stateLock.unlock()
+					return
+				}
+				generation &+= 1
+				let requestGeneration = generation
+				setupDisplayIDs = targetIDs
+				latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
+				updateTelemetryContextLocked(
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime,
+					targetIDs: targetIDs
+				)
+				let staleStreams = streams.values
+				streams.removeAll()
+				stateLock.unlock()
+
+				for staleStream in staleStreams {
+					staleStream.stop()
+				}
+
+				configureStreams(
+					targets: targets,
+					preparedFilters: preparedFilters,
+					generation: requestGeneration,
+					captureID: captureID,
+					source: source
+				)
+				return
+			}
+		}
 		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
 			[weak self] content, error in
 			guard let self else {
@@ -356,6 +474,30 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		source: String,
 		startedAtUptime: TimeInterval
 	) {
+		if let content = Self.cachedShareableContent() {
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: true,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+			let preparedFilters = Self.contentFilters(
+				for: targets,
+				in: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+			)
+			configureStreams(
+				targets: targets,
+				preparedFilters: preparedFilters,
+				generation: requestGeneration,
+				captureID: captureID,
+				source: source
+			)
+			return
+		}
 		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
 			[weak self] content, error in
 			guard let self else {
@@ -584,6 +726,20 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			selfCaptureSafe: true,
 			selfCaptureFilterComplete: record.selfCaptureFilterComplete
 		)
+	}
+
+	func resolveSnapshot(
+		containing point: CGPoint,
+		after token: FrozenFrameLatchToken?,
+		maxWait: TimeInterval
+	) -> SnapshotResolution {
+		if let snapshot = snapshot(containing: point, after: token, maxWait: maxWait) {
+			return .resolved(snapshot)
+		}
+		if needsSelfCaptureCompleteFrame(containing: point) {
+			return .pendingSelfCaptureFrame
+		}
+		return .noFreshFrame
 	}
 
 	private func freshRecordLocked(displayID: CGDirectDisplayID, token: FrozenFrameLatchToken?)

--- a/native/macos-host/Sources/RsnapNativeHostKit/GlobalHotKeyCenter.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/GlobalHotKeyCenter.swift
@@ -84,10 +84,20 @@ final class GlobalHotKeyCenter {
 			&hotKeyRef
 		)
 		guard status == noErr else {
+			NativeHostTelemetry.lifecycleWarning(
+				"native_host.hotkey_register_failed",
+				detail:
+					"binding=\(binding.rawValue),keyCode=\(definition.keyCode),modifiers=\(definition.modifiers),status=\(status)"
+			)
 			return
 		}
 		hotKeyRefs[binding] = hotKeyRef
 		registeredBindings.insert(binding)
+		NativeHostTelemetry.lifecycleEvent(
+			"native_host.hotkey_registered",
+			detail:
+				"binding=\(binding.rawValue),keyCode=\(definition.keyCode),modifiers=\(definition.modifiers)"
+		)
 	}
 
 	private func unregister(_ binding: Binding) {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -16,6 +16,7 @@ struct LivePositionDisplay: Equatable {
 struct LiveColorDisplay: Equatable {
 	let hexText: String
 	let hexSlotWidth: CGFloat
+	let isPending: Bool
 }
 
 struct LiveChromeBackdropSnapshot {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeWindows.swift
@@ -371,7 +371,7 @@ private final class LiveChromeBackdropWindow: NSWindow {
 		animationBehavior = .none
 		isOpaque = false
 		level = NSWindow.Level(rawValue: NSWindow.Level.screenSaver.rawValue - 1)
-		sharingType = .readOnly
+		sharingType = .none
 		titleVisibility = .hidden
 		titlebarAppearsTransparent = true
 		orderOut(nil)

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
@@ -29,6 +29,24 @@ final class LiveFrameStreamBroker {
 	private var didEmitRgbDiagnosticSample = false
 	private var issueDiagnosticSamplesRemaining = 0
 
+	func prepareSampler(reason: String = "unspecified") {
+		let startedAt = ProcessInfo.processInfo.systemUptime
+		stateLock.lock()
+		let created: Bool
+		if sampler == nil {
+			sampler = Self.makeSampler(exceptionWindowIDs: selfCaptureExceptionWindowIDs)
+			created = sampler != nil
+		} else {
+			created = false
+		}
+		stateLock.unlock()
+		NativeHostTelemetry.liveStreamSamplerPrepared(
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAt),
+			created: created,
+			reason: reason
+		)
+	}
+
 	func updateSelfCaptureExceptionWindowIDs(_ windowIDs: Set<CGWindowID>) {
 		stateLock.lock()
 		guard windowIDs != selfCaptureExceptionWindowIDs else {
@@ -105,7 +123,6 @@ final class LiveFrameStreamBroker {
 		didEmitRgbDiagnosticSample = false
 		issueDiagnosticSamplesRemaining = 0
 		let sampler = self.sampler
-		self.sampler = nil
 		stateLock.unlock()
 		guard let sampler else {
 			return

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
@@ -25,6 +25,9 @@ final class LiveFrameStreamBroker {
 	private var activeTelemetryCaptureID: UInt64 = 0
 	private var telemetryStartedAtUptime: TimeInterval?
 	private var didEmitFirstRgbSample = false
+	private var didEmitEmptyDiagnosticSample = false
+	private var didEmitRgbDiagnosticSample = false
+	private var issueDiagnosticSamplesRemaining = 0
 
 	func updateSelfCaptureExceptionWindowIDs(_ windowIDs: Set<CGWindowID>) {
 		stateLock.lock()
@@ -56,6 +59,9 @@ final class LiveFrameStreamBroker {
 			activeTelemetryCaptureID = captureID
 			telemetryStartedAtUptime = startedAt
 			didEmitFirstRgbSample = false
+			didEmitEmptyDiagnosticSample = false
+			didEmitRgbDiagnosticSample = false
+			issueDiagnosticSamplesRemaining = 4
 		}
 		if sampler == nil {
 			sampler = Self.makeSampler(exceptionWindowIDs: selfCaptureExceptionWindowIDs)
@@ -95,6 +101,9 @@ final class LiveFrameStreamBroker {
 		activeTelemetryCaptureID = 0
 		telemetryStartedAtUptime = nil
 		didEmitFirstRgbSample = false
+		didEmitEmptyDiagnosticSample = false
+		didEmitRgbDiagnosticSample = false
+		issueDiagnosticSamplesRemaining = 0
 		let sampler = self.sampler
 		self.sampler = nil
 		stateLock.unlock()
@@ -105,10 +114,19 @@ final class LiveFrameStreamBroker {
 	}
 
 	func sample(at point: CGPoint, sidePixels: Int) -> LiveChromeSample? {
+		let sampleStartedAt = ProcessInfo.processInfo.systemUptime
 		stateLock.lock()
 		let sampler = self.sampler
+		let captureID = activeTelemetryCaptureID
 		stateLock.unlock()
 		guard let sampler, let monitor = monitor(containing: point) else {
+			emitDiagnosticSampleIfNeeded(
+				captureID: captureID,
+				startedAt: sampleStartedAt,
+				outcome: "inactive",
+				frameAgeMilliseconds: -1,
+				hasPatch: false
+			)
 			return nil
 		}
 		let samplerPoint = Self.appKitPointToQuartz(point, mainDisplayHeight: mainDisplayHeight)
@@ -119,12 +137,45 @@ final class LiveFrameStreamBroker {
 				patchSidePixels: sidePixels
 			)
 		else {
+			emitDiagnosticSampleIfNeeded(
+				captureID: captureID,
+				startedAt: sampleStartedAt,
+				outcome: "empty",
+				frameAgeMilliseconds: -1,
+				hasPatch: false
+			)
 			return nil
 		}
-		guard let capturedAtUptime = sample.capturedAtUptime,
-			ProcessInfo.processInfo.systemUptime - capturedAtUptime
-				<= LiveRgbSample.maximumDisplayAge
-		else {
+		guard let capturedAtUptime = sample.capturedAtUptime else {
+			emitDiagnosticSampleIfNeeded(
+				captureID: captureID,
+				startedAt: sampleStartedAt,
+				outcome: "missing_metadata",
+				frameAgeMilliseconds: -1,
+				hasPatch: sample.patchRGBA != nil
+			)
+			return nil
+		}
+		let frameAge = ProcessInfo.processInfo.systemUptime - capturedAtUptime
+		let frameAgeMilliseconds = frameAge * 1_000
+		guard frameAge <= LiveRgbSample.maximumDisplayAge else {
+			emitDiagnosticSampleIfNeeded(
+				captureID: captureID,
+				startedAt: sampleStartedAt,
+				outcome: "stale",
+				frameAgeMilliseconds: frameAgeMilliseconds,
+				hasPatch: sample.patchRGBA != nil
+			)
+			return nil
+		}
+		guard sample.rgb != nil else {
+			emitDiagnosticSampleIfNeeded(
+				captureID: captureID,
+				startedAt: sampleStartedAt,
+				outcome: "no_rgb",
+				frameAgeMilliseconds: frameAgeMilliseconds,
+				hasPatch: sample.patchRGBA != nil
+			)
 			return nil
 		}
 
@@ -133,6 +184,13 @@ final class LiveFrameStreamBroker {
 			rgbCapturedAtUptime: capturedAtUptime,
 			rgbSource: "live_stream",
 			loupePatch: cgImage(from: sample)
+		)
+		emitDiagnosticSampleIfNeeded(
+			captureID: captureID,
+			startedAt: sampleStartedAt,
+			outcome: "rgb",
+			frameAgeMilliseconds: frameAgeMilliseconds,
+			hasPatch: chromeSample.loupePatch != nil
 		)
 		emitFirstRgbTelemetryIfNeeded(chromeSample)
 		return chromeSample
@@ -213,6 +271,44 @@ final class LiveFrameStreamBroker {
 			captureID: captureID,
 			totalMilliseconds: totalMilliseconds,
 			hasPatch: sample.loupePatch != nil
+		)
+	}
+
+	private func emitDiagnosticSampleIfNeeded(
+		captureID: UInt64,
+		startedAt: TimeInterval,
+		outcome: String,
+		frameAgeMilliseconds: Double,
+		hasPatch: Bool
+	) {
+		guard captureID != 0 else {
+			return
+		}
+		stateLock.lock()
+		let shouldEmit: Bool
+		switch outcome {
+		case "empty", "inactive":
+			shouldEmit = !didEmitEmptyDiagnosticSample
+			didEmitEmptyDiagnosticSample = true
+		case "rgb":
+			shouldEmit = !didEmitRgbDiagnosticSample
+			didEmitRgbDiagnosticSample = true
+		default:
+			shouldEmit = issueDiagnosticSamplesRemaining > 0
+			if shouldEmit {
+				issueDiagnosticSamplesRemaining -= 1
+			}
+		}
+		stateLock.unlock()
+		guard shouldEmit else {
+			return
+		}
+		NativeHostTelemetry.liveStreamSample(
+			captureID: captureID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAt),
+			outcome: outcome,
+			frameAgeMilliseconds: frameAgeMilliseconds,
+			hasPatch: hasPatch
 		)
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveFrameStream.swift
@@ -12,8 +12,6 @@ final class LiveFrameStreamBroker {
 	}
 
 	private static let primeThrottleInterval: TimeInterval = 1.0 / 120.0
-	private static let seedSampleMaxAttempts = 4
-	private static let seedSampleRetryInterval: TimeInterval = 1.0 / 120.0
 
 	private let stateLock = NSLock()
 	private var sampler: RsnapLiveSampler?
@@ -24,10 +22,9 @@ final class LiveFrameStreamBroker {
 	private var lastPrimedMonitorID: UInt32?
 	private var lastPrimeGeneration: UInt64 = 0
 	private var lastPrimeUptime: TimeInterval = 0
-
-	init() {
-		sampler = Self.makeSampler(exceptionWindowIDs: [])
-	}
+	private var activeTelemetryCaptureID: UInt64 = 0
+	private var telemetryStartedAtUptime: TimeInterval?
+	private var didEmitFirstRgbSample = false
 
 	func updateSelfCaptureExceptionWindowIDs(_ windowIDs: Set<CGWindowID>) {
 		stateLock.lock()
@@ -43,13 +40,23 @@ final class LiveFrameStreamBroker {
 		lastPrimeGeneration = 0
 		lastPrimeUptime = 0
 		let oldSampler = sampler
-		sampler = Self.makeSampler(exceptionWindowIDs: windowIDs)
+		if oldSampler != nil {
+			sampler = Self.makeSampler(exceptionWindowIDs: windowIDs)
+		}
 		stateLock.unlock()
 		try? oldSampler?.reset()
 	}
 
-	func start(for screens: [NSScreen], prewarmPoint: CGPoint? = nil) {
+	func start(for screens: [NSScreen], prewarmPoint: CGPoint? = nil, captureID: UInt64 = 0) {
+		let startedAt = ProcessInfo.processInfo.systemUptime
 		stateLock.lock()
+		if captureID != 0,
+			activeTelemetryCaptureID != captureID || telemetryStartedAtUptime == nil
+		{
+			activeTelemetryCaptureID = captureID
+			telemetryStartedAtUptime = startedAt
+			didEmitFirstRgbSample = false
+		}
 		if sampler == nil {
 			sampler = Self.makeSampler(exceptionWindowIDs: selfCaptureExceptionWindowIDs)
 		}
@@ -85,7 +92,11 @@ final class LiveFrameStreamBroker {
 		lastPrimedMonitorID = nil
 		lastPrimeGeneration = 0
 		lastPrimeUptime = 0
+		activeTelemetryCaptureID = 0
+		telemetryStartedAtUptime = nil
+		didEmitFirstRgbSample = false
 		let sampler = self.sampler
+		self.sampler = nil
 		stateLock.unlock()
 		guard let sampler else {
 			return
@@ -110,15 +121,25 @@ final class LiveFrameStreamBroker {
 		else {
 			return nil
 		}
+		guard let capturedAtUptime = sample.capturedAtUptime,
+			ProcessInfo.processInfo.systemUptime - capturedAtUptime
+				<= LiveRgbSample.maximumDisplayAge
+		else {
+			return nil
+		}
 
-		return LiveChromeSample(
+		let chromeSample = LiveChromeSample(
 			rgbSample: sample.rgb,
+			rgbCapturedAtUptime: capturedAtUptime,
+			rgbSource: "live_stream",
 			loupePatch: cgImage(from: sample)
 		)
+		emitFirstRgbTelemetryIfNeeded(chromeSample)
+		return chromeSample
 	}
 
-	func rgbSample(at point: CGPoint) -> RGBSample? {
-		sample(at: point, sidePixels: 0)?.rgbSample
+	func rgbSample(at point: CGPoint) -> LiveRgbSample? {
+		sample(at: point, sidePixels: 0)?.rgb
 	}
 
 	func patch(in rect: CGRect) -> CGImage? {
@@ -159,28 +180,6 @@ final class LiveFrameStreamBroker {
 		prime(monitor: monitor)
 	}
 
-	func seedSample(
-		at point: CGPoint,
-		sidePixels: Int
-	) -> LiveChromeSample? {
-		var latestSample: LiveChromeSample?
-		for attempt in 0..<Self.seedSampleMaxAttempts {
-			let sample = sample(at: point, sidePixels: sidePixels)
-			if sample?.rgbSample != nil {
-				return sample
-			}
-			if sample != nil {
-				latestSample = sample
-			}
-			guard attempt + 1 < Self.seedSampleMaxAttempts else {
-				break
-			}
-			prime(at: point)
-			Thread.sleep(forTimeInterval: Self.seedSampleRetryInterval)
-		}
-		return latestSample
-	}
-
 	private func monitor(containing point: CGPoint) -> SamplerMonitor? {
 		stateLock.lock()
 		let monitors = self.monitors
@@ -190,6 +189,31 @@ final class LiveFrameStreamBroker {
 
 	private static func makeSampler(exceptionWindowIDs: Set<CGWindowID>) -> RsnapLiveSampler? {
 		try? RsnapLiveSampler(selfCaptureExceptionWindowIDs: exceptionWindowIDs.sorted())
+	}
+
+	private func emitFirstRgbTelemetryIfNeeded(_ sample: LiveChromeSample) {
+		guard sample.rgbSample != nil else {
+			return
+		}
+		let captureID: UInt64
+		let totalMilliseconds: Double
+		stateLock.lock()
+		guard !didEmitFirstRgbSample, activeTelemetryCaptureID != 0 else {
+			stateLock.unlock()
+			return
+		}
+		didEmitFirstRgbSample = true
+		captureID = activeTelemetryCaptureID
+		totalMilliseconds =
+			telemetryStartedAtUptime.map {
+				NativeHostTelemetry.milliseconds(since: $0)
+			} ?? 0
+		stateLock.unlock()
+		NativeHostTelemetry.liveStreamFirstRgbSample(
+			captureID: captureID,
+			totalMilliseconds: totalMilliseconds,
+			hasPatch: sample.loupePatch != nil
+		)
 	}
 
 	private func prime(monitor: SamplerMonitor) {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -152,7 +152,16 @@ final class WindowSnapshotFeed {
 }
 
 final class ChromeSampleFeed: @unchecked Sendable {
-	typealias FrameRgbSampler = @Sendable (CGPoint) -> RGBSample?
+	private struct FirstRgbTelemetry {
+		let captureID: UInt64
+		let totalMilliseconds: Double
+		let refreshCount: UInt64
+		let source: String
+		let hasPatch: Bool
+		let includeLoupePatch: Bool
+	}
+
+	typealias FrameRgbSampler = @Sendable (CGPoint) -> LiveRgbSample?
 	typealias FramePatchSampler = @Sendable (CGPoint, Int) -> CGImage?
 	typealias BackgroundSampler =
 		@Sendable (CGPoint, LiveColorSampleSource, Int, Bool) -> LiveChromeSample?
@@ -202,6 +211,10 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private var latestSamplePoint: CGPoint?
 	private var lastRefreshUptime: TimeInterval?
 	private var lastPointChangeUptime = ProcessInfo.processInfo.systemUptime
+	private var activeCaptureID: UInt64 = 0
+	private var activationStartedAtUptime: TimeInterval?
+	private var refreshCount: UInt64 = 0
+	private var didEmitFirstRgbSample = false
 
 	init(
 		broker: LiveFrameStreamBroker,
@@ -217,8 +230,18 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		self.sampleUpdated = sampleUpdated
 	}
 
-	func start(targetFramesPerSecond: Int = NativeHostDisplayRefresh.targetFramesPerSecond) {
+	func start(
+		targetFramesPerSecond: Int = NativeHostDisplayRefresh.targetFramesPerSecond,
+		captureID: UInt64 = 0
+	) {
 		stop()
+		let startedAt = ProcessInfo.processInfo.systemUptime
+		stateLock.lock()
+		activeCaptureID = captureID
+		activationStartedAtUptime = startedAt
+		refreshCount = 0
+		didEmitFirstRgbSample = false
+		stateLock.unlock()
 		let timer = DispatchSource.makeTimerSource(queue: queue)
 		let intervalNanoseconds = max(
 			1,
@@ -238,6 +261,10 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		}
 		self.timer = timer
 		timer.resume()
+		NativeHostTelemetry.liveChromeSampleFeedStarted(
+			captureID: captureID,
+			targetHz: targetFramesPerSecond
+		)
 	}
 
 	func stop() {
@@ -256,6 +283,10 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		lastBackgroundProbeUptime = 0
 		lastRefreshUptime = nil
 		lastPointChangeUptime = ProcessInfo.processInfo.systemUptime
+		activeCaptureID = 0
+		activationStartedAtUptime = nil
+		refreshCount = 0
+		didEmitFirstRgbSample = false
 		stateLock.unlock()
 	}
 
@@ -280,7 +311,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			} ?? (point != nil)
 		if sidePixelsChanged || patchDemandChanged {
 			latestSample = latestSample.map {
-				LiveChromeSample(rgbSample: $0.rgbSample, loupePatch: nil)
+				LiveChromeSample(rgb: $0.rgb, loupePatch: nil)
 			}
 		}
 		if pointChanged || sourceChanged {
@@ -314,7 +345,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		guard let rgbSample = frameRgbSampler(point) else {
 			return nil
 		}
-		let sample = LiveChromeSample(rgbSample: rgbSample, loupePatch: nil)
+		let sample = LiveChromeSample(rgb: rgbSample, loupePatch: nil)
 		stateLock.lock()
 		self.latestSample = sample
 		self.latestSamplePoint = point
@@ -348,6 +379,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		let previousPoint = latestSamplePoint
 		let lastRefreshUptime = self.lastRefreshUptime
 		let pointIdleDuration = now - lastPointChangeUptime
+		refreshCount &+= 1
+		let currentRefreshCount = refreshCount
 		self.lastRefreshUptime = now
 		stateLock.unlock()
 		if let lastRefreshUptime {
@@ -374,25 +407,32 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			: nil
 		let streamRgbSample =
 			frameRgbSample == nil
-			? (streamSample?.rgbSample ?? broker.rgbSample(at: point))
+			? (streamSample?.rgb ?? broker.rgbSample(at: point))
 			: nil
+		let reusableRgbSample = Self.reusableRgbSample(
+			previousSample: previousSample, previousPoint: previousPoint, point: point, now: now)
 		let rgbSample =
 			frameRgbSample
 			?? streamRgbSample
-			?? Self.reusableRgbSample(
-				previousSample: previousSample, previousPoint: previousPoint, point: point)
+			?? reusableRgbSample
+		let rgbSource =
+			Self.rgbSampleSource(
+				frameRgbSample: frameRgbSample,
+				streamRgbSample: streamRgbSample,
+				reusableRgbSample: reusableRgbSample
+			)
 		if frameRgbSample == nil, let source {
 			enqueueBackgroundSampleIfNeeded(
 				point: point,
 				source: source,
 				sidePixels: sidePixels,
 				includeLoupePatch: includeLoupePatch,
-				streamRgbSample: streamRgbSample,
+				streamRgbSample: streamRgbSample?.rgb,
 				pointIdleDuration: pointIdleDuration
 			)
 		}
 		let patchSample =
-			Self.sampleWithUpdatedPatch(rgbSample: nil, loupePatch: framePatchSample)
+			Self.sampleWithUpdatedPatch(rgb: nil, loupePatch: framePatchSample)
 			?? streamSample
 			?? Self.reusablePatchSample(
 				previousSample: previousSample,
@@ -401,34 +441,103 @@ final class ChromeSampleFeed: @unchecked Sendable {
 				includeLoupePatch: includeLoupePatch
 			)
 		let sample = Self.sampleWithUpdatedPatch(
-			rgbSample: rgbSample,
+			rgb: rgbSample,
 			patchSample: patchSample
 		)
 		stateLock.lock()
 		latestSample = sample
 		latestSamplePoint = sample == nil ? nil : point
+		let firstRgbTelemetry = makeFirstRgbTelemetryLocked(
+			rgbSample: rgbSample?.rgb,
+			source: rgbSource,
+			refreshCount: currentRefreshCount,
+			hasPatch: sample?.loupePatch != nil,
+			includeLoupePatch: includeLoupePatch
+		)
 		stateLock.unlock()
+		emit(firstRgbTelemetry)
 		sampleRefreshDurationMetric.recordMillisecondsSince(refreshStartedAt)
+	}
+
+	private static func rgbSampleSource(
+		frameRgbSample: LiveRgbSample?,
+		streamRgbSample: LiveRgbSample?,
+		reusableRgbSample: LiveRgbSample?
+	) -> String {
+		if frameRgbSample != nil {
+			return "frame_authority"
+		}
+		if streamRgbSample != nil {
+			return "live_stream"
+		}
+		if reusableRgbSample != nil {
+			return "reusable_cache"
+		}
+		return "none"
+	}
+
+	private func makeFirstRgbTelemetryLocked(
+		rgbSample: RGBSample?,
+		source: String,
+		refreshCount: UInt64,
+		hasPatch: Bool,
+		includeLoupePatch: Bool
+	) -> FirstRgbTelemetry? {
+		guard rgbSample != nil, !didEmitFirstRgbSample else {
+			return nil
+		}
+		didEmitFirstRgbSample = true
+		return FirstRgbTelemetry(
+			captureID: activeCaptureID,
+			totalMilliseconds: activationStartedAtUptime.map {
+				NativeHostTelemetry.milliseconds(since: $0)
+			} ?? 0,
+			refreshCount: refreshCount,
+			source: source,
+			hasPatch: hasPatch,
+			includeLoupePatch: includeLoupePatch
+		)
+	}
+
+	private func emit(_ telemetry: FirstRgbTelemetry?) {
+		guard let telemetry else {
+			return
+		}
+		NativeHostTelemetry.liveChromeFirstRgbSample(
+			captureID: telemetry.captureID,
+			totalMilliseconds: telemetry.totalMilliseconds,
+			refreshCount: telemetry.refreshCount,
+			source: telemetry.source,
+			hasPatch: telemetry.hasPatch,
+			includeLoupePatch: telemetry.includeLoupePatch
+		)
 	}
 
 	private static func reusableRgbSample(
 		previousSample: LiveChromeSample?,
 		previousPoint: CGPoint?,
-		point: CGPoint
-	) -> RGBSample? {
+		point: CGPoint,
+		now: TimeInterval
+	) -> LiveRgbSample? {
 		reusableRgbSample(
-			rgbSample: previousSample?.rgbSample,
+			rgbSample: previousSample?.rgb,
 			previousPoint: previousPoint,
-			point: point
+			point: point,
+			now: now
 		)
 	}
 
 	private static func reusableRgbSample(
-		rgbSample: RGBSample?,
+		rgbSample: LiveRgbSample?,
 		previousPoint: CGPoint?,
-		point: CGPoint
-	) -> RGBSample? {
+		point: CGPoint,
+		now: TimeInterval
+	) -> LiveRgbSample? {
 		guard let previousPoint, pointsEquivalent(previousPoint, point) else {
+			return nil
+		}
+		guard rgbSample?.isFresh(maximumAge: LiveRgbSample.maximumReusableAge, now: now) == true
+		else {
 			return nil
 		}
 		return rgbSample
@@ -515,34 +624,48 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	) {
 		let startedAt = ProcessInfo.processInfo.systemUptime
 		let sample = backgroundSampler(point, source, sidePixels, includeLoupePatch)
+		let sampleRgb = sample?.rgb
+		let sampleRgbValue = sampleRgb?.rgb
+		let sampleLoupePatch = sample?.loupePatch
 		backgroundSampleDurationMetric.recordMillisecondsSince(startedAt)
-		let shouldNotify: Bool
 		stateLock.lock()
 		backgroundRefreshQueued = false
-		if let desiredPoint,
-			let sample,
+		let currentRefreshCount = refreshCount
+		guard let desiredPoint,
+			sample != nil,
 			desiredSource == source,
 			Self.pointsEquivalent(desiredPoint, point)
-		{
-			if shouldProbeForCorrection, let rgbSample = sample.rgbSample {
-				backgroundCorrectionMode = !Self.isLikelyOverlayWhite(rgbSample)
-			}
-			latestSample = LiveChromeSample(
-				rgbSample: sample.rgbSample ?? latestSample?.rgbSample,
-				loupePatch: sample.loupePatch ?? latestSample?.loupePatch
-			)
-			latestSamplePoint = point
-			shouldNotify = Self.shouldNotifySampleUpdated(
-				now: ProcessInfo.processInfo.systemUptime,
-				lastPointChangeUptime: lastPointChangeUptime
-			)
-		} else {
-			shouldNotify = false
+		else {
+			stateLock.unlock()
+			return
 		}
+		if shouldProbeForCorrection, let rgbSample = sampleRgbValue {
+			backgroundCorrectionMode = !Self.isLikelyOverlayWhite(rgbSample)
+		}
+		let previousRgb = latestSample?.rgb
+		let previousLoupePatch = latestSample?.loupePatch
+		latestSample = LiveChromeSample(
+			rgb: sampleRgb ?? previousRgb,
+			loupePatch: sampleLoupePatch ?? previousLoupePatch
+		)
+		latestSamplePoint = point
+		let firstRgbTelemetry = makeFirstRgbTelemetryLocked(
+			rgbSample: sampleRgbValue,
+			source: "background_fallback",
+			refreshCount: currentRefreshCount,
+			hasPatch: sampleLoupePatch != nil,
+			includeLoupePatch: includeLoupePatch
+		)
+		let shouldNotify = Self.shouldNotifySampleUpdated(
+			now: ProcessInfo.processInfo.systemUptime,
+			lastPointChangeUptime: lastPointChangeUptime
+		)
 		stateLock.unlock()
+		emit(firstRgbTelemetry)
 		if shouldNotify {
 			sampleUpdated()
 		}
+		return
 	}
 
 	private static func shouldNotifySampleUpdated(
@@ -557,21 +680,21 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	}
 
 	private static func sampleWithUpdatedPatch(
-		rgbSample: RGBSample?,
+		rgb: LiveRgbSample?,
 		patchSample: LiveChromeSample?
 	) -> LiveChromeSample? {
-		sampleWithUpdatedPatch(rgbSample: rgbSample, loupePatch: patchSample?.loupePatch)
+		sampleWithUpdatedPatch(rgb: rgb, loupePatch: patchSample?.loupePatch)
 	}
 
 	private static func sampleWithUpdatedPatch(
-		rgbSample: RGBSample?,
+		rgb: LiveRgbSample?,
 		loupePatch: CGImage?
 	) -> LiveChromeSample? {
-		guard rgbSample != nil || loupePatch != nil else {
+		guard rgb != nil || loupePatch != nil else {
 			return nil
 		}
 		return LiveChromeSample(
-			rgbSample: rgbSample,
+			rgb: rgb,
 			loupePatch: loupePatch
 		)
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -161,21 +161,35 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		let includeLoupePatch: Bool
 	}
 
+	private struct BackgroundSampleTelemetry {
+		let captureID: UInt64
+		let totalMilliseconds: Double
+		let outcome: String
+		let source: String
+		let includeLoupePatch: Bool
+		let immediate: Bool
+	}
+
 	typealias FrameRgbSampler = @Sendable (CGPoint) -> LiveRgbSample?
 	typealias FramePatchSampler = @Sendable (CGPoint, Int) -> CGImage?
 	typealias BackgroundSampler =
 		@Sendable (CGPoint, LiveColorSampleSource, Int, Bool) -> LiveChromeSample?
+	typealias FirstRgbSampled = @Sendable () -> Void
 	typealias SampleUpdated = () -> Void
 
 	private let broker: LiveFrameStreamBroker
 	private let frameRgbSampler: FrameRgbSampler
 	private let framePatchSampler: FramePatchSampler
 	private let backgroundSampler: BackgroundSampler
+	private let firstRgbSampled: FirstRgbSampled
 	private let sampleUpdated: SampleUpdated
 	private let queue = DispatchQueue(
 		label: "ink.hack.rsnap.native-host.chrome-sample-feed", qos: .userInteractive)
 	private let backgroundQueue = DispatchQueue(
-		label: "ink.hack.rsnap.native-host.chrome-sample-feed.background", qos: .userInteractive)
+		label: "ink.hack.rsnap.native-host.chrome-sample-feed.background",
+		qos: .userInteractive,
+		attributes: .concurrent
+	)
 	private let stateLock = NSLock()
 	private let sampleRefreshGapMetric = NativeHostTelemetry.distribution(
 		"live_chrome.sample_refresh_gap",
@@ -194,12 +208,15 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	)
 	private static let backgroundProbeMinimumInterval: TimeInterval = 0.25
 	private static let backgroundProbeIdleDelay: TimeInterval = 0.08
+	private static let missingRgbProbeMinimumInterval: TimeInterval = 1.0 / 120.0
+	private static let maximumBackgroundSamplesInFlight = 1
 	private static let sampleUpdatedNotificationIdleDelay =
 		NativeHostDisplayRefresh.frameInterval(
 			forTargetFramesPerSecond: NativeHostDisplayRefresh.fallbackFramesPerSecond)
 	private var timer: DispatchSourceTimer?
 	private var refreshQueued = false
-	private var backgroundRefreshQueued = false
+	private var backgroundSamplesInFlight = 0
+	private var backgroundRefreshPending = false
 	private var backgroundCorrectionMode = false
 	private var whiteStreamRunHasProbed = false
 	private var lastBackgroundProbeUptime: TimeInterval = 0
@@ -215,18 +232,22 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private var activationStartedAtUptime: TimeInterval?
 	private var refreshCount: UInt64 = 0
 	private var didEmitFirstRgbSample = false
+	private var didEmitEmptyBackgroundSample = false
+	private var liveStreamRgbReady = false
 
 	init(
 		broker: LiveFrameStreamBroker,
 		frameRgbSampler: @escaping FrameRgbSampler = { _ in nil },
 		framePatchSampler: @escaping FramePatchSampler = { _, _ in nil },
 		backgroundSampler: @escaping BackgroundSampler,
+		firstRgbSampled: @escaping FirstRgbSampled = {},
 		sampleUpdated: @escaping SampleUpdated = {}
 	) {
 		self.broker = broker
 		self.frameRgbSampler = frameRgbSampler
 		self.framePatchSampler = framePatchSampler
 		self.backgroundSampler = backgroundSampler
+		self.firstRgbSampled = firstRgbSampled
 		self.sampleUpdated = sampleUpdated
 	}
 
@@ -241,6 +262,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		activationStartedAtUptime = startedAt
 		refreshCount = 0
 		didEmitFirstRgbSample = false
+		didEmitEmptyBackgroundSample = false
+		liveStreamRgbReady = false
 		stateLock.unlock()
 		let timer = DispatchSource.makeTimerSource(queue: queue)
 		let intervalNanoseconds = max(
@@ -277,7 +300,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		latestSample = nil
 		latestSamplePoint = nil
 		refreshQueued = false
-		backgroundRefreshQueued = false
+		backgroundSamplesInFlight = 0
+		backgroundRefreshPending = false
 		backgroundCorrectionMode = false
 		whiteStreamRunHasProbed = false
 		lastBackgroundProbeUptime = 0
@@ -287,6 +311,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		activationStartedAtUptime = nil
 		refreshCount = 0
 		didEmitFirstRgbSample = false
+		didEmitEmptyBackgroundSample = false
+		liveStreamRgbReady = false
 		stateLock.unlock()
 	}
 
@@ -421,7 +447,14 @@ final class ChromeSampleFeed: @unchecked Sendable {
 				streamRgbSample: streamRgbSample,
 				reusableRgbSample: reusableRgbSample
 			)
-		if frameRgbSample == nil, let source {
+		let shouldUseDisplayPointSampler: Bool
+		stateLock.lock()
+		if frameRgbSample != nil || streamRgbSample != nil {
+			liveStreamRgbReady = true
+		}
+		shouldUseDisplayPointSampler = !liveStreamRgbReady
+		stateLock.unlock()
+		if frameRgbSample == nil, let source, shouldUseDisplayPointSampler {
 			enqueueBackgroundSampleIfNeeded(
 				point: point,
 				source: source,
@@ -511,6 +544,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			hasPatch: telemetry.hasPatch,
 			includeLoupePatch: telemetry.includeLoupePatch
 		)
+		firstRgbSampled()
 	}
 
 	private static func reusableRgbSample(
@@ -567,11 +601,11 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		streamRgbSample: RGBSample?,
 		pointIdleDuration: TimeInterval
 	) {
-		guard pointIdleDuration >= Self.backgroundProbeIdleDelay else {
-			return
-		}
 		let now = ProcessInfo.processInfo.systemUptime
 		let shouldProbe: Bool
+		let shouldNotifyImmediately: Bool
+		let sampleSidePixels: Int
+		let sampleIncludesLoupePatch: Bool
 		stateLock.lock()
 		if let streamRgbSample, !Self.isLikelyOverlayWhite(streamRgbSample) {
 			backgroundCorrectionMode = false
@@ -580,37 +614,56 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			return
 		}
 		if streamRgbSample == nil {
-			guard now - lastBackgroundProbeUptime >= Self.backgroundProbeMinimumInterval else {
+			guard now - lastBackgroundProbeUptime >= Self.missingRgbProbeMinimumInterval else {
 				stateLock.unlock()
 				return
 			}
 			lastBackgroundProbeUptime = now
 			shouldProbe = false
+			shouldNotifyImmediately = true
+			sampleSidePixels = 1
+			sampleIncludesLoupePatch = false
 		} else if backgroundCorrectionMode {
+			guard pointIdleDuration >= Self.backgroundProbeIdleDelay else {
+				stateLock.unlock()
+				return
+			}
 			shouldProbe = false
+			shouldNotifyImmediately = false
+			sampleSidePixels = sidePixels
+			sampleIncludesLoupePatch = includeLoupePatch
 		} else if !whiteStreamRunHasProbed,
 			now - lastBackgroundProbeUptime >= Self.backgroundProbeMinimumInterval
 		{
+			guard pointIdleDuration >= Self.backgroundProbeIdleDelay else {
+				stateLock.unlock()
+				return
+			}
 			whiteStreamRunHasProbed = true
 			lastBackgroundProbeUptime = now
 			shouldProbe = true
+			shouldNotifyImmediately = false
+			sampleSidePixels = sidePixels
+			sampleIncludesLoupePatch = includeLoupePatch
 		} else {
 			stateLock.unlock()
 			return
 		}
-		guard !backgroundRefreshQueued else {
+		guard backgroundSamplesInFlight < Self.maximumBackgroundSamplesInFlight else {
+			backgroundRefreshPending = true
 			stateLock.unlock()
 			return
 		}
-		backgroundRefreshQueued = true
+		backgroundSamplesInFlight += 1
 		stateLock.unlock()
 		backgroundQueue.async { [weak self] in
 			self?.refreshBackgroundSample(
 				point: point,
 				source: source,
-				sidePixels: sidePixels,
-				includeLoupePatch: includeLoupePatch,
-				shouldProbeForCorrection: shouldProbe
+				sidePixels: sampleSidePixels,
+				includeLoupePatch: sampleIncludesLoupePatch,
+				shouldProbeForCorrection: shouldProbe,
+				shouldNotifyImmediately: shouldNotifyImmediately
 			)
 		}
 	}
@@ -620,23 +673,44 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		source: LiveColorSampleSource,
 		sidePixels: Int,
 		includeLoupePatch: Bool,
-		shouldProbeForCorrection: Bool
+		shouldProbeForCorrection: Bool,
+		shouldNotifyImmediately: Bool
 	) {
 		let startedAt = ProcessInfo.processInfo.systemUptime
 		let sample = backgroundSampler(point, source, sidePixels, includeLoupePatch)
 		let sampleRgb = sample?.rgb
 		let sampleRgbValue = sampleRgb?.rgb
 		let sampleLoupePatch = sample?.loupePatch
-		backgroundSampleDurationMetric.recordMillisecondsSince(startedAt)
+		let sampleMilliseconds = NativeHostTelemetry.milliseconds(since: startedAt)
+		backgroundSampleDurationMetric.record(sampleMilliseconds)
 		stateLock.lock()
-		backgroundRefreshQueued = false
+		let shouldRefreshPending = finishBackgroundSampleLocked()
 		let currentRefreshCount = refreshCount
 		guard let desiredPoint,
 			sample != nil,
 			desiredSource == source,
 			Self.pointsEquivalent(desiredPoint, point)
 		else {
+			let shouldLogEmptyBackgroundSample =
+				sample == nil && (!didEmitEmptyBackgroundSample || sampleMilliseconds >= 20)
+			if shouldLogEmptyBackgroundSample {
+				didEmitEmptyBackgroundSample = true
+			}
+			let backgroundSampleTelemetry =
+				shouldLogEmptyBackgroundSample
+				? BackgroundSampleTelemetry(
+					captureID: activeCaptureID,
+					totalMilliseconds: sampleMilliseconds,
+					outcome: "empty",
+					source: "display_point",
+					includeLoupePatch: includeLoupePatch,
+					immediate: shouldNotifyImmediately
+				) : nil
 			stateLock.unlock()
+			emit(backgroundSampleTelemetry)
+			if shouldRefreshPending {
+				enqueueRefresh()
+			}
 			return
 		}
 		if shouldProbeForCorrection, let rgbSample = sampleRgbValue {
@@ -651,21 +725,80 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		latestSamplePoint = point
 		let firstRgbTelemetry = makeFirstRgbTelemetryLocked(
 			rgbSample: sampleRgbValue,
-			source: "background_fallback",
+			source: sampleRgb?.source ?? "background_sample",
 			refreshCount: currentRefreshCount,
 			hasPatch: sampleLoupePatch != nil,
 			includeLoupePatch: includeLoupePatch
 		)
-		let shouldNotify = Self.shouldNotifySampleUpdated(
-			now: ProcessInfo.processInfo.systemUptime,
-			lastPointChangeUptime: lastPointChangeUptime
-		)
+		let shouldLogBackgroundSample =
+			firstRgbTelemetry != nil || sampleMilliseconds >= 20
+		let backgroundSampleTelemetry =
+			shouldLogBackgroundSample
+			? BackgroundSampleTelemetry(
+				captureID: activeCaptureID,
+				totalMilliseconds: sampleMilliseconds,
+				outcome: Self.backgroundSampleOutcome(
+					hasRgb: sampleRgbValue != nil,
+					hasPatch: sampleLoupePatch != nil
+				),
+				source: sampleRgb?.source ?? "background_sample",
+				includeLoupePatch: includeLoupePatch,
+				immediate: shouldNotifyImmediately
+			) : nil
+		let shouldNotify =
+			shouldNotifyImmediately
+			|| Self.shouldNotifySampleUpdated(
+				now: ProcessInfo.processInfo.systemUptime,
+				lastPointChangeUptime: lastPointChangeUptime
+			)
 		stateLock.unlock()
+		emit(backgroundSampleTelemetry)
 		emit(firstRgbTelemetry)
 		if shouldNotify {
 			sampleUpdated()
 		}
-		return
+		if shouldRefreshPending {
+			enqueueRefresh()
+		}
+	}
+
+	private func finishBackgroundSampleLocked() -> Bool {
+		backgroundSamplesInFlight = max(0, backgroundSamplesInFlight - 1)
+		guard backgroundRefreshPending,
+			backgroundSamplesInFlight < Self.maximumBackgroundSamplesInFlight,
+			desiredPoint != nil
+		else {
+			return false
+		}
+		backgroundRefreshPending = false
+		return true
+	}
+
+	private static func backgroundSampleOutcome(hasRgb: Bool, hasPatch: Bool) -> String {
+		if hasRgb, hasPatch {
+			return "rgb_patch"
+		}
+		if hasRgb {
+			return "rgb"
+		}
+		if hasPatch {
+			return "patch"
+		}
+		return "empty"
+	}
+
+	private func emit(_ telemetry: BackgroundSampleTelemetry?) {
+		guard let telemetry else {
+			return
+		}
+		NativeHostTelemetry.liveChromeBackgroundSample(
+			captureID: telemetry.captureID,
+			totalMilliseconds: telemetry.totalMilliseconds,
+			outcome: telemetry.outcome,
+			source: telemetry.source,
+			includeLoupePatch: telemetry.includeLoupePatch,
+			immediate: telemetry.immediate
+		)
 	}
 
 	private static func shouldNotifySampleUpdated(

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1368,6 +1368,7 @@ final class LiveOverlayRenderer {
 	private var lastChromeRenderUptime: TimeInterval?
 	private var lastActiveChromeRenderUptime: TimeInterval?
 	private var lastHudColorPending: Bool?
+	private var hudColorRevealArmed = true
 	private var activeHudHexRollTarget: String?
 	private var hudHexRollAnimationEndUptime: TimeInterval?
 
@@ -1930,13 +1931,19 @@ final class LiveOverlayRenderer {
 			hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
 			hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveBackgroundAnimationKey)
 			hudHexLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
-			ensureHudColorPendingPulse(on: hudSwatchLayer, from: 0.44, to: 0.78)
-			ensureHudColorPendingPulse(on: hudHexLayer, from: 0.48, to: 0.86)
+			if hudColorRevealArmed {
+				ensureHudColorPendingPulse(on: hudSwatchLayer, from: 0.44, to: 0.78)
+				ensureHudColorPendingPulse(on: hudHexLayer, from: 0.48, to: 0.86)
+			} else {
+				hudSwatchLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
+				hudHexLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
+			}
 			lastHudColorPending = true
 			return
 		}
 
 		let wasPending = lastHudColorPending == true
+		let shouldAnimateReveal = wasPending && hudColorRevealArmed
 		let priorSwatchColor =
 			wasPending ? hudSwatchLayer.presentation()?.backgroundColor : nil
 		let priorSwatchOpacity =
@@ -1945,8 +1952,9 @@ final class LiveOverlayRenderer {
 		hudSwatchLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
 		hudHexLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
 		lastHudColorPending = false
+		hudColorRevealArmed = false
 
-		guard wasPending else {
+		guard shouldAnimateReveal else {
 			updateHudHexRollVisibility(target: resolvedHexText, frame: hexFrame)
 			return
 		}
@@ -2035,26 +2043,28 @@ final class LiveOverlayRenderer {
 		hudHexRollLayer.isHidden = false
 		hudHexRollLayer.frame = frame
 
-		let hashWidth = ceil("#".size(using: font).width)
-		let digitWidth = ceil("0".size(using: font).width)
 		let lineHeight = ceil(LiveOverlayTypography.lineHeight)
+		let characterFrames = hudHexCharacterFrames(
+			for: target,
+			font: font,
+			lineHeight: lineHeight
+		)
 		let hashLayer = makeHudHexRollTextLayer(
 			text: "#",
 			font: font,
 			color: textColor.withAlphaComponent(0.72),
-			frame: CGRect(x: 0, y: 0, width: hashWidth, height: lineHeight)
+			frame: characterFrames.first ?? CGRect(x: 0, y: 0, width: 0, height: lineHeight)
 		)
 		hudHexRollLayer.addSublayer(hashLayer)
 
 		for (index, targetDigit) in targetDigits.enumerated() {
+			let characterFrame =
+				index + 1 < characterFrames.count
+				? characterFrames[index + 1]
+				: CGRect(x: 0, y: 0, width: 0, height: lineHeight)
 			let columnLayer = CALayer()
 			columnLayer.masksToBounds = true
-			columnLayer.frame = CGRect(
-				x: hashWidth + CGFloat(index) * digitWidth,
-				y: 0,
-				width: digitWidth,
-				height: lineHeight
-			)
+			columnLayer.frame = characterFrame
 			hudHexRollLayer.addSublayer(columnLayer)
 			addHudHexRollDigit(
 				to: columnLayer,
@@ -2064,7 +2074,25 @@ final class LiveOverlayRenderer {
 				textColor: textColor,
 				initialOpacity: initialOpacity,
 				lineHeight: lineHeight,
-				digitWidth: digitWidth
+				digitWidth: characterFrame.width
+			)
+		}
+	}
+
+	private func hudHexCharacterFrames(
+		for text: String,
+		font: NSFont,
+		lineHeight: CGFloat
+	) -> [CGRect] {
+		let characters = Array(text)
+		return characters.indices.map { index in
+			let prefixStart = String(characters.prefix(index)).size(using: font).width
+			let prefixEnd = String(characters.prefix(index + 1)).size(using: font).width
+			return CGRect(
+				x: prefixStart,
+				y: 0,
+				width: max(prefixEnd - prefixStart, 1),
+				height: lineHeight
 			)
 		}
 	}
@@ -2174,7 +2202,7 @@ final class LiveOverlayRenderer {
 		layer.font = font
 		layer.fontSize = font.pointSize
 		layer.foregroundColor = color.cgColor
-		layer.alignmentMode = .center
+		layer.alignmentMode = .left
 		layer.frame = frame
 		layer.isWrapped = false
 		return layer
@@ -2224,6 +2252,7 @@ final class LiveOverlayRenderer {
 
 	private func resetHudColorAnimationState() {
 		lastHudColorPending = nil
+		hudColorRevealArmed = true
 		activeHudHexRollTarget = nil
 		hudHexRollAnimationEndUptime = nil
 		hudSwatchLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -209,7 +209,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private static let backgroundProbeMinimumInterval: TimeInterval = 0.25
 	private static let backgroundProbeIdleDelay: TimeInterval = 0.08
 	private static let missingRgbProbeMinimumInterval: TimeInterval = 1.0 / 120.0
-	private static let maximumBackgroundSamplesInFlight = 1
+	private static let maximumInitialBackgroundSamplesInFlight = 2
+	private static let maximumSteadyBackgroundSamplesInFlight = 2
 	private static let sampleUpdatedNotificationIdleDelay =
 		NativeHostDisplayRefresh.frameInterval(
 			forTargetFramesPerSecond: NativeHostDisplayRefresh.fallbackFramesPerSecond)
@@ -228,8 +229,10 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private var latestSamplePoint: CGPoint?
 	private var lastRefreshUptime: TimeInterval?
 	private var lastPointChangeUptime = ProcessInfo.processInfo.systemUptime
+	private var running = false
 	private var activeCaptureID: UInt64 = 0
 	private var activationStartedAtUptime: TimeInterval?
+	private var generation: UInt64 = 0
 	private var refreshCount: UInt64 = 0
 	private var didEmitFirstRgbSample = false
 	private var didEmitEmptyBackgroundSample = false
@@ -258,6 +261,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		stop()
 		let startedAt = ProcessInfo.processInfo.systemUptime
 		stateLock.lock()
+		generation &+= 1
+		running = true
 		activeCaptureID = captureID
 		activationStartedAtUptime = startedAt
 		refreshCount = 0
@@ -294,6 +299,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		timer?.cancel()
 		timer = nil
 		stateLock.lock()
+		generation &+= 1
+		running = false
 		desiredPoint = nil
 		desiredIncludesLoupePatch = false
 		desiredSource = nil
@@ -351,8 +358,9 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		desiredSource = source
 		let shouldRefresh =
 			pointChanged || activating || sourceChanged || sidePixelsChanged || patchDemandChanged
+		let running = self.running
 		stateLock.unlock()
-		if shouldRefresh {
+		if shouldRefresh, running {
 			enqueueRefresh()
 		}
 	}
@@ -361,7 +369,11 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		stateLock.lock()
 		let latestSample = self.latestSample
 		let latestSamplePoint = self.latestSamplePoint
+		let running = self.running
 		stateLock.unlock()
+		guard running else {
+			return nil
+		}
 		guard let point else {
 			return latestSample
 		}
@@ -396,6 +408,11 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		let now = ProcessInfo.processInfo.systemUptime
 		let refreshStartedAt = now
 		stateLock.lock()
+		guard running else {
+			refreshQueued = false
+			stateLock.unlock()
+			return
+		}
 		refreshQueued = false
 		let point = desiredPoint
 		let sidePixels = desiredSidePixels
@@ -606,6 +623,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		let shouldNotifyImmediately: Bool
 		let sampleSidePixels: Int
 		let sampleIncludesLoupePatch: Bool
+		let sampleGeneration: UInt64
 		stateLock.lock()
 		if let streamRgbSample, !Self.isLikelyOverlayWhite(streamRgbSample) {
 			backgroundCorrectionMode = false
@@ -649,12 +667,13 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			stateLock.unlock()
 			return
 		}
-		guard backgroundSamplesInFlight < Self.maximumBackgroundSamplesInFlight else {
+		guard backgroundSamplesInFlight < maximumBackgroundSamplesInFlightLocked() else {
 			backgroundRefreshPending = true
 			stateLock.unlock()
 			return
 		}
 		backgroundSamplesInFlight += 1
+		sampleGeneration = generation
 		stateLock.unlock()
 		backgroundQueue.async { [weak self] in
 			self?.refreshBackgroundSample(
@@ -663,7 +682,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 				sidePixels: sampleSidePixels,
 				includeLoupePatch: sampleIncludesLoupePatch,
 				shouldProbeForCorrection: shouldProbe,
-				shouldNotifyImmediately: shouldNotifyImmediately
+				shouldNotifyImmediately: shouldNotifyImmediately,
+				generation: sampleGeneration
 			)
 		}
 	}
@@ -674,7 +694,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		sidePixels: Int,
 		includeLoupePatch: Bool,
 		shouldProbeForCorrection: Bool,
-		shouldNotifyImmediately: Bool
+		shouldNotifyImmediately: Bool,
+		generation sampleGeneration: UInt64
 	) {
 		let startedAt = ProcessInfo.processInfo.systemUptime
 		let sample = backgroundSampler(point, source, sidePixels, includeLoupePatch)
@@ -684,6 +705,10 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		let sampleMilliseconds = NativeHostTelemetry.milliseconds(since: startedAt)
 		backgroundSampleDurationMetric.record(sampleMilliseconds)
 		stateLock.lock()
+		guard generation == sampleGeneration else {
+			stateLock.unlock()
+			return
+		}
 		let shouldRefreshPending = finishBackgroundSampleLocked()
 		let currentRefreshCount = refreshCount
 		guard let desiredPoint,
@@ -765,13 +790,19 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private func finishBackgroundSampleLocked() -> Bool {
 		backgroundSamplesInFlight = max(0, backgroundSamplesInFlight - 1)
 		guard backgroundRefreshPending,
-			backgroundSamplesInFlight < Self.maximumBackgroundSamplesInFlight,
+			backgroundSamplesInFlight < maximumBackgroundSamplesInFlightLocked(),
 			desiredPoint != nil
 		else {
 			return false
 		}
 		backgroundRefreshPending = false
 		return true
+	}
+
+	private func maximumBackgroundSamplesInFlightLocked() -> Int {
+		didEmitFirstRgbSample
+			? Self.maximumSteadyBackgroundSamplesInFlight
+			: Self.maximumInitialBackgroundSamplesInFlight
 	}
 
 	private static func backgroundSampleOutcome(hasRgb: Bool, hasPatch: Bool) -> String {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1315,6 +1315,7 @@ final class LiveOverlayRenderer {
 	private let hudStrokeLayer = CAShapeLayer()
 	private let hudPositionLayer = CATextLayer()
 	private let hudHexLayer = CATextLayer()
+	private let hudHexRollLayer = CALayer()
 	private let hudSwatchLayer = CALayer()
 	private let hudKeycapLayer = CALayer()
 	private let hudKeycapTextLayer = CATextLayer()
@@ -1349,6 +1350,10 @@ final class LiveOverlayRenderer {
 	private static let hudColorPendingAnimationKey = "rsnap.hud.color.pending"
 	private static let hudColorResolveAnimationKey = "rsnap.hud.color.resolve"
 	private static let hudColorResolveBackgroundAnimationKey = "rsnap.hud.color.resolve.background"
+	private static let hudColorRollAnimationKey = "rsnap.hud.color.roll"
+	private static let hudColorRollDuration: TimeInterval = 0.52
+	private static let hudColorRollDigitStagger: TimeInterval = 0.032
+	private static let hexWheel = Array("0123456789ABCDEF")
 	private enum LayerZ {
 		static let frozenDisplay: CGFloat = 0
 		static let scrim: CGFloat = 10
@@ -1363,6 +1368,8 @@ final class LiveOverlayRenderer {
 	private var lastChromeRenderUptime: TimeInterval?
 	private var lastActiveChromeRenderUptime: TimeInterval?
 	private var lastHudColorPending: Bool?
+	private var activeHudHexRollTarget: String?
+	private var hudHexRollAnimationEndUptime: TimeInterval?
 
 	init(hostView: NSView) {
 		self.hostView = hostView
@@ -1467,10 +1474,12 @@ final class LiveOverlayRenderer {
 		}
 		for hudSublayer in [
 			hudGlassLayer, hudFillLayer, hudStrokeLayer, hudSwatchLayer, hudPositionLayer,
-			hudHexLayer, hudKeycapLayer, hudKeycapTextLayer,
+			hudHexLayer, hudHexRollLayer, hudKeycapLayer, hudKeycapTextLayer,
 		] {
 			hudLayer.addSublayer(hudSublayer)
 		}
+		hudHexRollLayer.masksToBounds = false
+		hudHexRollLayer.isHidden = true
 		for loupeSublayer in [
 			loupeGlassLayer, loupeFillLayer, loupeStrokeLayer, loupePatchLayer, loupeCenterLayer,
 		] {
@@ -1863,15 +1872,20 @@ final class LiveOverlayRenderer {
 		let hexTextColor =
 			snapshot.colorDisplay.isPending
 			? palette.labelText.withAlphaComponent(0.46) : palette.labelText
+		let hexFrame = CGRect(
+			x: cursorX, y: baselineY, width: ceil(snapshot.colorDisplay.hexSlotWidth),
+			height: ceil(LiveOverlayTypography.lineHeight))
 		applyText(
 			hudHexLayer, text: snapshot.colorDisplay.hexText, font: font, color: hexTextColor,
-			frame: CGRect(
-				x: cursorX, y: baselineY, width: ceil(snapshot.colorDisplay.hexSlotWidth),
-				height: ceil(LiveOverlayTypography.lineHeight)), alignment: .left)
+			frame: hexFrame, alignment: .left)
 		updateHudColorAnimation(
 			isPending: snapshot.colorDisplay.isPending,
 			pendingSwatchColor: pendingSwatchColor,
-			resolvedSwatchColor: swatchColor
+			resolvedSwatchColor: swatchColor,
+			resolvedHexText: snapshot.colorDisplay.hexText,
+			hexFrame: hexFrame,
+			font: font,
+			textColor: palette.labelText
 		)
 		cursorX += snapshot.colorDisplay.hexSlotWidth + CaptureChrome.hudGroupSpacing
 
@@ -1904,9 +1918,15 @@ final class LiveOverlayRenderer {
 	private func updateHudColorAnimation(
 		isPending: Bool,
 		pendingSwatchColor: NSColor,
-		resolvedSwatchColor: NSColor
+		resolvedSwatchColor: NSColor,
+		resolvedHexText: String,
+		hexFrame: CGRect,
+		font: NSFont,
+		textColor: NSColor
 	) {
 		if isPending {
+			clearHudHexRollAnimation()
+			hudHexLayer.isHidden = false
 			hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
 			hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveBackgroundAnimationKey)
 			hudHexLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
@@ -1927,6 +1947,7 @@ final class LiveOverlayRenderer {
 		lastHudColorPending = false
 
 		guard wasPending else {
+			updateHudHexRollVisibility(target: resolvedHexText, frame: hexFrame)
 			return
 		}
 
@@ -1934,9 +1955,12 @@ final class LiveOverlayRenderer {
 			to: hudSwatchLayer,
 			fromOpacity: priorSwatchOpacity.map(CGFloat.init) ?? 0.62
 		)
-		addHudColorResolveAnimation(
-			to: hudHexLayer,
-			fromOpacity: priorHexOpacity.map(CGFloat.init) ?? 0.62
+		beginHudHexRollAnimation(
+			target: resolvedHexText,
+			frame: hexFrame,
+			font: font,
+			textColor: textColor,
+			initialOpacity: priorHexOpacity.map(CGFloat.init) ?? 0.62
 		)
 		let colorAnimation = CABasicAnimation(keyPath: "backgroundColor")
 		colorAnimation.fromValue = priorSwatchColor ?? pendingSwatchColor.cgColor
@@ -1976,13 +2000,239 @@ final class LiveOverlayRenderer {
 		layer.add(animation, forKey: Self.hudColorResolveAnimationKey)
 	}
 
+	private func updateHudHexRollVisibility(target: String, frame: CGRect) {
+		guard let animationEnd = hudHexRollAnimationEndUptime,
+			ProcessInfo.processInfo.systemUptime < animationEnd,
+			activeHudHexRollTarget == target
+		else {
+			clearHudHexRollAnimation()
+			hudHexLayer.isHidden = false
+			return
+		}
+
+		hudHexLayer.isHidden = true
+		hudHexRollLayer.isHidden = false
+		hudHexRollLayer.frame = frame
+	}
+
+	private func beginHudHexRollAnimation(
+		target: String,
+		frame: CGRect,
+		font: NSFont,
+		textColor: NSColor,
+		initialOpacity: CGFloat
+	) {
+		clearHudHexRollAnimation()
+		activeHudHexRollTarget = target
+		let now = ProcessInfo.processInfo.systemUptime
+		let targetDigits = Array(target.dropFirst())
+		let digitCount = max(targetDigits.count, 0)
+		hudHexRollAnimationEndUptime =
+			now + Self.hudColorRollDuration
+			+ (Double(max(digitCount - 1, 0)) * Self.hudColorRollDigitStagger)
+			+ 0.08
+		hudHexLayer.isHidden = true
+		hudHexRollLayer.isHidden = false
+		hudHexRollLayer.frame = frame
+
+		let hashWidth = ceil("#".size(using: font).width)
+		let digitWidth = ceil("0".size(using: font).width)
+		let lineHeight = ceil(LiveOverlayTypography.lineHeight)
+		let hashLayer = makeHudHexRollTextLayer(
+			text: "#",
+			font: font,
+			color: textColor.withAlphaComponent(0.72),
+			frame: CGRect(x: 0, y: 0, width: hashWidth, height: lineHeight)
+		)
+		hudHexRollLayer.addSublayer(hashLayer)
+
+		for (index, targetDigit) in targetDigits.enumerated() {
+			let columnLayer = CALayer()
+			columnLayer.masksToBounds = true
+			columnLayer.frame = CGRect(
+				x: hashWidth + CGFloat(index) * digitWidth,
+				y: 0,
+				width: digitWidth,
+				height: lineHeight
+			)
+			hudHexRollLayer.addSublayer(columnLayer)
+			addHudHexRollDigit(
+				to: columnLayer,
+				targetDigit: String(targetDigit),
+				index: index,
+				font: font,
+				textColor: textColor,
+				initialOpacity: initialOpacity,
+				lineHeight: lineHeight,
+				digitWidth: digitWidth
+			)
+		}
+	}
+
+	private func addHudHexRollDigit(
+		to columnLayer: CALayer,
+		targetDigit: String,
+		index: Int,
+		font: NSFont,
+		textColor: NSColor,
+		initialOpacity: CGFloat,
+		lineHeight: CGFloat,
+		digitWidth: CGFloat
+	) {
+		let baseFrame = CGRect(x: 0, y: 0, width: digitWidth, height: lineHeight)
+		let startLayer = makeHudHexRollTextLayer(
+			text: "0",
+			font: font,
+			color: textColor.withAlphaComponent(0.58),
+			frame: baseFrame
+		)
+		startLayer.opacity = 0
+		columnLayer.addSublayer(startLayer)
+
+		let firstTumblerLayer = makeHudHexRollTextLayer(
+			text: tumblerDigit(for: targetDigit, index: index, offset: 5),
+			font: font,
+			color: textColor.withAlphaComponent(0.62),
+			frame: baseFrame
+		)
+		firstTumblerLayer.opacity = 0
+		columnLayer.addSublayer(firstTumblerLayer)
+
+		let secondTumblerLayer = makeHudHexRollTextLayer(
+			text: tumblerDigit(for: targetDigit, index: index, offset: 11),
+			font: font,
+			color: textColor.withAlphaComponent(0.72),
+			frame: baseFrame
+		)
+		secondTumblerLayer.opacity = 0
+		columnLayer.addSublayer(secondTumblerLayer)
+
+		let targetLayer = makeHudHexRollTextLayer(
+			text: targetDigit,
+			font: font,
+			color: textColor,
+			frame: baseFrame
+		)
+		targetLayer.opacity = 0
+		columnLayer.addSublayer(targetLayer)
+
+		let stagger = Double(index) * Self.hudColorRollDigitStagger
+		addHudRollAnimation(
+			to: startLayer,
+			fromY: 0,
+			toY: -lineHeight * 0.92,
+			opacityValues: [max(initialOpacity, 0.52), 0],
+			keyTimes: [0, 1],
+			beginOffset: stagger,
+			duration: 0.18
+		)
+		addHudRollAnimation(
+			to: firstTumblerLayer,
+			fromY: lineHeight * 1.05,
+			toY: -lineHeight * 0.78,
+			opacityValues: [0, 0.58, 0],
+			keyTimes: [0, 0.48, 1],
+			beginOffset: stagger + 0.045,
+			duration: 0.22
+		)
+		addHudRollAnimation(
+			to: secondTumblerLayer,
+			fromY: lineHeight * 0.98,
+			toY: -lineHeight * 0.55,
+			opacityValues: [0, 0.72, 0],
+			keyTimes: [0, 0.55, 1],
+			beginOffset: stagger + 0.15,
+			duration: 0.24
+		)
+		addHudRollAnimation(
+			to: targetLayer,
+			fromY: lineHeight * 0.9,
+			toY: 0,
+			opacityValues: [0, 1, 1],
+			keyTimes: [0, 0.7, 1],
+			beginOffset: stagger + 0.28,
+			duration: 0.24,
+			timing: .easeOut
+		)
+	}
+
+	private func tumblerDigit(for targetDigit: String, index: Int, offset: Int) -> String {
+		let targetIndex = Self.hexWheel.firstIndex(of: Character(targetDigit)) ?? 0
+		let wheelIndex = (targetIndex + index + offset) % Self.hexWheel.count
+		return String(Self.hexWheel[wheelIndex])
+	}
+
+	private func makeHudHexRollTextLayer(
+		text: String,
+		font: NSFont,
+		color: NSColor,
+		frame: CGRect
+	) -> CATextLayer {
+		let layer = CATextLayer()
+		layer.contentsScale = hostView?.window?.backingScaleFactor ?? 2
+		layer.string = text
+		layer.font = font
+		layer.fontSize = font.pointSize
+		layer.foregroundColor = color.cgColor
+		layer.alignmentMode = .center
+		layer.frame = frame
+		layer.isWrapped = false
+		return layer
+	}
+
+	private func addHudRollAnimation(
+		to layer: CALayer,
+		fromY: CGFloat,
+		toY: CGFloat,
+		opacityValues: [CGFloat],
+		keyTimes: [CGFloat],
+		beginOffset: TimeInterval,
+		duration: TimeInterval,
+		timing: CAMediaTimingFunctionName = .easeInEaseOut
+	) {
+		let translation = CABasicAnimation(keyPath: "transform.translation.y")
+		translation.fromValue = fromY
+		translation.toValue = toY
+
+		let opacity = CAKeyframeAnimation(keyPath: "opacity")
+		opacity.values = opacityValues.map { NSNumber(value: Double($0)) }
+		opacity.keyTimes = keyTimes.map { NSNumber(value: Double($0)) }
+
+		let group = CAAnimationGroup()
+		group.animations = [translation, opacity]
+		group.beginTime = CACurrentMediaTime() + beginOffset
+		group.duration = duration
+		group.timingFunction = CAMediaTimingFunction(name: timing)
+		group.fillMode = .both
+		group.isRemovedOnCompletion = false
+		layer.add(group, forKey: Self.hudColorRollAnimationKey)
+	}
+
+	private func clearHudHexRollAnimation() {
+		activeHudHexRollTarget = nil
+		hudHexRollAnimationEndUptime = nil
+		hudHexRollLayer.removeAllAnimations()
+		for sublayer in hudHexRollLayer.sublayers ?? [] {
+			sublayer.removeAllAnimations()
+			for childLayer in sublayer.sublayers ?? [] {
+				childLayer.removeAllAnimations()
+			}
+			sublayer.removeFromSuperlayer()
+		}
+		hudHexRollLayer.isHidden = true
+	}
+
 	private func resetHudColorAnimationState() {
 		lastHudColorPending = nil
+		activeHudHexRollTarget = nil
+		hudHexRollAnimationEndUptime = nil
 		hudSwatchLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
 		hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
 		hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveBackgroundAnimationKey)
 		hudHexLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
 		hudHexLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
+		hudHexLayer.isHidden = false
+		clearHudHexRollAnimation()
 	}
 
 	private func renderLoupe(_ snapshot: LivePreviewSnapshot) {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -208,9 +208,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	)
 	private static let backgroundProbeMinimumInterval: TimeInterval = 0.25
 	private static let backgroundProbeIdleDelay: TimeInterval = 0.08
-	private static let missingRgbProbeMinimumInterval: TimeInterval = 1.0 / 120.0
-	private static let maximumInitialBackgroundSamplesInFlight = 2
-	private static let maximumSteadyBackgroundSamplesInFlight = 2
+	private static let maximumBackgroundSamplesInFlight = 1
 	private static let sampleUpdatedNotificationIdleDelay =
 		NativeHostDisplayRefresh.frameInterval(
 			forTargetFramesPerSecond: NativeHostDisplayRefresh.fallbackFramesPerSecond)
@@ -632,15 +630,8 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			return
 		}
 		if streamRgbSample == nil {
-			guard now - lastBackgroundProbeUptime >= Self.missingRgbProbeMinimumInterval else {
-				stateLock.unlock()
-				return
-			}
-			lastBackgroundProbeUptime = now
-			shouldProbe = false
-			shouldNotifyImmediately = true
-			sampleSidePixels = 1
-			sampleIncludesLoupePatch = false
+			stateLock.unlock()
+			return
 		} else if backgroundCorrectionMode {
 			guard pointIdleDuration >= Self.backgroundProbeIdleDelay else {
 				stateLock.unlock()
@@ -667,7 +658,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 			stateLock.unlock()
 			return
 		}
-		guard backgroundSamplesInFlight < maximumBackgroundSamplesInFlightLocked() else {
+		guard backgroundSamplesInFlight < Self.maximumBackgroundSamplesInFlight else {
 			backgroundRefreshPending = true
 			stateLock.unlock()
 			return
@@ -711,6 +702,13 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		}
 		let shouldRefreshPending = finishBackgroundSampleLocked()
 		let currentRefreshCount = refreshCount
+		if liveStreamRgbReady, sampleLoupePatch == nil {
+			stateLock.unlock()
+			if shouldRefreshPending {
+				enqueueRefresh()
+			}
+			return
+		}
 		guard let desiredPoint,
 			sample != nil,
 			desiredSource == source,
@@ -790,19 +788,13 @@ final class ChromeSampleFeed: @unchecked Sendable {
 	private func finishBackgroundSampleLocked() -> Bool {
 		backgroundSamplesInFlight = max(0, backgroundSamplesInFlight - 1)
 		guard backgroundRefreshPending,
-			backgroundSamplesInFlight < maximumBackgroundSamplesInFlightLocked(),
+			backgroundSamplesInFlight < Self.maximumBackgroundSamplesInFlight,
 			desiredPoint != nil
 		else {
 			return false
 		}
 		backgroundRefreshPending = false
 		return true
-	}
-
-	private func maximumBackgroundSamplesInFlightLocked() -> Int {
-		didEmitFirstRgbSample
-			? Self.maximumSteadyBackgroundSamplesInFlight
-			: Self.maximumInitialBackgroundSamplesInFlight
 	}
 
 	private static func backgroundSampleOutcome(hasRgb: Bool, hasPatch: Bool) -> String {

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1346,6 +1346,9 @@ final class LiveOverlayRenderer {
 		category: "LiveChromeTelemetry"
 	)
 	private static let activeInputWindow: TimeInterval = 0.25
+	private static let hudColorPendingAnimationKey = "rsnap.hud.color.pending"
+	private static let hudColorResolveAnimationKey = "rsnap.hud.color.resolve"
+	private static let hudColorResolveBackgroundAnimationKey = "rsnap.hud.color.resolve.background"
 	private enum LayerZ {
 		static let frozenDisplay: CGFloat = 0
 		static let scrim: CGFloat = 10
@@ -1359,6 +1362,7 @@ final class LiveOverlayRenderer {
 	private var lastRenderedFocusFlowAnimates = false
 	private var lastChromeRenderUptime: TimeInterval?
 	private var lastActiveChromeRenderUptime: TimeInterval?
+	private var lastHudColorPending: Bool?
 
 	init(hostView: NSView) {
 		self.hostView = hostView
@@ -1535,6 +1539,7 @@ final class LiveOverlayRenderer {
 		lastRenderedFocusFlowAnimates = false
 		lastChromeRenderUptime = nil
 		lastActiveChromeRenderUptime = nil
+		resetHudColorAnimationState()
 		hoverFlowLayer.hide()
 	}
 
@@ -1795,6 +1800,7 @@ final class LiveOverlayRenderer {
 	private func renderHud(_ snapshot: LivePreviewSnapshot) {
 		guard let hudFrame = snapshot.hudFrame else {
 			hudLayer.isHidden = true
+			resetHudColorAnimationState()
 			return
 		}
 		let palette = CaptureChrome.palette(for: snapshot.theme, settings: snapshot.settings)
@@ -1842,22 +1848,31 @@ final class LiveOverlayRenderer {
 			height: swatchSize.height
 		)
 		hudSwatchLayer.cornerRadius = 0
+		let pendingSwatchColor = palette.labelText.withAlphaComponent(0.16)
 		let swatchColor =
 			snapshot.rgbSample.map {
 				NSColor(
 					calibratedRed: CGFloat($0.r) / 255, green: CGFloat($0.g) / 255,
 					blue: CGFloat($0.b) / 255, alpha: 1)
-			} ?? NSColor(calibratedWhite: 1, alpha: 0.12)
+			} ?? pendingSwatchColor
 		hudSwatchLayer.backgroundColor = swatchColor.cgColor
 		hudSwatchLayer.borderColor = palette.swatchStroke.cgColor
 		hudSwatchLayer.borderWidth = 1
 		cursorX += swatchSize.width + CaptureChrome.hudColorItemSpacing
 
+		let hexTextColor =
+			snapshot.colorDisplay.isPending
+			? palette.labelText.withAlphaComponent(0.46) : palette.labelText
 		applyText(
-			hudHexLayer, text: snapshot.colorDisplay.hexText, font: font, color: palette.labelText,
+			hudHexLayer, text: snapshot.colorDisplay.hexText, font: font, color: hexTextColor,
 			frame: CGRect(
 				x: cursorX, y: baselineY, width: ceil(snapshot.colorDisplay.hexSlotWidth),
 				height: ceil(LiveOverlayTypography.lineHeight)), alignment: .left)
+		updateHudColorAnimation(
+			isPending: snapshot.colorDisplay.isPending,
+			pendingSwatchColor: pendingSwatchColor,
+			resolvedSwatchColor: swatchColor
+		)
 		cursorX += snapshot.colorDisplay.hexSlotWidth + CaptureChrome.hudGroupSpacing
 
 		if snapshot.keycapVisible {
@@ -1884,6 +1899,90 @@ final class LiveOverlayRenderer {
 			hudKeycapLayer.isHidden = true
 			hudKeycapTextLayer.isHidden = true
 		}
+	}
+
+	private func updateHudColorAnimation(
+		isPending: Bool,
+		pendingSwatchColor: NSColor,
+		resolvedSwatchColor: NSColor
+	) {
+		if isPending {
+			hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
+			hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveBackgroundAnimationKey)
+			hudHexLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
+			ensureHudColorPendingPulse(on: hudSwatchLayer, from: 0.44, to: 0.78)
+			ensureHudColorPendingPulse(on: hudHexLayer, from: 0.48, to: 0.86)
+			lastHudColorPending = true
+			return
+		}
+
+		let wasPending = lastHudColorPending == true
+		let priorSwatchColor =
+			wasPending ? hudSwatchLayer.presentation()?.backgroundColor : nil
+		let priorSwatchOpacity =
+			wasPending ? hudSwatchLayer.presentation()?.opacity : nil
+		let priorHexOpacity = wasPending ? hudHexLayer.presentation()?.opacity : nil
+		hudSwatchLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
+		hudHexLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
+		lastHudColorPending = false
+
+		guard wasPending else {
+			return
+		}
+
+		addHudColorResolveAnimation(
+			to: hudSwatchLayer,
+			fromOpacity: priorSwatchOpacity.map(CGFloat.init) ?? 0.62
+		)
+		addHudColorResolveAnimation(
+			to: hudHexLayer,
+			fromOpacity: priorHexOpacity.map(CGFloat.init) ?? 0.62
+		)
+		let colorAnimation = CABasicAnimation(keyPath: "backgroundColor")
+		colorAnimation.fromValue = priorSwatchColor ?? pendingSwatchColor.cgColor
+		colorAnimation.toValue = resolvedSwatchColor.cgColor
+		colorAnimation.duration = 0.16
+		colorAnimation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+		hudSwatchLayer.add(
+			colorAnimation,
+			forKey: Self.hudColorResolveBackgroundAnimationKey
+		)
+	}
+
+	private func ensureHudColorPendingPulse(
+		on layer: CALayer,
+		from fromOpacity: Float,
+		to toOpacity: Float
+	) {
+		guard layer.animation(forKey: Self.hudColorPendingAnimationKey) == nil else {
+			return
+		}
+		let animation = CABasicAnimation(keyPath: "opacity")
+		animation.fromValue = fromOpacity
+		animation.toValue = toOpacity
+		animation.duration = 0.42
+		animation.autoreverses = true
+		animation.repeatCount = .infinity
+		animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+		layer.add(animation, forKey: Self.hudColorPendingAnimationKey)
+	}
+
+	private func addHudColorResolveAnimation(to layer: CALayer, fromOpacity: CGFloat) {
+		let animation = CABasicAnimation(keyPath: "opacity")
+		animation.fromValue = fromOpacity
+		animation.toValue = 1
+		animation.duration = 0.16
+		animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+		layer.add(animation, forKey: Self.hudColorResolveAnimationKey)
+	}
+
+	private func resetHudColorAnimationState() {
+		lastHudColorPending = nil
+		hudSwatchLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
+		hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
+		hudSwatchLayer.removeAnimation(forKey: Self.hudColorResolveBackgroundAnimationKey)
+		hudHexLayer.removeAnimation(forKey: Self.hudColorPendingAnimationKey)
+		hudHexLayer.removeAnimation(forKey: Self.hudColorResolveAnimationKey)
 	}
 
 	private func renderLoupe(_ snapshot: LivePreviewSnapshot) {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -9,8 +9,8 @@ import RsnapHostBridge
 import Vision
 
 struct LiveRgbSample: Sendable {
-	static let maximumDisplayAge: TimeInterval = 0.18
-	static let maximumReusableAge: TimeInterval = 0.08
+	static let maximumDisplayAge: TimeInterval = 0.10
+	static let maximumReusableAge: TimeInterval = 0.04
 
 	let rgb: RGBSample
 	let capturedAtUptime: TimeInterval
@@ -68,6 +68,7 @@ struct LiveColorSampleSource: Equatable, Sendable {
 	let referenceWindowID: CGWindowID
 	let desktopFrame: CGRect
 	let screenFrame: CGRect
+	let displayID: CGDirectDisplayID
 	let scaleFactor: CGFloat
 }
 
@@ -77,6 +78,33 @@ private struct LiveChromeRefreshTelemetryKey: Equatable {
 	let hudGlassMode: String
 	let liquidGlassStyle: String
 	let liquidGlassAvailable: Bool
+}
+
+private final class DisplayPointImageRace: @unchecked Sendable {
+	private let lock = NSLock()
+	let finished = DispatchSemaphore(value: 0)
+	private var result: CGImage?
+
+	func complete(_ image: CGImage?) {
+		guard let image else {
+			return
+		}
+		lock.lock()
+		let shouldSignal = result == nil
+		if shouldSignal {
+			result = image
+		}
+		lock.unlock()
+		if shouldSignal {
+			finished.signal()
+		}
+	}
+
+	func image() -> CGImage? {
+		lock.lock()
+		defer { lock.unlock() }
+		return result
+	}
 }
 
 @MainActor private let frozenEffectCIContext = CIContext(options: nil)
@@ -353,6 +381,9 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
 		refreshStatusMenuState()
 		scheduleLaunchPermissionOnboardingIfNeeded()
+		DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) { [weak self] in
+			self?.sessionController.refreshShareableContentCacheIfPermitted(source: "launch")
+		}
 		NativeHostTelemetry.lifecycleEvent(
 			"native_host.finish_launching_end",
 			detail: "statusItemPresent=\(statusItem != nil)"
@@ -710,6 +741,26 @@ final class CaptureSessionController: NSObject {
 		return captureID
 	}
 
+	func refreshShareableContentCacheIfPermitted(source: String) {
+		guard session == nil else {
+			DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) { [weak self] in
+				self?.refreshShareableContentCacheIfPermitted(source: source)
+			}
+			return
+		}
+		guard NativePermissions.status(for: .screenRecording) else {
+			return
+		}
+		frozenFrameAuthority.refreshShareableContentCache(
+			captureID: currentCaptureTelemetryID,
+			source: source
+		)
+	}
+
+	func hasFreshShareableContentCache() -> Bool {
+		frozenFrameAuthority.hasFreshShareableContentCache()
+	}
+
 	@discardableResult
 	func warmLiveSamplingIfPossible(
 		at point: CGPoint,
@@ -735,10 +786,6 @@ final class CaptureSessionController: NSObject {
 			return nil
 		}
 		let screens = NSScreen.screens
-		let liveStreamStartedAt = ProcessInfo.processInfo.systemUptime
-		liveFrameStream.start(for: screens, prewarmPoint: point, captureID: captureID)
-		let liveStreamStartMilliseconds =
-			NativeHostTelemetry.milliseconds(since: liveStreamStartedAt)
 		let frozenAuthorityStartedAt = ProcessInfo.processInfo.systemUptime
 		frozenFrameAuthority.start(
 			for: screens,
@@ -755,7 +802,7 @@ final class CaptureSessionController: NSObject {
 			source: source,
 			totalMilliseconds: NativeHostTelemetry.milliseconds(since: warmStartedAt),
 			frozenAuthorityStartMilliseconds: frozenAuthorityStartMilliseconds,
-			liveStreamStartMilliseconds: liveStreamStartMilliseconds,
+			liveStreamStartMilliseconds: 0,
 			seedSampleMilliseconds: 0,
 			sampleReady: false,
 			screenCount: screenCount
@@ -791,21 +838,14 @@ final class CaptureSessionController: NSObject {
 			captureStateDidChange?()
 			return
 		}
-
 		do {
 			let startPoint = NSEvent.mouseLocation
-			var warmMilliseconds = 0.0
 			let initialRgbSample: RGBSample? = nil
 			frozenFrameLatchToken = nil
 			// The Rust live sampler treats these IDs as current-process windows to
 			// include through the app-level exclusion. Overlay windows must stay out
 			// of this list so color sampling sees the desktop under the capture UI.
 			liveFrameStream.updateSelfCaptureExceptionWindowIDs(capturableOwnWindowIDs)
-			liveFrameStream.start(
-				for: NSScreen.screens,
-				prewarmPoint: startPoint,
-				captureID: captureID
-			)
 			let desktopFrame = CaptureOverlayController.desktopFrame
 			let windowSnapshotStartedAt = ProcessInfo.processInfo.systemUptime
 			let initialWindowSnapshots = WindowSnapshotFeed.snapshots(desktopFrame: desktopFrame)
@@ -856,7 +896,6 @@ final class CaptureSessionController: NSObject {
 					}
 					let selfCaptureExceptionWindowIDs =
 						overlayController.selfCaptureExceptionWindowIDs
-					let warmStartedAt = ProcessInfo.processInfo.systemUptime
 					_ = self.warmLiveSamplingIfPossible(
 						at: startPoint,
 						source: "capture_overlay_preflight",
@@ -865,8 +904,6 @@ final class CaptureSessionController: NSObject {
 						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
 						includedCurrentProcessWindowIDs: capturableOwnWindowIDs
 					)
-					warmMilliseconds =
-						NativeHostTelemetry.milliseconds(since: warmStartedAt)
 				}
 			)
 			let overlayShowMilliseconds =
@@ -879,7 +916,7 @@ final class CaptureSessionController: NSObject {
 			NativeHostTelemetry.captureStartTiming(
 				captureID: captureID,
 				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
-				warmMilliseconds: warmMilliseconds,
+				warmMilliseconds: 0,
 				windowSnapshotMilliseconds: windowSnapshotMilliseconds,
 				sessionSetupMilliseconds: sessionSetupMilliseconds,
 				overlayShowMilliseconds: overlayShowMilliseconds,
@@ -998,6 +1035,7 @@ final class CaptureSessionController: NSObject {
 		}
 
 		do {
+			overlayController?.prepareCaptureStreamsNow(trigger: "primary_interaction")
 			liveFrameStream.prime(at: point)
 			frozenFrameLatchToken = frozenFrameAuthority.latchToken(containing: point)
 			beginHostLocalFrozenSelectingIfPossible(at: point)
@@ -1730,24 +1768,26 @@ final class CaptureSessionController: NSObject {
 		let token =
 			frozenFrameLatchToken ?? frozenFrameAuthority.latchToken(containing: selectionCenter)
 		let snapshotStartedAt = ProcessInfo.processInfo.systemUptime
-		let frozenFrame = frozenFrameAuthority.snapshot(
+		let snapshotResolution = frozenFrameAuthority.resolveSnapshot(
 			containing: selectionCenter,
 			after: token,
 			maxWait: frozenFrameLatchWait(containing: selectionCenter)
 		)
 		let snapshotWaitMilliseconds =
 			NativeHostTelemetry.milliseconds(since: snapshotStartedAt)
-		guard let frozenFrame else {
-			guard frozenFrameAuthority.needsSelfCaptureCompleteFrame(containing: selectionCenter)
-			else {
-				try failFrozenCommit(
-					captureID: captureID,
-					commitStartedAt: commitStartedAt,
-					snapshotWaitMilliseconds: snapshotWaitMilliseconds,
-					hadLatchToken: hadLatchToken
-				)
-				return
-			}
+		switch snapshotResolution {
+		case .resolved(let frozenFrame):
+			try finishFrozenCommit(
+				captureID: captureID,
+				selection: selection,
+				editable: editable,
+				frozenFrame: frozenFrame,
+				commitStartedAt: commitStartedAt,
+				snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+				hadLatchToken: hadLatchToken,
+				syncAfterReport: false
+			)
+		case .pendingSelfCaptureFrame:
 			let pendingCommit = PendingFrozenCommit(
 				id: nextPendingFrozenCommitID,
 				captureID: captureID,
@@ -1764,18 +1804,14 @@ final class CaptureSessionController: NSObject {
 				pendingCommit,
 				selectionCenter: selectionCenter
 			)
-			return
+		case .noFreshFrame:
+			try failFrozenCommit(
+				captureID: captureID,
+				commitStartedAt: commitStartedAt,
+				snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+				hadLatchToken: hadLatchToken
+			)
 		}
-		try finishFrozenCommit(
-			captureID: captureID,
-			selection: selection,
-			editable: editable,
-			frozenFrame: frozenFrame,
-			commitStartedAt: commitStartedAt,
-			snapshotWaitMilliseconds: snapshotWaitMilliseconds,
-			hadLatchToken: hadLatchToken,
-			syncAfterReport: false
-		)
 	}
 
 	private func schedulePendingFrozenCommit(
@@ -1791,7 +1827,7 @@ final class CaptureSessionController: NSObject {
 				- (ProcessInfo.processInfo.systemUptime - pendingCommit.snapshotStartedAtUptime)
 		)
 		frozenCommitQueue.async { [weak self] in
-			let frozenFrame = authority.snapshot(
+			let snapshotResolution = authority.resolveSnapshot(
 				containing: selectionCenter,
 				after: pendingCommit.token,
 				maxWait: remainingWait
@@ -1799,7 +1835,7 @@ final class CaptureSessionController: NSObject {
 			DispatchQueue.main.async {
 				self?.finishPendingFrozenCommit(
 					pendingCommit,
-					frozenFrame: frozenFrame
+					snapshotResolution: snapshotResolution
 				)
 			}
 		}
@@ -1807,7 +1843,7 @@ final class CaptureSessionController: NSObject {
 
 	private func finishPendingFrozenCommit(
 		_ pendingCommit: PendingFrozenCommit,
-		frozenFrame: FrozenFrameSnapshot?
+		snapshotResolution: FrozenFrameAuthority.SnapshotResolution
 	) {
 		guard
 			let currentPending = pendingFrozenCommit,
@@ -1819,7 +1855,29 @@ final class CaptureSessionController: NSObject {
 		}
 		let snapshotWaitMilliseconds =
 			NativeHostTelemetry.milliseconds(since: pendingCommit.snapshotStartedAtUptime)
-		guard let frozenFrame else {
+		switch snapshotResolution {
+		case .resolved(let frozenFrame):
+			do {
+				try finishFrozenCommit(
+					captureID: pendingCommit.captureID,
+					selection: pendingCommit.selection,
+					editable: pendingCommit.editable,
+					frozenFrame: frozenFrame,
+					commitStartedAt: pendingCommit.startedAtUptime,
+					snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+					hadLatchToken: pendingCommit.hadLatchToken,
+					syncAfterReport: true
+				)
+			} catch {
+				NativeHostTelemetry.captureWarning(
+					"capture.freeze_commit_failed",
+					captureID: pendingCommit.captureID,
+					stage: "finish_pending_commit",
+					error: String(describing: error)
+				)
+				tearDownCapture()
+			}
+		case .pendingSelfCaptureFrame, .noFreshFrame:
 			do {
 				try failFrozenCommit(
 					captureID: pendingCommit.captureID,
@@ -1835,27 +1893,6 @@ final class CaptureSessionController: NSObject {
 					error: String(describing: error)
 				)
 			}
-			return
-		}
-		do {
-			try finishFrozenCommit(
-				captureID: pendingCommit.captureID,
-				selection: pendingCommit.selection,
-				editable: pendingCommit.editable,
-				frozenFrame: frozenFrame,
-				commitStartedAt: pendingCommit.startedAtUptime,
-				snapshotWaitMilliseconds: snapshotWaitMilliseconds,
-				hadLatchToken: pendingCommit.hadLatchToken,
-				syncAfterReport: true
-			)
-		} catch {
-			NativeHostTelemetry.captureWarning(
-				"capture.freeze_commit_failed",
-				captureID: pendingCommit.captureID,
-				stage: "finish_pending_commit",
-				error: String(describing: error)
-			)
-			tearDownCapture()
 		}
 	}
 
@@ -3247,6 +3284,11 @@ final class CaptureOverlayController {
 		frameRgbSampler: frameRgbSampler,
 		framePatchSampler: framePatchSampler,
 		backgroundSampler: Self.chromeSampleAtDisplayPoint,
+		firstRgbSampled: { [weak self] in
+			DispatchQueue.main.async { [weak self] in
+				self?.prepareCaptureStreamsNow(trigger: "first_rgb")
+			}
+		},
 		sampleUpdated: { [weak self] in
 			DispatchQueue.main.async { [weak self] in
 				(self?.primaryWindow as? CaptureOverlayWindow)?.hostView
@@ -3255,6 +3297,7 @@ final class CaptureOverlayController {
 		}
 	)
 	private let liveChromeBackdrops = LiveChromeBackdropWindowController()
+	private var pendingCaptureStreamPreparation: (() -> Void)?
 
 	init(
 		controller: CaptureSessionController,
@@ -3317,9 +3360,12 @@ final class CaptureOverlayController {
 		}
 		collapsedForFrozen = false
 		if let prepareCaptureStreams {
-			prepareCaptureStreams()
+			pendingCaptureStreamPreparation = prepareCaptureStreams
 		} else {
 			liveFrameStream.start(for: NSScreen.screens, prewarmPoint: focusPoint)
+		}
+		if controller?.hasFreshShareableContentCache() == true {
+			prepareCaptureStreamsNow(trigger: "activation_cached")
 		}
 		windowSnapshotFeed.start(
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
@@ -3336,6 +3382,22 @@ final class CaptureOverlayController {
 			focusedWindow.hostView.refreshLivePresentationNow()
 			focusedWindow.displayIfNeeded()
 		}
+		DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(35)) { [weak self] in
+			self?.prepareCaptureStreamsNow(trigger: "first_rgb_timeout")
+		}
+	}
+
+	fileprivate func prepareCaptureStreamsNow(trigger: String) {
+		guard let prepareCaptureStreams = pendingCaptureStreamPreparation else {
+			return
+		}
+		pendingCaptureStreamPreparation = nil
+		NativeHostTelemetry.captureEvent(
+			"capture.stream_prepare_started",
+			captureID: controller?.activeTelemetryCaptureID ?? 0,
+			detail: "trigger=\(trigger)"
+		)
+		prepareCaptureStreams()
 	}
 
 	fileprivate func update(
@@ -3455,6 +3517,7 @@ final class CaptureOverlayController {
 	}
 
 	func close() {
+		pendingCaptureStreamPreparation = nil
 		windowSnapshotFeed.stop()
 		chromeSampleFeed.stop()
 		liveChromeBackdrops.hideAll()
@@ -3594,12 +3657,21 @@ final class CaptureOverlayController {
 		let screen =
 			NSScreen.screens.first(where: { $0.frame.contains(point) })
 			?? referenceWindow.screen
+		guard let displayID = screen.flatMap(Self.displayID) else {
+			return nil
+		}
 		return LiveColorSampleSource(
 			referenceWindowID: CGWindowID(referenceWindow.windowNumber),
 			desktopFrame: Self.desktopFrame,
 			screenFrame: screen?.frame ?? referenceWindow.frame,
+			displayID: displayID,
 			scaleFactor: screen?.backingScaleFactor ?? 1
 		)
+	}
+
+	private static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+		(screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+			.uint32Value
 	}
 
 	func captureImageBelowOverlay(in rect: CGRect, near point: CGPoint) -> CGImage? {
@@ -3628,20 +3700,18 @@ final class CaptureOverlayController {
 		sidePixels: Int,
 		includeLoupePatch: Bool
 	) -> LiveChromeSample? {
+		let rgbSample = rgbSampleAtDisplayPoint(point, source: source)
 		let loupePatch =
 			includeLoupePatch
 			? loupePatchAtDisplayPoint(point, source: source, sidePixels: sidePixels)
 			: nil
-		let rgbSample =
-			loupePatch.flatMap(rgbSample(from:))
-			?? rgbSampleAtDisplayPoint(point, source: source)
 		guard rgbSample != nil || loupePatch != nil else {
 			return nil
 		}
 		return LiveChromeSample(
 			rgbSample: rgbSample,
 			rgbCapturedAtUptime: ProcessInfo.processInfo.systemUptime,
-			rgbSource: "background_fallback",
+			rgbSource: "display_point",
 			loupePatch: loupePatch
 		)
 	}
@@ -3661,12 +3731,10 @@ final class CaptureOverlayController {
 		guard !sampleRect.isNull, sampleRect.width > 0, sampleRect.height > 0 else {
 			return nil
 		}
-		if let image = captureImageBelowOverlay(in: sampleRect, source: source),
-			let sample = rgbSample(from: image)
-		{
-			return sample
+		guard let image = captureImageOnDisplay(in: sampleRect, source: source) else {
+			return nil
 		}
-		return nil
+		return rgbSample(from: image)
 	}
 
 	nonisolated private static func loupePatchAtDisplayPoint(
@@ -3703,6 +3771,27 @@ final class CaptureOverlayController {
 			windowID: source.referenceWindowID,
 			imageOption: [.boundsIgnoreFraming, .bestResolution]
 		)
+	}
+
+	nonisolated private static func captureImageOnDisplay(
+		in rect: CGRect,
+		source: LiveColorSampleSource
+	) -> CGImage? {
+		let displayRect = appKitRectToQuartz(rect, desktopFrame: source.desktopFrame)
+		guard !displayRect.isNull, displayRect.width > 0, displayRect.height > 0 else {
+			return nil
+		}
+		return firstDisplayPointImage {
+			displayCreateImageForRect?(source.displayID, displayRect)?
+				.takeRetainedValue()
+		} windowListCapture: {
+			legacyWindowListImage(
+				quartzRect: displayRect,
+				windowListOption: .optionOnScreenOnly,
+				windowID: kCGNullWindowID,
+				imageOption: [.boundsIgnoreFraming, .bestResolution]
+			)
+		}
 	}
 
 	nonisolated private static func rgbSample(from image: CGImage) -> RGBSample? {
@@ -3786,6 +3875,57 @@ final class CaptureOverlayController {
 			CGWindowID,
 			UInt32
 		) -> Unmanaged<CGImage>?
+
+	private typealias DisplayCreateImageForRect =
+		@convention(c) (
+			CGDirectDisplayID,
+			CGRect
+		) -> Unmanaged<CGImage>?
+
+	nonisolated private static let displayCreateImageForRect: DisplayCreateImageForRect? = {
+		guard
+			let coreGraphics = dlopen(
+				"/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+				RTLD_LAZY
+			)
+		else {
+			return nil
+		}
+		guard let symbol = dlsym(coreGraphics, "CGDisplayCreateImageForRect") else {
+			dlclose(coreGraphics)
+			return nil
+		}
+		return unsafeBitCast(symbol, to: DisplayCreateImageForRect.self)
+	}()
+
+	nonisolated private static let displayPointRaceQueue = DispatchQueue(
+		label: "ink.hack.rsnap.native-host.display-point-race",
+		qos: .userInteractive,
+		attributes: .concurrent
+	)
+
+	nonisolated private static func firstDisplayPointImage(
+		displayCapture: @escaping @Sendable () -> CGImage?,
+		windowListCapture: @escaping @Sendable () -> CGImage?
+	) -> CGImage? {
+		let group = DispatchGroup()
+		let race = DisplayPointImageRace()
+		group.enter()
+		displayPointRaceQueue.async {
+			race.complete(displayCapture())
+			group.leave()
+		}
+		group.enter()
+		displayPointRaceQueue.async {
+			race.complete(windowListCapture())
+			group.leave()
+		}
+		group.notify(queue: displayPointRaceQueue) {
+			race.finished.signal()
+		}
+		race.finished.wait()
+		return race.image()
+	}
 
 	nonisolated private static let legacyWindowListCreateImage: LegacyWindowListCreateImage? = {
 		guard

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -8,9 +8,56 @@ import QuartzCore
 import RsnapHostBridge
 import Vision
 
+struct LiveRgbSample: Sendable {
+	static let maximumDisplayAge: TimeInterval = 0.18
+	static let maximumReusableAge: TimeInterval = 0.08
+
+	let rgb: RGBSample
+	let capturedAtUptime: TimeInterval
+	let source: String
+
+	func ageMilliseconds(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Double {
+		max(0, now - capturedAtUptime) * 1_000
+	}
+
+	func isFresh(
+		maximumAge: TimeInterval = Self.maximumDisplayAge,
+		now: TimeInterval = ProcessInfo.processInfo.systemUptime
+	) -> Bool {
+		now - capturedAtUptime <= maximumAge
+	}
+}
+
 struct LiveChromeSample {
-	let rgbSample: RGBSample?
+	let rgb: LiveRgbSample?
 	let loupePatch: CGImage?
+
+	var rgbSample: RGBSample? {
+		rgb?.rgb
+	}
+
+	init(rgb: LiveRgbSample?, loupePatch: CGImage?) {
+		self.rgb = rgb
+		self.loupePatch = loupePatch
+	}
+
+	init(
+		rgbSample: RGBSample?,
+		rgbCapturedAtUptime: TimeInterval? = nil,
+		rgbSource: String = "unqualified",
+		loupePatch: CGImage?
+	) {
+		if let rgbSample, let rgbCapturedAtUptime {
+			rgb = LiveRgbSample(
+				rgb: rgbSample,
+				capturedAtUptime: rgbCapturedAtUptime,
+				source: rgbSource
+			)
+		} else {
+			rgb = nil
+		}
+		self.loupePatch = loupePatch
+	}
 }
 
 enum LiveSamplingBudget {
@@ -257,7 +304,6 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	private let settingsStore = NativeHostSettingsStore()
 	private let globalHotKeys = GlobalHotKeyCenter()
 	private var lifecycleActivity: NSObjectProtocol?
-	private var liveSamplingPrewarmWorkItem: DispatchWorkItem?
 	private var selfCaptureRegistrationWindow: NSWindow?
 	private var didBootstrap = false
 	private var didPresentLaunchPermissionOnboarding = false
@@ -306,7 +352,6 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		)
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
 		refreshStatusMenuState()
-		scheduleLiveSamplingPrewarm()
 		scheduleLaunchPermissionOnboardingIfNeeded()
 		NativeHostTelemetry.lifecycleEvent(
 			"native_host.finish_launching_end",
@@ -316,6 +361,10 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 
 	public func applicationDidFinishLaunching(_ notification: Notification) {
 		finishLaunching()
+	}
+
+	public func applicationWillTerminate(_ notification: Notification) {
+		sessionController.releaseScreenCaptureStreams()
 	}
 
 	private func showSelfCaptureRegistrationWindow() {
@@ -509,29 +558,6 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		)
 	}
 
-	private func scheduleLiveSamplingPrewarm() {
-		liveSamplingPrewarmWorkItem?.cancel()
-		let workItem = DispatchWorkItem { [weak self] in
-			self?.liveSamplingPrewarmWorkItem = nil
-			self?.prewarmLiveSamplingIfPossible()
-		}
-		liveSamplingPrewarmWorkItem = workItem
-		DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: workItem)
-	}
-
-	private func prewarmLiveSamplingIfPossible() {
-		guard !sessionController.isCaptureActive else {
-			return
-		}
-		let point = NSEvent.mouseLocation
-		let sample = sessionController.warmLiveSamplingIfPossible(
-			at: point, source: "startup_prewarm", captureID: 0)
-		NativeHostTelemetry.lifecycleDebug(
-			"native_host.live_sampling_prewarm",
-			detail: "sampleReady=\(sample?.rgbSample != nil)"
-		)
-	}
-
 	@objc
 	private func settingsDidChange() {
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
@@ -586,6 +612,18 @@ final class CaptureSessionController: NSObject {
 		let desktopFrame: CGRect
 	}
 
+	private struct PendingFrozenCommit: Sendable {
+		let id: UInt64
+		let captureID: UInt64
+		let generation: UInt64
+		let selection: CGRect
+		let editable: Bool
+		let token: FrozenFrameLatchToken?
+		let startedAtUptime: TimeInterval
+		let snapshotStartedAtUptime: TimeInterval
+		let hadLatchToken: Bool
+	}
+
 	private static let autoCenterMaxIterations = 6
 	private static let displayFirstFrameWait: TimeInterval = 0.025
 	private static let coldSelfCaptureRecoveryWait: TimeInterval = 3.5
@@ -595,15 +633,20 @@ final class CaptureSessionController: NSObject {
 	private let settingsStore: NativeHostSettingsStore
 	private let liveFrameStream = LiveFrameStreamBroker()
 	private let frozenFrameAuthority = FrozenFrameAuthority()
+	private let frozenCommitQueue = DispatchQueue(
+		label: "ink.hack.rsnap.frozen-commit",
+		qos: .userInitiated
+	)
 	private let captureSuccessSound = CaptureSuccessSound.load()
 	private var session: RsnapHostSession?
 	private var overlayController: CaptureOverlayController?
 	private var frozenFrameLatchToken: FrozenFrameLatchToken?
+	private var pendingFrozenCommit: PendingFrozenCommit?
+	private var nextPendingFrozenCommitID: UInt64 = 1
 	private var frozenSnapshotGeneration: UInt64 = 0
 	private var completedHostEffect: HostEffectKind?
 	private var scrollCaptureState: NativeScrollCaptureState?
 	private var scrollCaptureGlobalMonitor: Any?
-	private var liveStreamPrimedByStartupPrewarm = false
 	private var nextCaptureTelemetryID: UInt64 = 1
 	private var activeCaptureTelemetryID: UInt64?
 	var captureStateDidChange: (() -> Void)?
@@ -673,6 +716,7 @@ final class CaptureSessionController: NSObject {
 		source: String = "capture",
 		captureID: UInt64 = 0,
 		excludeSelfFromFrozenAuthority: Bool = false,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID> = [],
 		includedCurrentProcessWindowIDs: Set<CGWindowID> = []
 	) -> LiveChromeSample? {
 		let warmStartedAt = ProcessInfo.processInfo.systemUptime
@@ -691,35 +735,32 @@ final class CaptureSessionController: NSObject {
 			return nil
 		}
 		let screens = NSScreen.screens
+		let liveStreamStartedAt = ProcessInfo.processInfo.systemUptime
+		liveFrameStream.start(for: screens, prewarmPoint: point, captureID: captureID)
+		let liveStreamStartMilliseconds =
+			NativeHostTelemetry.milliseconds(since: liveStreamStartedAt)
 		let frozenAuthorityStartedAt = ProcessInfo.processInfo.systemUptime
 		frozenFrameAuthority.start(
 			for: screens,
 			captureID: captureID,
 			source: source,
 			rebuildContentFilter: excludeSelfFromFrozenAuthority,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
 			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
 		)
 		let frozenAuthorityStartMilliseconds =
 			NativeHostTelemetry.milliseconds(since: frozenAuthorityStartedAt)
-		let liveStreamStartedAt = ProcessInfo.processInfo.systemUptime
-		liveFrameStream.start(for: screens, prewarmPoint: point)
-		liveStreamPrimedByStartupPrewarm = source == "startup_prewarm"
-		let liveStreamStartMilliseconds =
-			NativeHostTelemetry.milliseconds(since: liveStreamStartedAt)
-		let seedStartedAt = ProcessInfo.processInfo.systemUptime
-		let sample = liveFrameStream.seedSample(at: point, sidePixels: 1)
-		let seedSampleMilliseconds = NativeHostTelemetry.milliseconds(since: seedStartedAt)
 		NativeHostTelemetry.liveSamplingWarmTiming(
 			captureID: captureID,
 			source: source,
 			totalMilliseconds: NativeHostTelemetry.milliseconds(since: warmStartedAt),
 			frozenAuthorityStartMilliseconds: frozenAuthorityStartMilliseconds,
 			liveStreamStartMilliseconds: liveStreamStartMilliseconds,
-			seedSampleMilliseconds: seedSampleMilliseconds,
-			sampleReady: sample?.rgbSample != nil,
+			seedSampleMilliseconds: 0,
+			sampleReady: false,
 			screenCount: screenCount
 		)
-		return sample
+		return nil
 	}
 
 	func startCapture(capturableOwnWindowIDs: Set<CGWindowID> = []) {
@@ -753,20 +794,18 @@ final class CaptureSessionController: NSObject {
 
 		do {
 			let startPoint = NSEvent.mouseLocation
-			prepareLiveSamplingForCaptureStart()
-			liveFrameStream.updateSelfCaptureExceptionWindowIDs(capturableOwnWindowIDs)
-			let warmStartedAt = ProcessInfo.processInfo.systemUptime
-			let initialSample = warmLiveSamplingIfPossible(
-				at: startPoint,
-				source: "start_capture",
-				captureID: captureID,
-				includedCurrentProcessWindowIDs: capturableOwnWindowIDs
-			)
-			let initialRgbSample =
-				initialSample?.rgbSample
-				?? frozenFrameAuthority.rgbSample(containing: startPoint)
-			let warmMilliseconds = NativeHostTelemetry.milliseconds(since: warmStartedAt)
+			var warmMilliseconds = 0.0
+			let initialRgbSample: RGBSample? = nil
 			frozenFrameLatchToken = nil
+			// The Rust live sampler treats these IDs as current-process windows to
+			// include through the app-level exclusion. Overlay windows must stay out
+			// of this list so color sampling sees the desktop under the capture UI.
+			liveFrameStream.updateSelfCaptureExceptionWindowIDs(capturableOwnWindowIDs)
+			liveFrameStream.start(
+				for: NSScreen.screens,
+				prewarmPoint: startPoint,
+				captureID: captureID
+			)
 			let desktopFrame = CaptureOverlayController.desktopFrame
 			let windowSnapshotStartedAt = ProcessInfo.processInfo.systemUptime
 			let initialWindowSnapshots = WindowSnapshotFeed.snapshots(desktopFrame: desktopFrame)
@@ -797,7 +836,7 @@ final class CaptureSessionController: NSObject {
 				controller: self,
 				liveFrameStream: liveFrameStream,
 				frameRgbSampler: { [frozenFrameAuthority] point in
-					frozenFrameAuthority.rgbSample(containing: point)
+					frozenFrameAuthority.liveRgbSample(containing: point)
 				},
 				framePatchSampler: { [frozenFrameAuthority] point, sidePixels in
 					frozenFrameAuthority.loupePatch(containing: point, sidePixels: sidePixels)
@@ -810,24 +849,26 @@ final class CaptureSessionController: NSObject {
 				chrome: chromeState,
 				settings: settingsStore.settings,
 				focusPoint: startPoint,
-				initialWindowSnapshots: initialWindowSnapshots
+				initialWindowSnapshots: initialWindowSnapshots,
+				prepareCaptureStreams: { [weak self, weak overlayController] in
+					guard let self, let overlayController else {
+						return
+					}
+					let selfCaptureExceptionWindowIDs =
+						overlayController.selfCaptureExceptionWindowIDs
+					let warmStartedAt = ProcessInfo.processInfo.systemUptime
+					_ = self.warmLiveSamplingIfPossible(
+						at: startPoint,
+						source: "capture_overlay_preflight",
+						captureID: captureID,
+						excludeSelfFromFrozenAuthority: true,
+						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+						includedCurrentProcessWindowIDs: capturableOwnWindowIDs
+					)
+					warmMilliseconds =
+						NativeHostTelemetry.milliseconds(since: warmStartedAt)
+				}
 			)
-			if frozenFrameAuthority.hasSelfCaptureCompleteFrame(containing: startPoint) {
-				NativeHostTelemetry.captureEvent(
-					"capture.self_capture_rebuild_skipped",
-					captureID: captureID,
-					detail: "startup_complete_filter"
-				)
-			} else {
-				frozenFrameAuthority.start(
-					for: NSScreen.screens,
-					captureID: captureID,
-					source: "capture_overlay_visible",
-					rebuildContentFilter: true,
-					selfCaptureExceptionWindowIDs: overlayController.selfCaptureExceptionWindowIDs,
-					includedCurrentProcessWindowIDs: capturableOwnWindowIDs
-				)
-			}
 			let overlayShowMilliseconds =
 				NativeHostTelemetry.milliseconds(since: overlayShowStartedAt)
 			(NSApp.delegate as? NativeHostApplicationController)?.window =
@@ -860,14 +901,6 @@ final class CaptureSessionController: NSObject {
 			)
 			tearDownCapture()
 		}
-	}
-
-	private func prepareLiveSamplingForCaptureStart() {
-		guard liveStreamPrimedByStartupPrewarm else {
-			return
-		}
-		liveFrameStream.stop()
-		liveStreamPrimedByStartupPrewarm = false
 	}
 
 	private func ensureCapturePermissions() -> Bool {
@@ -960,6 +993,9 @@ final class CaptureSessionController: NSObject {
 			pointerMoved(to: point)
 			return
 		}
+		guard pendingFrozenCommit == nil else {
+			return
+		}
 
 		do {
 			liveFrameStream.prime(at: point)
@@ -997,6 +1033,9 @@ final class CaptureSessionController: NSObject {
 	func continuePrimaryInteraction(to point: CGPoint) {
 		guard scene.mode == .live else {
 			pointerMoved(to: point)
+			return
+		}
+		guard pendingFrozenCommit == nil else {
 			return
 		}
 
@@ -1037,6 +1076,9 @@ final class CaptureSessionController: NSObject {
 			pointerMoved(to: point)
 			return
 		}
+		guard pendingFrozenCommit == nil else {
+			return
+		}
 
 		overlayController?.markLivePrimaryInteractionReleased(at: point)
 		do {
@@ -1062,8 +1104,10 @@ final class CaptureSessionController: NSObject {
 			)
 			try syncCore()
 			if scene.mode == .live {
-				chromeState.endHostLocalFrozenSelecting()
-				refreshOverlay()
+				if pendingFrozenCommit == nil {
+					chromeState.endHostLocalFrozenSelecting()
+					refreshOverlay()
+				}
 			}
 		} catch {
 			chromeState.endHostLocalFrozenSelecting()
@@ -1674,18 +1718,19 @@ final class CaptureSessionController: NSObject {
 	}
 
 	private func commitFrozenSelection(_ selection: CGRect, editable: Bool) throws {
-		guard let session else {
+		guard session != nil else {
 			return
 		}
 		let captureID = currentCaptureTelemetryID
 		let commitStartedAt = ProcessInfo.processInfo.systemUptime
 		frozenSnapshotGeneration &+= 1
+		let generation = frozenSnapshotGeneration
 		let selectionCenter = CGPoint(x: selection.midX, y: selection.midY)
 		let hadLatchToken = frozenFrameLatchToken != nil
 		let token =
 			frozenFrameLatchToken ?? frozenFrameAuthority.latchToken(containing: selectionCenter)
 		let snapshotStartedAt = ProcessInfo.processInfo.systemUptime
-		let frozenFrame = snapshotForFrozenCommit(
+		let frozenFrame = frozenFrameAuthority.snapshot(
 			containing: selectionCenter,
 			after: token,
 			maxWait: frozenFrameLatchWait(containing: selectionCenter)
@@ -1693,24 +1738,166 @@ final class CaptureSessionController: NSObject {
 		let snapshotWaitMilliseconds =
 			NativeHostTelemetry.milliseconds(since: snapshotStartedAt)
 		guard let frozenFrame else {
-			frozenFrameLatchToken = nil
-			chromeState.endHostLocalFrozenSelecting()
-			refreshOverlay()
-			NativeHostTelemetry.captureWarning(
-				"capture.freeze_commit_failed",
+			guard frozenFrameAuthority.needsSelfCaptureCompleteFrame(containing: selectionCenter)
+			else {
+				try failFrozenCommit(
+					captureID: captureID,
+					commitStartedAt: commitStartedAt,
+					snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+					hadLatchToken: hadLatchToken
+				)
+				return
+			}
+			let pendingCommit = PendingFrozenCommit(
+				id: nextPendingFrozenCommitID,
 				captureID: captureID,
-				stage: "authority_snapshot",
-				error: "no_fresh_frame"
-			)
-			NativeHostTelemetry.freezeCommitFailureTiming(
-				captureID: captureID,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: commitStartedAt),
-				snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+				generation: generation,
+				selection: selection,
+				editable: editable,
+				token: token,
+				startedAtUptime: commitStartedAt,
+				snapshotStartedAtUptime: snapshotStartedAt,
 				hadLatchToken: hadLatchToken
 			)
-			try sendHostStatusMessage("Could not freeze the current frame.")
+			nextPendingFrozenCommitID &+= 1
+			schedulePendingFrozenCommit(
+				pendingCommit,
+				selectionCenter: selectionCenter
+			)
 			return
 		}
+		try finishFrozenCommit(
+			captureID: captureID,
+			selection: selection,
+			editable: editable,
+			frozenFrame: frozenFrame,
+			commitStartedAt: commitStartedAt,
+			snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+			hadLatchToken: hadLatchToken,
+			syncAfterReport: false
+		)
+	}
+
+	private func schedulePendingFrozenCommit(
+		_ pendingCommit: PendingFrozenCommit,
+		selectionCenter: CGPoint
+	) {
+		pendingFrozenCommit = pendingCommit
+		refreshOverlay()
+		let authority = frozenFrameAuthority
+		let remainingWait = max(
+			0,
+			Self.coldSelfCaptureRecoveryWait
+				- (ProcessInfo.processInfo.systemUptime - pendingCommit.snapshotStartedAtUptime)
+		)
+		frozenCommitQueue.async { [weak self] in
+			let frozenFrame = authority.snapshot(
+				containing: selectionCenter,
+				after: pendingCommit.token,
+				maxWait: remainingWait
+			)
+			DispatchQueue.main.async {
+				self?.finishPendingFrozenCommit(
+					pendingCommit,
+					frozenFrame: frozenFrame
+				)
+			}
+		}
+	}
+
+	private func finishPendingFrozenCommit(
+		_ pendingCommit: PendingFrozenCommit,
+		frozenFrame: FrozenFrameSnapshot?
+	) {
+		guard
+			let currentPending = pendingFrozenCommit,
+			currentPending.id == pendingCommit.id,
+			currentPending.generation == pendingCommit.generation,
+			scene.mode == .live
+		else {
+			return
+		}
+		let snapshotWaitMilliseconds =
+			NativeHostTelemetry.milliseconds(since: pendingCommit.snapshotStartedAtUptime)
+		guard let frozenFrame else {
+			do {
+				try failFrozenCommit(
+					captureID: pendingCommit.captureID,
+					commitStartedAt: pendingCommit.startedAtUptime,
+					snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+					hadLatchToken: pendingCommit.hadLatchToken
+				)
+			} catch {
+				NativeHostTelemetry.captureWarning(
+					"capture.freeze_commit_failed",
+					captureID: pendingCommit.captureID,
+					stage: "authority_snapshot_status",
+					error: String(describing: error)
+				)
+			}
+			return
+		}
+		do {
+			try finishFrozenCommit(
+				captureID: pendingCommit.captureID,
+				selection: pendingCommit.selection,
+				editable: pendingCommit.editable,
+				frozenFrame: frozenFrame,
+				commitStartedAt: pendingCommit.startedAtUptime,
+				snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+				hadLatchToken: pendingCommit.hadLatchToken,
+				syncAfterReport: true
+			)
+		} catch {
+			NativeHostTelemetry.captureWarning(
+				"capture.freeze_commit_failed",
+				captureID: pendingCommit.captureID,
+				stage: "finish_pending_commit",
+				error: String(describing: error)
+			)
+			tearDownCapture()
+		}
+	}
+
+	private func failFrozenCommit(
+		captureID: UInt64,
+		commitStartedAt: TimeInterval,
+		snapshotWaitMilliseconds: Double,
+		hadLatchToken: Bool
+	) throws {
+		pendingFrozenCommit = nil
+		frozenFrameLatchToken = nil
+		chromeState.endHostLocalFrozenSelecting()
+		refreshOverlay()
+		NativeHostTelemetry.captureWarning(
+			"capture.freeze_commit_failed",
+			captureID: captureID,
+			stage: "authority_snapshot",
+			error: "no_fresh_frame"
+		)
+		NativeHostTelemetry.freezeCommitFailureTiming(
+			captureID: captureID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: commitStartedAt),
+			snapshotWaitMilliseconds: snapshotWaitMilliseconds,
+			hadLatchToken: hadLatchToken
+		)
+		try sendHostStatusMessage("Could not freeze the current frame.")
+	}
+
+	private func finishFrozenCommit(
+		captureID: UInt64,
+		selection: CGRect,
+		editable: Bool,
+		frozenFrame: FrozenFrameSnapshot,
+		commitStartedAt: TimeInterval,
+		snapshotWaitMilliseconds: Double,
+		hadLatchToken: Bool,
+		syncAfterReport: Bool
+	) throws {
+		guard let session else {
+			return
+		}
+		pendingFrozenCommit = nil
 		frozenFrameLatchToken = nil
 		chromeState.resetFrozenChrome()
 		chromeState.frozenSelectionSnapshot = selection
@@ -1750,32 +1937,13 @@ final class CaptureSessionController: NSObject {
 			baseReady: chromeState.frozenBaseImage != nil
 		)
 		try session.send(report: .freezeSnapshotCommitted(selection: selection))
+		if syncAfterReport {
+			try syncCore()
+		}
 	}
 
 	private func frozenFrameLatchWait(containing _: CGPoint) -> TimeInterval {
 		Self.displayFirstFrameWait
-	}
-
-	private func snapshotForFrozenCommit(
-		containing point: CGPoint,
-		after token: FrozenFrameLatchToken?,
-		maxWait: TimeInterval
-	) -> FrozenFrameSnapshot? {
-		if let frozenFrame = frozenFrameAuthority.snapshot(
-			containing: point,
-			after: token,
-			maxWait: maxWait
-		) {
-			return frozenFrame
-		}
-		guard frozenFrameAuthority.needsSelfCaptureCompleteFrame(containing: point) else {
-			return nil
-		}
-		return frozenFrameAuthority.snapshot(
-			containing: point,
-			after: token,
-			maxWait: max(0, Self.coldSelfCaptureRecoveryWait - maxWait)
-		)
 	}
 
 	private func hostOwnedFrozenPresentationScene(for selection: CGRect, editable: Bool)
@@ -2570,8 +2738,6 @@ final class CaptureSessionController: NSObject {
 		let rgbSample =
 			chromeSample?.rgbSample
 			?? frozenFrameAuthority.rgbSample(containing: point)
-			?? chromeState.rgbSample
-			?? scene.rgb
 		let highlightedWindow = highlightedWindow(at: point)
 		chromeState.rgbSample = rgbSample
 		chromeState.loupePatch = scene.loupeVisible ? chromeSample?.loupePatch : nil
@@ -2758,9 +2924,9 @@ final class CaptureSessionController: NSObject {
 
 	private func tearDownCapture() {
 		let captureID = currentCaptureTelemetryID
-		liveFrameStream.stop()
+		releaseScreenCaptureStreams()
 		liveFrameStream.updateSelfCaptureExceptionWindowIDs([])
-		liveStreamPrimedByStartupPrewarm = false
+		pendingFrozenCommit = nil
 		frozenFrameLatchToken = nil
 		frozenSnapshotGeneration &+= 1
 		completedHostEffect = nil
@@ -2792,6 +2958,11 @@ final class CaptureSessionController: NSObject {
 			NativeHostTelemetry.captureEvent("capture.teardown", captureID: captureID)
 		}
 		activeCaptureTelemetryID = nil
+	}
+
+	fileprivate func releaseScreenCaptureStreams() {
+		liveFrameStream.stop()
+		frozenFrameAuthority.stop()
 	}
 
 	@objc
@@ -3110,7 +3281,8 @@ final class CaptureOverlayController {
 		chrome: CaptureChromeState,
 		settings: NativeHostSettings,
 		focusPoint: CGPoint,
-		initialWindowSnapshots: [WindowSnapshot]
+		initialWindowSnapshots: [WindowSnapshot],
+		prepareCaptureStreams: (() -> Void)? = nil
 	) {
 		close()
 		var targetWindow: CaptureOverlayWindow?
@@ -3144,11 +3316,16 @@ final class CaptureOverlayController {
 			}
 		}
 		collapsedForFrozen = false
-		liveFrameStream.start(for: NSScreen.screens, prewarmPoint: focusPoint)
+		if let prepareCaptureStreams {
+			prepareCaptureStreams()
+		} else {
+			liveFrameStream.start(for: NSScreen.screens, prewarmPoint: focusPoint)
+		}
 		windowSnapshotFeed.start(
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
 		chromeSampleFeed.start(
-			targetFramesPerSecond: NativeHostDisplayRefresh.samplingFramesPerSecond())
+			targetFramesPerSecond: NativeHostDisplayRefresh.samplingFramesPerSecond(),
+			captureID: controller?.activeTelemetryCaptureID ?? 0)
 		chromeSampleFeed.updateDemand(
 			point: focusPoint,
 			sidePixels: 1,
@@ -3371,7 +3548,7 @@ final class CaptureOverlayController {
 
 		let _ = point
 		if wantsLoupePatch, let latestSample {
-			return LiveChromeSample(rgbSample: latestSample.rgbSample, loupePatch: nil)
+			return LiveChromeSample(rgb: latestSample.rgb, loupePatch: nil)
 		}
 		return latestSample
 	}
@@ -3461,7 +3638,12 @@ final class CaptureOverlayController {
 		guard rgbSample != nil || loupePatch != nil else {
 			return nil
 		}
-		return LiveChromeSample(rgbSample: rgbSample, loupePatch: loupePatch)
+		return LiveChromeSample(
+			rgbSample: rgbSample,
+			rgbCapturedAtUptime: ProcessInfo.processInfo.systemUptime,
+			rgbSource: "background_fallback",
+			loupePatch: loupePatch
+		)
 	}
 
 	nonisolated private static func rgbSampleAtDisplayPoint(
@@ -4009,7 +4191,7 @@ final class CaptureHostView: NSView {
 	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
 	private var latestLiveChromeSample: LiveChromeSample?
 	private var latestLiveChromeSamplePoint: CGPoint?
-	private var latestLiveRgbSample: RGBSample?
+	private var latestLiveRgbSample: LiveRgbSample?
 	private var latestLiveRgbSamplePoint: CGPoint?
 	private var glassPatchCache: [GlassSurfaceKind: GlassPatchCache] = [:]
 	private lazy var liveRenderer = LiveOverlayRenderer(hostView: self)
@@ -4777,7 +4959,8 @@ final class CaptureHostView: NSView {
 		let metrics = Self.hudLayoutMetrics
 		let font = metrics.font
 		let positionDisplay = currentPositionDisplay()
-		let rgbSample = cachedLiveRgbSample(matching: livePointerPreviewGlobal ?? scene.pointer)
+		let rgbSample = cachedLiveRgbSample(matching: livePointerPreviewGlobal ?? scene.pointer)?
+			.rgb
 		let colorDisplay = currentLiveColorDisplay(for: rgbSample)
 		let itemSpacing: CGFloat = 8
 		let swatchSize = CGSize(width: 10, height: 10)
@@ -6206,7 +6389,8 @@ final class CaptureHostView: NSView {
 		guard let dragSelectionLocal = currentImmediateLiveDragSelectionLocal() else {
 			return nil
 		}
-		let rgbSample = cachedLiveRgbSample(matching: livePointerPreviewGlobal ?? scene.pointer)
+		let rgbSample = cachedLiveRgbSample(matching: livePointerPreviewGlobal ?? scene.pointer)?
+			.rgb
 		return LivePreviewSnapshot(
 			bounds: bounds,
 			theme: chromeTheme(),
@@ -6255,8 +6439,8 @@ final class CaptureHostView: NSView {
 			hudFrame: nil,
 			loupeFrame: nil,
 			positionDisplay: currentPositionDisplay(),
-			colorDisplay: currentLiveColorDisplay(for: latestLiveRgbSample),
-			rgbSample: latestLiveRgbSample,
+			colorDisplay: currentLiveColorDisplay(for: latestLiveRgbSample?.rgb),
+			rgbSample: latestLiveRgbSample?.rgb,
 			keycapVisible: false,
 			inputUptime: nil,
 			loupePatch: nil,
@@ -6581,7 +6765,7 @@ final class CaptureHostView: NSView {
 				wantsLoupePatch: wantsLoupePatch
 			)
 			seedLiveChromeSampleCache(resolvedSample, point: point)
-			if let rgbSample = resolvedSample.rgbSample {
+			if let rgbSample = resolvedSample.rgb {
 				seedLiveRgbSampleCache(rgbSample, point: point)
 			}
 			return resolvedSample
@@ -6589,7 +6773,7 @@ final class CaptureHostView: NSView {
 		if let cachedSample = cachedLiveChromeSample(matching: point) {
 			return cachedSample
 		}
-		if chrome.rgbSample != nil || chrome.loupePatch != nil,
+		if chrome.loupePatch != nil,
 			liveSamplePoint(scene.pointer, matches: point)
 		{
 			seedLiveChromeSampleCache(from: chrome, point: scene.pointer)
@@ -6610,13 +6794,13 @@ final class CaptureHostView: NSView {
 			let cachedPatch = cachedSample.loupePatch
 		{
 			return LiveChromeSample(
-				rgbSample: sample.rgbSample ?? cachedSample.rgbSample,
+				rgb: sample.rgb,
 				loupePatch: cachedPatch
 			)
 		}
 		if liveSamplePoint(scene.pointer, matches: point), let chromePatch = chrome.loupePatch {
 			return LiveChromeSample(
-				rgbSample: sample.rgbSample ?? chrome.rgbSample,
+				rgb: sample.rgb,
 				loupePatch: chromePatch
 			)
 		}
@@ -6624,33 +6808,26 @@ final class CaptureHostView: NSView {
 	}
 
 	private func liveRgbSample(from sample: LiveChromeSample?, at point: CGPoint?) -> RGBSample? {
-		if let rgbSample = sample?.rgbSample {
-			seedLiveRgbSampleCache(rgbSample, point: point)
-			return rgbSample
-		}
-		if let rgbSample = chrome.rgbSample,
-			liveSamplePoint(scene.pointer, matches: point)
+		if let rgbSample = sample?.rgb,
+			rgbSample.isFresh()
 		{
-			seedLiveRgbSampleCache(rgbSample, point: scene.pointer)
-			return rgbSample
+			seedLiveRgbSampleCache(rgbSample, point: point)
+			return rgbSample.rgb
 		}
-		return cachedLiveRgbSample(matching: point)
+		return cachedLiveRgbSample(matching: point)?.rgb
 	}
 
 	private func seedLiveChromeSampleCache(from chrome: CaptureChromeState, point: CGPoint?) {
-		guard chrome.rgbSample != nil || chrome.loupePatch != nil else {
+		guard chrome.loupePatch != nil else {
 			return
 		}
 		seedLiveChromeSampleCache(
 			LiveChromeSample(
-				rgbSample: chrome.rgbSample,
+				rgb: nil,
 				loupePatch: chrome.loupePatch
 			),
 			point: point
 		)
-		if let rgbSample = chrome.rgbSample {
-			seedLiveRgbSampleCache(rgbSample, point: point)
-		}
 	}
 
 	private func seedLiveChromeSampleCache(_ sample: LiveChromeSample, point: CGPoint?) {
@@ -6658,7 +6835,7 @@ final class CaptureHostView: NSView {
 		latestLiveChromeSamplePoint = point
 	}
 
-	private func seedLiveRgbSampleCache(_ rgbSample: RGBSample, point: CGPoint?) {
+	private func seedLiveRgbSampleCache(_ rgbSample: LiveRgbSample, point: CGPoint?) {
 		latestLiveRgbSample = rgbSample
 		latestLiveRgbSamplePoint = point
 	}
@@ -6667,11 +6844,22 @@ final class CaptureHostView: NSView {
 		guard liveSamplePoint(latestLiveChromeSamplePoint, matches: point) else {
 			return nil
 		}
+		guard let latestLiveChromeSample else {
+			return nil
+		}
+		guard latestLiveChromeSample.rgb == nil || latestLiveChromeSample.rgb?.isFresh() == true
+		else {
+			return LiveChromeSample(rgb: nil, loupePatch: latestLiveChromeSample.loupePatch)
+		}
 		return latestLiveChromeSample
 	}
 
-	private func cachedLiveRgbSample(matching point: CGPoint?) -> RGBSample? {
+	private func cachedLiveRgbSample(matching point: CGPoint?) -> LiveRgbSample? {
 		guard liveSamplePoint(latestLiveRgbSamplePoint, matches: point) else {
+			return nil
+		}
+		guard latestLiveRgbSample?.isFresh(maximumAge: LiveRgbSample.maximumReusableAge) == true
+		else {
 			return nil
 		}
 		return latestLiveRgbSample

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -355,6 +355,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		)
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
 		refreshStatusMenuState()
+		sessionController.prepareLiveFrameStreamSampler(reason: "launch")
 		scheduleLaunchPermissionOnboardingIfNeeded()
 		DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) { [weak self] in
 			self?.sessionController.refreshShareableContentCacheIfPermitted(source: "launch")
@@ -707,6 +708,10 @@ final class CaptureSessionController: NSObject {
 
 	var activeTelemetryCaptureID: UInt64 {
 		currentCaptureTelemetryID
+	}
+
+	func prepareLiveFrameStreamSampler(reason: String) {
+		liveFrameStream.prepareSampler(reason: reason)
 	}
 
 	private func allocateCaptureTelemetryID() -> UInt64 {
@@ -2994,7 +2999,6 @@ final class CaptureSessionController: NSObject {
 				return
 			}
 			self.liveFrameStream.stop()
-			self.liveFrameStream.updateSelfCaptureExceptionWindowIDs([])
 			self.pendingLiveFrameStreamRelease = nil
 		}
 		if immediate {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -80,33 +80,6 @@ private struct LiveChromeRefreshTelemetryKey: Equatable {
 	let liquidGlassAvailable: Bool
 }
 
-private final class DisplayPointImageRace: @unchecked Sendable {
-	private let lock = NSLock()
-	let finished = DispatchSemaphore(value: 0)
-	private var result: CGImage?
-
-	func complete(_ image: CGImage?) {
-		guard let image else {
-			return
-		}
-		lock.lock()
-		let shouldSignal = result == nil
-		if shouldSignal {
-			result = image
-		}
-		lock.unlock()
-		if shouldSignal {
-			finished.signal()
-		}
-	}
-
-	func image() -> CGImage? {
-		lock.lock()
-		defer { lock.unlock() }
-		return result
-	}
-}
-
 @MainActor private let frozenEffectCIContext = CIContext(options: nil)
 
 private enum CaptureSuccessSound {
@@ -381,7 +354,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
 		refreshStatusMenuState()
 		scheduleLaunchPermissionOnboardingIfNeeded()
-		DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) { [weak self] in
+		DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) { [weak self] in
 			self?.sessionController.refreshShareableContentCacheIfPermitted(source: "launch")
 		}
 		NativeHostTelemetry.lifecycleEvent(
@@ -840,13 +813,13 @@ final class CaptureSessionController: NSObject {
 		}
 		do {
 			let startPoint = NSEvent.mouseLocation
+			let desktopFrame = CaptureOverlayController.desktopFrame
 			let initialRgbSample: RGBSample? = nil
 			frozenFrameLatchToken = nil
 			// The Rust live sampler treats these IDs as current-process windows to
 			// include through the app-level exclusion. Overlay windows must stay out
 			// of this list so color sampling sees the desktop under the capture UI.
 			liveFrameStream.updateSelfCaptureExceptionWindowIDs(capturableOwnWindowIDs)
-			let desktopFrame = CaptureOverlayController.desktopFrame
 			let windowSnapshotStartedAt = ProcessInfo.processInfo.systemUptime
 			let initialWindowSnapshots = WindowSnapshotFeed.snapshots(desktopFrame: desktopFrame)
 			let windowSnapshotMilliseconds =
@@ -3284,11 +3257,6 @@ final class CaptureOverlayController {
 		frameRgbSampler: frameRgbSampler,
 		framePatchSampler: framePatchSampler,
 		backgroundSampler: Self.chromeSampleAtDisplayPoint,
-		firstRgbSampled: { [weak self] in
-			DispatchQueue.main.async { [weak self] in
-				self?.prepareCaptureStreamsNow(trigger: "first_rgb")
-			}
-		},
 		sampleUpdated: { [weak self] in
 			DispatchQueue.main.async { [weak self] in
 				(self?.primaryWindow as? CaptureOverlayWindow)?.hostView
@@ -3364,26 +3332,31 @@ final class CaptureOverlayController {
 		} else {
 			liveFrameStream.start(for: NSScreen.screens, prewarmPoint: focusPoint)
 		}
-		if controller?.hasFreshShareableContentCache() == true {
-			prepareCaptureStreamsNow(trigger: "activation_cached")
+		for window in windows {
+			window.displayIfNeeded()
 		}
 		windowSnapshotFeed.start(
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
-		chromeSampleFeed.start(
-			targetFramesPerSecond: NativeHostDisplayRefresh.samplingFramesPerSecond(),
-			captureID: controller?.activeTelemetryCaptureID ?? 0)
-		chromeSampleFeed.updateDemand(
-			point: focusPoint,
-			sidePixels: 1,
-			includeLoupePatch: false,
-			source: liveColorSampleSource(near: focusPoint)
-		)
-		if let focusedWindow {
-			focusedWindow.hostView.refreshLivePresentationNow()
-			focusedWindow.displayIfNeeded()
-		}
-		DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(35)) { [weak self] in
-			self?.prepareCaptureStreamsNow(trigger: "first_rgb_timeout")
+		let captureID = controller?.activeTelemetryCaptureID ?? 0
+		DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(12)) { [weak self] in
+			guard let self, !self.windows.isEmpty,
+				self.controller?.activeTelemetryCaptureID == captureID
+			else {
+				return
+			}
+			self.chromeSampleFeed.start(
+				targetFramesPerSecond: NativeHostDisplayRefresh.samplingFramesPerSecond(),
+				captureID: captureID)
+			self.chromeSampleFeed.updateDemand(
+				point: focusPoint,
+				sidePixels: 1,
+				includeLoupePatch: false,
+				source: self.liveColorSampleSource(near: focusPoint)
+			)
+			if let focusedWindow {
+				focusedWindow.hostView.refreshLivePresentationNow()
+				focusedWindow.displayIfNeeded()
+			}
 		}
 	}
 
@@ -3731,7 +3704,13 @@ final class CaptureOverlayController {
 		guard !sampleRect.isNull, sampleRect.width > 0, sampleRect.height > 0 else {
 			return nil
 		}
-		guard let image = captureImageOnDisplay(in: sampleRect, source: source) else {
+		guard
+			let image = captureImageBelowOverlay(
+				in: sampleRect,
+				source: source,
+				imageOption: [.boundsIgnoreFraming]
+			)
+		else {
 			return nil
 		}
 		return rgbSample(from: image)
@@ -3754,7 +3733,13 @@ final class CaptureOverlayController {
 		guard !sampleRect.isNull, sampleRect.width > 0, sampleRect.height > 0 else {
 			return nil
 		}
-		guard let image = captureImageBelowOverlay(in: sampleRect, source: source) else {
+		guard
+			let image = captureImageBelowOverlay(
+				in: sampleRect,
+				source: source,
+				imageOption: [.boundsIgnoreFraming, .bestResolution]
+			)
+		else {
 			return nil
 		}
 		return normalizedPatchImage(image, sidePixels: sidePixels)
@@ -3762,36 +3747,16 @@ final class CaptureOverlayController {
 
 	nonisolated private static func captureImageBelowOverlay(
 		in rect: CGRect,
-		source: LiveColorSampleSource
+		source: LiveColorSampleSource,
+		imageOption: CGWindowImageOption
 	) -> CGImage? {
 		let quartzRect = appKitRectToQuartz(rect, desktopFrame: source.desktopFrame)
 		return legacyWindowListImage(
 			quartzRect: quartzRect,
 			windowListOption: .optionOnScreenBelowWindow,
 			windowID: source.referenceWindowID,
-			imageOption: [.boundsIgnoreFraming, .bestResolution]
+			imageOption: imageOption
 		)
-	}
-
-	nonisolated private static func captureImageOnDisplay(
-		in rect: CGRect,
-		source: LiveColorSampleSource
-	) -> CGImage? {
-		let displayRect = appKitRectToQuartz(rect, desktopFrame: source.desktopFrame)
-		guard !displayRect.isNull, displayRect.width > 0, displayRect.height > 0 else {
-			return nil
-		}
-		return firstDisplayPointImage {
-			displayCreateImageForRect?(source.displayID, displayRect)?
-				.takeRetainedValue()
-		} windowListCapture: {
-			legacyWindowListImage(
-				quartzRect: displayRect,
-				windowListOption: .optionOnScreenOnly,
-				windowID: kCGNullWindowID,
-				imageOption: [.boundsIgnoreFraming, .bestResolution]
-			)
-		}
 	}
 
 	nonisolated private static func rgbSample(from image: CGImage) -> RGBSample? {
@@ -3875,57 +3840,6 @@ final class CaptureOverlayController {
 			CGWindowID,
 			UInt32
 		) -> Unmanaged<CGImage>?
-
-	private typealias DisplayCreateImageForRect =
-		@convention(c) (
-			CGDirectDisplayID,
-			CGRect
-		) -> Unmanaged<CGImage>?
-
-	nonisolated private static let displayCreateImageForRect: DisplayCreateImageForRect? = {
-		guard
-			let coreGraphics = dlopen(
-				"/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
-				RTLD_LAZY
-			)
-		else {
-			return nil
-		}
-		guard let symbol = dlsym(coreGraphics, "CGDisplayCreateImageForRect") else {
-			dlclose(coreGraphics)
-			return nil
-		}
-		return unsafeBitCast(symbol, to: DisplayCreateImageForRect.self)
-	}()
-
-	nonisolated private static let displayPointRaceQueue = DispatchQueue(
-		label: "ink.hack.rsnap.native-host.display-point-race",
-		qos: .userInteractive,
-		attributes: .concurrent
-	)
-
-	nonisolated private static func firstDisplayPointImage(
-		displayCapture: @escaping @Sendable () -> CGImage?,
-		windowListCapture: @escaping @Sendable () -> CGImage?
-	) -> CGImage? {
-		let group = DispatchGroup()
-		let race = DisplayPointImageRace()
-		group.enter()
-		displayPointRaceQueue.async {
-			race.complete(displayCapture())
-			group.leave()
-		}
-		group.enter()
-		displayPointRaceQueue.async {
-			race.complete(windowListCapture())
-			group.leave()
-		}
-		group.notify(queue: displayPointRaceQueue) {
-			race.finished.signal()
-		}
-		race.finished.wait()
-		return race.image()
-	}
 
 	nonisolated private static let legacyWindowListCreateImage: LegacyWindowListCreateImage? = {
 		guard

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -7033,7 +7033,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func currentLiveColorDisplay(for sample: RGBSample?) -> LiveColorDisplay {
-		let placeholderHex = "#------"
+		let placeholderHex = "#000000"
 		let hexText =
 			sample.map { String(format: "#%02X%02X%02X", $0.r, $0.g, $0.b) }
 			?? placeholderHex

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -5144,7 +5144,7 @@ final class CaptureHostView: NSView {
 					blue: CGFloat($0.b) / 255,
 					alpha: 1
 				)
-			} ?? NSColor(calibratedWhite: 1, alpha: 0.12)
+			} ?? palette.labelText.withAlphaComponent(0.16)
 		context.setFillColor(swatchColor.cgColor)
 		context.fill(swatchRect)
 		context.setStrokeColor(palette.swatchStroke.cgColor)
@@ -5155,7 +5155,8 @@ final class CaptureHostView: NSView {
 		drawText(
 			colorDisplay.hexText,
 			at: CGPoint(x: cursorX, y: baselineY),
-			color: palette.labelText,
+			color: colorDisplay.isPending
+				? palette.labelText.withAlphaComponent(0.46) : palette.labelText,
 			font: font
 		)
 		cursorX += colorDisplay.hexSlotWidth + itemSpacing
@@ -7032,12 +7033,14 @@ final class CaptureHostView: NSView {
 	}
 
 	private func currentLiveColorDisplay(for sample: RGBSample?) -> LiveColorDisplay {
-		let placeholderHex = ""
+		let placeholderHex = "#------"
 		let hexText =
-			sample.map { String(format: "#%02X%02X%02X", $0.r, $0.g, $0.b) } ?? placeholderHex
+			sample.map { String(format: "#%02X%02X%02X", $0.r, $0.g, $0.b) }
+			?? placeholderHex
 		return LiveColorDisplay(
 			hexText: hexText,
-			hexSlotWidth: Self.hudLayoutMetrics.hexSlotWidth
+			hexSlotWidth: Self.hudLayoutMetrics.hexSlotWidth,
+			isPending: sample == nil
 		)
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -9,7 +9,9 @@ import RsnapHostBridge
 import Vision
 
 struct LiveRgbSample: Sendable {
-	static let maximumDisplayAge: TimeInterval = 0.10
+	// SCStream may stop emitting while the captured display is static; FrozenFrameAuthority
+	// applies its own strict age budget for authoritative screenshot frames.
+	static let maximumDisplayAge: TimeInterval = 60.0
 	static let maximumReusableAge: TimeInterval = 0.04
 
 	let rgb: RGBSample
@@ -368,7 +370,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	}
 
 	public func applicationWillTerminate(_ notification: Notification) {
-		sessionController.releaseScreenCaptureStreams()
+		sessionController.releaseScreenCaptureStreams(immediate: true)
 	}
 
 	private func showSelfCaptureRegistrationWindow() {
@@ -633,6 +635,7 @@ final class CaptureSessionController: NSObject {
 	private static let coldSelfCaptureRecoveryWait: TimeInterval = 3.5
 	private static let scrollCaptureForwardingPassthrough: TimeInterval = 0.055
 	private static let scrollCaptureSampleDelay: TimeInterval = 0.04
+	private static let liveFrameStreamReleaseGrace: TimeInterval = 0.75
 
 	private let settingsStore: NativeHostSettingsStore
 	private let liveFrameStream = LiveFrameStreamBroker()
@@ -653,6 +656,7 @@ final class CaptureSessionController: NSObject {
 	private var scrollCaptureGlobalMonitor: Any?
 	private var nextCaptureTelemetryID: UInt64 = 1
 	private var activeCaptureTelemetryID: UInt64?
+	private var pendingLiveFrameStreamRelease: DispatchWorkItem?
 	var captureStateDidChange: (() -> Void)?
 	private var scene = SceneSnapshot(
 		mode: .hidden,
@@ -819,7 +823,14 @@ final class CaptureSessionController: NSObject {
 			// The Rust live sampler treats these IDs as current-process windows to
 			// include through the app-level exclusion. Overlay windows must stay out
 			// of this list so color sampling sees the desktop under the capture UI.
+			pendingLiveFrameStreamRelease?.cancel()
+			pendingLiveFrameStreamRelease = nil
 			liveFrameStream.updateSelfCaptureExceptionWindowIDs(capturableOwnWindowIDs)
+			liveFrameStream.start(
+				for: NSScreen.screens,
+				prewarmPoint: startPoint,
+				captureID: captureID
+			)
 			let windowSnapshotStartedAt = ProcessInfo.processInfo.systemUptime
 			let initialWindowSnapshots = WindowSnapshotFeed.snapshots(desktopFrame: desktopFrame)
 			let windowSnapshotMilliseconds =
@@ -869,6 +880,11 @@ final class CaptureSessionController: NSObject {
 					}
 					let selfCaptureExceptionWindowIDs =
 						overlayController.selfCaptureExceptionWindowIDs
+					self.liveFrameStream.start(
+						for: NSScreen.screens,
+						prewarmPoint: startPoint,
+						captureID: captureID
+					)
 					_ = self.warmLiveSamplingIfPossible(
 						at: startPoint,
 						source: "capture_overlay_preflight",
@@ -2935,7 +2951,6 @@ final class CaptureSessionController: NSObject {
 	private func tearDownCapture() {
 		let captureID = currentCaptureTelemetryID
 		releaseScreenCaptureStreams()
-		liveFrameStream.updateSelfCaptureExceptionWindowIDs([])
 		pendingFrozenCommit = nil
 		frozenFrameLatchToken = nil
 		frozenSnapshotGeneration &+= 1
@@ -2970,9 +2985,28 @@ final class CaptureSessionController: NSObject {
 		activeCaptureTelemetryID = nil
 	}
 
-	fileprivate func releaseScreenCaptureStreams() {
-		liveFrameStream.stop()
+	fileprivate func releaseScreenCaptureStreams(immediate: Bool = false) {
+		pendingLiveFrameStreamRelease?.cancel()
+		pendingLiveFrameStreamRelease = nil
 		frozenFrameAuthority.stop()
+		let releaseLiveFrameStream = { [weak self] in
+			guard let self else {
+				return
+			}
+			self.liveFrameStream.stop()
+			self.liveFrameStream.updateSelfCaptureExceptionWindowIDs([])
+			self.pendingLiveFrameStreamRelease = nil
+		}
+		if immediate {
+			releaseLiveFrameStream()
+			return
+		}
+		let workItem = DispatchWorkItem(block: releaseLiveFrameStream)
+		pendingLiveFrameStreamRelease = workItem
+		DispatchQueue.main.asyncAfter(
+			deadline: .now() + Self.liveFrameStreamReleaseGrace,
+			execute: workItem
+		)
 	}
 
 	@objc
@@ -3329,34 +3363,30 @@ final class CaptureOverlayController {
 		collapsedForFrozen = false
 		if let prepareCaptureStreams {
 			pendingCaptureStreamPreparation = prepareCaptureStreams
-		} else {
-			liveFrameStream.start(for: NSScreen.screens, prewarmPoint: focusPoint)
 		}
+		liveFrameStream.start(
+			for: NSScreen.screens,
+			prewarmPoint: focusPoint,
+			captureID: controller?.activeTelemetryCaptureID ?? 0
+		)
 		for window in windows {
 			window.displayIfNeeded()
 		}
 		windowSnapshotFeed.start(
 			desktopFrame: Self.desktopFrame, initialSnapshots: initialWindowSnapshots)
 		let captureID = controller?.activeTelemetryCaptureID ?? 0
-		DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(12)) { [weak self] in
-			guard let self, !self.windows.isEmpty,
-				self.controller?.activeTelemetryCaptureID == captureID
-			else {
-				return
-			}
-			self.chromeSampleFeed.start(
-				targetFramesPerSecond: NativeHostDisplayRefresh.samplingFramesPerSecond(),
-				captureID: captureID)
-			self.chromeSampleFeed.updateDemand(
-				point: focusPoint,
-				sidePixels: 1,
-				includeLoupePatch: false,
-				source: self.liveColorSampleSource(near: focusPoint)
-			)
-			if let focusedWindow {
-				focusedWindow.hostView.refreshLivePresentationNow()
-				focusedWindow.displayIfNeeded()
-			}
+		chromeSampleFeed.start(
+			targetFramesPerSecond: NativeHostDisplayRefresh.samplingFramesPerSecond(),
+			captureID: captureID)
+		chromeSampleFeed.updateDemand(
+			point: focusPoint,
+			sidePixels: 1,
+			includeLoupePatch: false,
+			source: liveColorSampleSource(near: focusPoint)
+		)
+		if let focusedWindow {
+			focusedWindow.hostView.refreshLivePresentationNow()
+			focusedWindow.displayIfNeeded()
 		}
 	}
 
@@ -3673,6 +3703,12 @@ final class CaptureOverlayController {
 		sidePixels: Int,
 		includeLoupePatch: Bool
 	) -> LiveChromeSample? {
+		guard displayPointSampleGate.wait(timeout: .now()) == .success else {
+			return nil
+		}
+		defer {
+			displayPointSampleGate.signal()
+		}
 		let rgbSample = rgbSampleAtDisplayPoint(point, source: source)
 		let loupePatch =
 			includeLoupePatch
@@ -3705,11 +3741,7 @@ final class CaptureOverlayController {
 			return nil
 		}
 		guard
-			let image = captureImageBelowOverlay(
-				in: sampleRect,
-				source: source,
-				imageOption: [.boundsIgnoreFraming]
-			)
+			let image = captureImageOnDisplay(in: sampleRect, source: source)
 		else {
 			return nil
 		}
@@ -3757,6 +3789,18 @@ final class CaptureOverlayController {
 			windowID: source.referenceWindowID,
 			imageOption: imageOption
 		)
+	}
+
+	nonisolated private static func captureImageOnDisplay(
+		in rect: CGRect,
+		source: LiveColorSampleSource
+	) -> CGImage? {
+		let displayRect = appKitRectToQuartz(rect, desktopFrame: source.desktopFrame)
+		guard !displayRect.isNull, displayRect.width > 0, displayRect.height > 0 else {
+			return nil
+		}
+		return displayCreateImageForRect?(source.displayID, displayRect)?
+			.takeRetainedValue()
 	}
 
 	nonisolated private static func rgbSample(from image: CGImage) -> RGBSample? {
@@ -3840,6 +3884,30 @@ final class CaptureOverlayController {
 			CGWindowID,
 			UInt32
 		) -> Unmanaged<CGImage>?
+
+	private typealias DisplayCreateImageForRect =
+		@convention(c) (
+			CGDirectDisplayID,
+			CGRect
+		) -> Unmanaged<CGImage>?
+
+	nonisolated private static let displayPointSampleGate = DispatchSemaphore(value: 1)
+
+	nonisolated private static let displayCreateImageForRect: DisplayCreateImageForRect? = {
+		guard
+			let coreGraphics = dlopen(
+				"/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+				RTLD_LAZY
+			)
+		else {
+			return nil
+		}
+		guard let symbol = dlsym(coreGraphics, "CGDisplayCreateImageForRect") else {
+			dlclose(coreGraphics)
+			return nil
+		}
+		return unsafeBitCast(symbol, to: DisplayCreateImageForRect.self)
+	}()
 
 	nonisolated private static let legacyWindowListCreateImage: LegacyWindowListCreateImage? = {
 		guard
@@ -3986,7 +4054,7 @@ final class CaptureOverlayWindow: NSPanel {
 		isMovable = false
 		isOpaque = false
 		level = .screenSaver
-		sharingType = .readOnly
+		sharingType = .none
 		titleVisibility = .hidden
 		titlebarAppearsTransparent = true
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -116,6 +116,38 @@ enum NativeHostTelemetry {
 		)
 	}
 
+	static func liveChromeFirstRgbSample(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		refreshCount: UInt64,
+		source: String,
+		hasPatch: Bool,
+		includeLoupePatch: Bool
+	) {
+		liveChromeLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=live_chrome.first_rgb_sample totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) refreshCount=\(refreshCount, privacy: .public) source=\(source, privacy: .public) hasPatch=\(hasPatch, privacy: .public) includeLoupePatch=\(includeLoupePatch, privacy: .public)"
+		)
+	}
+
+	static func liveChromeSampleFeedStarted(
+		captureID: UInt64,
+		targetHz: Int
+	) {
+		liveChromeLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=live_chrome.sample_feed_started targetHz=\(targetHz, privacy: .public)"
+		)
+	}
+
+	static func liveStreamFirstRgbSample(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		hasPatch: Bool
+	) {
+		liveChromeLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=live_chrome.live_stream_first_rgb_sample totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) hasPatch=\(hasPatch, privacy: .public)"
+		)
+	}
+
 	static func liveChromeInputSummary(
 		captureID: UInt64,
 		reason: String,

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -148,6 +148,16 @@ enum NativeHostTelemetry {
 		)
 	}
 
+	static func liveStreamSamplerPrepared(
+		totalMilliseconds: Double,
+		created: Bool,
+		reason: String
+	) {
+		liveChromeLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) event=live_chrome.live_stream_sampler_prepared totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) created=\(created, privacy: .public) reason=\(reason, privacy: .public)"
+		)
+	}
+
 	static func liveStreamSample(
 		captureID: UInt64,
 		totalMilliseconds: Double,

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -148,6 +148,31 @@ enum NativeHostTelemetry {
 		)
 	}
 
+	static func liveStreamSample(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		outcome: String,
+		frameAgeMilliseconds: Double,
+		hasPatch: Bool
+	) {
+		liveChromeLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=live_chrome.live_stream_sample totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) outcome=\(outcome, privacy: .public) frameAgeMs=\(frameAgeMilliseconds, format: .fixed(precision: 2), privacy: .public) hasPatch=\(hasPatch, privacy: .public)"
+		)
+	}
+
+	static func liveChromeBackgroundSample(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		outcome: String,
+		source: String,
+		includeLoupePatch: Bool,
+		immediate: Bool
+	) {
+		liveChromeLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=live_chrome.background_sample totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) outcome=\(outcome, privacy: .public) source=\(source, privacy: .public) includeLoupePatch=\(includeLoupePatch, privacy: .public) immediate=\(immediate, privacy: .public)"
+		)
+	}
+
 	static func liveChromeInputSummary(
 		captureID: UInt64,
 		reason: String,

--- a/packages/rsnap-host-ffi/include/rsnap_host_ffi.h
+++ b/packages/rsnap-host-ffi/include/rsnap_host_ffi.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#define RSNAP_HOST_FFI_ABI_VERSION 16u
+#define RSNAP_HOST_FFI_ABI_VERSION 17u
 #define RSNAP_TOOLBAR_ITEM_CAPACITY 16u
 #define RSNAP_STATUS_MESSAGE_CAPACITY 256u
 #define RSNAP_LIVE_SAMPLE_PATCH_CAPACITY 4096u
@@ -220,6 +220,10 @@ typedef struct RsnapHostRequestValue {
 typedef struct RsnapLiveSample {
 	struct RsnapRgb rgb;
 	uint8_t has_rgb;
+	uint8_t has_frame_metadata;
+	uint64_t frame_age_micros;
+	uint64_t frame_seq;
+	uint64_t stream_generation;
 	uint32_t patch_width;
 	uint32_t patch_height;
 	uint32_t patch_len;

--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -1009,15 +1009,16 @@ pub unsafe extern "C" fn rsnap_live_sampler_sample_cursor(
 		patch_width_px,
 		patch_height_px,
 	);
-	let mut out = RsnapLiveSample::default();
-
 	let Some(sample) = sample else {
 		return RsnapStatus::Empty;
 	};
-	out.has_frame_metadata = 1;
-	out.frame_age_micros = sample.frame_age_micros;
-	out.frame_seq = sample.frame_seq;
-	out.stream_generation = sample.stream_generation;
+	let mut out = RsnapLiveSample {
+		has_frame_metadata: 1,
+		frame_age_micros: sample.frame_age_micros,
+		frame_seq: sample.frame_seq,
+		stream_generation: sample.stream_generation,
+		..Default::default()
+	};
 
 	if let Some(rgb) = sample.sample.rgb {
 		out.rgb = RsnapRgb { r: rgb.r, g: rgb.g, b: rgb.b };

--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -24,7 +24,7 @@ use rsnap_overlay::scroll_stitching::{
 };
 
 /// ABI version exported by the thin C host bridge.
-pub const RSNAP_HOST_FFI_ABI_VERSION: u32 = 16;
+pub const RSNAP_HOST_FFI_ABI_VERSION: u32 = 17;
 
 const RSNAP_TOOLBAR_ITEM_CAPACITY: usize = 16;
 const RSNAP_STATUS_MESSAGE_CAPACITY: usize = 256;
@@ -70,6 +70,14 @@ pub struct RsnapLiveSample {
 	pub rgb: RsnapRgb,
 	/// Non-zero when `rgb` is present.
 	pub has_rgb: u8,
+	/// Non-zero when frame provenance fields are present.
+	pub has_frame_metadata: u8,
+	/// Age of the sampled ScreenCaptureKit frame in microseconds.
+	pub frame_age_micros: u64,
+	/// Monotonic sequence of the sampled ScreenCaptureKit frame.
+	pub frame_seq: u64,
+	/// Live stream generation that produced the sampled frame.
+	pub stream_generation: u64,
 	/// Sampled loupe patch width in pixels.
 	pub patch_width: u32,
 	/// Sampled loupe patch height in pixels.
@@ -84,6 +92,10 @@ impl Default for RsnapLiveSample {
 		Self {
 			rgb: RsnapRgb::default(),
 			has_rgb: 0,
+			has_frame_metadata: 0,
+			frame_age_micros: 0,
+			frame_seq: 0,
+			stream_generation: 0,
 			patch_width: 0,
 			patch_height: 0,
 			patch_len: 0,
@@ -991,7 +1003,7 @@ pub unsafe extern "C" fn rsnap_live_sampler_sample_cursor(
 		return RsnapStatus::NullOutput;
 	}
 
-	let sample = handle.sampler.sample_cursor(
+	let sample = handle.sampler.sample_cursor_with_metadata(
 		decode_overlay_monitor(monitor),
 		decode_overlay_point(point),
 		patch_width_px,
@@ -999,11 +1011,19 @@ pub unsafe extern "C" fn rsnap_live_sampler_sample_cursor(
 	);
 	let mut out = RsnapLiveSample::default();
 
-	if let Some(rgb) = sample.rgb {
+	let Some(sample) = sample else {
+		return RsnapStatus::Empty;
+	};
+	out.has_frame_metadata = 1;
+	out.frame_age_micros = sample.frame_age_micros;
+	out.frame_seq = sample.frame_seq;
+	out.stream_generation = sample.stream_generation;
+
+	if let Some(rgb) = sample.sample.rgb {
 		out.rgb = RsnapRgb { r: rgb.r, g: rgb.g, b: rgb.b };
 		out.has_rgb = 1;
 	}
-	if let Some(patch) = sample.patch {
+	if let Some(patch) = sample.sample.patch {
 		let bytes = patch.as_raw();
 		let len = bytes.len().min(RSNAP_LIVE_SAMPLE_PATCH_CAPACITY);
 

--- a/packages/rsnap-overlay/src/host_live_sampling_macos.rs
+++ b/packages/rsnap-overlay/src/host_live_sampling_macos.rs
@@ -3,6 +3,18 @@
 use crate::live_frame_stream_macos::{CursorSampleRequest, MacLiveFrameStream};
 use crate::state::{GlobalPoint, LiveCursorSample, MonitorRect};
 
+/// Live cursor sample plus the ScreenCaptureKit frame metadata that produced it.
+pub struct HostLiveCursorSample {
+	/// Sampled RGB and optional patch payload.
+	pub sample: LiveCursorSample,
+	/// Age of the sampled ScreenCaptureKit frame in microseconds.
+	pub frame_age_micros: u64,
+	/// Monotonic live stream frame sequence.
+	pub frame_seq: u64,
+	/// Live stream generation for the active monitor stream.
+	pub stream_generation: u64,
+}
+
 /// Thin public wrapper around the proven macOS live frame stream used by the
 /// native host for RGB and loupe sampling.
 pub struct HostMacLiveSampler {
@@ -52,6 +64,35 @@ impl HostMacLiveSampler {
 				),
 			)
 			.unwrap_or(LiveCursorSample { rgb: None, patch: None })
+	}
+
+	#[must_use]
+	/// Samples the current RGB value and optional loupe patch with frame provenance.
+	pub fn sample_cursor_with_metadata(
+		&mut self,
+		monitor: MonitorRect,
+		point: GlobalPoint,
+		patch_width_px: u32,
+		patch_height_px: u32,
+	) -> Option<HostLiveCursorSample> {
+		let (x_px, y_px) = monitor.local_u32_pixels(point)?;
+		let sample = self.stream.latest_cursor_frame_sample(
+			monitor,
+			CursorSampleRequest::with_optional_patch(
+				x_px,
+				y_px,
+				patch_width_px > 0 && patch_height_px > 0,
+				patch_width_px,
+				patch_height_px,
+			),
+		)?;
+
+		Some(HostLiveCursorSample {
+			sample: sample.sample,
+			frame_age_micros: sample.frame_age.as_micros().min(u128::from(u64::MAX)) as u64,
+			frame_seq: sample.frame_seq,
+			stream_generation: sample.stream_generation,
+		})
 	}
 
 	/// Starts warming the ScreenCaptureKit stream for the requested monitor without

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -407,6 +407,7 @@ impl MacLiveFrameStream {
 					request.patch_width_px,
 					request.patch_height_px,
 				)?;
+
 				Some(LiveCursorFrameSample {
 					sample,
 					frame_age: Instant::now().saturating_duration_since(frame.captured_at),

--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -135,6 +135,13 @@ pub(crate) struct OrderedRegionFrame {
 	pub(crate) image: RgbaImage,
 }
 
+pub(crate) struct LiveCursorFrameSample {
+	pub(crate) sample: LiveCursorSample,
+	pub(crate) frame_age: Duration,
+	pub(crate) frame_seq: u64,
+	pub(crate) stream_generation: u64,
+}
+
 #[derive(Clone, Copy)]
 pub(crate) struct CursorSampleRequest {
 	pub(crate) x_px: u32,
@@ -382,16 +389,30 @@ impl MacLiveFrameStream {
 		monitor: MonitorRect,
 		request: CursorSampleRequest,
 	) -> Option<LiveCursorSample> {
+		self.latest_cursor_frame_sample(monitor, request).map(|sample| sample.sample)
+	}
+
+	pub(crate) fn latest_cursor_frame_sample(
+		&self,
+		monitor: MonitorRect,
+		request: CursorSampleRequest,
+	) -> Option<LiveCursorFrameSample> {
 		let sample =
 			self.shared_latest_frame.latest_frame_for_monitor(monitor.id).and_then(|frame| {
-				sample_cursor_from_pixel_buffer(
+				let sample = sample_cursor_from_pixel_buffer(
 					&frame.pixel_buffer,
 					request.x_px,
 					request.y_px,
 					request.want_patch,
 					request.patch_width_px,
 					request.patch_height_px,
-				)
+				)?;
+				Some(LiveCursorFrameSample {
+					sample,
+					frame_age: Instant::now().saturating_duration_since(frame.captured_at),
+					frame_seq: frame.frame_seq,
+					stream_generation: frame.stream_generation,
+				})
 			});
 
 		if sample.is_none() {


### PR DESCRIPTION
## Summary
- release screen recording resources outside active capture while keeping cold activation responsive
- reduce cold live color sampling latency by retaining/preparing the live sampler worker and tightening stream/sampler ownership
- smooth cold HUD color reveal with a one-shot hex tumbler animation that does not replay during pointer movement sample gaps

## Validation
- cargo make fmt-swift-check
- cargo make build-swift-strict
- git diff --check
- ./scripts/build_and_run.sh run