### PR TITLE
Fix Settings tint color panel tracking

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -1260,9 +1260,6 @@ private struct SettingsColorWell: NSViewRepresentable {
 		view.allowsColorPanel = isEnabled
 		view.color = NSColor(selection).usingColorSpace(.deviceRGB) ?? NSColor(selection)
 		view.coordinator = context.coordinator
-		if NSColorPanel.sharedColorPanelExists, NSColorPanel.shared.isVisible {
-			NSColorPanel.shared.color = view.color
-		}
 	}
 
 	func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
## Summary
- stop syncing the shared NSColorPanel color from SwiftUI updates while the tint panel is visible
- keep the panel initialized from the current tint only when opening it, so AppKit can own drag tracking

## Validation
- cargo make fmt-swift
- cargo make lint-swift
- cargo make test-macos-native-host
- cargo make test-macos-native-host-stage
- ./scripts/build_and_run.sh run
- manual Settings > Appearance > Tint color retest passed