### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,88 @@
+name: GitHub Pages
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/pages.yml"
+      - "assets/app-icon/generated/app-icon-default-preview.png"
+      - "index.html"
+      - "site/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/pages.yml"
+      - "assets/app-icon/generated/app-icon-default-preview.png"
+      - "index.html"
+      - "site/**"
+  workflow_dispatch: {}
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  package:
+    name: Package static site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch latest code
+        uses: actions/checkout@v6
+
+      - name: Build Pages artifact
+        run: |
+          set -euo pipefail
+
+          rm -rf _site
+          mkdir -p _site/assets/app-icon/generated
+
+          cp index.html _site/
+          cp -R site _site/site
+          cp \
+            assets/app-icon/generated/app-icon-default-preview.png \
+            _site/assets/app-icon/generated/
+
+          touch _site/.nojekyll
+
+          test -f _site/index.html
+          test -f _site/site/main.js
+          test -f _site/site/styles.css
+          test -f _site/assets/app-icon/generated/app-icon-default-preview.png
+
+      - name: Configure Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v6.0.0
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5.0.0
+        with:
+          path: _site
+
+      - name: Upload preview artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rsnap-pages-preview
+          path: _site
+          retention-days: 7
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: package
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v5.0.0


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow for the static Rsnap homepage
- package only the homepage files, site assets, app icon, and .nojekyll
- deploy on main pushes and keep PRs to artifact packaging only

## Validation
- actionlint .github/workflows/pages.yml
- node --check site/main.js
- git diff --check
- local Pages package smoke copied the exact publish set into a temporary _site directory

## Notes
- Repository Pages is already configured for workflow deployment at https://hack-ink.github.io/rsnap/.