### PR TITLE
Refine homepage support links

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,6 @@
         <span>Rsnap</span>
       </a>
       <nav class="nav-links" aria-label="Site">
-        <a href="#flow">Flow</a>
-        <a href="#details">Details</a>
         <a href="https://github.com/hack-ink/rsnap" rel="noreferrer">GitHub</a>
       </nav>
     </header>
@@ -47,16 +45,10 @@
             <a class="button button-primary" href="https://github.com/hack-ink/rsnap/releases">
               Download for macOS
             </a>
-            <a class="button button-secondary" href="https://github.com/hack-ink/rsnap">
-              View source
+            <a class="button button-secondary" href="https://x.com/YvetteCipher" rel="noreferrer">
+              Follow Yvette on X
             </a>
           </div>
-        </div>
-
-        <div class="hero-spec" aria-hidden="true">
-          <span>Live RGB</span>
-          <span>Frozen copy</span>
-          <span>Scroll stitch</span>
         </div>
       </section>
 
@@ -120,6 +112,20 @@
                 <dd>Dragged-region freezes can stitch downward scrolling into one image.</dd>
               </div>
             </dl>
+          </div>
+        </div>
+      </section>
+
+      <section class="creator-band" aria-labelledby="creator-title">
+        <div class="section-inner creator-grid">
+          <p class="section-number">04</p>
+          <div>
+            <h2 id="creator-title">Support the work without turning Rsnap into paid software.</h2>
+            <p>
+              Yvette shares progress, design notes, and release updates on X. Attention there helps
+              fund continued work while keeping Rsnap free for people who need a sharper capture
+              tool.
+            </p>
           </div>
         </div>
       </section>

--- a/site/main.js
+++ b/site/main.js
@@ -625,7 +625,6 @@ function onScroll() {
 function revealElements() {
   const targets = [
     document.querySelector(".hero-copy"),
-    document.querySelector(".hero-spec"),
     ...document.querySelectorAll(".section-inner > *"),
     ...document.querySelectorAll(".flow-steps article"),
   ].filter(Boolean);

--- a/site/styles.css
+++ b/site/styles.css
@@ -87,6 +87,7 @@ main,
   top: 0;
   right: 0;
   left: 0;
+  z-index: 8;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -118,7 +119,6 @@ main,
 .section-number,
 .flow-steps span,
 dt,
-.hero-spec,
 .site-footer {
   letter-spacing: 0;
 }
@@ -260,35 +260,6 @@ h1 {
   background: rgba(16, 18, 20, 0.82);
 }
 
-.hero-spec {
-  position: absolute;
-  right: max(42px, calc((100vw - 1200px) / 2));
-  bottom: 70px;
-  z-index: 4;
-  display: grid;
-  grid-auto-flow: column;
-  gap: 24px;
-  color: rgba(248, 251, 255, 0.52);
-  font-size: 0.82rem;
-  font-weight: 760;
-}
-
-.hero-spec span {
-  position: relative;
-  padding-top: 16px;
-}
-
-.hero-spec span::before {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 42px;
-  height: 2px;
-  background: var(--accent);
-  box-shadow: 0 0 18px rgba(140, 244, 255, 0.45);
-  content: "";
-}
-
 .section-inner {
   width: min(1180px, calc(100% - 84px));
   margin: 0 auto;
@@ -426,6 +397,33 @@ dd {
   color: var(--muted);
 }
 
+.creator-band {
+  padding: 116px 0;
+  border-top: 1px solid rgba(248, 251, 255, 0.08);
+  border-bottom: 1px solid rgba(248, 251, 255, 0.08);
+  background:
+    radial-gradient(circle at 82% 28%, rgba(140, 244, 255, 0.12), transparent 34%),
+    linear-gradient(180deg, rgba(7, 10, 11, 0.96), rgba(5, 5, 6, 0.96));
+}
+
+.creator-grid {
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  gap: 34px;
+  align-items: start;
+}
+
+.creator-grid h2 {
+  max-width: 760px;
+}
+
+.creator-grid p:not(.section-number) {
+  max-width: 650px;
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: 1.04rem;
+}
+
 .final-cta {
   padding: 120px 0 132px;
   background: linear-gradient(180deg, rgba(7, 9, 10, 0.92), #050506);
@@ -466,7 +464,6 @@ dd {
 }
 
 .hero-copy,
-.hero-spec,
 .section-inner > *,
 .flow-steps article {
   transition:
@@ -475,7 +472,6 @@ dd {
 }
 
 .motion-ready .hero-copy:not(.is-visible),
-.motion-ready .hero-spec:not(.is-visible),
 .motion-ready .section-inner > *:not(.is-visible),
 .motion-ready .flow-steps article:not(.is-visible) {
   opacity: 0;
@@ -483,7 +479,6 @@ dd {
 }
 
 .motion-ready .is-visible.hero-copy,
-.motion-ready .is-visible.hero-spec,
 .motion-ready .section-inner > .is-visible,
 .motion-ready .flow-steps article.is-visible {
   opacity: 1;
@@ -518,19 +513,13 @@ dd {
     padding-top: 28px;
   }
 
-  .hero-spec {
-    right: auto;
-    bottom: 44px;
-    left: 24px;
-    gap: 18px;
-  }
-
   .section-inner {
     width: min(100% - 48px, 720px);
   }
 
   .intro-grid,
-  .detail-grid {
+  .detail-grid,
+  .creator-grid {
     grid-template-columns: 1fr;
     gap: 22px;
   }
@@ -589,9 +578,9 @@ dd {
     height: 30px;
   }
 
-  .nav-links a:nth-child(1),
-  .nav-links a:nth-child(2) {
-    display: none;
+  .nav-links {
+    gap: 10px;
+    font-size: 0.82rem;
   }
 
   .hero {
@@ -630,10 +619,6 @@ dd {
     width: 100%;
   }
 
-  .hero-spec {
-    display: none;
-  }
-
   .section-inner {
     width: calc(100% - 36px);
   }
@@ -641,6 +626,7 @@ dd {
   .intro-band,
   .flow-section,
   .details-section,
+  .creator-band,
   .final-cta {
     padding: 68px 0;
   }


### PR DESCRIPTION
## Summary
- remove repeated non-clickable hero/status links from the homepage header and hero overlay
- keep the Yvette X follow action beside the download CTA only
- add a single creator-support section explaining the free software support model
- raise the fixed header above the page content so the GitHub link is actually clickable

## Validation
- node --check site/main.js
- git diff --check
- local static preview at http://127.0.0.1:4173/
- clicked the header GitHub link in the in-app browser and verified it navigates to https://github.com/hack-ink/rsnap
