### PR TITLE
Prepare v0.1.0 release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ permissions:
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   CARGO_TERM_COLOR: always
-
   RUST_BACKTRACE: full
+  MACOS_RELEASE_ASSET: rsnap-aarch64-apple-darwin.zip
 
 on:
   push:
@@ -19,51 +19,34 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build:
-    name: Build ${{ matrix.target.name }} package
-    runs-on: ${{ matrix.target.os }}
-    strategy:
-      matrix:
-        target:
-          [
-            { name: aarch64-apple-darwin, os: macos-latest },
-            { name: x86_64-unknown-linux-gnu, os: ubuntu-latest },
-            { name: x86_64-pc-windows-msvc, os: windows-latest },
-          ]
+  build-macos:
+    name: Build notarized macOS package
+    runs-on: macos-latest
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v6
 
-      - name: Install Linux desktop build dependencies
-        if: matrix.target.os == 'ubuntu-latest'
+      - name: Verify release tag and runner
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libayatana-appindicator3-dev \
-            libdbus-1-dev \
-            libegl-dev \
-            libgtk-3-dev \
-            libpipewire-0.3-dev \
-            libwayland-dev \
-            libxcb1-dev \
-            libxdo-dev \
-            libxrandr-dev
+          set -euo pipefail
+
+          VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+          if [[ "v${VERSION}" != "${GITHUB_REF_NAME}" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match Cargo workspace version ${VERSION}" >&2
+            exit 1
+          fi
+
+          if [[ "$(uname -m)" != "arm64" ]]; then
+            echo "The macOS release asset is named for aarch64; expected an arm64 runner." >&2
+            exit 1
+          fi
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: true
-          components: rustfmt, clippy
-
-      - name: Add target
-        run: rustup target add ${{ matrix.target.name }}
-
-      - name: Build
-        if: matrix.target.os != 'macos-latest'
-        run: cargo build --profile final-release --locked --target ${{ matrix.target.name }}
 
       - name: Bundle, sign, notarize, and pack (macOS)
-        if: matrix.target.os == 'macos-latest'
         env:
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -71,9 +54,9 @@ jobs:
           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           APPLE_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
           APPLE_NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
-          RSNAP_BUNDLE_PROFILE: final-release
-          RSNAP_BUNDLE_TARGET: ${{ matrix.target.name }}
         run: |
+          set -euo pipefail
+
           for required_secret in \
             APPLE_CERTIFICATE_P12_BASE64 \
             APPLE_CERTIFICATE_PASSWORD \
@@ -160,31 +143,20 @@ jobs:
 
           ditto -c -k --sequesterRsrc --keepParent \
             "${APP_PATH}" \
-            "rsnap-${{ matrix.target.name }}.zip"
-
-      - name: Pack (Windows)
-        if: matrix.target.os == 'windows-latest'
-        run: |
-          mv target/${{ matrix.target.name }}/final-release/rsnap.exe .
-          Compress-Archive -Path rsnap.exe -DestinationPath rsnap-${{ matrix.target.name }}.zip
-
-      - name: Pack (Linux)
-        if: matrix.target.os == 'ubuntu-latest'
-        run: |
-          mv target/${{ matrix.target.name }}/final-release/rsnap .
-          tar -czvf rsnap-${{ matrix.target.name }}.tar.gz rsnap
+            "${MACOS_RELEASE_ASSET}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: rsnap-${{ matrix.target.name }}
-          path: rsnap-${{ matrix.target.name }}.*
+          name: rsnap-aarch64-apple-darwin
+          path: ${{ env.MACOS_RELEASE_ASSET }}
+          if-no-files-found: error
           retention-days: 1
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-macos]
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -205,70 +177,3 @@ jobs:
           discussion_category_name: Announcements
           generate_release_notes: true
           files: artifacts/*
-
-  publish-on-crates-io:
-    name: Publish on crates.io
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Fetch latest code
-        uses: actions/checkout@v6
-
-      - name: Install Linux desktop build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libayatana-appindicator3-dev \
-            libdbus-1-dev \
-            libegl-dev \
-            libgtk-3-dev \
-            libpipewire-0.3-dev \
-            libwayland-dev \
-            libxcb1-dev \
-            libxdo-dev \
-            libxrandr-dev
-
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: true
-          components: rustfmt, clippy
-
-      - name: Login
-        run: cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Publish rsnap-capture-core
-        run: |
-          cargo publish -p rsnap-capture-core --locked
-
-      - name: Wait for rsnap-capture-core publication
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          for _ in $(seq 1 24); do
-            if curl -fsSL "https://crates.io/api/v1/crates/rsnap-capture-core/${VERSION}" > /dev/null; then
-              exit 0
-            fi
-            sleep 20
-          done
-          echo "Timed out waiting for rsnap-capture-core ${VERSION} on crates.io"
-          exit 1
-
-      - name: Publish rsnap-overlay
-        run: |
-          cargo publish -p rsnap-overlay --locked
-
-      - name: Wait for rsnap-overlay publication
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          for _ in $(seq 1 24); do
-            if curl -fsSL "https://crates.io/api/v1/crates/rsnap-overlay/${VERSION}" > /dev/null; then
-              exit 0
-            fi
-            sleep 20
-          done
-          echo "Timed out waiting for rsnap-overlay ${VERSION} on crates.io"
-          exit 1
-
-      - name: Publish rsnap
-        run: |
-          cargo publish -p rsnap --locked

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -172,14 +172,15 @@ args = [
 
 
 # Test
-# | task      | type      | cwd |
-# | --------- | --------- | --- |
-# | test      | composite |     |
-# | test-rust | command   |     |
-# | test-host-reset | composite | |
-# | test-rust-host-reset | command | |
-# | test-host-ffi-header | command | |
-# | test-macos-native-host-stage | command | |
+# | task                         | type      | purpose |
+# | ---------------------------- | --------- | ------- |
+# | test                         | composite | default Rust suite |
+# | test-rust                    | command   | workspace nextest |
+# | test-host-reset              | composite | reset boundary probes |
+# | test-rust-host-reset         | command   | Rust core/FFI tests |
+# | test-host-ffi-header         | command   | exported C header smoke |
+# | test-macos-native-host       | command   | Swift bridge probes |
+# | test-macos-native-host-stage | command   | staged app bundle smoke |
 
 [tasks.test]
 workspace = false
@@ -197,6 +198,8 @@ args = [
 	"--all-targets",
 	"--all-features",
 ]
+
+# Host/core reset tests.
 
 [tasks.test-host-reset]
 workspace = false
@@ -228,27 +231,7 @@ args = [
 	"packages/rsnap-host-ffi/tests/header_smoke.c",
 ]
 
-[tasks.build-host-ffi-staticlib]
-workspace = false
-command = "cargo"
-args = [
-	"build",
-	"-p",
-	"rsnap-host-ffi",
-]
-
-[tasks.build-swift-strict]
-workspace = false
-dependencies = [
-	"build-host-ffi-staticlib",
-]
-script = '''
-RSNAP_HOST_FFI_LIB_DIR="$PWD/target/debug" \
-swift build --package-path native/macos-host \
-	--explicit-target-dependency-import-check error \
-	-Xswiftc -warnings-as-errors \
-	-Xswiftc -strict-concurrency=complete
-'''
+# Native host probes.
 
 [tasks.test-macos-native-host]
 workspace = false
@@ -285,6 +268,34 @@ if plutil -extract LSUIElement raw "$APP_PATH/Contents/Info.plist" >/dev/null 2>
   echo "LSUIElement must stay unset so Settings is a normal foreground window" >&2
   exit 1
 fi
+'''
+
+# Build
+# | task                     | type    | purpose |
+# | ------------------------ | ------- | ------- |
+# | build-host-ffi-staticlib | command | Rust static library for Swift |
+# | build-swift-strict       | command | Swift strict-concurrency build |
+
+[tasks.build-host-ffi-staticlib]
+workspace = false
+command = "cargo"
+args = [
+	"build",
+	"-p",
+	"rsnap-host-ffi",
+]
+
+[tasks.build-swift-strict]
+workspace = false
+dependencies = [
+	"build-host-ffi-staticlib",
+]
+script = '''
+RSNAP_HOST_FFI_LIB_DIR="$PWD/target/debug" \
+swift build --package-path native/macos-host \
+	--explicit-target-dependency-import-check error \
+	-Xswiftc -warnings-as-errors \
+	-Xswiftc -strict-concurrency=complete
 '''
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Rsnap
 
-macOS-first screenshot prototype in native-host / Rust-core reset.
+macOS-first screenshot app built with a native host and Rust core.
 
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Language Checks](https://github.com/hack-ink/rsnap/actions/workflows/language.yml/badge.svg?branch=main)](https://github.com/hack-ink/rsnap/actions/workflows/language.yml)
@@ -25,10 +25,9 @@ macOS-first screenshot prototype in native-host / Rust-core reset.
 - In Frozen mode, `Space` copies the current frozen PNG to the clipboard and exits.
 - In Frozen mode, Cmd+S (macOS) / Ctrl+S saves the current PNG to disk and exits.
 - On macOS, Frozen mode can recognize text from the current capture and copy the result to the clipboard from the toolbar.
-- After a dragged region freeze, press `s` or use the frozen toolbar `Scroll Capture ↓` action to enter scroll capture.
-- Scroll capture is currently implemented on macOS for dragged-region freezes and uses image-first downward stitching with a live side preview.
-- Upward scrolling may be observed for rewind/reacquire, but it never appends stitched rows.
-- `Esc` cancels capture; during scroll capture, `Esc` / `Back` returns to normal Frozen mode.
+- Frozen toolbar tools include pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
+  OCR, copy, and save.
+- `Esc` cancels capture.
 - Glass HUD with Classic Glass by default and Liquid Glass on supported macOS.
 - Tab-triggered loupe sample and frozen-mode toolbar for quick action access.
 
@@ -63,13 +62,14 @@ Prototype / in active development.
 ## Capture platform support
 
 - Live sampling path: **macOS 12.3+** via ScreenCaptureKit. Live loupe/window
-  sampling uses `SCStream`; downward scroll capture uses discrete
-  `SCScreenshotManager` region screenshots plus pairwise registration.
+  sampling uses `SCStream`.
 - Live mode is stream-first and does not capture full display on cursor movement.
-- Frozen capture and scroll-capture imagery on macOS use the native capture stack;
+- Frozen capture imagery on macOS uses the native capture stack;
   `docs/spec/capture-session.md` is the current contract source of truth.
 - Menubar and Dock are not included in live window-outline targeting.
 - Windows support is planned (minimum Windows 10), but not implemented yet.
+- The scroll-capture engine, deterministic replay, and benchmark surfaces remain in the repository,
+  but the v0.1.0 native-host release does not expose scroll capture in the toolbar.
 
 ## Usage
 
@@ -77,9 +77,11 @@ Prototype / in active development.
 
 #### Download macOS Build
 
-Download the latest macOS zip from the
-[GitHub Releases](https://github.com/hack-ink/rsnap/releases) page, unzip it, and move
-`Rsnap.app` to `/Applications`.
+Download the latest macOS zip:
+
+<https://github.com/hack-ink/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip>
+
+Unzip it and move `Rsnap.app` to `/Applications`.
 
 #### Build from Source
 
@@ -141,22 +143,21 @@ Rsnap currently relies on **Screen Recording** permission to capture other apps/
 
 - In Frozen mode, use Cmd+S (macOS) / Ctrl+S to save a PNG to disk and exit.
 - On macOS, use the frozen toolbar `Recognize Text` action to copy recognized text from the current frozen capture and exit.
-- After entering scroll capture from a dragged region on macOS, downward scrolling may append newly proven rows into the side preview.
-  Upward scrolling never appends. Returning to already-stitched content should not grow the export; only newly proven content may be added.
-  The scroll-capture commit path uses discrete region screenshots plus pairwise image registration; clipboard and save must match the committed preview the user sees.
-  `Space` copies the stitched image, Cmd+S (macOS) / Ctrl+S saves it, and `Esc` / `Back`
-  returns to the original Frozen capture without exiting.
 - Output is configured in the native `Settings…` window:
   - `output directory` (default: Desktop)
   - `filename prefix` (default: `Rsnap`, sanitized to `[A-Za-z0-9_-]`)
   - `output naming` (`timestamp` or `sequence`)
 
+### Current scroll-capture status
+
+Scroll capture is temporarily hidden in the v0.1.0 native-host release. The retained Rust
+scroll-capture session, deterministic replay, and benchmark surfaces remain for validation and
+future re-enablement, but users should not expect a `Scroll Capture` toolbar item in this release.
+
 ## Development
 
 ```sh
-cargo make fmt
-cargo make lint
-cargo make test
+cargo make checks
 cargo make test-host-reset
 cargo make test-macos-native-host-stage
 ./scripts/build_and_run.sh --verify
@@ -198,6 +199,7 @@ For durable command selection, verification order, baseline workflow, and asset 
 
 - `docs/runbook/performance-validation.md`
 - `docs/reference/smoke-perf-validation-surface.md`
+- `docs/runbook/validate-release.md`
 
 The capture-session contract lives at `docs/spec/capture-session.md`.
 

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -17,6 +17,10 @@ Depends on: `docs/runbook/performance-validation.md`; `docs/spec/performance.md`
 Covers: The current layer map for smoke/perf entrypoints, deterministic replay/bench surfaces,
 overlay runtime integration tests, and scroll-capture session semantics tests.
 
+Release exposure note: v0.1.0 hides user-facing scroll capture in the native host. The
+scroll-capture entries in this reference describe retained internal validation assets, not a
+visible toolbar feature in that release.
+
 ## Layer definitions
 
 | Layer | Owns | Typical artifact |

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -17,6 +17,11 @@ Depends on: `docs/spec/performance.md`
 Outputs: A clear command choice for the regression class you are testing, plus a repeatable local
 baseline workflow for the committed Criterion benchmark targets.
 
+Current release status: v0.1.0 hides user-facing scroll capture in the native host. The replay and
+benchmark commands in this runbook still own retained internal scroll-capture engine validation and
+future re-enablement work, but they are not evidence that the v0.1.0 toolbar exposes scroll
+capture.
+
 ## Command selection
 
 Use the smallest command that matches the regression surface:
@@ -69,7 +74,7 @@ worker-pairwise self-check path when no recorded user trace is available.
   - Runs the core native visual contract smoke.
   - Runs the native HUD-follow responsiveness smoke.
 
-For the downward scroll-capture rebuild, the expected verification sequence is:
+For a future downward scroll-capture re-enablement, the expected verification sequence is:
 
 1. `cargo make checks`
 2. `scripts/smoke/replay-scroll-capture.sh`

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -14,6 +14,10 @@ Depends on: `docs/spec/performance.md`
 Outputs: A repeatable local benchmark run, an optional saved Criterion baseline, and a clear
 understanding of what the synthetic fixture is intended to cover.
 
+Current release status: v0.1.0 hides user-facing scroll capture in the native host. This runbook
+still applies to the retained internal scroll-capture engine, replay, and future re-enablement
+work.
+
 If you are debugging correctness rather than hot-path speed, route through
 `docs/runbook/performance-validation.md` first. That runbook owns replay,
 self-check, semantic analysis, and macOS smoke command selection.
@@ -31,8 +35,7 @@ Properties:
 
 - Each scenario builds a synthetic RGBA document with deterministic row and column structure.
 - The document deliberately includes low-information side margins and more informative interior
-  bands so the same informative-span and overlap-selection logic used in shipping scroll capture is
-  exercised in benchmarks.
+  bands so the retained informative-span and overlap-selection logic is exercised in benchmarks.
 - Benchmark windows are cropped from that document at fixed offsets, so repeated runs always feed
   the same base frame, shifted comparison frame, and fingerprint frame.
 - The current scenarios are `baseline` and `wide`.

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -6,14 +6,14 @@ Read this when: You are preparing a formal Rsnap release tag or verifying the pu
 artifacts immediately after the tag workflow completes.
 
 Preconditions: `main` is clean and synced, the intended release version is committed in
-`Cargo.toml`, GitHub Actions release secrets are configured, and a logged-in macOS desktop session
-is available for native-host smoke and manual checks.
+`Cargo.toml`, GitHub Actions macOS signing/notary release secrets are configured, and a logged-in
+macOS desktop session is available for native-host smoke and manual checks.
 
 Depends on: `docs/spec/app-identity.md`; `docs/spec/settings.md`; `docs/spec/telemetry.md`;
 `docs/runbook/performance-validation.md`; `.github/workflows/release.yml`
 
 Verification: Local checks, dedicated macOS smoke/perf evidence, release workflow success, signed
-and notarized macOS artifact acceptance, and manual first-run/user-flow validation.
+and notarized macOS zip acceptance, and manual first-run/user-flow validation.
 
 ## Before Tagging
 
@@ -22,7 +22,6 @@ and notarized macOS artifact acceptance, and manual first-run/user-flow validati
    - No existing local or remote tag already uses `v<version>`.
 2. Confirm release credentials:
    - Apple signing certificate and notary credentials are available to the Release workflow.
-   - `CARGO_REGISTRY_TOKEN` is available if the crates.io publish job should run.
 3. Confirm local gates:
    - `cargo make checks`
    - `cargo make test-host-reset`
@@ -49,7 +48,9 @@ Validate these user-visible flows:
 - Live HUD, Tab loupe sampling, window outline, dragged-region freeze, click-window freeze, and
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
-  scroll capture, Recognize Text, copy, and save.
+  Recognize Text, copy, and save.
+- Scroll capture is hidden in the v0.1.0 native-host release: the toolbar must not show a scroll
+  capture item, and pressing `s` must not enter scroll capture.
 - Light and dark appearance; Classic Glass and Liquid Glass where the OS supports Liquid Glass.
 - Output directory, filename prefix, sequence/timestamp naming, clipboard copy, and save failure
   handling where practical.
@@ -68,14 +69,15 @@ user-entered annotation text.
 1. Push the annotated release tag only after local and manual RC validation pass.
 2. Watch the Release workflow for the exact tag.
 3. Treat a build, signing, notarization, or packaging failure as a release blocker.
-4. Treat crates.io publishing as dependent on successful build/package jobs; do not publish crates
-   manually unless the workflow failure has been diagnosed and the already-published state is clear.
+4. The Release workflow publishes the notarized macOS zip plus checksum files to the GitHub
+   release. It does not publish crates.io packages or non-macOS desktop archives for v0.1.0.
 
 ## Published Artifact Check
 
 After the Release workflow succeeds:
 
-1. Download the macOS zip from the GitHub release.
+1. Download `rsnap-aarch64-apple-darwin.zip` from the GitHub release or from:
+   `https://github.com/hack-ink/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip`
 2. Unzip it and verify identity:
    - The app bundle is `Rsnap.app`.
    - `CFBundleName` and `CFBundleDisplayName` are `Rsnap`.
@@ -87,6 +89,5 @@ codesign --verify --deep --strict /path/to/Rsnap.app
 spctl -a -vvv --type exec /path/to/Rsnap.app
 ```
 
-4. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, save, and scroll
-   capture check.
+4. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, and save check.
 5. Confirm release notes and checksums were published with the artifacts.

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -1,12 +1,12 @@
 # Rsnap Capture Session Contract
 
 Purpose: Define the product-level normative contract for Rsnap capture flow, Frozen-mode
-behavior, export readiness, and macOS-first scroll capture.
+behavior, export readiness, and scroll-capture availability.
 
 Status: normative
 
 Read this when: You are implementing, reviewing, or validating capture behavior, live-mode
-feedback, export flow, or scroll-capture behavior.
+feedback, export flow, or scroll-capture availability.
 
 Not this document: Platform window ownership, native host implementation strategy, or historical
 macOS shell design. Use `docs/spec/platform-host-boundary.md` for the host/core boundary,
@@ -17,7 +17,7 @@ Defines:
 - capture-session entry, live-mode, frozen-mode, and export invariants
 - the display-first Frozen contract
 - the distinction between display readiness and export readiness
-- the current macOS-first scroll-capture contract
+- the current scroll-capture exposure gate and internal contract when the feature is enabled
 - the presence of Frozen-mode annotation state in session output
 - the existence of a separate Frozen-toolbar layout contract for primary-toolbar anchoring
 
@@ -148,8 +148,8 @@ product level rather than binding itself to a particular window toolkit or shell
 - Frozen-mode display readiness and export readiness are separate:
   - pointer drag/reposition, pen, arrow, text, spotlight, and toolbar visibility are
     display-driven
-  - copy, save, OCR, scroll capture, mosaic, and any final-byte-dependent action are gated on
-    export readiness
+  - copy, save, OCR, mosaic, scroll capture when enabled, and any final-byte-dependent action are
+    gated on export readiness
 - Background region/fullscreen/window-background freezes SHOULD complete directly from a fresh
   live-stream snapshot when one is available.
 - If no usable display-first path is available yet, the session may wait briefly for a follow-up
@@ -162,9 +162,12 @@ product level rather than binding itself to a particular window toolkit or shell
 
 ## Scroll capture
 
-- On macOS, scroll capture is available only from a dragged-region freeze.
-- The frozen toolbar may expose `Scroll Capture Down`, and plain `s` may start scroll capture,
-  whenever the frozen capture source is a dragged region on macOS.
+- The v0.1.0 native-host release does not expose scroll capture. The frozen toolbar MUST NOT show a
+  scroll-capture item while the native-host scroll-capture gate is disabled, and plain `s` MUST NOT
+  enter scroll capture in that state.
+- When scroll capture is re-enabled, it is available only from a dragged-region freeze on macOS.
+- When scroll capture is re-enabled, the frozen toolbar may expose `Scroll Capture Down`, and plain
+  `s` may start scroll capture, whenever the frozen capture source is a dragged region on macOS.
 - Scroll capture uses discrete monitor-region screenshots from the native platform capture API as
   the source of truth for committed downward growth.
 - Pairwise image registration plus overlap proof between adjacent discrete screenshots is the
@@ -182,7 +185,8 @@ product level rather than binding itself to a particular window toolkit or shell
 - `Space` copies the stitched image and exits. Cmd+S (macOS) / Ctrl+S saves it and exits.
   `Esc` / `Back` stops scroll capture and restores the original Frozen capture.
 - Verification order is part of the contract: deterministic and replay entrypoints must pass
-  before any final live touchpad acceptance run is treated as authoritative.
+  before any final live touchpad acceptance run is treated as authoritative for re-enabling the
+  feature.
 
 ## HUD and control defaults
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Rsnap - macOS-first screenshot capture</title>
     <meta
       name="description"
-      content="Rsnap is a macOS-first screenshot tool for frozen regions, pixel inspection, OCR, and scroll stitching."
+      content="Rsnap is a macOS-first screenshot tool for frozen regions, pixel inspection, OCR, and annotation."
     />
     <meta name="theme-color" content="#050506" />
     <meta property="og:title" content="Rsnap" />
@@ -39,10 +39,13 @@
           <h1 id="hero-title">Rsnap</h1>
           <p class="hero-line">Capture before the moment moves.</p>
           <p class="hero-text">
-            A menubar screenshot tool for frozen regions, exact pixels, OCR, and long scrolls.
+            A menubar screenshot tool for frozen regions, exact pixels, OCR, and annotations.
           </p>
           <div class="hero-actions" aria-label="Primary actions">
-            <a class="button button-primary" href="https://github.com/hack-ink/rsnap/releases">
+            <a
+              class="button button-primary"
+              href="https://github.com/hack-ink/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip"
+            >
               Download for macOS
             </a>
             <a class="button button-secondary" href="https://x.com/YvetteCipher" rel="noreferrer">
@@ -58,7 +61,7 @@
           <h2 id="intro-title">A capture surface built around the instant between seeing and saving.</h2>
           <p>
             Rsnap stays out of the dock, starts from the keyboard, and keeps the result ready for
-            copy, save, text recognition, or a longer stitched capture.
+            copy, save, text recognition, or quick markup.
           </p>
         </div>
       </section>
@@ -81,7 +84,7 @@
             <article>
               <span>03</span>
               <h3>Extract the output.</h3>
-              <p>Copy pixels, recognize text, save a file, or continue into scroll stitching.</p>
+            <p>Copy pixels, recognize text, save a file, or annotate before export.</p>
             </article>
           </div>
         </div>
@@ -108,8 +111,8 @@
                 <dd>Space copies, Cmd+S saves, and OCR extracts text from the result.</dd>
               </div>
               <div>
-                <dt>Scroll</dt>
-                <dd>Dragged-region freezes can stitch downward scrolling into one image.</dd>
+                <dt>Annotate</dt>
+                <dd>Use pen, arrow, text, mosaic, and spotlight tools before copying or saving.</dd>
               </div>
             </dl>
           </div>
@@ -133,8 +136,11 @@
       <section class="final-cta" aria-labelledby="final-title">
         <div class="section-inner">
           <h2 id="final-title">Keep the screenshot step invisible.</h2>
-          <a class="button button-primary" href="https://github.com/hack-ink/rsnap/releases">
-            Get the latest build
+          <a
+            class="button button-primary"
+            href="https://github.com/hack-ink/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip"
+          >
+            Download latest macOS zip
           </a>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- narrow the tag release workflow to a notarized macOS zip asset
- update README, docs, and GitHub Pages download links for the v0.1.0 macOS release
- reorganize Makefile test/build sections below test-rust without changing task behavior

## Validation
- actionlint .github/workflows/release.yml .github/workflows/pages.yml .github/workflows/language.yml
- cargo make fmt-toml-check
- git diff --check
- semantic drift audit: pass; direct latest-release URL substring hits are intentional
- cargo make checks
- cargo make test-host-reset
- cargo make test-macos-native-host-stage