### PR TITLE
Allow signed-only macOS release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-macos:
-    name: Build notarized macOS package
+    name: Build signed macOS package
     runs-on: macos-latest
     steps:
       - name: Fetch latest code
@@ -46,7 +46,7 @@ jobs:
         with:
           cache: true
 
-      - name: Bundle, sign, notarize, and pack (macOS)
+      - name: Bundle, sign, optionally notarize, and pack (macOS)
         env:
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -60,19 +60,24 @@ jobs:
           for required_secret in \
             APPLE_CERTIFICATE_P12_BASE64 \
             APPLE_CERTIFICATE_PASSWORD \
-            APPLE_SIGNING_IDENTITY \
-            APPLE_NOTARY_KEY_ID \
-            APPLE_NOTARY_KEY_P8; do
+            APPLE_SIGNING_IDENTITY; do
             if [[ -z "${!required_secret:-}" ]]; then
               echo "Missing required secret: ${required_secret}" >&2
               exit 1
             fi
           done
 
+          NOTARY_ENABLED=0
+          if [[ -n "${APPLE_NOTARY_KEY_ID:-}" && -n "${APPLE_NOTARY_KEY_P8:-}" ]]; then
+            NOTARY_ENABLED=1
+          else
+            echo "::warning::Apple notary credentials are incomplete; publishing a signed but unnotarized macOS zip."
+          fi
+
           CERT_PATH="${RUNNER_TEMP}/apple-cert.p12"
           KEYCHAIN_PATH="${RUNNER_TEMP}/build.keychain-db"
           KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
-          NOTARY_KEY_PATH="${RUNNER_TEMP}/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
+          NOTARY_KEY_PATH=""
 
           CERT_PATH="${CERT_PATH}" python - <<'PY'
           import base64
@@ -83,7 +88,10 @@ jobs:
           )
           PY
 
-          printf '%s' "${APPLE_NOTARY_KEY_P8}" > "${NOTARY_KEY_PATH}"
+          if [[ "${NOTARY_ENABLED}" == "1" ]]; then
+            NOTARY_KEY_PATH="${RUNNER_TEMP}/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
+            printf '%s' "${APPLE_NOTARY_KEY_P8}" > "${NOTARY_KEY_PATH}"
+          fi
 
           security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
           security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
@@ -100,7 +108,7 @@ jobs:
 
           RSNAP_NATIVE_HOST_RUST_PROFILE=final-release \
           RSNAP_NATIVE_HOST_SWIFT_CONFIGURATION=release \
-          RSNAP_NATIVE_HOST_SKIP_SIGN=1 \
+          RSNAP_NATIVE_HOST_SIGN_IDENTITY="${APPLE_SIGNING_IDENTITY}" \
           ./scripts/build_and_run.sh stage
 
           APP_PATH="target/rsnap-native-host/Rsnap.app"
@@ -114,32 +122,29 @@ jobs:
           test "$(plutil -extract CFBundleName raw "${APP_PATH}/Contents/Info.plist")" = "Rsnap"
           test "$(plutil -extract CFBundleDisplayName raw "${APP_PATH}/Contents/Info.plist")" = "Rsnap"
 
-          codesign \
-            --force \
-            --options runtime \
-            --timestamp \
-            --sign "${APPLE_SIGNING_IDENTITY}" \
-            "${APP_PATH}"
           codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+          codesign -dv --verbose=4 "${APP_PATH}"
 
-          NOTARY_ZIP="${RUNNER_TEMP}/Rsnap-notary.zip"
-          ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${NOTARY_ZIP}"
+          if [[ "${NOTARY_ENABLED}" == "1" ]]; then
+            NOTARY_ZIP="${RUNNER_TEMP}/Rsnap-notary.zip"
+            ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${NOTARY_ZIP}"
 
-          NOTARY_ARGS=(
-            submit
-            "${NOTARY_ZIP}"
-            --wait
-            --timeout 30m
-            --key "${NOTARY_KEY_PATH}"
-            --key-id "${APPLE_NOTARY_KEY_ID}"
-          )
-          if [[ -n "${APPLE_NOTARY_ISSUER:-}" ]]; then
-            NOTARY_ARGS+=(--issuer "${APPLE_NOTARY_ISSUER}")
+            NOTARY_ARGS=(
+              submit
+              "${NOTARY_ZIP}"
+              --wait
+              --timeout 30m
+              --key "${NOTARY_KEY_PATH}"
+              --key-id "${APPLE_NOTARY_KEY_ID}"
+            )
+            if [[ -n "${APPLE_NOTARY_ISSUER:-}" ]]; then
+              NOTARY_ARGS+=(--issuer "${APPLE_NOTARY_ISSUER}")
+            fi
+            xcrun notarytool "${NOTARY_ARGS[@]}"
+
+            xcrun stapler staple "${APP_PATH}"
+            spctl -a -vvv --type exec "${APP_PATH}"
           fi
-          xcrun notarytool "${NOTARY_ARGS[@]}"
-
-          xcrun stapler staple "${APP_PATH}"
-          spctl -a -vvv --type exec "${APP_PATH}"
 
           ditto -c -k --sequesterRsrc --keepParent \
             "${APP_PATH}" \

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ cargo build --workspace
 cargo run -p rsnap
 ```
 
-#### macOS Gatekeeper approval for unsigned builds
+#### macOS Gatekeeper approval for signed but unnotarized builds
 
-Current preview builds may not be notarized by a certified Apple Developer account. If macOS
-blocks `Rsnap.app` after you unzip a downloaded build, use the quarantine override only for a
-bundle you built yourself or downloaded from this repository's GitHub Releases page.
+Current preview release builds are signed, but may not be notarized by Apple. If macOS blocks
+`Rsnap.app` after you unzip a downloaded build, use the quarantine override only for a bundle you
+built yourself or downloaded from this repository's GitHub Releases page.
 
 Move the app to `/Applications`, then run:
 

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -6,14 +6,16 @@ Read this when: You are preparing a formal Rsnap release tag or verifying the pu
 artifacts immediately after the tag workflow completes.
 
 Preconditions: `main` is clean and synced, the intended release version is committed in
-`Cargo.toml`, GitHub Actions macOS signing/notary release secrets are configured, and a logged-in
-macOS desktop session is available for native-host smoke and manual checks.
+`Cargo.toml`, GitHub Actions macOS signing release secrets are configured, optional Apple notary
+credentials are configured only when a notarized build is required, and a logged-in macOS desktop
+session is available for native-host smoke and manual checks.
 
 Depends on: `docs/spec/app-identity.md`; `docs/spec/settings.md`; `docs/spec/telemetry.md`;
 `docs/runbook/performance-validation.md`; `.github/workflows/release.yml`
 
 Verification: Local checks, dedicated macOS smoke/perf evidence, release workflow success, signed
-and notarized macOS zip acceptance, and manual first-run/user-flow validation.
+macOS zip acceptance, optional notarization evidence when notary credentials are configured, and
+manual first-run/user-flow validation.
 
 ## Before Tagging
 
@@ -21,7 +23,9 @@ and notarized macOS zip acceptance, and manual first-run/user-flow validation.
    - `Cargo.toml` `workspace.package.version` matches the intended tag without a leading `v`.
    - No existing local or remote tag already uses `v<version>`.
 2. Confirm release credentials:
-   - Apple signing certificate and notary credentials are available to the Release workflow.
+   - Apple signing certificate secrets are available to the Release workflow.
+   - Apple notary credentials are optional for v0.1.0; when absent, the Release workflow still
+     publishes a signed but unnotarized macOS zip.
 3. Confirm local gates:
    - `cargo make checks`
    - `cargo make test-host-reset`
@@ -68,9 +72,11 @@ user-entered annotation text.
 
 1. Push the annotated release tag only after local and manual RC validation pass.
 2. Watch the Release workflow for the exact tag.
-3. Treat a build, signing, notarization, or packaging failure as a release blocker.
-4. The Release workflow publishes the notarized macOS zip plus checksum files to the GitHub
-   release. It does not publish crates.io packages or non-macOS desktop archives for v0.1.0.
+3. Treat a build, signing, or packaging failure as a release blocker.
+4. Treat notarization failure as a release blocker only when notary credentials are configured.
+5. The Release workflow publishes the signed macOS zip plus checksum files to the GitHub release.
+   It notarizes and staples the app only when notary credentials are configured. It does not
+   publish crates.io packages or non-macOS desktop archives for v0.1.0.
 
 ## Published Artifact Check
 
@@ -82,12 +88,21 @@ After the Release workflow succeeds:
    - The app bundle is `Rsnap.app`.
    - `CFBundleName` and `CFBundleDisplayName` are `Rsnap`.
    - `CFBundleIdentifier` is `ink.hack.rsnap`.
-3. Verify signature and Gatekeeper acceptance:
+3. Verify the signature:
 
 ```sh
 codesign --verify --deep --strict /path/to/Rsnap.app
+```
+
+4. For a notarized build, verify Gatekeeper acceptance:
+
+```sh
 spctl -a -vvv --type exec /path/to/Rsnap.app
 ```
 
-4. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, and save check.
-5. Confirm release notes and checksums were published with the artifacts.
+For a signed but unnotarized build, Gatekeeper may still block a quarantined download. Use the
+quarantine override documented in `README.md` only for a bundle built locally or downloaded from
+this repository's GitHub Releases page.
+
+5. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, and save check.
+6. Confirm release notes and checksums were published with the artifacts.


### PR DESCRIPTION
## Summary
- make Apple notarization optional for the macOS release workflow
- sign the release app through the same native-host staging path used locally
- align README and release runbook around signed but unnotarized preview builds

## Validation
- actionlint .github/workflows/release.yml
- git diff --check
- /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py (agent verdict: pass; stale --force hit is unrelated scroll replay text)