### PR TITLE
Remove manual release checksum generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,16 +165,9 @@ jobs:
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
-
-      - name: Hash
-        run: |
-          mkdir -p artifacts
-          mv -- rsnap-*/* artifacts/
-          cd artifacts
-          sha256sum -- * | tee ../SHA256
-          md5sum -- * | tee ../MD5
-          mv ../SHA256 .
-          mv ../MD5 .
+        with:
+          name: rsnap-aarch64-apple-darwin
+          path: artifacts
 
       - name: Publish
         uses: softprops/action-gh-release@v3

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -74,9 +74,9 @@ user-entered annotation text.
 2. Watch the Release workflow for the exact tag.
 3. Treat a build, signing, or packaging failure as a release blocker.
 4. Treat notarization failure as a release blocker only when notary credentials are configured.
-5. The Release workflow publishes the signed macOS zip plus checksum files to the GitHub release.
-   It notarizes and staples the app only when notary credentials are configured. It does not
-   publish crates.io packages or non-macOS desktop archives for v0.1.0.
+5. The Release workflow publishes the signed macOS zip to the GitHub release. It notarizes and
+   staples the app only when notary credentials are configured. It does not publish crates.io
+   packages or non-macOS desktop archives for v0.1.0.
 
 ## Published Artifact Check
 
@@ -105,4 +105,4 @@ quarantine override documented in `README.md` only for a bundle built locally or
 this repository's GitHub Releases page.
 
 5. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, and save check.
-6. Confirm release notes and checksums were published with the artifacts.
+6. Confirm release notes and the macOS zip were published.


### PR DESCRIPTION
## Summary
- remove the hand-written release Hash step and SHA256/MD5 files
- keep the release job publishing the macOS zip from a stable artifacts/ path
- update the release runbook so it no longer promises checksum files

## Root cause
The failed v0.1.0 release passed macOS build/sign/package, then failed in the Ubuntu Release job because the Hash script assumed downloaded artifacts lived under an rsnap-*/* subdirectory. The download-artifact@v8 log showed the artifact was downloaded to the workspace root layout instead, so the rsnap-*/* glob matched nothing and mv failed with cannot stat. GitHub Releases already expose asset digests, so the manual checksum step is unnecessary.

## Validation
- actionlint .github/workflows/release.yml
- git diff --check HEAD
- /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py --rev main (agent verdict: pass)