### PR TITLE
Prepare v0.1.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,5 @@ jobs:
       - name: Publish
         uses: softprops/action-gh-release@v3
         with:
-          discussion_category_name: Announcements
           generate_release_notes: true
           files: artifacts/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,7 +3363,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "image",
  "serde",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.1.0"
+version     = "0.1.1"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -52,9 +52,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.1.0", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.1.0", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.1.0", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.1.1", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.1.1", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.1.1", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prototype / in active development.
 - Menubar and Dock are not included in live window-outline targeting.
 - Windows support is planned (minimum Windows 10), but not implemented yet.
 - The scroll-capture engine, deterministic replay, and benchmark surfaces remain in the repository,
-  but the v0.1.0 native-host release does not expose scroll capture in the toolbar.
+  but the v0.1.1 native-host release does not expose scroll capture in the toolbar.
 
 ## Usage
 
@@ -150,7 +150,7 @@ Rsnap currently relies on **Screen Recording** permission to capture other apps/
 
 ### Current scroll-capture status
 
-Scroll capture is temporarily hidden in the v0.1.0 native-host release. The retained Rust
+Scroll capture is temporarily hidden in the v0.1.1 native-host release. The retained Rust
 scroll-capture session, deterministic replay, and benchmark surfaces remain for validation and
 future re-enablement, but users should not expect a `Scroll Capture` toolbar item in this release.
 

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -17,7 +17,7 @@ Depends on: `docs/runbook/performance-validation.md`; `docs/spec/performance.md`
 Covers: The current layer map for smoke/perf entrypoints, deterministic replay/bench surfaces,
 overlay runtime integration tests, and scroll-capture session semantics tests.
 
-Release exposure note: v0.1.0 hides user-facing scroll capture in the native host. The
+Release exposure note: v0.1.1 hides user-facing scroll capture in the native host. The
 scroll-capture entries in this reference describe retained internal validation assets, not a
 visible toolbar feature in that release.
 

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -17,9 +17,9 @@ Depends on: `docs/spec/performance.md`
 Outputs: A clear command choice for the regression class you are testing, plus a repeatable local
 baseline workflow for the committed Criterion benchmark targets.
 
-Current release status: v0.1.0 hides user-facing scroll capture in the native host. The replay and
+Current release status: v0.1.1 hides user-facing scroll capture in the native host. The replay and
 benchmark commands in this runbook still own retained internal scroll-capture engine validation and
-future re-enablement work, but they are not evidence that the v0.1.0 toolbar exposes scroll
+future re-enablement work, but they are not evidence that the v0.1.1 toolbar exposes scroll
 capture.
 
 ## Command selection

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -14,7 +14,7 @@ Depends on: `docs/spec/performance.md`
 Outputs: A repeatable local benchmark run, an optional saved Criterion baseline, and a clear
 understanding of what the synthetic fixture is intended to cover.
 
-Current release status: v0.1.0 hides user-facing scroll capture in the native host. This runbook
+Current release status: v0.1.1 hides user-facing scroll capture in the native host. This runbook
 still applies to the retained internal scroll-capture engine, replay, and future re-enablement
 work.
 

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -24,7 +24,7 @@ manual first-run/user-flow validation.
    - No existing local or remote tag already uses `v<version>`.
 2. Confirm release credentials:
    - Apple signing certificate secrets are available to the Release workflow.
-   - Apple notary credentials are optional for v0.1.0; when absent, the Release workflow still
+   - Apple notary credentials are optional for v0.1.1; when absent, the Release workflow still
      publishes a signed but unnotarized macOS zip.
 3. Confirm local gates:
    - `cargo make checks`
@@ -53,7 +53,7 @@ Validate these user-visible flows:
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
   Recognize Text, copy, and save.
-- Scroll capture is hidden in the v0.1.0 native-host release: the toolbar must not show a scroll
+- Scroll capture is hidden in the v0.1.1 native-host release: the toolbar must not show a scroll
   capture item, and pressing `s` must not enter scroll capture.
 - Light and dark appearance; Classic Glass and Liquid Glass where the OS supports Liquid Glass.
 - Output directory, filename prefix, sequence/timestamp naming, clipboard copy, and save failure
@@ -76,7 +76,7 @@ user-entered annotation text.
 4. Treat notarization failure as a release blocker only when notary credentials are configured.
 5. The Release workflow publishes the signed macOS zip to the GitHub release. It notarizes and
    staples the app only when notary credentials are configured. It does not publish crates.io
-   packages or non-macOS desktop archives for v0.1.0.
+   packages or non-macOS desktop archives for v0.1.1.
 
 ## Published Artifact Check
 

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -162,7 +162,7 @@ product level rather than binding itself to a particular window toolkit or shell
 
 ## Scroll capture
 
-- The v0.1.0 native-host release does not expose scroll capture. The frozen toolbar MUST NOT show a
+- The v0.1.1 native-host release does not expose scroll capture. The frozen toolbar MUST NOT show a
   scroll-capture item while the native-host scroll-capture gate is disabled, and plain `s` MUST NOT
   enter scroll capture in that state.
 - When scroll capture is re-enabled, it is available only from a dragged-region freeze on macOS.


### PR DESCRIPTION
## Summary
- bump the workspace release version to 0.1.1
- keep the macOS release publish path from artifacts/ and remove the invalid Discussion category
- update README and release docs from v0.1.0 to v0.1.1

## Release failure notes
- The earlier v0.1.0 notary failure was caused by missing APPLE_NOTARY_KEY_ID / APPLE_NOTARY_KEY_P8; the workflow now treats notarization as optional and still publishes a signed macOS zip.
- The next v0.1.0 failure was the removed Hash step: download-artifact@v8 downloaded the artifact in a layout that did not match the rsnap-*/* glob, so mv could not stat it. GitHub Releases already exposes an asset digest.
- The latest v0.1.0 publish failure happened after the zip uploaded successfully; finalization failed because discussion_category_name: Announcements is not a valid Discussion category for this repo.

## Validation
- actionlint .github/workflows/release.yml
- cargo make fmt-toml-check
- cargo metadata --format-version 1
- git diff --check
- /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py --rev main (agent verdict: pass)