### PR TITLE
Polish frozen toolbar annotations for 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,7 +3363,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "image",
  "serde",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.1.1"
+version     = "0.1.2"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -52,9 +52,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.1.1", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.1.1", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.1.1", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.1.2", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.1.2", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.1.2", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prototype / in active development.
 - Menubar and Dock are not included in live window-outline targeting.
 - Windows support is planned (minimum Windows 10), but not implemented yet.
 - The scroll-capture engine, deterministic replay, and benchmark surfaces remain in the repository,
-  but the v0.1.1 native-host release does not expose scroll capture in the toolbar.
+  but the v0.1.2 native-host release does not expose scroll capture in the toolbar.
 
 ## Usage
 
@@ -150,7 +150,7 @@ Rsnap currently relies on **Screen Recording** permission to capture other apps/
 
 ### Current scroll-capture status
 
-Scroll capture is temporarily hidden in the v0.1.1 native-host release. The retained Rust
+Scroll capture is temporarily hidden in the v0.1.2 native-host release. The retained Rust
 scroll-capture session, deterministic replay, and benchmark surfaces remain for validation and
 future re-enablement, but users should not expect a `Scroll Capture` toolbar item in this release.
 

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -17,7 +17,7 @@ Depends on: `docs/runbook/performance-validation.md`; `docs/spec/performance.md`
 Covers: The current layer map for smoke/perf entrypoints, deterministic replay/bench surfaces,
 overlay runtime integration tests, and scroll-capture session semantics tests.
 
-Release exposure note: v0.1.1 hides user-facing scroll capture in the native host. The
+Release exposure note: v0.1.2 hides user-facing scroll capture in the native host. The
 scroll-capture entries in this reference describe retained internal validation assets, not a
 visible toolbar feature in that release.
 

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -17,9 +17,9 @@ Depends on: `docs/spec/performance.md`
 Outputs: A clear command choice for the regression class you are testing, plus a repeatable local
 baseline workflow for the committed Criterion benchmark targets.
 
-Current release status: v0.1.1 hides user-facing scroll capture in the native host. The replay and
+Current release status: v0.1.2 hides user-facing scroll capture in the native host. The replay and
 benchmark commands in this runbook still own retained internal scroll-capture engine validation and
-future re-enablement work, but they are not evidence that the v0.1.1 toolbar exposes scroll
+future re-enablement work, but they are not evidence that the v0.1.2 toolbar exposes scroll
 capture.
 
 ## Command selection

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -14,7 +14,7 @@ Depends on: `docs/spec/performance.md`
 Outputs: A repeatable local benchmark run, an optional saved Criterion baseline, and a clear
 understanding of what the synthetic fixture is intended to cover.
 
-Current release status: v0.1.1 hides user-facing scroll capture in the native host. This runbook
+Current release status: v0.1.2 hides user-facing scroll capture in the native host. This runbook
 still applies to the retained internal scroll-capture engine, replay, and future re-enablement
 work.
 

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -24,7 +24,7 @@ manual first-run/user-flow validation.
    - No existing local or remote tag already uses `v<version>`.
 2. Confirm release credentials:
    - Apple signing certificate secrets are available to the Release workflow.
-   - Apple notary credentials are optional for v0.1.1; when absent, the Release workflow still
+   - Apple notary credentials are optional for v0.1.2; when absent, the Release workflow still
      publishes a signed but unnotarized macOS zip.
 3. Confirm local gates:
    - `cargo make checks`
@@ -53,7 +53,7 @@ Validate these user-visible flows:
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
   Recognize Text, copy, and save.
-- Scroll capture is hidden in the v0.1.1 native-host release: the toolbar must not show a scroll
+- Scroll capture is hidden in the v0.1.2 native-host release: the toolbar must not show a scroll
   capture item, and pressing `s` must not enter scroll capture.
 - Light and dark appearance; Classic Glass and Liquid Glass where the OS supports Liquid Glass.
 - Output directory, filename prefix, sequence/timestamp naming, clipboard copy, and save failure
@@ -76,7 +76,7 @@ user-entered annotation text.
 4. Treat notarization failure as a release blocker only when notary credentials are configured.
 5. The Release workflow publishes the signed macOS zip to the GitHub release. It notarizes and
    staples the app only when notary credentials are configured. It does not publish crates.io
-   packages or non-macOS desktop archives for v0.1.1.
+   packages or non-macOS desktop archives for v0.1.2.
 
 ## Published Artifact Check
 

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -162,7 +162,7 @@ product level rather than binding itself to a particular window toolkit or shell
 
 ## Scroll capture
 
-- The v0.1.1 native-host release does not expose scroll capture. The frozen toolbar MUST NOT show a
+- The v0.1.2 native-host release does not expose scroll capture. The frozen toolbar MUST NOT show a
   scroll-capture item while the native-host scroll-capture gate is disabled, and plain `s` MUST NOT
   enter scroll capture in that state.
 - When scroll capture is re-enabled, it is available only from a dragged-region freeze on macOS.

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -2938,28 +2938,33 @@ final class CaptureSessionController: NSObject {
 			context.restoreGState()
 		}
 
-		let spotlightRects = chromeState.frozenOverlay.spotlightRects.map(mapRect)
-		if !spotlightRects.isEmpty {
+		let spotlightAnnotations = chromeState.frozenOverlay.spotlightAnnotations.map {
+			(rect: mapRect($0.rect), style: $0.style)
+		}
+		let averageScale = (scaleX + scaleY) / 2
+		if !spotlightAnnotations.isEmpty {
 			context.saveGState()
 			context.setFillColor(NSColor.black.withAlphaComponent(0.32).cgColor)
 			context.fill(imageRect)
-			for rect in spotlightRects {
+			for annotation in spotlightAnnotations {
 				context.saveGState()
-				context.clip(to: rect)
+				context.clip(to: annotation.rect)
 				context.draw(image, in: imageRect)
 				context.restoreGState()
 			}
 			context.restoreGState()
 
-			context.setStrokeColor(
-				NSColor(calibratedRed: 167 / 255, green: 223 / 255, blue: 1, alpha: 0.96).cgColor)
-			context.setLineWidth(2 * ((scaleX + scaleY) / 2))
-			for rect in spotlightRects {
-				context.stroke(rect.insetBy(dx: scaleX, dy: scaleY))
+			for annotation in spotlightAnnotations {
+				drawFrozenSpotlightBorder(
+					for: annotation.rect,
+					style: annotation.style,
+					scale: averageScale,
+					alpha: 0.96,
+					in: context
+				)
 			}
 		}
 
-		let averageScale = (scaleX + scaleY) / 2
 		for stroke in chromeState.frozenOverlay.penStrokes {
 			guard let first = stroke.points.first else {
 				continue
@@ -6035,10 +6040,21 @@ final class CaptureHostView: NSView {
 	}
 
 	private func drawFrozenSpotlights(for selection: CGRect, in context: CGContext) {
-		let spotlightRects = chrome.frozenOverlay.spotlightRects.compactMap(localRect(from:))
-		let previewRect = chrome.frozenOverlay.previewSpotlightRect.flatMap(localRect(from:))
-		let allRects = spotlightRects + (previewRect.map { [$0] } ?? [])
-		guard !allRects.isEmpty else {
+		let spotlightAnnotations: [(rect: CGRect, style: FrozenSpotlightStyle)] =
+			chrome.frozenOverlay.spotlightAnnotations.compactMap { annotation in
+				guard let rect = localRect(from: annotation.rect) else {
+					return nil
+				}
+				return (rect: rect, style: annotation.style)
+			}
+		let previewAnnotation =
+			chrome.frozenOverlay.previewSpotlightAnnotation.flatMap { annotation in
+				localRect(from: annotation.rect).map { rect in
+					(rect: rect, style: annotation.style)
+				}
+			}
+		let allAnnotations = spotlightAnnotations + (previewAnnotation.map { [$0] } ?? [])
+		guard !allAnnotations.isEmpty else {
 			return
 		}
 
@@ -6046,16 +6062,19 @@ final class CaptureHostView: NSView {
 		context.setFillColor(NSColor.black.withAlphaComponent(0.32).cgColor)
 		context.fill(selection)
 		context.setBlendMode(.clear)
-		for rect in allRects {
-			context.fill(rect)
+		for annotation in allAnnotations {
+			context.fill(annotation.rect)
 		}
 		context.restoreGState()
 
-		context.setStrokeColor(
-			NSColor(calibratedRed: 167 / 255, green: 223 / 255, blue: 1, alpha: 0.92).cgColor)
-		context.setLineWidth(2)
-		for rect in allRects {
-			context.stroke(rect.insetBy(dx: 1, dy: 1))
+		for annotation in allAnnotations {
+			drawFrozenSpotlightBorder(
+				for: annotation.rect,
+				style: annotation.style,
+				scale: 1,
+				alpha: 0.92,
+				in: context
+			)
 		}
 	}
 
@@ -6179,7 +6198,7 @@ final class CaptureHostView: NSView {
 		let styleKind =
 			items.first(where: { $0.selected })
 			.flatMap { FrozenAnnotationStyleToolbarKind(selectedTool: $0.kind) }
-		let metrics = CaptureChrome.toolbarMetrics(hasAnnotationStyle: styleKind != nil)
+		let metrics = CaptureChrome.toolbarMetrics()
 		let itemCount = CGFloat(items.count)
 		let primaryContentWidth =
 			itemCount * metrics.buttonSize
@@ -6188,11 +6207,8 @@ final class CaptureHostView: NSView {
 			styleKind.map { annotationStyleContentWidth(for: $0, metrics: metrics) } ?? 0
 		let contentWidth = max(primaryContentWidth, styleContentWidth)
 		let width = contentWidth + metrics.horizontalPadding * 2
-		let height =
-			metrics.verticalPadding * 2
-			+ metrics.buttonSize
-			+ (styleKind == nil
-				? 0 : metrics.annotationStyleRowGap + metrics.annotationStyleRowHeight)
+		let primaryRowHeight = metrics.verticalPadding * 2 + metrics.buttonSize
+		let height = styleKind == nil ? primaryRowHeight : primaryRowHeight * 2
 		let desiredY = selection.maxY + metrics.gap
 		let wantsTop = settings.toolbarPlacement == .top
 		let placedAbove =
@@ -7874,7 +7890,7 @@ private enum FrozenAnnotationColor: CaseIterable, Equatable {
 }
 
 private struct FrozenBrushStyle: Equatable {
-	private static let defaultStrokeWidth: CGFloat = 3.5
+	private static let defaultStrokeWidth: CGFloat = 3.0
 	private static let minStrokeWidth: CGFloat = 1.0
 	private static let maxStrokeWidth: CGFloat = 24.0
 	private static let strokeWidthStep: CGFloat = 0.25
@@ -7902,6 +7918,39 @@ private struct FrozenBrushStyle: Equatable {
 			return false
 		}
 		strokeWidthPoints = clamped
+		return true
+	}
+}
+
+private struct FrozenSpotlightStyle: Equatable {
+	private static let defaultBorderWidth: CGFloat = 0.0
+	private static let minBorderWidth: CGFloat = 0.0
+	private static let maxBorderWidth: CGFloat = 24.0
+	private static let borderWidthStep: CGFloat = 0.25
+
+	var borderWidthPoints = defaultBorderWidth
+	var borderColor: FrozenAnnotationColor = .blue
+
+	mutating func applySizeSteps(_ steps: Int) -> Bool {
+		guard steps != 0 else {
+			return false
+		}
+		let direction = steps.signum()
+		var changed = false
+		for _ in 0..<abs(steps) {
+			changed =
+				setBorderWidth(borderWidthPoints + CGFloat(direction) * Self.borderWidthStep)
+				|| changed
+		}
+		return changed
+	}
+
+	private mutating func setBorderWidth(_ value: CGFloat) -> Bool {
+		let clamped = value.clamped(to: Self.minBorderWidth...Self.maxBorderWidth)
+		guard abs(clamped - borderWidthPoints) > .ulpOfOne else {
+			return false
+		}
+		borderWidthPoints = clamped
 		return true
 	}
 }
@@ -7953,15 +8002,18 @@ private enum FrozenAnnotationStyleAction: Equatable {
 
 private enum FrozenAnnotationStyleToolbarKind: Equatable {
 	case brush
+	case spotlight
 	case text
 
 	init?(selectedTool: ToolbarItemKind) {
 		switch selectedTool {
 		case .pen, .arrow:
 			self = .brush
+		case .spotlight:
+			self = .spotlight
 		case .text:
 			self = .text
-		case .pointer, .mosaic, .spotlight, .undo, .redo, .autoCenter, .scroll, .ocr, .copy, .save:
+		case .pointer, .mosaic, .undo, .redo, .autoCenter, .scroll, .ocr, .copy, .save:
 			return nil
 		}
 	}
@@ -7970,6 +8022,8 @@ private enum FrozenAnnotationStyleToolbarKind: Equatable {
 		switch self {
 		case .brush:
 			return 84
+		case .spotlight:
+			return 58
 		case .text:
 			return 58
 		}
@@ -7988,6 +8042,8 @@ private enum FrozenAnnotationStyleToolbarKind: Equatable {
 		switch self {
 		case .brush:
 			return state.brushStyle.color
+		case .spotlight:
+			return state.spotlightStyle.borderColor
 		case .text:
 			return state.textStyle.color
 		}
@@ -7996,15 +8052,9 @@ private enum FrozenAnnotationStyleToolbarKind: Equatable {
 	func sizeLabel(in state: FrozenAnnotationStyleState) -> String {
 		switch self {
 		case .brush:
-			let size = state.brushStyle.strokeWidthPoints
-			var text = String(format: "%.2f", Double(size))
-			while text.contains(".") && text.hasSuffix("0") {
-				text.removeLast()
-			}
-			if text.hasSuffix(".") {
-				text.removeLast()
-			}
-			return text
+			return Self.trimmedDecimalLabel(state.brushStyle.strokeWidthPoints)
+		case .spotlight:
+			return Self.trimmedDecimalLabel(state.spotlightStyle.borderWidthPoints)
 		case .text:
 			let size = state.textStyle.fontSizePoints
 			let text =
@@ -8014,10 +8064,22 @@ private enum FrozenAnnotationStyleToolbarKind: Equatable {
 			return "\(text) pt"
 		}
 	}
+
+	private static func trimmedDecimalLabel(_ value: CGFloat) -> String {
+		var text = String(format: "%.2f", Double(value))
+		while text.contains(".") && text.hasSuffix("0") {
+			text.removeLast()
+		}
+		if text.hasSuffix(".") {
+			text.removeLast()
+		}
+		return text
+	}
 }
 
 private struct FrozenAnnotationStyleState: Equatable {
 	var brushStyle = FrozenBrushStyle()
+	var spotlightStyle = FrozenSpotlightStyle()
 	var textStyle = FrozenTextStyle()
 
 	mutating func apply(
@@ -8037,6 +8099,16 @@ private struct FrozenAnnotationStyleState: Equatable {
 				return false
 			}
 			brushStyle.color = color
+			return true
+		case (.spotlight, .decreaseSize):
+			return spotlightStyle.applySizeSteps(-1)
+		case (.spotlight, .increaseSize):
+			return spotlightStyle.applySizeSteps(1)
+		case (.spotlight, .color(let color)):
+			guard spotlightStyle.borderColor != color else {
+				return false
+			}
+			spotlightStyle.borderColor = color
 			return true
 		case (.text, .decreaseSize):
 			return textStyle.applySizeSteps(-1)
@@ -8058,6 +8130,8 @@ private struct FrozenAnnotationStyleState: Equatable {
 		switch kind {
 		case .brush:
 			return brushStyle.applySizeSteps(steps)
+		case .spotlight:
+			return spotlightStyle.applySizeSteps(steps)
 		case .text:
 			return textStyle.applySizeSteps(steps)
 		}
@@ -8075,6 +8149,11 @@ private struct FrozenArrowAnnotation: Equatable {
 	var style: FrozenBrushStyle
 }
 
+private struct FrozenSpotlightAnnotation: Equatable {
+	var rect: CGRect
+	var style: FrozenSpotlightStyle
+}
+
 private struct FrozenTextAnnotation: Equatable {
 	var anchor: CGPoint
 	var text: String
@@ -8084,6 +8163,24 @@ private struct FrozenTextAnnotation: Equatable {
 private struct FrozenTextEditState {
 	var anchor: CGPoint
 	var text: String
+}
+
+private func drawFrozenSpotlightBorder(
+	for rect: CGRect,
+	style: FrozenSpotlightStyle,
+	scale: CGFloat,
+	alpha: CGFloat,
+	in context: CGContext
+) {
+	let lineWidth = style.borderWidthPoints * scale
+	guard lineWidth > .ulpOfOne else {
+		return
+	}
+	context.saveGState()
+	context.setStrokeColor(style.borderColor.nsColor(alpha: alpha).cgColor)
+	context.setLineWidth(lineWidth)
+	context.stroke(rect.insetBy(dx: lineWidth / 2, dy: lineWidth / 2))
+	context.restoreGState()
 }
 
 private func drawFrozenArrow(
@@ -8097,7 +8194,7 @@ private func drawFrozenArrow(
 	guard distance > .ulpOfOne else {
 		return
 	}
-	let strokeWidth = max(style.strokeWidthPoints * 1.4 * scale, 4.5 * scale)
+	let strokeWidth = style.strokeWidthPoints * 1.4 * scale
 	let headLength = min(max(strokeWidth * 4.2, 16 * scale), distance * 0.9)
 	let headSpread: CGFloat = .pi / 7
 	let angle = atan2(end.y - start.y, end.x - start.x)
@@ -8266,7 +8363,7 @@ private struct FrozenOverlayState {
 		case pen(FrozenBrushStroke)
 		case arrow(FrozenArrowAnnotation)
 		case mosaic(CGRect)
-		case spotlight(CGRect)
+		case spotlight(FrozenSpotlightAnnotation)
 		case text(FrozenTextAnnotation)
 	}
 
@@ -8276,7 +8373,7 @@ private struct FrozenOverlayState {
 		case mosaic(anchor: CGPoint, current: CGPoint)
 		case mosaicMove(index: Int, currentRect: CGRect, dragOffset: CGSize)
 		case textMove(index: Int, currentAnnotation: FrozenTextAnnotation, dragOffset: CGSize)
-		case spotlight(anchor: CGPoint, current: CGPoint)
+		case spotlight(anchor: CGPoint, current: CGPoint, style: FrozenSpotlightStyle)
 	}
 
 	private enum MoveTarget {
@@ -8349,7 +8446,11 @@ private struct FrozenOverlayState {
 				)
 			}
 		case .spotlight:
-			activeInteraction = .spotlight(anchor: point, current: point)
+			activeInteraction = .spotlight(
+				anchor: point,
+				current: point,
+				style: style.spotlightStyle
+			)
 		case .text:
 			let _ = commitTextEdit(style: style.textStyle)
 			activeTextEdit = FrozenTextEditState(anchor: selection.clamp(point), text: "")
@@ -8403,8 +8504,12 @@ private struct FrozenOverlayState {
 				),
 				dragOffset: dragOffset
 			)
-		case .spotlight(let anchor, _):
-			self.activeInteraction = .spotlight(anchor: anchor, current: selection.clamp(point))
+		case .spotlight(let anchor, _, let style):
+			self.activeInteraction = .spotlight(
+				anchor: anchor,
+				current: selection.clamp(point),
+				style: style
+			)
 		}
 
 		return true
@@ -8454,12 +8559,12 @@ private struct FrozenOverlayState {
 			} else {
 				edits[index] = .text(currentAnnotation)
 			}
-		case .spotlight(let anchor, let current):
+		case .spotlight(let anchor, let current, let style):
 			let rect = selection.normalizedRect(anchor: anchor, current: current)
 			guard rect.width >= 6, rect.height >= 6 else {
 				return false
 			}
-			edits.append(.spotlight(rect))
+			edits.append(.spotlight(FrozenSpotlightAnnotation(rect: rect, style: style)))
 		}
 
 		if changed {
@@ -8653,10 +8758,10 @@ private struct FrozenOverlayState {
 		}
 	}
 
-	var spotlightRects: [CGRect] {
+	var spotlightAnnotations: [FrozenSpotlightAnnotation] {
 		edits.compactMap {
-			if case .spotlight(let rect) = $0 {
-				return rect
+			if case .spotlight(let annotation) = $0 {
+				return annotation
 			}
 			return nil
 		}
@@ -8725,13 +8830,16 @@ private struct FrozenOverlayState {
 		return nil
 	}
 
-	var previewSpotlightRect: CGRect? {
-		if case .spotlight(let anchor, let current)? = activeInteraction {
-			return CGRect(
-				x: min(anchor.x, current.x),
-				y: min(anchor.y, current.y),
-				width: abs(current.x - anchor.x),
-				height: abs(current.y - anchor.y)
+	var previewSpotlightAnnotation: FrozenSpotlightAnnotation? {
+		if case .spotlight(let anchor, let current, let style)? = activeInteraction {
+			return FrozenSpotlightAnnotation(
+				rect: CGRect(
+					x: min(anchor.x, current.x),
+					y: min(anchor.y, current.y),
+					width: abs(current.x - anchor.x),
+					height: abs(current.y - anchor.y)
+				),
+				style: style
 			)
 		}
 		return nil
@@ -8811,7 +8919,6 @@ enum CaptureChrome {
 		let horizontalPadding: CGFloat
 		let verticalPadding: CGFloat
 		let gap: CGFloat
-		let annotationStyleRowGap: CGFloat
 		let annotationStyleRowHeight: CGFloat
 		let annotationStyleControlGap: CGFloat
 		let annotationSizeButtonWidth: CGFloat
@@ -8858,7 +8965,6 @@ enum CaptureChrome {
 	static let scrollMinimapScreenMargin: CGFloat = 10
 	static let scrollMinimapImageInset: CGFloat = 3
 	static let scrollMinimapCornerRadius: CGFloat = 9
-	static let annotationStyleRowGap: CGFloat = 4
 	static let annotationStyleRowHeight: CGFloat = 24
 	static let annotationStyleControlGap: CGFloat = 4
 	static let annotationSizeButtonWidth: CGFloat = 20
@@ -8870,11 +8976,10 @@ enum CaptureChrome {
 	static let selectionSizeBadgeInset: CGFloat = 8
 	static let selectionSizeBadgeToolbarAvoidance: CGFloat = 4
 
-	static func toolbarMetrics(hasAnnotationStyle: Bool) -> ToolbarMetrics {
+	static func toolbarMetrics() -> ToolbarMetrics {
 		let baseHeight =
 			toolbarVerticalPadding * 2
 			+ toolbarButtonSize
-			+ (hasAnnotationStyle ? annotationStyleRowGap + annotationStyleRowHeight : 0)
 		let targetHeight = toolbarTargetHeight
 		let scale = min(1, targetHeight / max(baseHeight, 1))
 		return ToolbarMetrics(
@@ -8884,7 +8989,6 @@ enum CaptureChrome {
 			horizontalPadding: hudInnerMarginX * scale,
 			verticalPadding: toolbarVerticalPadding * scale,
 			gap: toolbarGap * scale,
-			annotationStyleRowGap: annotationStyleRowGap * scale,
 			annotationStyleRowHeight: annotationStyleRowHeight * scale,
 			annotationStyleControlGap: annotationStyleControlGap * scale,
 			annotationSizeButtonWidth: annotationSizeButtonWidth * scale,
@@ -9430,7 +9534,7 @@ private enum FrozenToolbarDrawing {
 				color: palette.labelText,
 				context: context
 			)
-		case .text:
+		case .spotlight, .text:
 			drawCenteredText(
 				layout.kind.sizeLabel(in: state),
 				in: layout.displayFrame,

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -56,7 +56,7 @@ if [[ "$SWIFT_CONFIGURATION" == "release" ]]; then
 fi
 
 APP_VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -n 1)"
-APP_VERSION="${APP_VERSION:-0.1.0}"
+APP_VERSION="${APP_VERSION:-0.1.2}"
 
 relink_native_host_if_missing() {
 	local product_dir link_file swift_frameworks sdk swiftc


### PR DESCRIPTION
## Summary
- keep frozen annotation toolbar size stable when second-row style controls are shown
- make arrow thickness controls effective and set the shared brush/arrow default to 3
- add spotlight border color and width controls, defaulting width to 0 for no border
- bump workspace, staged app fallback, and release docs to 0.1.2

## Validation
- cargo check --workspace --all-targets
- cargo make fmt-swift-check
- cargo make build-swift-strict
- cargo make test-macos-native-host-stage
- cargo make fmt-toml-check
- git diff --check
- semantic drift audit: pass, no stale phrase hits
- staged Rsnap.app CFBundleShortVersionString and CFBundleVersion: 0.1.2