### PR TITLE
Fix Liquid Glass release toolchain gating

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -102,10 +102,16 @@ jobs:
 
   swift:
     name: Swift checks
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v6
+
+      - name: Print Apple toolchain
+        run: |
+          sw_vers
+          swift --version
+          xcodebuild -version
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
@@ -119,26 +125,7 @@ jobs:
           tool: cargo-make
 
       - name: Run Swift format lint
-        run: |
-          set -euo pipefail
-
-          SWIFT_FORMAT_REF="603.0.0-prerelease-2026-02-09"
-          SWIFT_FORMAT_REVISION="374ca240478f740794c1e60ea1693c439ee0b317"
-          SWIFT_FORMAT_DIR="$RUNNER_TEMP/swift-format"
-
-          git init "$SWIFT_FORMAT_DIR"
-          git -C "$SWIFT_FORMAT_DIR" remote add origin https://github.com/apple/swift-format.git
-          git -C "$SWIFT_FORMAT_DIR" fetch --depth 1 origin "refs/tags/$SWIFT_FORMAT_REF"
-          git -C "$SWIFT_FORMAT_DIR" checkout --detach FETCH_HEAD
-          test "$(git -C "$SWIFT_FORMAT_DIR" rev-parse HEAD)" = "$SWIFT_FORMAT_REVISION"
-
-          swift run --package-path "$SWIFT_FORMAT_DIR" swift-format \
-            lint \
-            --recursive \
-            --strict \
-            --parallel \
-            native/macos-host/Sources \
-            scripts/smoke/lib/live-hud-mouse-path.swift
+        run: cargo make lint-swift-format
 
       - name: Run SwiftLint and strict build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build-macos:
     name: Build signed macOS package
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v6
@@ -40,6 +40,10 @@ jobs:
             echo "The macOS release asset is named for aarch64; expected an arm64 runner." >&2
             exit 1
           fi
+
+          sw_vers
+          swift --version
+          xcodebuild -version
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://github.com/user-attachments/assets/ff2fe84f-f551-40e8-919c-66ae8a61f8e7
 - Frozen toolbar tools include pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
   OCR, copy, and save.
 - `Esc` cancels capture.
-- Glass HUD with Classic Glass by default and Liquid Glass on supported macOS.
+- Glass HUD with Classic Glass fallback and Liquid Glass in release builds on supported macOS.
 - Tab-triggered loupe sample and frozen-mode toolbar for quick action access.
 
 ## Status
@@ -132,7 +132,7 @@ Rsnap currently relies on **Screen Recording** permission to capture other apps/
 - The native `Settings…` window currently owns:
   - HUD glass enable/disable
   - HUD glass style (`Classic Glass` / `Liquid Glass`)
-  - Liquid Glass style (`Regular` / `Clear`) when supported by macOS
+  - Liquid Glass style (`Regular` / `Clear`) when supported by macOS and the current build
   - shared HUD tint / color, plus Classic Glass opacity / blur
   - HUD `Tab` hint visibility
   - loupe sample size (`small` / `medium` / `large`)

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -7,8 +7,10 @@ artifacts immediately after the tag workflow completes.
 
 Preconditions: `main` is clean and synced, the intended release version is committed in
 `Cargo.toml`, GitHub Actions macOS signing release secrets are configured, optional Apple notary
-credentials are configured only when a notarized build is required, and a logged-in macOS desktop
-session is available for native-host smoke and manual checks.
+credentials are configured only when a notarized build is required, the Release workflow runs the
+macOS package job on `macos-26` with Apple Swift 6.2 or newer so Liquid Glass API support is
+compiled into the app, and a logged-in macOS desktop session is available for native-host smoke and
+manual checks.
 
 Depends on: `docs/spec/app-identity.md`; `docs/spec/settings.md`; `docs/spec/telemetry.md`;
 `docs/runbook/performance-validation.md`; `.github/workflows/release.yml`
@@ -55,7 +57,8 @@ Validate these user-visible flows:
   Recognize Text, copy, and save.
 - Scroll capture is hidden in the v0.1.2 native-host release: the toolbar must not show a scroll
   capture item, and pressing `s` must not enter scroll capture.
-- Light and dark appearance; Classic Glass and Liquid Glass where the OS supports Liquid Glass.
+- Light and dark appearance; Classic Glass and Liquid Glass where the OS and current build support
+  Liquid Glass.
 - Output directory, filename prefix, sequence/timestamp naming, clipboard copy, and save failure
   handling where practical.
 

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -69,6 +69,8 @@ Defines:
 - Frozen resize handles: outward.
 - Live HUD hint keycap: enabled.
 - HUD glass: enabled, `liquid_glass`, `clear`.
+- `liquid_glass` resolves to Classic Glass when the native host is running before macOS 26 or
+  was built without Liquid Glass API support.
 - HUD opacity: `0.4999747693194925`.
 - HUD blur: `0.5032628676470589`.
 - HUD tint: `0.4990234375`.

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -382,14 +382,39 @@ enum LoupeSampleSizePreference: String, CaseIterable {
 }
 
 enum LiveChromeGlassMaterialSupport {
-	static let isLiquidGlassAvailable: Bool = {
+	static let isLiquidGlassBuildSupported: Bool = {
 		#if compiler(>=6.2)
-			if #available(macOS 26.0, *) {
-				return true
-			}
+			return true
+		#else
+			return false
 		#endif
-		return false
 	}()
+
+	static let isMacOSRuntimeSupported: Bool = {
+		let version = ProcessInfo.processInfo.operatingSystemVersion
+		return version.majorVersion >= 26
+	}()
+
+	static var isLiquidGlassAvailable: Bool {
+		isLiquidGlassBuildSupported && isMacOSRuntimeSupported
+	}
+
+	static var unavailableHelpText: String {
+		if isMacOSRuntimeSupported {
+			return "This build was made without Liquid Glass support."
+		}
+		return "Requires macOS 26."
+	}
+
+	static var settingsSubtitle: String {
+		if isLiquidGlassAvailable {
+			return "Liquid or blur."
+		}
+		if isMacOSRuntimeSupported {
+			return "Classic fallback in this build."
+		}
+		return "Classic fallback before macOS 26."
+	}
 }
 
 extension NativeHostSettings {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -723,7 +723,7 @@ private struct HudGlassModePicker: View {
 				) {
 					onSelect(mode)
 				}
-				.help(available ? mode.title : "Requires macOS 26.")
+				.help(available ? mode.title : LiveChromeGlassMaterialSupport.unavailableHelpText)
 			}
 		}
 		.padding(.horizontal, 1)
@@ -1013,9 +1013,7 @@ private struct AppearanceSettingsPanel: View {
 	}
 
 	private var materialSubtitle: String {
-		LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
-			? "Liquid or blur."
-			: "Classic fallback before macOS 26."
+		LiveChromeGlassMaterialSupport.settingsSubtitle
 	}
 
 	private var tintColorBinding: Binding<Color> {

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -58,6 +58,35 @@ fi
 APP_VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -n 1)"
 APP_VERSION="${APP_VERSION:-0.1.2}"
 
+require_liquid_glass_capable_swift_for_release() {
+	[[ "$SWIFT_CONFIGURATION" == "release" ]] || return 0
+
+	local swift_version_output
+	swift_version_output="$(swift --version 2>/dev/null || true)"
+	if python3 - "$swift_version_output" <<'PY'
+import re
+import sys
+
+match = re.search(r"Apple Swift version\s+(\d+)\.(\d+)", sys.argv[1])
+if not match:
+    sys.exit(1)
+
+major, minor = (int(match.group(1)), int(match.group(2)))
+sys.exit(0 if (major, minor) >= (6, 2) else 1)
+PY
+	then
+		return 0
+	fi
+
+	echo "error: release Rsnap native host builds require Apple Swift 6.2 or newer for Liquid Glass support." >&2
+	while IFS= read -r line; do
+		[[ -n "$line" ]] || continue
+		echo "error: found $line" >&2
+	done <<<"$swift_version_output"
+	echo "error: select a newer Xcode or set RSNAP_NATIVE_HOST_SWIFT_CONFIGURATION=debug for a local non-release fallback build." >&2
+	exit 1
+}
+
 relink_native_host_if_missing() {
 	local product_dir link_file swift_frameworks sdk swiftc
 	product_dir="$BUILD_ROOT/$EXECUTABLE_NAME.product"
@@ -313,12 +342,19 @@ sign_staged_app_bundle() {
 }
 
 compute_stage_fingerprint() {
-	python3 - "$ROOT_DIR" "$RUST_PROFILE" "$SWIFT_CONFIGURATION" "$APP_VERSION" <<'PY'
+	local swift_toolchain
+	swift_toolchain="$(
+		{
+			command -v swift
+			swift --version
+		} 2>/dev/null | tr '\n' ' '
+	)"
+	python3 - "$ROOT_DIR" "$RUST_PROFILE" "$SWIFT_CONFIGURATION" "$APP_VERSION" "$swift_toolchain" <<'PY'
 import hashlib
 import os
 import sys
 
-root, rust_profile, swift_configuration, app_version = sys.argv[1:]
+root, rust_profile, swift_configuration, app_version, swift_toolchain = sys.argv[1:]
 targets = [
 	"Cargo.toml",
 	"Cargo.lock",
@@ -336,7 +372,8 @@ targets = [
 skip_dirs = {".git", ".worktrees", "target", ".build"}
 
 hasher = hashlib.sha256()
-for value in (rust_profile, swift_configuration, app_version):
+# Toolchain changes can flip Swift compile-time availability gates, including Liquid Glass.
+for value in (rust_profile, swift_configuration, app_version, swift_toolchain):
 	hasher.update(value.encode("utf-8"))
 	hasher.update(b"\0")
 
@@ -400,6 +437,7 @@ if [[ "$MODE" != "stage" ]]; then
 	terminate_running_host
 fi
 
+require_liquid_glass_capable_swift_for_release
 canonicalize_app_bundle_name
 if [[ "${RSNAP_NATIVE_HOST_FORCE_REBUILD:-0}" != "1" ]] && staged_bundle_is_current; then
 	BUILD_ROOT=""


### PR DESCRIPTION
## Summary
- pin Swift and release GitHub Actions jobs to `macos-26` instead of floating `macos-latest`
- fail release staging when Apple Swift is older than 6.2 and include the Swift toolchain in the stage fingerprint
- clarify Liquid Glass Settings fallback copy and align README/spec/release runbook wording
- remove the old GitHub Actions-only swift-format workaround and route Swift format lint through `cargo make lint-swift-format`

## Root cause
The v0.1.2 GitHub release was built on `macos-latest`, which resolved to `macos-15-arm64` with SDK 15.5. The current Liquid Glass path is guarded by `#if compiler(>=6.2)`, so that release artifact compiled out the Liquid Glass code even when run on macOS 26.4.

## Validation
- `actionlint .github/workflows/language.yml .github/workflows/release.yml`
- `cargo make lint-swift-format`
- `cargo make lint-swift`
- `cargo make test-macos-native-host`
- `cargo make test-macos-native-host-stage`
- release-style `RSNAP_NATIVE_HOST_RUST_PROFILE=final-release RSNAP_NATIVE_HOST_SWIFT_CONFIGURATION=release ./scripts/build_and_run.sh stage`
- fake Swift 6.1 release-stage fail-closed probe
- `git diff --check`

## Notes
Existing v0.1.2 release artifacts still lack Liquid Glass. A new release is required for users to receive a bundle compiled with the macOS 26 SDK.