### PR TITLE
Fix live loupe sampling and chrome stacking

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -373,6 +373,7 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		stateLock.lock()
 		let latestSample = self.latestSample
 		let latestSamplePoint = self.latestSamplePoint
+		let includeLoupePatch = desiredIncludesLoupePatch
 		let running = self.running
 		stateLock.unlock()
 		guard running else {
@@ -387,7 +388,10 @@ final class ChromeSampleFeed: @unchecked Sendable {
 		guard let rgbSample = frameRgbSampler(point) else {
 			return nil
 		}
-		let sample = LiveChromeSample(rgb: rgbSample, loupePatch: nil)
+		let sample = LiveChromeSample(
+			rgb: rgbSample,
+			loupePatch: includeLoupePatch ? latestSample?.loupePatch : nil
+		)
 		stateLock.lock()
 		self.latestSample = sample
 		self.latestSamplePoint = point
@@ -1315,6 +1319,7 @@ private final class LiveScrimLayer: CALayer {
 final class LiveOverlayRenderer {
 	private weak var hostView: NSView?
 	private let rootLayer = CALayer()
+	private let chromeRootLayer = CALayer()
 	private let frozenDisplayLayer = CALayer()
 	private let scrimLayer = LiveScrimLayer()
 	private let topScrimLayer = CALayer()
@@ -1378,6 +1383,8 @@ final class LiveOverlayRenderer {
 		let contentLayer: CALayer
 	}
 	private enum LayerZ {
+		static let root: CGFloat = 100
+		static let chromeRoot: CGFloat = 300
 		static let frozenDisplay: CGFloat = 0
 		static let scrim: CGFloat = 10
 		static let selectionChrome: CGFloat = 30
@@ -1418,7 +1425,9 @@ final class LiveOverlayRenderer {
 			hostView.wantsLayer = true
 		}
 		hostView.layer?.addSublayer(rootLayer)
+		hostView.layer?.addSublayer(chromeRootLayer)
 		rootLayer.isHidden = true
+		chromeRootLayer.isHidden = true
 	}
 
 	func updateDisplayID(_ displayID: CGDirectDisplayID?, targetFramesPerSecond: Int) {
@@ -1467,8 +1476,10 @@ final class LiveOverlayRenderer {
 	}
 
 	private func configureLayers() {
-		rootLayer.zPosition = 100
+		rootLayer.zPosition = LayerZ.root
 		rootLayer.masksToBounds = true
+		chromeRootLayer.zPosition = LayerZ.chromeRoot
+		chromeRootLayer.masksToBounds = true
 		frozenDisplayLayer.isHidden = true
 		frozenDisplayLayer.zPosition = LayerZ.frozenDisplay
 		rootLayer.addSublayer(frozenDisplayLayer)
@@ -1505,7 +1516,7 @@ final class LiveOverlayRenderer {
 		for chromeLayer in [hudLayer, loupeLayer] {
 			chromeLayer.masksToBounds = false
 			chromeLayer.zPosition = LayerZ.hudChrome
-			rootLayer.addSublayer(chromeLayer)
+			chromeRootLayer.addSublayer(chromeLayer)
 		}
 		for hudSublayer in [
 			hudGlassLayer, hudFillLayer, hudStrokeLayer, hudSwatchLayer, hudPositionLayer,
@@ -1560,6 +1571,8 @@ final class LiveOverlayRenderer {
 		CATransaction.setDisableActions(true)
 		rootLayer.isHidden = false
 		rootLayer.frame = snapshot.bounds
+		chromeRootLayer.isHidden = false
+		chromeRootLayer.frame = snapshot.bounds
 		renderFrozenDisplay(snapshot)
 		renderFocus(snapshot)
 		lastRenderedFocusRect = snapshot.dragSelectionLocal ?? snapshot.hoverSelectionLocal
@@ -1579,6 +1592,7 @@ final class LiveOverlayRenderer {
 
 	private func hideRootAndResetRenderState() {
 		rootLayer.isHidden = true
+		chromeRootLayer.isHidden = true
 		lastRenderedFocusRect = nil
 		lastRenderedFocusFlowAnimates = false
 		lastChromeRenderUptime = nil
@@ -1605,6 +1619,8 @@ final class LiveOverlayRenderer {
 		CATransaction.setDisableActions(true)
 		rootLayer.isHidden = false
 		rootLayer.frame = snapshot.bounds
+		chromeRootLayer.isHidden = false
+		chromeRootLayer.frame = snapshot.bounds
 		let chromeExclusions = liveChromeRoundedExclusions(for: snapshot)
 		updateLiveScrimExclusions(excluding: chromeExclusions)
 		updateLiveFlowExclusions(excluding: chromeExclusions)

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -1257,7 +1257,8 @@ private final class SelectionFlowBandLayer: CALayer {
 	}
 }
 
-private final class LiveScrimLayer: CALayer {
+private final class LiveScrimLayer: CAShapeLayer {
+	private var renderedBounds = CGRect.null
 	private var focusRect = CGRect.null
 	private var roundedExclusions: [OverlayMaskGeometry.RoundedExclusion] = []
 	var scrimColor: CGColor =
@@ -1265,19 +1266,26 @@ private final class LiveScrimLayer: CALayer {
 
 	override init() {
 		super.init()
-		isOpaque = false
-		needsDisplayOnBoundsChange = true
+		configureShape()
 	}
 
 	override init(layer: Any) {
 		if let layer = layer as? LiveScrimLayer {
+			renderedBounds = layer.renderedBounds
 			focusRect = layer.focusRect
 			roundedExclusions = layer.roundedExclusions
 			scrimColor = layer.scrimColor
 		}
 		super.init(layer: layer)
+		configureShape()
+	}
+
+	private func configureShape() {
 		isOpaque = false
-		needsDisplayOnBoundsChange = true
+		fillRule = .evenOdd
+		fillColor = scrimColor
+		strokeColor = nil
+		needsDisplayOnBoundsChange = false
 	}
 
 	@available(*, unavailable)
@@ -1290,26 +1298,23 @@ private final class LiveScrimLayer: CALayer {
 		color: CGColor,
 		roundedExclusions: [OverlayMaskGeometry.RoundedExclusion]
 	) {
+		let currentBounds = bounds
 		guard
-			self.focusRect != focusRect
+			renderedBounds != currentBounds
+				|| self.focusRect != focusRect
 				|| !CFEqual(scrimColor, color)
 				|| self.roundedExclusions != roundedExclusions
 		else {
 			return
 		}
+		renderedBounds = currentBounds
 		self.focusRect = focusRect
 		self.scrimColor = color
 		self.roundedExclusions = roundedExclusions
-		setNeedsDisplay()
-	}
-
-	override func draw(in context: CGContext) {
-		context.clear(bounds)
-		OverlayMaskGeometry.drawScrim(
-			in: context,
-			bounds: bounds,
+		fillColor = color
+		path = OverlayMaskGeometry.scrimPath(
+			bounds: currentBounds,
 			focusRect: focusRect,
-			color: scrimColor,
 			roundedExclusions: roundedExclusions
 		)
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -3660,6 +3660,9 @@ final class CaptureOverlayController {
 		if latestSampleSatisfiesDemand {
 			return latestSample
 		}
+		if wantsLoupePatch, latestLoupePatchSatisfiesDemand {
+			return latestSample
+		}
 
 		let _ = point
 		if wantsLoupePatch, let latestSample {
@@ -4331,6 +4334,9 @@ final class CaptureHostView: NSView {
 		)
 	}()
 	private static let pendingHudHexWheel = Array("0123456789ABCDEF")
+	private static let liveChromeLiquidGlassZ: CGFloat = 200
+	private static let frozenToolbarLiquidGlassZ: CGFloat = 300
+	private static let frozenToolbarContentZ: CGFloat = 320
 
 	weak var controller: CaptureSessionController?
 
@@ -6535,7 +6541,7 @@ final class CaptureHostView: NSView {
 	private func currentLoupeFrame(hudFrame: CGRect) -> CGRect? {
 		currentLoupeFrame(
 			hudFrame: hudFrame,
-			patch: chrome.loupePatch,
+			patch: reusableLiveLoupePatch(),
 			alignTrailing: currentHudPlacement()?.flippedHorizontally ?? false
 		)
 	}
@@ -6809,7 +6815,7 @@ final class CaptureHostView: NSView {
 			? hudPlacement.flatMap {
 				currentLoupeFrame(
 					hudFrame: $0.frame,
-					patch: chrome.loupePatch,
+					patch: reusableLiveLoupePatch(),
 					alignTrailing: $0.flippedHorizontally
 				)
 			}
@@ -7009,6 +7015,9 @@ final class CaptureHostView: NSView {
 			seedLiveChromeSampleCache(from: chrome, point: scene.pointer)
 			return cachedLiveChromeSample(matching: point)
 		}
+		if wantsLoupePatch, let cachedPatch = reusableLiveLoupePatch() {
+			return LiveChromeSample(rgb: nil, loupePatch: cachedPatch)
+		}
 		return nil
 	}
 
@@ -7028,13 +7037,40 @@ final class CaptureHostView: NSView {
 				loupePatch: cachedPatch
 			)
 		}
-		if liveSamplePoint(scene.pointer, matches: point), let chromePatch = chrome.loupePatch {
+		if let cachedPatch = reusableLiveLoupePatch() {
+			return LiveChromeSample(
+				rgb: sample.rgb,
+				loupePatch: cachedPatch
+			)
+		}
+		if liveSamplePoint(scene.pointer, matches: point), let chromePatch = chrome.loupePatch,
+			liveLoupePatchMatchesCurrentSize(chromePatch)
+		{
 			return LiveChromeSample(
 				rgb: sample.rgb,
 				loupePatch: chromePatch
 			)
 		}
 		return sample
+	}
+
+	private func reusableLiveLoupePatch() -> CGImage? {
+		if let patch = latestLiveChromeSample?.loupePatch,
+			liveLoupePatchMatchesCurrentSize(patch)
+		{
+			return patch
+		}
+		if let patch = chrome.loupePatch,
+			liveLoupePatchMatchesCurrentSize(patch)
+		{
+			return patch
+		}
+		return nil
+	}
+
+	private func liveLoupePatchMatchesCurrentSize(_ patch: CGImage) -> Bool {
+		let sidePixels = settings.loupeSampleSize.sidePixels
+		return patch.width == sidePixels && patch.height == sidePixels
 	}
 
 	private func liveRgbSample(from sample: LiveChromeSample?, at point: CGPoint?) -> RGBSample? {
@@ -7344,14 +7380,14 @@ final class CaptureHostView: NSView {
 		effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .aqua ? .light : .dark
 	}
 
-	private func configureChromeLiquidGlassView(_ view: NSView) {
+	private func configureChromeLiquidGlassView(_ view: NSView, zPosition: CGFloat) {
 		view.isHidden = true
 		view.wantsLayer = true
 		view.layer?.cornerRadius = CaptureChrome.hudCornerRadius
 		view.layer?.masksToBounds = true
 		view.layer?.shadowOpacity = 0
 		view.layer?.shadowPath = nil
-		view.layer?.zPosition = 50
+		view.layer?.zPosition = zPosition
 	}
 
 	private func configureFrozenToolbarContentView(_ view: FrozenToolbarRenderView) {
@@ -7359,7 +7395,7 @@ final class CaptureHostView: NSView {
 		view.wantsLayer = true
 		view.layer?.backgroundColor = NSColor.clear.cgColor
 		view.layer?.isOpaque = false
-		view.layer?.zPosition = 320
+		view.layer?.zPosition = Self.frozenToolbarContentZ
 	}
 
 	private func updateChromeMaterialViews() {
@@ -7386,8 +7422,16 @@ final class CaptureHostView: NSView {
 			hideLiveLiquidGlassViews(removing: false)
 			return
 		}
-		updateLiveLiquidGlassView(&hudLiquidGlassView, frame: hudFrame)
-		updateLiveLiquidGlassView(&loupeLiquidGlassView, frame: loupeFrame)
+		updateLiveLiquidGlassView(
+			&hudLiquidGlassView,
+			frame: hudFrame,
+			zPosition: Self.liveChromeLiquidGlassZ
+		)
+		updateLiveLiquidGlassView(
+			&loupeLiquidGlassView,
+			frame: loupeFrame,
+			zPosition: Self.liveChromeLiquidGlassZ
+		)
 	}
 
 	private func moveExistingLiveLiquidGlassViews(hudFrame: CGRect?, loupeFrame: CGRect?) {
@@ -7414,7 +7458,11 @@ final class CaptureHostView: NSView {
 		view.isHidden = false
 	}
 
-	private func updateLiveLiquidGlassView(_ view: inout NSView?, frame: CGRect?) {
+	private func updateLiveLiquidGlassView(
+		_ view: inout NSView?,
+		frame: CGRect?,
+		zPosition: CGFloat
+	) {
 		guard let frame else {
 			view?.isHidden = true
 			return
@@ -7423,13 +7471,14 @@ final class CaptureHostView: NSView {
 			guard let createdView = LiveChromeLiquidGlassBridge.makeGlassView() else {
 				return
 			}
-			configureChromeLiquidGlassView(createdView)
+			configureChromeLiquidGlassView(createdView, zPosition: zPosition)
 			addSubview(createdView, positioned: .below, relativeTo: nil)
 			view = createdView
 		}
 		guard let activeView = view else {
 			return
 		}
+		activeView.layer?.zPosition = zPosition
 		LiveChromeLiquidGlassBridge.update(activeView, settings: settings)
 		if activeView.frame != frame {
 			activeView.frame = frame
@@ -7446,11 +7495,13 @@ final class CaptureHostView: NSView {
 		guard let createdView = LiveChromeLiquidGlassBridge.makeGlassView() else {
 			return
 		}
-		configureChromeLiquidGlassView(createdView)
+		configureChromeLiquidGlassView(
+			createdView,
+			zPosition: Self.frozenToolbarLiquidGlassZ
+		)
 		LiveChromeLiquidGlassBridge.update(createdView, settings: settings)
 		createdView.frame = .zero
 		createdView.isHidden = true
-		createdView.layer?.zPosition = 300
 		addSubview(createdView, positioned: .below, relativeTo: nil)
 		toolbarLiquidGlassView = createdView
 		ensureFrozenToolbarContentView(above: createdView)
@@ -7460,7 +7511,7 @@ final class CaptureHostView: NSView {
 	private func ensureFrozenToolbarContentView(above glassView: NSView) -> FrozenToolbarRenderView
 	{
 		if let toolbarLiquidGlassContentView {
-			toolbarLiquidGlassContentView.layer?.zPosition = 320
+			toolbarLiquidGlassContentView.layer?.zPosition = Self.frozenToolbarContentZ
 			return toolbarLiquidGlassContentView
 		}
 		let contentView = FrozenToolbarRenderView(frame: .zero)
@@ -7530,7 +7581,11 @@ final class CaptureHostView: NSView {
 			hideFrozenToolbarLiquidGlassView()
 			return
 		}
-		updateLiveLiquidGlassView(&toolbarLiquidGlassView, frame: layout.frame)
+		updateLiveLiquidGlassView(
+			&toolbarLiquidGlassView,
+			frame: layout.frame,
+			zPosition: Self.frozenToolbarLiquidGlassZ
+		)
 		guard let toolbarLiquidGlassView else {
 			frozenToolbarLiquidGlassVisible = false
 			frozenToolbarLiquidGlassContentDrawn = false
@@ -7540,7 +7595,7 @@ final class CaptureHostView: NSView {
 			}
 			return
 		}
-		toolbarLiquidGlassView.layer?.zPosition = 300
+		toolbarLiquidGlassView.layer?.zPosition = Self.frozenToolbarLiquidGlassZ
 		let contentView = ensureFrozenToolbarContentView(above: toolbarLiquidGlassView)
 		let frameChanged = contentView.frame != layout.frame
 		if contentView.frame != layout.frame {

--- a/native/macos-host/Sources/RsnapNativeHostKit/OverlayMaskGeometry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/OverlayMaskGeometry.swift
@@ -25,53 +25,53 @@ package enum OverlayMaskGeometry {
 	) {
 		context.saveGState()
 		context.setFillColor(color)
-		context.fill(bounds)
 		context.clip(to: bounds)
-		context.setBlendMode(.clear)
-		clearRect(focusRect, in: context)
-		for exclusion in roundedExclusions {
-			clearRoundedRect(exclusion, in: context)
-		}
-		for path in pathExclusions {
-			context.addPath(path)
-			context.fillPath()
-		}
+		context.addPath(
+			scrimPath(
+				bounds: bounds,
+				focusRect: focusRect,
+				roundedExclusions: roundedExclusions,
+				pathExclusions: pathExclusions
+			)
+		)
+		context.fillPath(using: .evenOdd)
 		context.restoreGState()
+	}
+
+	package static func scrimPath(
+		bounds: CGRect,
+		focusRect: CGRect,
+		roundedExclusions: [RoundedExclusion] = [],
+		pathExclusions: [CGPath] = []
+	) -> CGPath {
+		let path = CGMutablePath()
+		guard bounds.isRenderableMaskRect else {
+			return path
+		}
+		path.addRect(bounds)
+		if focusRect.isRenderableMaskRect {
+			path.addRect(focusRect)
+		}
+		for exclusion in roundedExclusions {
+			if let exclusionPath = roundedPath(for: exclusion) {
+				path.addPath(exclusionPath)
+			}
+		}
+		for exclusionPath in pathExclusions {
+			path.addPath(exclusionPath)
+		}
+		return path
 	}
 
 	package static func evenOddMaskPath(
 		bounds: CGRect,
 		roundedExclusions: [RoundedExclusion]
 	) -> CGPath {
-		let maskPath = CGMutablePath()
-		guard bounds.isRenderableMaskRect else {
-			return maskPath
-		}
-		maskPath.addRect(bounds)
-		for exclusion in roundedExclusions {
-			if let path = roundedPath(for: exclusion) {
-				maskPath.addPath(path)
-			}
-		}
-		return maskPath
-	}
-
-	private static func clearRect(_ rect: CGRect, in context: CGContext) {
-		guard rect.isRenderableMaskRect else {
-			return
-		}
-		context.fill(rect)
-	}
-
-	private static func clearRoundedRect(
-		_ exclusion: RoundedExclusion,
-		in context: CGContext
-	) {
-		guard let path = roundedPath(for: exclusion) else {
-			return
-		}
-		context.addPath(path)
-		context.fillPath()
+		scrimPath(
+			bounds: bounds,
+			focusRect: .null,
+			roundedExclusions: roundedExclusions
+		)
 	}
 
 	private static func roundedPath(for exclusion: RoundedExclusion) -> CGPath? {


### PR DESCRIPTION
## Summary
- keep live loupe visible by reusing the latest compatible loupe patch while fresh RGB sampling catches up
- keep HUD/loupe glass and chrome above selection flow without reintroducing dynamic flow masking
- move scrim hole geometry to a shared even-odd path so HUD/loupe glass can keep punchouts without clear-blend residue

## Verification
- cargo make fmt-swift-check
- cargo make build-swift-strict
- cargo make test-macos-native-host
- HUD_FOLLOW_CASES=loupe PATH_DURATION_MS=1800 PATH_CYCLES=2 scripts/smoke/native-hud-follow-macos.sh
- VISUAL_CONTRACT_CASES=liquid REPEATED_DRAG_FREEZES=1 REPEATED_CLICK_FREEZES=0 scripts/smoke/native-visual-contract-macos.sh
- git diff --check