### PR TITLE
Fix release workflow version scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+
           for required_secret in \
             APPLE_CERTIFICATE_P12_BASE64 \
             APPLE_CERTIFICATE_PASSWORD \


### PR DESCRIPTION
## Summary
- define VERSION inside the release packaging step before appcast generation

## Validation
- actionlint .github/workflows/release.yml
- git diff --check
