### PR TITLE
Add status menu maintenance actions

### DIFF
--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -38,7 +38,10 @@ Defines:
 
 ## Status Menu
 
-- The status menu must expose New Capture, Settings, and Quit.
+- The status menu must expose New Capture, Open Screenshots Folder, Check for Updates, Settings,
+  and Quit.
+- Open Screenshots Folder must open the configured output directory, creating it first when needed.
+- Check for Updates must invoke the same Sparkle-backed update check flow as the About section.
 - The status menu must not expose Cancel Capture. Capture cancellation is handled in-session by
   `Esc` and secondary click in both live and Frozen modes.
 - The status menu must not expose Permissions as a separate menu item. Permission status and

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -438,6 +438,27 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		settingsWindowController.present()
 	}
 
+	@objc
+	private func openScreenshotsFolder(_ sender: Any?) {
+		let outputDirectory = settingsStore.settings.outputDirectory
+		do {
+			try FileManager.default.createDirectory(
+				at: outputDirectory,
+				withIntermediateDirectories: true)
+			NSWorkspace.shared.open(outputDirectory)
+			NativeHostTelemetry.lifecycleEvent("native_host.output_directory_opened")
+		} catch {
+			NativeHostTelemetry.lifecycleWarning(
+				"native_host.output_directory_open_failed",
+				detail: "reason=create_or_open_failed")
+		}
+	}
+
+	@objc
+	private func checkForUpdates(_ sender: Any?) {
+		softwareUpdater.checkForUpdates(sender)
+	}
+
 	private func scheduleLaunchPermissionOnboardingIfNeeded() {
 		DispatchQueue.main.async { [weak self] in
 			_ = self?.presentPermissionRecoveryIfNeeded(
@@ -522,6 +543,15 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 			action: #selector(startCapture(_:)),
 			keyEquivalent: ""
 		)
+		menu.addItem(.separator())
+		menu.addItem(
+			withTitle: "Open Screenshots Folder",
+			action: #selector(openScreenshotsFolder(_:)),
+			keyEquivalent: "")
+		menu.addItem(
+			withTitle: "Check for Updates…",
+			action: #selector(checkForUpdates(_:)),
+			keyEquivalent: "")
 		menu.addItem(.separator())
 		menu.addItem(
 			withTitle: "Settings…", action: #selector(openSettings(_:)), keyEquivalent: ",")


### PR DESCRIPTION
## Summary
- add Open Screenshots Folder to the menu bar menu
- add Check for Updates… to the menu bar menu using the existing Sparkle flow
- update the Settings/status-menu spec

## Validation
- cargo make fmt-swift
- cargo make lint-swift
- cargo make test-macos-native-host
- cargo make test-macos-native-host-stage
- git diff --check
- semantic drift audit: pass
