### PR TITLE
Default Sparkle public update key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,6 @@ jobs:
           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           APPLE_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
           APPLE_NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
-          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
           SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
           set -euo pipefail
@@ -70,7 +69,6 @@ jobs:
             APPLE_CERTIFICATE_P12_BASE64 \
             APPLE_CERTIFICATE_PASSWORD \
             APPLE_SIGNING_IDENTITY \
-            SPARKLE_PUBLIC_ED_KEY \
             SPARKLE_PRIVATE_ED_KEY; do
             if [[ -z "${!required_secret:-}" ]]; then
               echo "Missing required secret: ${required_secret}" >&2
@@ -120,7 +118,6 @@ jobs:
           RSNAP_NATIVE_HOST_RUST_PROFILE=final-release \
           RSNAP_NATIVE_HOST_SWIFT_CONFIGURATION=release \
           RSNAP_NATIVE_HOST_SIGN_IDENTITY="${APPLE_SIGNING_IDENTITY}" \
-          RSNAP_SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY}" \
           ./scripts/build_and_run.sh stage
 
           APP_PATH="target/rsnap-native-host/Rsnap.app"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -269,6 +269,8 @@ plutil -extract CFBundleDisplayName raw "$APP_PATH/Contents/Info.plist" | grep -
 plutil -extract CFBundleIdentifier raw "$APP_PATH/Contents/Info.plist" | grep -qx 'ink.hack.rsnap'
 plutil -extract SUFeedURL raw "$APP_PATH/Contents/Info.plist" \
   | grep -qx 'https://github.com/hack-ink/rsnap/releases/latest/download/appcast.xml'
+plutil -extract SUPublicEDKey raw "$APP_PATH/Contents/Info.plist" \
+  | grep -qx 'X2EaTv6mCzkYxz75Hh+ldMkKlpzNlHRg5l7Kn9ke8Ow='
 plutil -extract SUEnableAutomaticChecks raw "$APP_PATH/Contents/Info.plist" | grep -qx 'true'
 plutil -extract SUAutomaticallyUpdate raw "$APP_PATH/Contents/Info.plist" | grep -qx 'true'
 plutil -extract SUScheduledCheckInterval raw "$APP_PATH/Contents/Info.plist" | grep -qx '86400'

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -26,9 +26,9 @@ manual first-run/user-flow validation.
    - No existing local or remote tag already uses `v<version>`.
 2. Confirm release credentials:
    - Apple signing certificate secrets are available to the Release workflow.
-   - Sparkle update signing secrets are available to the Release workflow:
-     `SPARKLE_PUBLIC_ED_KEY` for `SUPublicEDKey` and `SPARKLE_PRIVATE_ED_KEY` for signing the
-     published update archive.
+   - Sparkle update signing is configured: `SUPublicEDKey` is checked into
+     `scripts/build_and_run.sh`, and `SPARKLE_PRIVATE_ED_KEY` is available to the Release workflow
+     for signing the published update archive.
    - Apple notary credentials are optional for v0.1.4; when absent, the Release workflow still
      publishes a signed but unnotarized macOS zip.
 3. Confirm local gates:

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -7,6 +7,7 @@ EXECUTABLE_NAME="RsnapNativeHost"
 BUNDLE_ID="ink.hack.rsnap"
 MIN_SYSTEM_VERSION="14.0"
 DEFAULT_SIGN_IDENTITY="x@acg.box"
+DEFAULT_SPARKLE_PUBLIC_ED_KEY="X2EaTv6mCzkYxz75Hh+ldMkKlpzNlHRg5l7Kn9ke8Ow="
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_DIR="$ROOT_DIR/native/macos-host"
@@ -26,7 +27,9 @@ APP_ICON_NAME="AppIcon.icns"
 STATUS_ICON_SOURCE="$ROOT_DIR/assets/tray-icon/generated/tray-icon-template.png"
 STATUS_ICON_NAME="StatusBarIcon.png"
 SPARKLE_APPCAST_URL="${RSNAP_SPARKLE_APPCAST_URL:-https://github.com/hack-ink/rsnap/releases/latest/download/appcast.xml}"
-SPARKLE_PUBLIC_ED_KEY="${RSNAP_SPARKLE_PUBLIC_ED_KEY:-}"
+# The public update key is safe to ship in source. The override exists only for
+# local Sparkle smoke tests that generate a disposable key pair and appcast.
+SPARKLE_PUBLIC_ED_KEY="${RSNAP_SPARKLE_PUBLIC_ED_KEY:-$DEFAULT_SPARKLE_PUBLIC_ED_KEY}"
 BUILD_ROOT=""
 BUILD_BINARY=""
 SWIFT_BUILD_FLAGS=()
@@ -318,16 +321,10 @@ stage_app_bundle() {
   <true/>
   <key>SUAllowsAutomaticUpdates</key>
   <true/>
-PLIST
-)"
-
-	if [[ -n "$SPARKLE_PUBLIC_ED_KEY" ]]; then
-		info_plist_contents+="$(cat <<PLIST
   <key>SUPublicEDKey</key>
   <string>$SPARKLE_PUBLIC_ED_KEY</string>
 PLIST
 )"
-	fi
 
 	if [[ -f "$APP_RESOURCES/$APP_ICON_NAME" ]]; then
 		info_plist_contents+="$(cat <<PLIST


### PR DESCRIPTION
## Summary
- Ship the Sparkle public EdDSA update key as the default bundled SUPublicEDKey.
- Keep RSNAP_SPARKLE_PUBLIC_ED_KEY as the local Sparkle smoke-test override.
- Remove the release workflow public-key secret requirement and align the release runbook/stage validation.

## Validation
- git diff --check
- bash -n scripts/build_and_run.sh
- actionlint .github/workflows/release.yml
- cargo make fmt-toml-check
- python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py (agent verdict: pass)
- cargo make test-macos-native-host-stage