### PR TITLE
Check Sparkle updates on launch

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -157,7 +157,6 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		refreshStatusMenuState()
 		sessionController.prepareLiveFrameStreamSampler(reason: "launch")
 		scheduleLaunchPermissionOnboardingIfNeeded()
-		scheduleLaunchUpdateCheckIfEnabled()
 		DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) { [weak self] in
 			self?.sessionController.refreshShareableContentCacheIfPermitted(source: "launch")
 		}
@@ -263,12 +262,6 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 				source: "launch",
 				oncePerLaunch: true
 			)
-		}
-	}
-
-	private func scheduleLaunchUpdateCheckIfEnabled() {
-		Task { @MainActor [weak self] in
-			self?.softwareUpdater.checkForUpdatesInBackgroundOnLaunchIfEnabled()
 		}
 	}
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSoftwareUpdater.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSoftwareUpdater.swift
@@ -64,11 +64,13 @@ final class NativeHostSoftwareUpdater {
 
 	init() {
 		if Self.hasSparkleConfiguration {
-			updaterController = SPUStandardUpdaterController(
+			let controller = SPUStandardUpdaterController(
 				startingUpdater: true,
 				updaterDelegate: nil,
 				userDriverDelegate: nil)
+			updaterController = controller
 			NativeHostTelemetry.lifecycleEvent("native_host.sparkle_updater_started")
+			requestImmediateLaunchUpdateCheckIfEnabled(using: controller.updater)
 		} else {
 			updaterController = nil
 			NativeHostTelemetry.lifecycleWarning(
@@ -132,14 +134,17 @@ final class NativeHostSoftwareUpdater {
 		updaterController.checkForUpdates(sender)
 	}
 
-	func checkForUpdatesInBackgroundOnLaunchIfEnabled() {
-		guard let updater = updaterController?.updater else {
-			return
-		}
+	private func requestImmediateLaunchUpdateCheckIfEnabled(using updater: SPUUpdater) {
 		guard updater.automaticallyChecksForUpdates else {
 			NativeHostTelemetry.lifecycleDebug(
 				"native_host.sparkle_update_check_skipped",
 				detail: "source=launch,reason=disabled")
+			return
+		}
+		guard updater.sessionInProgress == false else {
+			NativeHostTelemetry.lifecycleDebug(
+				"native_host.sparkle_update_check_skipped",
+				detail: "source=launch,reason=session_in_progress")
 			return
 		}
 		updater.checkForUpdatesInBackground()
@@ -174,7 +179,7 @@ final class NativeHostSoftwareUpdater {
 		guard let checkedAt else {
 			return "Never checked."
 		}
-		return "Last checked \(checkedAt.formatted(date: .abbreviated, time: .shortened))."
+		return "Checked \(checkedAt.formatted(date: .omitted, time: .shortened))."
 	}
 
 	private static func nonEmptyInfoValue(forKey key: String) -> String? {


### PR DESCRIPTION
## Summary
- request a Sparkle background update check immediately after the updater starts when Auto Update is Notify or Install
- remove the later async launch scheduling path
- shorten the About Auto Update timestamp to `Checked <time>` so it fits the row

## Verification
- cargo make fmt-swift
- cargo make check-swift
- cargo make check-vstyle-swift
- cargo make test-macos-native-host
- scripts/build_and_run.sh --verify