### PR TITLE
Restore scroll capture toolbar actions

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -2227,7 +2227,7 @@ final class CaptureHostView: NSView {
 			case .scroll:
 				item.enabled = controller?.scrollCaptureToolbarEnabled ?? false
 			case .ocr:
-				item.enabled = originalItem.enabled && !scrollCaptureActive
+				item.enabled = originalItem.enabled
 			case .copy, .save:
 				item.enabled = originalItem.enabled
 			}

--- a/packages/rsnap-capture-core/src/session.rs
+++ b/packages/rsnap-capture-core/src/session.rs
@@ -147,12 +147,15 @@ impl CaptureSessionCore {
 	pub fn handle_host_report(&mut self, report: HostReport) {
 		match report {
 			HostReport::FreezeSnapshotCommitted { selection } => {
+				let selection_editable = self.pending_frozen_selection_editable
+					|| (self.scene.mode == CaptureMode::Frozen && self.frozen_selection_editable);
+
 				self.scene.mode = CaptureMode::Frozen;
 				self.scene.live_selection_preview = None;
 				self.scene.frozen_selection = Some(selection);
 				self.scene.active_monitor = None;
 				self.scene.highlighted_window = None;
-				self.frozen_selection_editable = self.pending_frozen_selection_editable;
+				self.frozen_selection_editable = selection_editable;
 				self.pending_frozen_selection_editable = false;
 				self.scene.cursor_intent = if self.frozen_selection_editable {
 					CursorIntent::Grab
@@ -886,6 +889,29 @@ mod tests {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
 
 		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
+
+		assert!(
+			session
+				.scene_model()
+				.toolbar_items
+				.iter()
+				.any(|item| item.kind == ToolbarItemKind::Scroll && item.enabled)
+		);
+
+		session.handle_host_event(HostEvent::ToolbarItemInvoked { item: ToolbarItemKind::Scroll });
+
+		assert_eq!(session.pop_host_request(), Some(HostRequest::StartScrollCapture));
+	}
+
+	#[test]
+	fn scroll_toolbar_survives_drag_region_recommit() {
+		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
+
+		enter_frozen_with_drag_selection(&mut session, GlobalRect::new(10, 20, 100, 50));
+
+		session.handle_host_report(HostReport::FreezeSnapshotCommitted {
+			selection: GlobalRect::new(20, 30, 100, 50),
+		});
 
 		assert!(
 			session


### PR DESCRIPTION
## Summary
- keep Recognize Text enabled while scroll capture is active so OCR can run on the scroll export
- preserve dragged-region editability across frozen selection recommits from move/auto-center flows so Scroll Screenshot remains available
- add regression coverage for starting scroll capture after a drag-region recommit

## Verification
- cargo make fmt-rust-check
- cargo make check-vstyle-rust
- cargo make test-host-reset
- cargo make check-rust
- cargo make fmt-swift-check
- cargo make check-swift
- cargo make test-macos-native-host
- cargo make check-vstyle-swift
- git diff --check
