### PR TITLE
Apply capture frame backgrounds to scroll capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
   - `Filename Prefix` (default: `Rsnap`, sanitized to `[A-Za-z0-9_-]`)
   - `Naming` (`Timestamp` or `Sequence`)
   - `Frame Preset` (`Off`, wallpaper, or gradient backgrounds)
-  - `Apply To` for drag-region, window, and scroll captures; fullscreen captures are excluded
+  - `Apply To` for drag-region and window captures; scroll capture follows drag-region, and
+    fullscreen captures are excluded
 
 ### Current scroll-capture status
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
   - `Filename Prefix` (default: `Rsnap`, sanitized to `[A-Za-z0-9_-]`)
   - `Naming` (`Timestamp` or `Sequence`)
   - `Frame Preset` (`Off`, wallpaper, or gradient backgrounds)
-  - `Apply To` for drag-region and window captures; fullscreen captures are excluded
+  - `Apply To` for drag-region, window, and scroll captures; fullscreen captures are excluded
 
 ### Current scroll-capture status
 

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -107,8 +107,8 @@ Defines:
   the current wallpaper path and present pixels, but bounded wallpaper thumbnail decoding and caching
   are Rust-owned.
 - Apply To must be disabled while Frame Preset is Off.
-- Capture frame effects may apply to drag-region captures, window captures, scroll captures, or all
-  three. Fullscreen captures are excluded from this setting.
+- Capture frame effects may apply to drag-region captures, window captures, or both. Scroll capture
+  follows drag-region applicability, and fullscreen captures are excluded from this setting.
 
 ## Permission Settings
 

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -107,8 +107,8 @@ Defines:
   the current wallpaper path and present pixels, but bounded wallpaper thumbnail decoding and caching
   are Rust-owned.
 - Apply To must be disabled while Frame Preset is Off.
-- Capture frame effects may apply to drag-region captures, window captures, or both. Fullscreen
-  captures are excluded from this setting.
+- Capture frame effects may apply to drag-region captures, window captures, scroll captures, or all
+  three. Fullscreen captures are excluded from this setting.
 
 ## Permission Settings
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Export.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Export.swift
@@ -160,6 +160,14 @@ extension CaptureSessionController {
 		}
 
 		if let scrollExport = try activeScrollCaptureExportImage() {
+			let result =
+				applyingCaptureFrameEffect
+				? applyCaptureFrameEffectIfNeeded(
+					to: scrollExport,
+					selection: selection,
+					hasOverlayEdits: false
+				)
+				: scrollExport
 			NativeHostTelemetry.frozenSelectionImageTiming(
 				captureID: currentCaptureTelemetryID,
 				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
@@ -168,11 +176,11 @@ extension CaptureSessionController {
 				compositeMilliseconds: 0,
 				source: "scroll_capture_export",
 				success: true,
-				width: scrollExport.width,
-				height: scrollExport.height,
+				width: result.width,
+				height: result.height,
 				hasOverlayEdits: false
 			)
-			return scrollExport
+			return result
 		}
 
 		let snapshotMatchedBefore = chromeState.frozenSelectionSnapshot == selection

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -200,6 +200,7 @@ struct NativeHostSettings: Equatable {
 		copy.hudTintHue = copy.hudTintHue.clamped(to: 0...1)
 		copy.hudTintSaturation = copy.hudTintSaturation.clamped(to: 0...1)
 		copy.hudTintBrightness = copy.hudTintBrightness.clamped(to: 0...1)
+		copy.captureFrameApplicability = copy.captureFrameApplicability.normalizedForStorage
 		return copy
 	}
 
@@ -431,7 +432,11 @@ package enum CaptureFrameBackgroundPreference: String, CaseIterable {
 enum CaptureFrameApplicabilityPreference: String, CaseIterable {
 	case dragRegion = "drag_region"
 	case window
+	case scrollCapture = "scroll_capture"
+	case all
 	case both
+
+	static let allCases: [Self] = [.dragRegion, .window, .scrollCapture, .all]
 
 	var title: String {
 		switch self {
@@ -439,18 +444,27 @@ enum CaptureFrameApplicabilityPreference: String, CaseIterable {
 			return "Drag"
 		case .window:
 			return "Window"
-		case .both:
-			return "Both"
+		case .scrollCapture:
+			return "Scroll"
+		case .all, .both:
+			return "All"
 		}
+	}
+
+	var normalizedForStorage: Self {
+		self == .both ? .all : self
 	}
 
 	func includes(_ source: CaptureFrameSource) -> Bool {
 		switch (self, source) {
-		case (.dragRegion, .dragRegion), (.window, .window), (.both, .dragRegion),
-			(.both, .window):
+		case (.dragRegion, .dragRegion), (.window, .window),
+			(.scrollCapture, .scrollCapture), (.all, .dragRegion),
+			(.all, .window), (.all, .scrollCapture), (.both, .dragRegion),
+			(.both, .window), (.both, .scrollCapture):
 			return true
-		case (.dragRegion, .window), (.window, .dragRegion), (_, .fullScreen),
-			(_, .scrollCapture), (_, .unknown):
+		case (.dragRegion, .window), (.dragRegion, .scrollCapture), (.window, .dragRegion),
+			(.window, .scrollCapture), (.scrollCapture, .dragRegion), (.scrollCapture, .window),
+			(_, .fullScreen), (_, .unknown):
 			return false
 		}
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -436,7 +436,7 @@ enum CaptureFrameApplicabilityPreference: String, CaseIterable {
 	case all
 	case both
 
-	static let allCases: [Self] = [.dragRegion, .window, .scrollCapture, .all]
+	static let allCases: [Self] = [.dragRegion, .window, .all]
 
 	var title: String {
 		switch self {
@@ -447,24 +447,31 @@ enum CaptureFrameApplicabilityPreference: String, CaseIterable {
 		case .scrollCapture:
 			return "Scroll"
 		case .all, .both:
-			return "All"
+			return "Both"
 		}
 	}
 
 	var normalizedForStorage: Self {
-		self == .both ? .all : self
+		switch self {
+		case .scrollCapture:
+			return .dragRegion
+		case .both:
+			return .all
+		case .dragRegion, .window, .all:
+			return self
+		}
 	}
 
 	func includes(_ source: CaptureFrameSource) -> Bool {
 		switch (self, source) {
-		case (.dragRegion, .dragRegion), (.window, .window),
-			(.scrollCapture, .scrollCapture), (.all, .dragRegion),
+		case (.dragRegion, .dragRegion), (.dragRegion, .scrollCapture),
+			(.window, .window), (.scrollCapture, .scrollCapture), (.all, .dragRegion),
 			(.all, .window), (.all, .scrollCapture), (.both, .dragRegion),
 			(.both, .window), (.both, .scrollCapture):
 			return true
-		case (.dragRegion, .window), (.dragRegion, .scrollCapture), (.window, .dragRegion),
-			(.window, .scrollCapture), (.scrollCapture, .dragRegion), (.scrollCapture, .window),
-			(_, .fullScreen), (_, .unknown):
+		case (.dragRegion, .window), (.window, .dragRegion), (.window, .scrollCapture),
+			(.scrollCapture, .dragRegion), (.scrollCapture, .window), (_, .fullScreen),
+			(_, .unknown):
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary
- apply capture-frame backgrounds to scroll-capture copy/save exports
- keep Apply To as Drag / Window / Both, with scroll capture following Drag
- update README and settings spec to match the merged applicability semantics

## Verification
- cargo make fmt-swift-check
- cargo make check-swift
- cargo make check-vstyle-swift
- git diff --check
- scripts/build_and_run.sh --verify