### PR TITLE
Optimize frozen capture export performance

### DIFF
--- a/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
+++ b/native/macos-host/Sources/RsnapHostBridge/HostFFI.swift
@@ -153,7 +153,7 @@ private func cgRect(from rect: RsnapPixelRect) -> CGRect {
 	)
 }
 
-public enum FrozenOverlayExportColor: UInt32, Equatable {
+public enum FrozenOverlayExportColor: UInt32, Equatable, Sendable {
 	case white = 0
 	case yellow = 1
 	case green = 2
@@ -179,7 +179,7 @@ public enum FrozenOverlayExportColor: UInt32, Equatable {
 	}
 }
 
-public struct FrozenOverlayExportStrokeStyle: Equatable {
+public struct FrozenOverlayExportStrokeStyle: Equatable, Sendable {
 	public var strokeWidthPoints: CGFloat
 	public var color: FrozenOverlayExportColor
 
@@ -189,7 +189,7 @@ public struct FrozenOverlayExportStrokeStyle: Equatable {
 	}
 }
 
-public struct FrozenOverlayExportSpotlightStyle: Equatable {
+public struct FrozenOverlayExportSpotlightStyle: Equatable, Sendable {
 	public var borderWidthPoints: CGFloat
 	public var borderColor: FrozenOverlayExportColor
 
@@ -199,7 +199,7 @@ public struct FrozenOverlayExportSpotlightStyle: Equatable {
 	}
 }
 
-public struct FrozenOverlayExportTextStyle: Equatable {
+public struct FrozenOverlayExportTextStyle: Equatable, Sendable {
 	public var fontSizePoints: CGFloat
 	public var color: FrozenOverlayExportColor
 
@@ -209,7 +209,7 @@ public struct FrozenOverlayExportTextStyle: Equatable {
 	}
 }
 
-public enum FrozenOverlayExportElement: Equatable {
+public enum FrozenOverlayExportElement: Equatable, Sendable {
 	case pen(points: [CGPoint], style: FrozenOverlayExportStrokeStyle)
 	case arrow(start: CGPoint, end: CGPoint, style: FrozenOverlayExportStrokeStyle)
 	case mosaic(rect: CGRect)

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureFrameEffect.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureFrameEffect.swift
@@ -2,7 +2,12 @@ import AppKit
 import CoreGraphics
 import RsnapHostBridge
 
-package enum CaptureFrameSource: Equatable {
+package struct CaptureFrameRenderEnvironment: Equatable, Sendable {
+	let screenScaleFactor: CGFloat
+	let wallpaperPath: String?
+}
+
+package enum CaptureFrameSource: Equatable, Sendable {
 	case dragRegion
 	case window
 	case fullScreen
@@ -20,9 +25,69 @@ package enum CaptureFrameEffectRenderer {
 		renderWithRust(
 			image: image,
 			background: background,
-			screen: screen,
 			source: source,
-			renderKind: .framedCapture
+			renderKind: .framedCapture,
+			environment: environment(for: background, screen: screen)
+		)
+	}
+
+	package static func render(
+		image: CGImage,
+		background: CaptureFrameBackgroundPreference,
+		source: CaptureFrameSource,
+		environment: CaptureFrameRenderEnvironment
+	) -> CGImage? {
+		guard
+			let rendered = renderSnapshot(
+				image: image,
+				background: background,
+				source: source,
+				environment: environment
+			)
+		else {
+			return nil
+		}
+
+		return NativeHostImageBridge.cgImage(from: rendered, shouldInterpolate: true)
+	}
+
+	package static func renderSnapshot(
+		image: CGImage,
+		background: CaptureFrameBackgroundPreference,
+		source: CaptureFrameSource,
+		environment: CaptureFrameRenderEnvironment
+	) -> RGBARegionSnapshot? {
+		guard
+			let sourceSnapshot = NativeHostImageBridge.rgbaSnapshot(
+				from: image,
+				interpolationQuality: .high,
+				bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+			)
+		else {
+			return nil
+		}
+
+		return renderWithRust(
+			sourceSnapshot: sourceSnapshot,
+			background: background,
+			sourceKind: source,
+			renderKind: .framedCapture,
+			environment: environment
+		)
+	}
+
+	package static func renderSnapshot(
+		source: RGBARegionSnapshot,
+		background: CaptureFrameBackgroundPreference,
+		sourceKind: CaptureFrameSource,
+		environment: CaptureFrameRenderEnvironment
+	) -> RGBARegionSnapshot? {
+		renderWithRust(
+			sourceSnapshot: source,
+			background: background,
+			sourceKind: sourceKind,
+			renderKind: .framedCapture,
+			environment: environment
 		)
 	}
 
@@ -34,9 +99,51 @@ package enum CaptureFrameEffectRenderer {
 		renderWithRust(
 			image: image,
 			background: background,
-			screen: screen,
 			source: .window,
-			renderKind: .windowSnapshot
+			renderKind: .windowSnapshot,
+			environment: environment(for: background, screen: screen)
+		)
+	}
+
+	package static func renderWindowSnapshot(
+		image: CGImage,
+		background: CaptureFrameBackgroundPreference,
+		environment: CaptureFrameRenderEnvironment
+	) -> CGImage? {
+		guard
+			let rendered = renderWindowSnapshotSnapshot(
+				image: image,
+				background: background,
+				environment: environment
+			)
+		else {
+			return nil
+		}
+
+		return NativeHostImageBridge.cgImage(from: rendered, shouldInterpolate: true)
+	}
+
+	package static func renderWindowSnapshotSnapshot(
+		image: CGImage,
+		background: CaptureFrameBackgroundPreference,
+		environment: CaptureFrameRenderEnvironment
+	) -> RGBARegionSnapshot? {
+		guard
+			let sourceSnapshot = NativeHostImageBridge.rgbaSnapshot(
+				from: image,
+				interpolationQuality: .high,
+				bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+			)
+		else {
+			return nil
+		}
+
+		return renderWithRust(
+			sourceSnapshot: sourceSnapshot,
+			background: background,
+			sourceKind: .window,
+			renderKind: .windowSnapshot,
+			environment: environment
 		)
 	}
 
@@ -68,10 +175,32 @@ package enum CaptureFrameEffectRenderer {
 	private static func renderWithRust(
 		image: CGImage,
 		background: CaptureFrameBackgroundPreference,
-		screen: NSScreen?,
 		source: CaptureFrameSource,
-		renderKind: CaptureFrameRenderKind
+		renderKind: CaptureFrameRenderKind,
+		environment: CaptureFrameRenderEnvironment
 	) -> CGImage? {
+		guard
+			let rendered = renderSnapshot(
+				from: image,
+				background: background,
+				source: source,
+				renderKind: renderKind,
+				environment: environment
+			)
+		else {
+			return nil
+		}
+
+		return NativeHostImageBridge.cgImage(from: rendered, shouldInterpolate: true)
+	}
+
+	private static func renderSnapshot(
+		from image: CGImage,
+		background: CaptureFrameBackgroundPreference,
+		source: CaptureFrameSource,
+		renderKind: CaptureFrameRenderKind,
+		environment: CaptureFrameRenderEnvironment
+	) -> RGBARegionSnapshot? {
 		guard
 			let sourceSnapshot = NativeHostImageBridge.rgbaSnapshot(
 				from: image,
@@ -81,20 +210,41 @@ package enum CaptureFrameEffectRenderer {
 		else {
 			return nil
 		}
-		guard
-			let rendered = try? RsnapCaptureFrameRenderer.render(
-				source: sourceSnapshot,
-				background: background.planKind,
-				screenScaleFactor: screen?.backingScaleFactor ?? 2,
-				sourceKind: source.planKind,
-				renderKind: renderKind,
-				wallpaperPath: systemWallpaperPath(for: background, screen: screen)
-			)
-		else {
-			return nil
-		}
 
-		return NativeHostImageBridge.cgImage(from: rendered, shouldInterpolate: true)
+		return renderWithRust(
+			sourceSnapshot: sourceSnapshot,
+			background: background,
+			sourceKind: source,
+			renderKind: renderKind,
+			environment: environment
+		)
+	}
+
+	private static func renderWithRust(
+		sourceSnapshot: RGBARegionSnapshot,
+		background: CaptureFrameBackgroundPreference,
+		sourceKind: CaptureFrameSource,
+		renderKind: CaptureFrameRenderKind,
+		environment: CaptureFrameRenderEnvironment
+	) -> RGBARegionSnapshot? {
+		try? RsnapCaptureFrameRenderer.render(
+			source: sourceSnapshot,
+			background: background.planKind,
+			screenScaleFactor: environment.screenScaleFactor,
+			sourceKind: sourceKind.planKind,
+			renderKind: renderKind,
+			wallpaperPath: environment.wallpaperPath
+		)
+	}
+
+	private static func environment(
+		for background: CaptureFrameBackgroundPreference,
+		screen: NSScreen?
+	) -> CaptureFrameRenderEnvironment {
+		CaptureFrameRenderEnvironment(
+			screenScaleFactor: screen?.backingScaleFactor ?? 2,
+			wallpaperPath: systemWallpaperPath(for: background, screen: screen)
+		)
 	}
 
 	private static func systemWallpaperPath(

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Export.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Export.swift
@@ -4,53 +4,499 @@ import Darwin
 import Foundation
 import RsnapHostBridge
 
+private struct FrozenSelectionImageRenderRequest: @unchecked Sendable {
+	let captureID: UInt64
+	let selection: CGRect
+	let scrollExportImage: CGImage?
+	let frozenDisplayFrame: CGRect?
+	let frozenDisplayImage: CGImage?
+	let frozenBaseImage: CGImage?
+	let frozenSelectionSnapshot: CGRect?
+	let overlayElements: [FrozenOverlayExportElement]
+	let hasOverlayEdits: Bool
+	let captureFrameSource: CaptureFrameSource
+	let captureFrameWindowID: CGWindowID?
+	let captureFrameEffectEnabled: Bool
+	let captureFrameBackground: CaptureFrameBackgroundPreference
+	let captureFrameApplicability: CaptureFrameApplicabilityPreference
+	let captureFrameEnvironment: CaptureFrameRenderEnvironment
+
+	var preparedExportKey: FrozenPreparedExportKey {
+		FrozenPreparedExportKey(
+			captureID: captureID,
+			selection: selection,
+			scrollExportWidth: scrollExportImage?.width ?? 0,
+			scrollExportHeight: scrollExportImage?.height ?? 0,
+			frozenDisplayFrame: frozenDisplayFrame,
+			frozenBaseWidth: frozenBaseImage?.width ?? 0,
+			frozenBaseHeight: frozenBaseImage?.height ?? 0,
+			frozenSelectionSnapshot: frozenSelectionSnapshot,
+			overlayElements: overlayElements,
+			hasOverlayEdits: hasOverlayEdits,
+			captureFrameSource: captureFrameSource,
+			captureFrameWindowID: captureFrameWindowID,
+			captureFrameEffectEnabled: captureFrameEffectEnabled,
+			captureFrameBackground: captureFrameBackground,
+			captureFrameApplicability: captureFrameApplicability,
+			captureFrameEnvironment: captureFrameEnvironment
+		)
+	}
+
+	var canPrepareExportInBackground: Bool {
+		// Scroll capture exports change as the stitched document grows; prepare those on demand
+		// until the scroll pipeline exposes a stable export revision.
+		scrollExportImage == nil
+	}
+}
+
+private struct FrozenPreparedExportKey: Equatable, @unchecked Sendable {
+	let captureID: UInt64
+	let selection: CGRect
+	let scrollExportWidth: Int
+	let scrollExportHeight: Int
+	let frozenDisplayFrame: CGRect?
+	let frozenBaseWidth: Int
+	let frozenBaseHeight: Int
+	let frozenSelectionSnapshot: CGRect?
+	let overlayElements: [FrozenOverlayExportElement]
+	let hasOverlayEdits: Bool
+	let captureFrameSource: CaptureFrameSource
+	let captureFrameWindowID: CGWindowID?
+	let captureFrameEffectEnabled: Bool
+	let captureFrameBackground: CaptureFrameBackgroundPreference
+	let captureFrameApplicability: CaptureFrameApplicabilityPreference
+	let captureFrameEnvironment: CaptureFrameRenderEnvironment
+}
+
+private struct FrozenSelectionImageRenderResult: @unchecked Sendable {
+	let image: CGImage?
+	let rgbaSnapshot: RGBARegionSnapshot?
+	let baseImage: CGImage?
+	let failureStage: String?
+	let ensureMilliseconds: Double
+	let refreshMilliseconds: Double
+	let compositeMilliseconds: Double
+	let source: String
+	let hasOverlayEdits: Bool
+	let width: Int
+	let height: Int
+}
+
+private struct FrozenRenderedImage: @unchecked Sendable {
+	let image: CGImage?
+	let rgbaSnapshot: RGBARegionSnapshot?
+
+	var width: Int {
+		rgbaSnapshot?.width ?? image?.width ?? 0
+	}
+
+	var height: Int {
+		rgbaSnapshot?.height ?? image?.height ?? 0
+	}
+}
+
+private struct CopyCaptureJobResult: @unchecked Sendable {
+	let pngData: Data?
+	let failureStage: String
+	let failureMessage: String
+	let captureImageMilliseconds: Double
+	let makeImageMilliseconds: Double
+	let width: Int
+	let height: Int
+	let cacheHit: Bool
+
+	var preparedCacheHit: Self {
+		Self(
+			pngData: pngData,
+			failureStage: failureStage,
+			failureMessage: failureMessage,
+			captureImageMilliseconds: 0,
+			makeImageMilliseconds: 0,
+			width: width,
+			height: height,
+			cacheHit: true
+		)
+	}
+}
+
+private struct SaveCaptureJobResult: @unchecked Sendable {
+	let outputURL: URL?
+	let failureMessage: String
+}
+
+private struct FrozenPreparedExportEntry: @unchecked Sendable {
+	let key: FrozenPreparedExportKey
+	let result: CopyCaptureJobResult
+}
+
+final class FrozenPreparedExportStore: @unchecked Sendable {
+	private let lock = NSLock()
+	private var generation: UInt64 = 0
+	private var inFlightKey: FrozenPreparedExportKey?
+	private var entry: FrozenPreparedExportEntry?
+
+	func reset() {
+		invalidate()
+	}
+
+	fileprivate func invalidate() {
+		lock.lock()
+		generation &+= 1
+		inFlightKey = nil
+		entry = nil
+		lock.unlock()
+	}
+
+	fileprivate func beginPreparing(for request: FrozenSelectionImageRenderRequest) -> UInt64? {
+		let key = request.preparedExportKey
+		lock.lock()
+		defer {
+			lock.unlock()
+		}
+		if entry?.key == key || inFlightKey == key {
+			return nil
+		}
+		inFlightKey = key
+		return generation
+	}
+
+	fileprivate func finishPreparing(
+		for request: FrozenSelectionImageRenderRequest,
+		generation preparedGeneration: UInt64,
+		result: CopyCaptureJobResult
+	) {
+		let key = request.preparedExportKey
+		lock.lock()
+		defer {
+			lock.unlock()
+		}
+		guard generation == preparedGeneration, inFlightKey == key else {
+			return
+		}
+		inFlightKey = nil
+		guard result.pngData != nil else {
+			entry = nil
+			return
+		}
+		entry = FrozenPreparedExportEntry(key: key, result: result)
+	}
+
+	fileprivate func result(matching request: FrozenSelectionImageRenderRequest)
+		-> CopyCaptureJobResult?
+	{
+		let key = request.preparedExportKey
+		lock.lock()
+		let result = entry?.key == key ? entry?.result.preparedCacheHit : nil
+		lock.unlock()
+		return result
+	}
+}
+
 extension CaptureSessionController {
 	func performCopy() throws {
-		guard let session else {
+		guard session != nil else {
 			return
 		}
 		let copyStartedAt = ProcessInfo.processInfo.systemUptime
-		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
-		guard let cgImage = try captureFrozenSelectionImage(applyingCaptureFrameEffect: true)
-		else {
-			NativeHostTelemetry.copyCaptureTiming(
-				captureID: currentCaptureTelemetryID,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
-				captureImageMilliseconds: NativeHostTelemetry.milliseconds(
-					since: captureImageStartedAt),
-				clearPasteboardMilliseconds: 0,
+		guard let request = try frozenSelectionImageRenderRequest() else {
+			logCopyCaptureFailure(
+				copyStartedAt: copyStartedAt,
+				captureImageMilliseconds: 0,
 				makeImageMilliseconds: 0,
-				writePasteboardMilliseconds: 0,
-				success: false,
 				failureStage: "capture_image",
 				width: 0,
 				height: 0
 			)
-			try sendHostStatusMessage("Could not capture the frozen selection.")
+			try setHostStatusMessage("Could not capture the frozen selection.")
+			refreshOverlay()
 			return
+		}
+
+		hostEffectJobGeneration &+= 1
+		let jobGeneration = hostEffectJobGeneration
+		try setHostStatusMessage("Copying capture...")
+		refreshOverlay()
+
+		if let preparedResult = frozenPreparedExportStore.result(matching: request) {
+			finishCopyCaptureJob(
+				preparedResult,
+				copyStartedAt: copyStartedAt,
+				jobGeneration: jobGeneration
+			)
+			return
+		}
+
+		let preparedExportStore = frozenPreparedExportStore
+		frozenImageRenderQueue.async { [weak self] in
+			let result =
+				preparedExportStore.result(matching: request)
+				?? Self.renderCopyCaptureJob(request: request)
+			DispatchQueue.main.async {
+				self?.finishCopyCaptureJob(
+					result,
+					copyStartedAt: copyStartedAt,
+					jobGeneration: jobGeneration
+				)
+			}
+		}
+	}
+
+	func performSave() throws {
+		guard session != nil else {
+			return
+		}
+		guard let request = try frozenSelectionImageRenderRequest() else {
+			try setHostStatusMessage("Could not capture the frozen selection.")
+			refreshOverlay()
+			return
+		}
+		let outputURL = try nextOutputURL()
+		hostEffectJobGeneration &+= 1
+		let jobGeneration = hostEffectJobGeneration
+		try setHostStatusMessage("Saving capture...")
+		refreshOverlay()
+
+		let preparedExportStore = frozenPreparedExportStore
+		frozenImageRenderQueue.async { [weak self] in
+			let result = Self.renderSaveCaptureJob(
+				request: request,
+				outputURL: outputURL,
+				preparedExportStore: preparedExportStore
+			)
+			DispatchQueue.main.async {
+				self?.finishSaveCaptureJob(result, jobGeneration: jobGeneration)
+			}
+		}
+	}
+
+	private func frozenSelectionImageRenderRequest() throws -> FrozenSelectionImageRenderRequest? {
+		guard let selection = currentFrozenSelection() else {
+			return nil
+		}
+		let scrollExportImage =
+			scrollCaptureState == nil ? nil : try activeScrollCaptureExportImage()
+		let settings = settingsStore.settings
+		let selectionCenter = CGPoint(x: selection.midX, y: selection.midY)
+		let screen = screen(containing: selectionCenter)
+		let wallpaperPath =
+			settings.captureFrameBackground == .systemWallpaper
+			? CaptureFrameEffectRenderer.systemWallpaperPath(screen: screen)
+			: nil
+		return FrozenSelectionImageRenderRequest(
+			captureID: currentCaptureTelemetryID,
+			selection: selection,
+			scrollExportImage: scrollExportImage,
+			frozenDisplayFrame: chromeState.frozenDisplayFrame,
+			frozenDisplayImage: chromeState.frozenDisplayImage,
+			frozenBaseImage: chromeState.frozenBaseImage,
+			frozenSelectionSnapshot: chromeState.frozenSelectionSnapshot,
+			overlayElements: chromeState.frozenOverlay.exportElements,
+			hasOverlayEdits: chromeState.frozenOverlay.canUndo
+				|| chromeState.frozenOverlay.hasActiveInteraction,
+			captureFrameSource: chromeState.captureFrameSource,
+			captureFrameWindowID: chromeState.captureFrameWindowID,
+			captureFrameEffectEnabled: settings.captureFrameEffectEnabled,
+			captureFrameBackground: settings.captureFrameBackground,
+			captureFrameApplicability: settings.captureFrameApplicability,
+			captureFrameEnvironment: CaptureFrameRenderEnvironment(
+				screenScaleFactor: screen?.backingScaleFactor ?? 2,
+				wallpaperPath: wallpaperPath
+			)
+		)
+	}
+
+	func invalidatePreparedFrozenExport() {
+		frozenPreparedExportStore.invalidate()
+	}
+
+	func schedulePreparedFrozenExport(reason: String) {
+		guard let request = try? frozenSelectionImageRenderRequest(),
+			request.canPrepareExportInBackground,
+			let preparationGeneration = frozenPreparedExportStore.beginPreparing(for: request)
+		else {
+			return
+		}
+
+		let preparedExportStore = frozenPreparedExportStore
+		frozenImageRenderQueue.async {
+			let startedAt = ProcessInfo.processInfo.systemUptime
+			let result = Self.renderCopyCaptureJob(request: request)
+			preparedExportStore.finishPreparing(
+				for: request,
+				generation: preparationGeneration,
+				result: result
+			)
+			NativeHostTelemetry.preparedFrozenExportTiming(
+				captureID: request.captureID,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAt),
+				captureImageMilliseconds: result.captureImageMilliseconds,
+				makeImageMilliseconds: result.makeImageMilliseconds,
+				success: result.pngData != nil,
+				reason: reason,
+				width: result.width,
+				height: result.height
+			)
+		}
+	}
+
+	nonisolated private static func renderCopyCaptureJob(
+		request: FrozenSelectionImageRenderRequest
+	) -> CopyCaptureJobResult {
+		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
+		let renderResult: FrozenSelectionImageRenderResult
+		do {
+			renderResult = try renderFrozenSelectionImage(
+				from: request,
+				applyingCaptureFrameEffect: true,
+				prefersPixelSnapshot: true
+			)
+		} catch {
+			let captureImageMilliseconds =
+				NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
+			return CopyCaptureJobResult(
+				pngData: nil,
+				failureStage: "capture_image",
+				failureMessage: "Could not capture the frozen selection.",
+				captureImageMilliseconds: captureImageMilliseconds,
+				makeImageMilliseconds: 0,
+				width: 0,
+				height: 0,
+				cacheHit: false
+			)
 		}
 		let captureImageMilliseconds =
 			NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
+		guard renderResult.rgbaSnapshot != nil || renderResult.image != nil else {
+			return CopyCaptureJobResult(
+				pngData: nil,
+				failureStage: renderResult.failureStage ?? "capture_image",
+				failureMessage: "Could not capture the frozen selection.",
+				captureImageMilliseconds: captureImageMilliseconds,
+				makeImageMilliseconds: 0,
+				width: renderResult.width,
+				height: renderResult.height,
+				cacheHit: false
+			)
+		}
 
 		let makeImageStartedAt = ProcessInfo.processInfo.systemUptime
-		guard let pngData = try Self.losslessPNGData(from: cgImage) else {
-			let makeImageMilliseconds = NativeHostTelemetry.milliseconds(since: makeImageStartedAt)
-			NativeHostTelemetry.copyCaptureTiming(
-				captureID: currentCaptureTelemetryID,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
-				captureImageMilliseconds: captureImageMilliseconds,
-				clearPasteboardMilliseconds: 0,
-				makeImageMilliseconds: makeImageMilliseconds,
-				writePasteboardMilliseconds: 0,
-				success: false,
-				failureStage: "encode_image",
-				width: cgImage.width,
-				height: cgImage.height
-			)
-			try sendHostStatusMessage("Could not encode the captured image.")
-			return
+		let pngData: Data?
+		if let snapshot = renderResult.rgbaSnapshot {
+			pngData = try? RsnapExportEncoder.pngData(from: snapshot)
+		} else if let cgImage = renderResult.image {
+			pngData = try? losslessPNGData(from: cgImage)
+		} else {
+			pngData = nil
 		}
 		let makeImageMilliseconds = NativeHostTelemetry.milliseconds(since: makeImageStartedAt)
+		let width = renderResult.rgbaSnapshot?.width ?? renderResult.image?.width ?? 0
+		let height = renderResult.rgbaSnapshot?.height ?? renderResult.image?.height ?? 0
+		guard let pngData else {
+			return CopyCaptureJobResult(
+				pngData: nil,
+				failureStage: "encode_image",
+				failureMessage: "Could not encode the captured image.",
+				captureImageMilliseconds: captureImageMilliseconds,
+				makeImageMilliseconds: makeImageMilliseconds,
+				width: width,
+				height: height,
+				cacheHit: false
+			)
+		}
+		return CopyCaptureJobResult(
+			pngData: pngData,
+			failureStage: "none",
+			failureMessage: "",
+			captureImageMilliseconds: captureImageMilliseconds,
+			makeImageMilliseconds: makeImageMilliseconds,
+			width: width,
+			height: height,
+			cacheHit: false
+		)
+	}
+
+	nonisolated private static func renderSaveCaptureJob(
+		request: FrozenSelectionImageRenderRequest,
+		outputURL: URL,
+		preparedExportStore: FrozenPreparedExportStore
+	) -> SaveCaptureJobResult {
+		if let preparedResult = preparedExportStore.result(matching: request),
+			let pngData = preparedResult.pngData
+		{
+			do {
+				try pngData.write(to: outputURL, options: .atomic)
+				return SaveCaptureJobResult(outputURL: outputURL, failureMessage: "")
+			} catch {
+				return SaveCaptureJobResult(
+					outputURL: nil,
+					failureMessage: "Could not save the capture."
+				)
+			}
+		}
+		return renderSaveCaptureJob(request: request, outputURL: outputURL)
+	}
+
+	nonisolated private static func renderSaveCaptureJob(
+		request: FrozenSelectionImageRenderRequest,
+		outputURL: URL
+	) -> SaveCaptureJobResult {
+		do {
+			let renderResult = try renderFrozenSelectionImage(
+				from: request,
+				applyingCaptureFrameEffect: true,
+				prefersPixelSnapshot: true
+			)
+			guard renderResult.rgbaSnapshot != nil || renderResult.image != nil else {
+				return SaveCaptureJobResult(
+					outputURL: nil,
+					failureMessage: "Could not capture the frozen selection."
+				)
+			}
+			let pngData: Data?
+			if let snapshot = renderResult.rgbaSnapshot {
+				pngData = try RsnapExportEncoder.pngData(from: snapshot)
+			} else if let cgImage = renderResult.image {
+				pngData = try losslessPNGData(from: cgImage)
+			} else {
+				pngData = nil
+			}
+			guard let pngData else {
+				return SaveCaptureJobResult(
+					outputURL: nil,
+					failureMessage: "Could not encode the captured image."
+				)
+			}
+			try pngData.write(to: outputURL, options: .atomic)
+			return SaveCaptureJobResult(outputURL: outputURL, failureMessage: "")
+		} catch {
+			return SaveCaptureJobResult(
+				outputURL: nil,
+				failureMessage: "Could not save the capture."
+			)
+		}
+	}
+
+	private func finishCopyCaptureJob(
+		_ result: CopyCaptureJobResult,
+		copyStartedAt: TimeInterval,
+		jobGeneration: UInt64
+	) {
+		guard hostEffectJobGeneration == jobGeneration, session != nil else {
+			return
+		}
+		guard let pngData = result.pngData else {
+			logCopyCaptureFailure(
+				copyStartedAt: copyStartedAt,
+				captureImageMilliseconds: result.captureImageMilliseconds,
+				makeImageMilliseconds: result.makeImageMilliseconds,
+				failureStage: result.failureStage,
+				width: result.width,
+				height: result.height
+			)
+			try? setHostStatusMessage(result.failureMessage)
+			refreshOverlay()
+			return
+		}
 
 		let pasteboard = NSPasteboard.general
 		let clearPasteboardStartedAt = ProcessInfo.processInfo.systemUptime
@@ -68,61 +514,95 @@ extension CaptureSessionController {
 			NativeHostTelemetry.copyCaptureTiming(
 				captureID: currentCaptureTelemetryID,
 				totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
-				captureImageMilliseconds: captureImageMilliseconds,
+				captureImageMilliseconds: result.captureImageMilliseconds,
 				clearPasteboardMilliseconds: clearPasteboardMilliseconds,
-				makeImageMilliseconds: makeImageMilliseconds,
+				makeImageMilliseconds: result.makeImageMilliseconds,
 				writePasteboardMilliseconds: writePasteboardMilliseconds,
 				success: false,
 				failureStage: "pasteboard_write",
-				width: cgImage.width,
-				height: cgImage.height
+				width: result.width,
+				height: result.height,
+				cacheHit: result.cacheHit
 			)
-			try sendHostStatusMessage("Could not copy the captured image.")
+			try? setHostStatusMessage("Could not copy the captured image.")
+			refreshOverlay()
 			return
 		}
 		NativeHostTelemetry.copyCaptureTiming(
 			captureID: currentCaptureTelemetryID,
 			totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
-			captureImageMilliseconds: captureImageMilliseconds,
+			captureImageMilliseconds: result.captureImageMilliseconds,
 			clearPasteboardMilliseconds: clearPasteboardMilliseconds,
-			makeImageMilliseconds: makeImageMilliseconds,
+			makeImageMilliseconds: result.makeImageMilliseconds,
 			writePasteboardMilliseconds: writePasteboardMilliseconds,
 			success: true,
 			failureStage: "none",
-			width: cgImage.width,
-			height: cgImage.height
+			width: result.width,
+			height: result.height,
+			cacheHit: result.cacheHit
 		)
-
-		captureSuccessSound.play()
-
-		try session.send(report: .hostEffectCompleted(.copyCapture))
-		try session.send(report: .statusMessage("Copied capture to clipboard."))
-		completedHostEffect = .copyCapture
+		completeHostEffect(.copyCapture, statusMessage: "Copied capture to clipboard.")
 	}
 
-	func performSave() throws {
-		guard let session else {
+	private func finishSaveCaptureJob(
+		_ result: SaveCaptureJobResult,
+		jobGeneration: UInt64
+	) {
+		guard hostEffectJobGeneration == jobGeneration, session != nil else {
 			return
 		}
-		guard let cgImage = try captureFrozenSelectionImage(applyingCaptureFrameEffect: true)
-		else {
-			try sendHostStatusMessage("Could not capture the frozen selection.")
+		guard let outputURL = result.outputURL else {
+			try? setHostStatusMessage(result.failureMessage)
+			refreshOverlay()
 			return
 		}
-		guard let pngData = try Self.losslessPNGData(from: cgImage) else {
-			try sendHostStatusMessage("Could not encode the captured image.")
-			return
-		}
-
-		let outputURL = try nextOutputURL()
-		try pngData.write(to: outputURL, options: .atomic)
-
-		captureSuccessSound.play()
-
-		try session.send(report: .hostEffectCompleted(.saveCapture))
-		try session.send(report: .statusMessage("Saved capture to \(outputURL.lastPathComponent)."))
-		completedHostEffect = .saveCapture
+		completeHostEffect(
+			.saveCapture,
+			statusMessage: "Saved capture to \(outputURL.lastPathComponent)."
+		)
 	}
+
+	private func completeHostEffect(_ effect: HostEffectKind, statusMessage: String) {
+		do {
+			captureSuccessSound.play()
+			try session?.send(report: .hostEffectCompleted(effect))
+			try session?.send(report: .statusMessage(statusMessage))
+			completedHostEffect = effect
+			tearDownCapture()
+		} catch {
+			NativeHostTelemetry.captureWarning(
+				"capture.host_effect_complete_failed",
+				captureID: currentCaptureTelemetryID,
+				stage: String(describing: effect),
+				error: String(describing: error)
+			)
+			try? setHostStatusMessage(statusMessage)
+			refreshOverlay()
+		}
+	}
+
+	private func logCopyCaptureFailure(
+		copyStartedAt: TimeInterval,
+		captureImageMilliseconds: Double,
+		makeImageMilliseconds: Double,
+		failureStage: String,
+		width: Int,
+		height: Int
+	) {
+		NativeHostTelemetry.copyCaptureTiming(
+			captureID: currentCaptureTelemetryID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: copyStartedAt),
+			captureImageMilliseconds: captureImageMilliseconds,
+			clearPasteboardMilliseconds: 0,
+			makeImageMilliseconds: makeImageMilliseconds,
+			writePasteboardMilliseconds: 0,
+			success: false,
+			failureStage: failureStage,
+			width: width,
+			height: height
+		)
+	}
+
 	func activeScrollCaptureExportImage() throws -> CGImage? {
 		guard Self.scrollCaptureEnabled else {
 			return nil
@@ -143,7 +623,7 @@ extension CaptureSessionController {
 		-> CGImage?
 	{
 		let captureStartedAt = ProcessInfo.processInfo.systemUptime
-		guard let selection = currentFrozenSelection() else {
+		guard let request = try frozenSelectionImageRenderRequest() else {
 			NativeHostTelemetry.frozenSelectionImageTiming(
 				captureID: currentCaptureTelemetryID,
 				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
@@ -158,96 +638,363 @@ extension CaptureSessionController {
 			)
 			return nil
 		}
+		let result = try Self.renderFrozenSelectionImage(
+			from: request,
+			applyingCaptureFrameEffect: applyingCaptureFrameEffect,
+			prefersPixelSnapshot: false
+		)
+		if let baseImage = result.baseImage,
+			chromeState.frozenSelectionSnapshot == request.selection,
+			chromeState.frozenBaseImage == nil
+		{
+			chromeState.frozenBaseImage = baseImage
+		}
+		return result.image
+	}
 
-		if let scrollExport = try activeScrollCaptureExportImage() {
-			let result =
-				applyingCaptureFrameEffect
-				? applyCaptureFrameEffectIfNeeded(
-					to: scrollExport,
-					selection: selection,
-					hasOverlayEdits: false
-				)
-				: scrollExport
-			NativeHostTelemetry.frozenSelectionImageTiming(
-				captureID: currentCaptureTelemetryID,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
-				ensureMilliseconds: 0,
-				refreshMilliseconds: 0,
-				compositeMilliseconds: 0,
-				source: "scroll_capture_export",
-				success: true,
-				width: result.width,
-				height: result.height,
-				hasOverlayEdits: false
+	nonisolated private static func renderFrozenSelectionImage(
+		from request: FrozenSelectionImageRenderRequest,
+		applyingCaptureFrameEffect: Bool,
+		prefersPixelSnapshot: Bool = false
+	) throws -> FrozenSelectionImageRenderResult {
+		let captureStartedAt = ProcessInfo.processInfo.systemUptime
+		if let scrollExport = request.scrollExportImage {
+			return renderScrollExportImage(
+				scrollExport,
+				request: request,
+				captureStartedAt: captureStartedAt,
+				applyingCaptureFrameEffect: applyingCaptureFrameEffect,
+				prefersPixelSnapshot: prefersPixelSnapshot
 			)
-			return result
 		}
+		return try renderDisplayFrozenSelectionImage(
+			from: request,
+			captureStartedAt: captureStartedAt,
+			applyingCaptureFrameEffect: applyingCaptureFrameEffect,
+			prefersPixelSnapshot: prefersPixelSnapshot
+		)
+	}
 
-		let snapshotMatchedBefore = chromeState.frozenSelectionSnapshot == selection
-		let hadBaseImageBefore = chromeState.frozenBaseImage != nil
-		let hadFrozenDisplayImageBefore = chromeState.frozenDisplayImage != nil
-		let hasOverlayEdits =
-			chromeState.frozenOverlay.canUndo || chromeState.frozenOverlay.hasActiveInteraction
+	nonisolated private static func renderScrollExportImage(
+		_ scrollExport: CGImage,
+		request: FrozenSelectionImageRenderRequest,
+		captureStartedAt: TimeInterval,
+		applyingCaptureFrameEffect: Bool,
+		prefersPixelSnapshot: Bool
+	) -> FrozenSelectionImageRenderResult {
+		let result =
+			applyingCaptureFrameEffect
+			? applyCaptureFrameEffectIfNeeded(
+				to: scrollExport,
+				request: request,
+				hasOverlayEdits: false,
+				prefersPixelSnapshot: prefersPixelSnapshot
+			)
+			: FrozenRenderedImage(image: scrollExport, rgbaSnapshot: nil)
+		logFrozenSelectionImageTiming(
+			request: request,
+			captureStartedAt: captureStartedAt,
+			ensureMilliseconds: 0,
+			refreshMilliseconds: 0,
+			compositeMilliseconds: 0,
+			source: "scroll_capture_export",
+			success: true,
+			width: result.width,
+			height: result.height,
+			hasOverlayEdits: false
+		)
+		return FrozenSelectionImageRenderResult(
+			image: result.image,
+			rgbaSnapshot: result.rgbaSnapshot,
+			baseImage: nil,
+			failureStage: nil,
+			ensureMilliseconds: 0,
+			refreshMilliseconds: 0,
+			compositeMilliseconds: 0,
+			source: "scroll_capture_export",
+			hasOverlayEdits: false,
+			width: result.width,
+			height: result.height
+		)
+	}
+
+	nonisolated private static func renderDisplayFrozenSelectionImage(
+		from request: FrozenSelectionImageRenderRequest,
+		captureStartedAt: TimeInterval,
+		applyingCaptureFrameEffect: Bool,
+		prefersPixelSnapshot: Bool
+	) throws -> FrozenSelectionImageRenderResult {
+		let snapshotMatchedBefore = request.frozenSelectionSnapshot == request.selection
+		let hadBaseImageBefore = request.frozenBaseImage != nil
+		let hadFrozenDisplayImageBefore = request.frozenDisplayImage != nil
 		let ensureStartedAt = ProcessInfo.processInfo.systemUptime
-		ensureFrozenBaseImageFromDisplayIfNeeded(for: selection)
+		let baseImage =
+			snapshotMatchedBefore
+			? request.frozenBaseImage
+				?? frozenBaseImageFromDisplay(
+					displayFrame: request.frozenDisplayFrame,
+					displayImage: request.frozenDisplayImage,
+					selection: request.selection
+				)
+			: frozenBaseImageFromDisplay(
+				displayFrame: request.frozenDisplayFrame,
+				displayImage: request.frozenDisplayImage,
+				selection: request.selection
+			)
 		let ensureMilliseconds = NativeHostTelemetry.milliseconds(since: ensureStartedAt)
-		var refreshedFromFrozenDisplay = false
-		var refreshMilliseconds = 0.0
-		if chromeState.frozenSelectionSnapshot != selection || chromeState.frozenBaseImage == nil {
-			let refreshStartedAt = ProcessInfo.processInfo.systemUptime
-			refreshedFromFrozenDisplay = refreshFrozenBaseImageFromDisplay(for: selection)
-			refreshMilliseconds = NativeHostTelemetry.milliseconds(since: refreshStartedAt)
-		}
-		guard let baseImage = chromeState.frozenBaseImage else {
-			NativeHostTelemetry.frozenSelectionImageTiming(
-				captureID: currentCaptureTelemetryID,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+		guard let baseImage else {
+			logFrozenSelectionImageTiming(
+				request: request,
+				captureStartedAt: captureStartedAt,
 				ensureMilliseconds: ensureMilliseconds,
-				refreshMilliseconds: refreshMilliseconds,
+				refreshMilliseconds: 0,
 				compositeMilliseconds: 0,
 				source: "missing_base",
 				success: false,
 				width: 0,
 				height: 0,
-				hasOverlayEdits: hasOverlayEdits
+				hasOverlayEdits: request.hasOverlayEdits
 			)
-			return nil
+			return FrozenSelectionImageRenderResult(
+				image: nil,
+				rgbaSnapshot: nil,
+				baseImage: nil,
+				failureStage: "capture_image",
+				ensureMilliseconds: ensureMilliseconds,
+				refreshMilliseconds: 0,
+				compositeMilliseconds: 0,
+				source: "missing_base",
+				hasOverlayEdits: request.hasOverlayEdits,
+				width: 0,
+				height: 0
+			)
 		}
 
 		let compositeStartedAt = ProcessInfo.processInfo.systemUptime
-		let composited = try compositeFrozenOverlay(on: baseImage, selection: selection)
+		let composited = try compositeFrozenOverlay(
+			on: baseImage,
+			selection: request.selection,
+			elements: request.overlayElements,
+			prefersPixelSnapshot: prefersPixelSnapshot || applyingCaptureFrameEffect
+		)
 		let result =
 			applyingCaptureFrameEffect
 			? applyCaptureFrameEffectIfNeeded(
 				to: composited,
-				selection: selection,
-				hasOverlayEdits: hasOverlayEdits
+				request: request,
+				hasOverlayEdits: request.hasOverlayEdits,
+				prefersPixelSnapshot: prefersPixelSnapshot
 			)
 			: composited
 		let compositeMilliseconds = NativeHostTelemetry.milliseconds(since: compositeStartedAt)
 		let imageSource: String
-		if refreshedFromFrozenDisplay {
-			imageSource = "frozen_display_refresh"
-		} else if snapshotMatchedBefore, hadBaseImageBefore {
+		if snapshotMatchedBefore, hadBaseImageBefore {
 			imageSource = "cached_base"
 		} else if hadFrozenDisplayImageBefore {
 			imageSource = "frozen_display_crop"
 		} else {
 			imageSource = "unknown_base"
 		}
-		NativeHostTelemetry.frozenSelectionImageTiming(
-			captureID: currentCaptureTelemetryID,
-			totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+		logFrozenSelectionImageTiming(
+			request: request,
+			captureStartedAt: captureStartedAt,
 			ensureMilliseconds: ensureMilliseconds,
-			refreshMilliseconds: refreshMilliseconds,
+			refreshMilliseconds: 0,
 			compositeMilliseconds: compositeMilliseconds,
 			source: imageSource,
 			success: true,
 			width: result.width,
 			height: result.height,
+			hasOverlayEdits: request.hasOverlayEdits
+		)
+		return FrozenSelectionImageRenderResult(
+			image: result.image,
+			rgbaSnapshot: result.rgbaSnapshot,
+			baseImage: baseImage,
+			failureStage: nil,
+			ensureMilliseconds: ensureMilliseconds,
+			refreshMilliseconds: 0,
+			compositeMilliseconds: compositeMilliseconds,
+			source: imageSource,
+			hasOverlayEdits: request.hasOverlayEdits,
+			width: result.width,
+			height: result.height
+		)
+	}
+
+	nonisolated private static func frozenBaseImageFromDisplay(
+		displayFrame: CGRect?,
+		displayImage: CGImage?,
+		selection: CGRect
+	) -> CGImage? {
+		guard let displayFrame, let displayImage else {
+			return nil
+		}
+		return cropFrozenDisplayImage(
+			displayImage,
+			displayFrame: displayFrame,
+			selection: selection
+		)
+	}
+
+	nonisolated private static func logFrozenSelectionImageTiming(
+		request: FrozenSelectionImageRenderRequest,
+		captureStartedAt: TimeInterval,
+		ensureMilliseconds: Double,
+		refreshMilliseconds: Double,
+		compositeMilliseconds: Double,
+		source: String,
+		success: Bool,
+		width: Int,
+		height: Int,
+		hasOverlayEdits: Bool
+	) {
+		NativeHostTelemetry.frozenSelectionImageTiming(
+			captureID: request.captureID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+			ensureMilliseconds: ensureMilliseconds,
+			refreshMilliseconds: refreshMilliseconds,
+			compositeMilliseconds: compositeMilliseconds,
+			source: source,
+			success: success,
+			width: width,
+			height: height,
 			hasOverlayEdits: hasOverlayEdits
 		)
-		return result
+	}
+
+	nonisolated private static func applyCaptureFrameEffectIfNeeded(
+		to image: CGImage,
+		request: FrozenSelectionImageRenderRequest,
+		hasOverlayEdits: Bool,
+		prefersPixelSnapshot: Bool
+	) -> FrozenRenderedImage {
+		applyCaptureFrameEffectIfNeeded(
+			to: FrozenRenderedImage(image: image, rgbaSnapshot: nil),
+			request: request,
+			hasOverlayEdits: hasOverlayEdits,
+			prefersPixelSnapshot: prefersPixelSnapshot
+		)
+	}
+
+	nonisolated private static func applyCaptureFrameEffectIfNeeded(
+		to image: FrozenRenderedImage,
+		request: FrozenSelectionImageRenderRequest,
+		hasOverlayEdits: Bool,
+		prefersPixelSnapshot: Bool
+	) -> FrozenRenderedImage {
+		guard request.captureFrameEffectEnabled,
+			request.captureFrameApplicability.includes(request.captureFrameSource)
+		else {
+			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+		}
+		if hasOverlayEdits == false,
+			request.captureFrameSource == .window,
+			let windowID = request.captureFrameWindowID,
+			let windowImage = captureFrameWindowImage(windowID: windowID)
+		{
+			guard
+				let snapshot = CaptureFrameEffectRenderer.renderWindowSnapshotSnapshot(
+					image: windowImage,
+					background: request.captureFrameBackground,
+					environment: request.captureFrameEnvironment
+				)
+			else {
+				return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+			}
+
+			let renderedImage =
+				prefersPixelSnapshot
+				? nil
+				: NativeHostImageBridge.cgImage(from: snapshot, shouldInterpolate: true)
+			if prefersPixelSnapshot == false, renderedImage == nil {
+				return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+			}
+			return FrozenRenderedImage(
+				image: renderedImage,
+				rgbaSnapshot: snapshot
+			)
+		}
+		let renderedSnapshot: RGBARegionSnapshot?
+		if let sourceSnapshot = image.rgbaSnapshot {
+			renderedSnapshot = CaptureFrameEffectRenderer.renderSnapshot(
+				source: sourceSnapshot,
+				background: request.captureFrameBackground,
+				sourceKind: request.captureFrameSource,
+				environment: request.captureFrameEnvironment
+			)
+		} else if let sourceImage = image.image {
+			renderedSnapshot = CaptureFrameEffectRenderer.renderSnapshot(
+				image: sourceImage,
+				background: request.captureFrameBackground,
+				source: request.captureFrameSource,
+				environment: request.captureFrameEnvironment
+			)
+		} else {
+			renderedSnapshot = nil
+		}
+		guard let renderedSnapshot else {
+			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+		}
+
+		let renderedImage =
+			prefersPixelSnapshot
+			? nil
+			: NativeHostImageBridge.cgImage(from: renderedSnapshot, shouldInterpolate: true)
+		if prefersPixelSnapshot == false, renderedImage == nil {
+			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+		}
+		return FrozenRenderedImage(
+			image: renderedImage,
+			rgbaSnapshot: renderedSnapshot
+		)
+	}
+
+	nonisolated private static func resolvedRenderedImage(
+		_ image: FrozenRenderedImage,
+		prefersPixelSnapshot: Bool
+	) -> FrozenRenderedImage {
+		if prefersPixelSnapshot || image.image != nil {
+			return image
+		}
+		guard let snapshot = image.rgbaSnapshot else {
+			return image
+		}
+		return FrozenRenderedImage(
+			image: NativeHostImageBridge.cgImage(from: snapshot),
+			rgbaSnapshot: snapshot
+		)
+	}
+
+	nonisolated private static func compositeFrozenOverlay(
+		on image: CGImage,
+		selection: CGRect,
+		elements: [FrozenOverlayExportElement],
+		prefersPixelSnapshot: Bool
+	) throws -> FrozenRenderedImage {
+		guard elements.isEmpty == false else {
+			return FrozenRenderedImage(image: image, rgbaSnapshot: nil)
+		}
+
+		guard
+			let snapshot = NativeHostImageBridge.rgbaSnapshot(from: image),
+			let renderedSnapshot = try? RsnapExportEncoder.frozenOverlayExportImage(
+				from: snapshot,
+				selection: selection,
+				elements: elements
+			)
+		else {
+			throw HostBridgeError.ffiStatus(
+				context: "converting frozen overlay export image",
+				code: 4)
+		}
+
+		return FrozenRenderedImage(
+			image: prefersPixelSnapshot
+				? nil
+				: NativeHostImageBridge.cgImage(from: renderedSnapshot),
+			rgbaSnapshot: renderedSnapshot
+		)
 	}
 
 	func applyCaptureFrameEffectIfNeeded(
@@ -283,6 +1030,10 @@ extension CaptureSessionController {
 		guard let windowID = chromeState.captureFrameWindowID else {
 			return nil
 		}
+		return Self.captureFrameWindowImage(windowID: windowID)
+	}
+
+	nonisolated static func captureFrameWindowImage(windowID: CGWindowID) -> CGImage? {
 		guard let createImage = Self.captureFrameWindowListCreateImage else {
 			return nil
 		}
@@ -350,7 +1101,7 @@ extension CaptureSessionController {
 		)
 	}
 
-	static func cropFrozenDisplayImage(
+	nonisolated static func cropFrozenDisplayImage(
 		_ image: CGImage,
 		displayFrame: CGRect,
 		selection: CGRect
@@ -368,7 +1119,7 @@ extension CaptureSessionController {
 		return image.cropping(to: cropRect)
 	}
 
-	static func losslessPNGData(from image: CGImage) throws -> Data? {
+	nonisolated static func losslessPNGData(from image: CGImage) throws -> Data? {
 		guard let snapshot = NativeHostImageBridge.rgbaSnapshot(from: image) else {
 			return nil
 		}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+FrozenInteraction.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+FrozenInteraction.swift
@@ -248,6 +248,7 @@ extension CaptureSessionController {
 		}
 
 		frozenSnapshotGeneration &+= 1
+		invalidatePreparedFrozenExport()
 		let generation = frozenSnapshotGeneration
 		let captureID = currentCaptureTelemetryID
 		chromeState.frozenBaseImage = nil
@@ -263,6 +264,7 @@ extension CaptureSessionController {
 			do {
 				try self.session?.send(report: .freezeSnapshotCommitted(selection: nextSelection))
 				try self.syncCore()
+				self.schedulePreparedFrozenExport(reason: "selection_transform")
 				NativeHostTelemetry.captureEvent(
 					"capture.frozen_selection_transform_commit",
 					captureID: captureID
@@ -390,11 +392,13 @@ extension CaptureSessionController {
 
 		do {
 			frozenSnapshotGeneration &+= 1
+			invalidatePreparedFrozenExport()
 			chromeState.frozenSelectionSnapshot = nextSelection
 			chromeState.frozenBaseImage =
 				nextBaseImage ?? frozenBaseImageFromDisplay(for: nextSelection)
 			try session?.send(report: .freezeSnapshotCommitted(selection: nextSelection))
 			try syncCore()
+			schedulePreparedFrozenExport(reason: "auto_center")
 		} catch {
 			NativeHostTelemetry.captureWarning(
 				"capture.frozen_auto_center_failed",

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+HostRequests.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+HostRequests.swift
@@ -269,6 +269,7 @@ extension CaptureSessionController {
 		}
 		pendingFrozenCommit = nil
 		frozenFrameLatchToken = nil
+		invalidatePreparedFrozenExport()
 		chromeState.resetFrozenChrome()
 		chromeState.frozenSelectionSnapshot = selection
 		chromeState.frozenSelectionEditable = editable
@@ -317,6 +318,7 @@ extension CaptureSessionController {
 		if syncAfterReport {
 			try syncCore()
 		}
+		schedulePreparedFrozenExport(reason: "freeze_commit")
 	}
 
 	func frozenFrameLatchWait(containing _: CGPoint) -> TimeInterval {

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Runtime.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Runtime.swift
@@ -75,6 +75,8 @@ extension CaptureSessionController {
 		pendingFrozenCommit = nil
 		frozenFrameLatchToken = nil
 		frozenSnapshotGeneration &+= 1
+		hostEffectJobGeneration &+= 1
+		frozenPreparedExportStore.reset()
 		completedHostEffect = nil
 		removeNativeScrollCaptureMonitor()
 		scrollCaptureState = nil
@@ -131,6 +133,7 @@ extension CaptureSessionController {
 
 	@objc
 	func settingsDidChange() {
+		invalidatePreparedFrozenExport()
 		overlayController?.update(
 			scene: scene,
 			chrome: chromeState,

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController.swift
@@ -56,6 +56,11 @@ final class CaptureSessionController: NSObject {
 		label: "ink.hack.rsnap.scroll-capture-stitch",
 		qos: .userInitiated
 	)
+	let frozenImageRenderQueue = DispatchQueue(
+		label: "ink.hack.rsnap.frozen-image-render",
+		qos: .userInitiated
+	)
+	let frozenPreparedExportStore = FrozenPreparedExportStore()
 	let captureSuccessSound = CaptureSuccessSound.load()
 	let ocrCompletionSound = OcrCompletionSound.load()
 	var session: RsnapHostSession?
@@ -64,6 +69,7 @@ final class CaptureSessionController: NSObject {
 	var pendingFrozenCommit: PendingFrozenCommit?
 	var nextPendingFrozenCommitID: UInt64 = 1
 	var frozenSnapshotGeneration: UInt64 = 0
+	var hostEffectJobGeneration: UInt64 = 0
 	var completedHostEffect: HostEffectKind?
 	var scrollCaptureState: NativeScrollCaptureState?
 	var scrollCaptureGlobalMonitor: Any?

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -409,7 +409,7 @@ enum LoupeSampleSizePreference: String, CaseIterable {
 	}
 }
 
-package enum CaptureFrameBackgroundPreference: String, CaseIterable {
+package enum CaptureFrameBackgroundPreference: String, CaseIterable, Sendable {
 	case systemWallpaper = "system_wallpaper"
 	case aurora
 	case graphite
@@ -429,7 +429,7 @@ package enum CaptureFrameBackgroundPreference: String, CaseIterable {
 	}
 }
 
-enum CaptureFrameApplicabilityPreference: String, CaseIterable {
+enum CaptureFrameApplicabilityPreference: String, CaseIterable, Sendable {
 	case dragRegion = "drag_region"
 	case window
 	case scrollCapture = "scroll_capture"

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTelemetry.swift
@@ -351,10 +351,26 @@ enum NativeHostTelemetry {
 		success: Bool,
 		failureStage: String,
 		width: Int,
+		height: Int,
+		cacheHit: Bool = false
+	) {
+		captureTimingLogger.info(
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.copy_capture totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) captureImageMs=\(captureImageMilliseconds, format: .fixed(precision: 2), privacy: .public) clearPasteboardMs=\(clearPasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) makeImageMs=\(makeImageMilliseconds, format: .fixed(precision: 2), privacy: .public) writePasteboardMs=\(writePasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) success=\(success, privacy: .public) failureStage=\(failureStage, privacy: .public) width=\(width, privacy: .public) height=\(height, privacy: .public) cacheHit=\(cacheHit, privacy: .public)"
+		)
+	}
+
+	static func preparedFrozenExportTiming(
+		captureID: UInt64,
+		totalMilliseconds: Double,
+		captureImageMilliseconds: Double,
+		makeImageMilliseconds: Double,
+		success: Bool,
+		reason: String,
+		width: Int,
 		height: Int
 	) {
 		captureTimingLogger.info(
-			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.copy_capture totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) captureImageMs=\(captureImageMilliseconds, format: .fixed(precision: 2), privacy: .public) clearPasteboardMs=\(clearPasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) makeImageMs=\(makeImageMilliseconds, format: .fixed(precision: 2), privacy: .public) writePasteboardMs=\(writePasteboardMilliseconds, format: .fixed(precision: 2), privacy: .public) success=\(success, privacy: .public) failureStage=\(failureStage, privacy: .public) width=\(width, privacy: .public) height=\(height, privacy: .public)"
+			"schema=\(schema, privacy: .public) runID=\(runID, privacy: .public) captureID=\(captureID, privacy: .public) event=capture_timing.prepared_frozen_export totalMs=\(totalMilliseconds, format: .fixed(precision: 2), privacy: .public) captureImageMs=\(captureImageMilliseconds, format: .fixed(precision: 2), privacy: .public) makeImageMs=\(makeImageMilliseconds, format: .fixed(precision: 2), privacy: .public) success=\(success, privacy: .public) reason=\(reason, privacy: .public) width=\(width, privacy: .public) height=\(height, privacy: .public)"
 		)
 	}
 

--- a/packages/rsnap-overlay/src/frozen_export.rs
+++ b/packages/rsnap-overlay/src/frozen_export.rs
@@ -168,7 +168,7 @@ impl ExportTransform {
 		}
 
 		let x = (point.x - self.selection.x) * self.scale_x;
-		let y = (point.y - self.selection.y) * self.scale_y;
+		let y = (self.selection.y + self.selection.height - point.y) * self.scale_y;
 
 		f64_pair_to_pos2(x, y)
 	}
@@ -179,7 +179,7 @@ impl ExportTransform {
 		}
 
 		let x = (rect.x - self.selection.x) * self.scale_x;
-		let y = (rect.y - self.selection.y) * self.scale_y;
+		let y = (self.selection.y + self.selection.height - (rect.y + rect.height)) * self.scale_y;
 		let width = rect.width * self.scale_x;
 		let height = rect.height * self.scale_y;
 		let origin = f64_pair_to_pos2(x, y)?;
@@ -791,8 +791,48 @@ mod tests {
 
 		assert_eq!(rendered.dimensions(), image.dimensions());
 		assert_ne!(rendered.as_raw(), image.as_raw());
-		assert_eq!(rendered.get_pixel(12, 3), image.get_pixel(12, 3));
-		assert!(rendered.get_pixel(0, 10)[0] < image.get_pixel(0, 10)[0] + 1);
+		assert_eq!(rendered.get_pixel(12, 8), image.get_pixel(12, 8));
+		assert!(rendered.get_pixel(1, 5)[1] < image.get_pixel(1, 5)[1]);
+	}
+
+	#[test]
+	fn export_compositor_maps_display_y_to_image_top_left_pixels() {
+		let image = RgbaImage::from_pixel(20, 20, Rgba([24, 24, 24, 255]));
+		let bottom_point = FrozenOverlayExportElement::Pen(FrozenOverlayExportPen {
+			points: vec![FrozenOverlayExportPoint::new(10.0, 0.0)],
+			style: FrozenOverlayExportStrokeStyle {
+				stroke_width_points: 2.0,
+				rgba: [255, 107, 107, 255],
+			},
+		});
+		let top_point = FrozenOverlayExportElement::Pen(FrozenOverlayExportPen {
+			points: vec![FrozenOverlayExportPoint::new(10.0, 20.0)],
+			style: FrozenOverlayExportStrokeStyle {
+				stroke_width_points: 2.0,
+				rgba: [255, 107, 107, 255],
+			},
+		});
+		let bottom_rendered = frozen_export::render_frozen_overlay_export_rgba(
+			image.width(),
+			image.height(),
+			image.as_raw(),
+			DisplayPointRect::new(0.0, 0.0, 20.0, 20.0),
+			&[bottom_point],
+		)
+		.expect("valid bottom-point export");
+		let top_rendered = frozen_export::render_frozen_overlay_export_rgba(
+			image.width(),
+			image.height(),
+			image.as_raw(),
+			DisplayPointRect::new(0.0, 0.0, 20.0, 20.0),
+			&[top_point],
+		)
+		.expect("valid top-point export");
+
+		assert_ne!(bottom_rendered.get_pixel(10, 19), image.get_pixel(10, 19));
+		assert_eq!(bottom_rendered.get_pixel(10, 0), image.get_pixel(10, 0));
+		assert_ne!(top_rendered.get_pixel(10, 0), image.get_pixel(10, 0));
+		assert_eq!(top_rendered.get_pixel(10, 19), image.get_pixel(10, 19));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
- move frozen capture copy/save rendering and PNG generation off the main thread
- prepare reusable frozen export PNGs after freeze commit so copy/save can hit cache
- keep direct RGBA overlay export fast path and fix export Y-axis mapping for annotations

## Verification
- cargo test -p rsnap-overlay frozen_export -- --nocapture
- cargo make fmt-check
- cargo make check-vstyle
- cargo make check-rust
- cargo make check-swift
- cargo make test-macos-native-host
- git diff --check
- ./scripts/build_and_run.sh --verify