### PR TITLE
Prepare v0.2.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "color-eyre",
  "fast_image_resize",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.1"
+version     = "0.2.2"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -54,9 +54,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.2.1", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.1", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.2.1", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.2.2", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.2", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.2.2", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -73,11 +73,10 @@ Prototype / in active development.
   `docs/spec/capture-session.md` is the current contract source of truth.
 - Menubar and Dock are not included in live window-outline targeting.
 - Windows support is planned (minimum Windows 10), but not implemented yet.
-- The scroll-capture engine, deterministic replay, and benchmark surfaces remain in the repository,
-  but the v0.2.1 native-host release does not expose scroll capture in the toolbar. On this
-  development branch, scroll capture uses ordered ScreenCaptureKit region frames, overlay-local
-  wheel forwarding, and Rust-owned fail-closed stitching on macOS. Release readiness for broader
-  target apps is governed by `docs/runbook/scroll-capture-recovery-plan.md`.
+- As of v0.2.2, the native-host release exposes Scroll Capture for dragged-region Frozen captures
+  on macOS. It uses ordered ScreenCaptureKit region frames, overlay-local wheel forwarding, and
+  Rust-owned fail-closed stitching. Release readiness for broader target apps is governed by
+  `docs/runbook/scroll-capture-recovery-plan.md`.
 
 ## Usage
 
@@ -130,8 +129,8 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
 - Normal region/window/monitor capture does not require Accessibility or Input Monitoring.
 - The retained scroll-capture path uses Screen Recording-backed screenshots plus overlay-local
   wheel forwarding; it does not require Accessibility, Input Monitoring, Accessibility target
-  acquisition, app scripting, or browser/DOM access. The v0.2.1 native-host release does not expose
-  scroll capture in the toolbar.
+  acquisition, app scripting, or browser/DOM access. The v0.2.2 native-host release exposes Scroll
+  Capture from dragged-region Frozen captures only.
 - macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when Rsnap bypasses the system picker.
 - Settings -> Permissions shows Screen Recording as the required capture permission.
 - Normal native capture depends on Screen Recording; if access is missing, Rsnap opens the Screen Recording page in System Settings and shows a floating drag-to-grant guide.
@@ -167,15 +166,14 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
 
 ### Current scroll-capture status
 
-Scroll capture is temporarily hidden in the v0.2.1 native-host release. The retained Rust
-scroll-capture session, deterministic replay, and benchmark surfaces remain for validation and
-future re-enablement, but users should not expect a `Scroll Capture` toolbar item in that release.
+As of v0.2.2, Scroll Capture is exposed for dragged-region Frozen captures on macOS. It remains
+absent for window-click and fullscreen freezes. The retained Rust scroll-capture session,
+deterministic replay, and benchmark surfaces remain the validation authority for stitching behavior.
 
-On this development branch, scroll capture targets dragged-region Frozen capture on macOS. The
-implementation commits downward growth only after ordered-frame pairwise registration plus overlap
-proof, fails closed on weak registration or rewind, and forwards wheel input to target apps through
-one universal path. Follow `docs/runbook/scroll-capture-recovery-plan.md` for release-scope
-validation.
+The implementation commits downward growth only after ordered-frame pairwise registration plus
+overlap proof, fails closed on weak registration or rewind, and forwards wheel input to target apps
+through one universal path. Follow `docs/runbook/scroll-capture-recovery-plan.md` for
+release-scope validation beyond the deterministic and native smoke surfaces.
 
 ## Development
 

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -17,11 +17,10 @@ Depends on: `docs/runbook/performance-validation.md`; `docs/spec/performance.md`
 Covers: The current layer map for smoke/perf entrypoints, deterministic replay/bench surfaces,
 overlay runtime integration tests, and scroll-capture session semantics tests.
 
-Release exposure note: v0.2.1 hides user-facing scroll capture in the native host. On this
-development branch, scroll capture is implemented behind the current validation contract. The
-scroll-capture entries in this reference describe retained validation assets and recovery surfaces;
-follow `docs/runbook/scroll-capture-recovery-plan.md` before making a release-scope readiness claim
-for broader target apps.
+Release exposure note: v0.2.2 exposes user-facing Scroll Capture for dragged-region Frozen captures
+in the native host. The scroll-capture entries in this reference remain the retained validation
+assets and recovery surfaces; follow `docs/runbook/scroll-capture-recovery-plan.md` before making a
+release-scope readiness claim for broader target apps.
 
 ## Layer definitions
 

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -17,11 +17,10 @@ Depends on: `docs/spec/performance.md`
 Outputs: A clear command choice for the regression class you are testing, plus a repeatable local
 baseline workflow for the committed Criterion benchmark targets.
 
-Current release status: v0.2.1 hides user-facing scroll capture in the native host. On this
-development branch, scroll capture is implemented under the validation contract. The replay and
-benchmark commands in this runbook still own retained internal scroll-capture engine validation, but
-they do not prove that a release toolbar exposes scroll capture and do not replace the recovery plan
-or a final target-app acceptance run for broader release claims.
+Current release status: v0.2.2 exposes user-facing Scroll Capture for dragged-region Frozen
+captures in the native host. The replay and benchmark commands in this runbook still own retained
+internal scroll-capture engine validation, but they do not replace the recovery plan or a final
+target-app acceptance run for broader release claims.
 
 ## Command selection
 

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -14,10 +14,9 @@ Depends on: `docs/spec/performance.md`
 Outputs: A repeatable local benchmark run, an optional saved Criterion baseline, and a clear
 understanding of what the synthetic fixture is intended to cover.
 
-Current release status: v0.2.1 hides user-facing scroll capture in the native host. On this
-development branch, scroll capture is implemented under the validation contract. This runbook
-applies to the retained internal scroll-capture engine, replay, and stitching validation work; it is
-not release-readiness evidence by itself.
+Current release status: v0.2.2 exposes user-facing Scroll Capture for dragged-region Frozen
+captures in the native host. This runbook applies to the retained internal scroll-capture engine,
+replay, and stitching validation work; it is not release-readiness evidence by itself.
 
 If you are debugging correctness rather than hot-path speed, route through
 `docs/runbook/performance-validation.md` first. That runbook owns replay,

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -57,13 +57,12 @@ Validate these user-visible flows:
 - Live HUD, Tab loupe sampling, window outline, dragged-region freeze, click-window freeze, and
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
-  Recognize Text, copy, and save.
-- For the v0.2.1 native-host release, scroll capture is hidden: the toolbar must not show a scroll
-  capture item, and pressing `s` must not enter scroll capture.
-- If a later release candidate includes Scroll Capture, `docs/runbook/scroll-capture-recovery-plan.md`
-  must have exited successfully first. Then Scroll Capture must stay absent for window-click and
-  fullscreen freezes, must start from a dragged-region freeze via toolbar or plain `s`, and must
-  pass the live acceptance run in that plan.
+  Recognize Text, Scroll Capture, copy, and save.
+- For the v0.2.2 native-host release, Scroll Capture must stay absent for window-click and
+  fullscreen freezes, remain available after dragged-region movement or auto-center, start from a
+  dragged-region freeze via toolbar or plain `s`, and pass the functional scroll path in
+  `docs/runbook/scroll-capture-recovery-plan.md`. Scroll toolbar Liquid Glass cadence and
+  performance metrics are excluded from the v0.2.2 publish gate and tracked as follow-up work.
 - Light and dark appearance; Classic Glass and Liquid Glass where the OS and current build support
   Liquid Glass.
 - Settings -> About update rows: `Auto Update` and `Release Version` must use Title Case for row

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -166,9 +166,8 @@ This section defines the target contract. The current development branch must fo
 `docs/runbook/scroll-capture-recovery-plan.md` before claiming that the implementation satisfies
 this contract.
 
-- The v0.2.1 native-host release does not expose scroll capture. The frozen toolbar MUST NOT show a
-  scroll-capture item while the native-host scroll-capture gate is disabled, and plain `s` MUST NOT
-  enter scroll capture in that state.
+- The frozen toolbar MUST NOT show a scroll-capture item while the native-host scroll-capture gate
+  is disabled, and plain `s` MUST NOT enter scroll capture in that state.
 - If scroll capture is exposed, it is available only from a dragged-region freeze on macOS.
 - The frozen toolbar may expose `Scroll Capture`, and plain `s` may start scroll capture, only when
   the frozen capture source is a dragged region on macOS.


### PR DESCRIPTION
## Summary
- bump Rsnap workspace packages and lockfile to 0.2.2
- update release/docs wording for the v0.2.2 Scroll Capture exposure contract
- document that scroll toolbar Liquid Glass cadence/performance metrics are excluded from the v0.2.2 publish gate and tracked separately

## Validation
- cargo make checks
- cargo make test-host-reset
- cargo make test-macos-native-host-stage
- cargo metadata --locked --no-deps --format-version 1
- semantic drift audit reviewed with explicit performance-gate waiver

## Known follow-up
- Scroll toolbar Liquid Glass cadence/performance smoke remains a separate follow-up and is intentionally not blocking this release.