### PR TITLE
Release v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "color-eyre",
  "fast_image_resize",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.2"
+version     = "0.2.3"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -54,9 +54,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.2.2", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.2", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.2.2", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.2.3", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.3", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.2.3", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Prototype / in active development.
   `docs/spec/capture-session.md` is the current contract source of truth.
 - Menubar and Dock are not included in live window-outline targeting.
 - Windows support is planned (minimum Windows 10), but not implemented yet.
-- As of v0.2.2, the native-host release exposes Scroll Capture for dragged-region Frozen captures
+- As of v0.2.3, the native-host release exposes Scroll Capture for dragged-region Frozen captures
   on macOS. It uses ordered ScreenCaptureKit region frames, overlay-local wheel forwarding, and
   Rust-owned fail-closed stitching. Release readiness for broader target apps is governed by
   `docs/runbook/scroll-capture-recovery-plan.md`.
@@ -129,7 +129,7 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
 - Normal region/window/monitor capture does not require Accessibility or Input Monitoring.
 - The retained scroll-capture path uses Screen Recording-backed screenshots plus overlay-local
   wheel forwarding; it does not require Accessibility, Input Monitoring, Accessibility target
-  acquisition, app scripting, or browser/DOM access. The v0.2.2 native-host release exposes Scroll
+  acquisition, app scripting, or browser/DOM access. The v0.2.3 native-host release exposes Scroll
   Capture from dragged-region Frozen captures only.
 - macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when Rsnap bypasses the system picker.
 - Settings -> Permissions shows Screen Recording as the required capture permission.
@@ -166,7 +166,7 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
 
 ### Current scroll-capture status
 
-As of v0.2.2, Scroll Capture is exposed for dragged-region Frozen captures on macOS. It remains
+As of v0.2.3, Scroll Capture is exposed for dragged-region Frozen captures on macOS. It remains
 absent for window-click and fullscreen freezes. The retained Rust scroll-capture session,
 deterministic replay, and benchmark surfaces remain the validation authority for stitching behavior.
 

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -17,7 +17,7 @@ Depends on: `docs/runbook/performance-validation.md`; `docs/spec/performance.md`
 Covers: The current layer map for smoke/perf entrypoints, deterministic replay/bench surfaces,
 overlay runtime integration tests, and scroll-capture session semantics tests.
 
-Release exposure note: v0.2.2 exposes user-facing Scroll Capture for dragged-region Frozen captures
+Release exposure note: v0.2.3 exposes user-facing Scroll Capture for dragged-region Frozen captures
 in the native host. The scroll-capture entries in this reference remain the retained validation
 assets and recovery surfaces; follow `docs/runbook/scroll-capture-recovery-plan.md` before making a
 release-scope readiness claim for broader target apps.

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -17,7 +17,7 @@ Depends on: `docs/spec/performance.md`
 Outputs: A clear command choice for the regression class you are testing, plus a repeatable local
 baseline workflow for the committed Criterion benchmark targets.
 
-Current release status: v0.2.2 exposes user-facing Scroll Capture for dragged-region Frozen
+Current release status: v0.2.3 exposes user-facing Scroll Capture for dragged-region Frozen
 captures in the native host. The replay and benchmark commands in this runbook still own retained
 internal scroll-capture engine validation, but they do not replace the recovery plan or a final
 target-app acceptance run for broader release claims.

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -14,7 +14,7 @@ Depends on: `docs/spec/performance.md`
 Outputs: A repeatable local benchmark run, an optional saved Criterion baseline, and a clear
 understanding of what the synthetic fixture is intended to cover.
 
-Current release status: v0.2.2 exposes user-facing Scroll Capture for dragged-region Frozen
+Current release status: v0.2.3 exposes user-facing Scroll Capture for dragged-region Frozen
 captures in the native host. This runbook applies to the retained internal scroll-capture engine,
 replay, and stitching validation work; it is not release-readiness evidence by itself.
 

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -58,11 +58,12 @@ Validate these user-visible flows:
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
   Recognize Text, Scroll Capture, copy, and save.
-- For the v0.2.2 native-host release, Scroll Capture must stay absent for window-click and
+- For the v0.2.3 native-host release, Scroll Capture must stay absent for window-click and
   fullscreen freezes, remain available after dragged-region movement or auto-center, start from a
   dragged-region freeze via toolbar or plain `s`, and pass the functional scroll path in
-  `docs/runbook/scroll-capture-recovery-plan.md`. Scroll toolbar Liquid Glass cadence and
-  performance metrics are excluded from the v0.2.2 publish gate and tracked as follow-up work.
+  `docs/runbook/scroll-capture-recovery-plan.md`. Scroll toolbar Liquid Glass cadence, dynamic
+  backdrop-change evidence, preview export latency, and cached copy/export timing are part of the
+  v0.2.3 publish gate.
 - Light and dark appearance; Classic Glass and Liquid Glass where the OS and current build support
   Liquid Glass.
 - Settings -> About update rows: `Auto Update` and `Release Version` must use Title Case for row

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -75,7 +75,7 @@ APP_VERSION="${RSNAP_NATIVE_HOST_APP_VERSION:-}"
 if [[ -z "$APP_VERSION" ]]; then
 	APP_VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -n 1)"
 fi
-APP_VERSION="${APP_VERSION:-0.2.1}"
+APP_VERSION="${APP_VERSION:-0.2.3}"
 
 require_liquid_glass_capable_swift_for_release() {
 	[[ "$SWIFT_CONFIGURATION" == "release" ]] || return 0


### PR DESCRIPTION
## Summary
- bump Rsnap workspace packages and native-host fallback app version to 0.2.3
- update README and release validation docs for the v0.2.3 scroll-capture gate
- document toolbar Liquid Glass cadence, backdrop-change evidence, preview export latency, and copy cache timing as release-blocking checks

## Verification
- cargo make fmt-toml-check
- bash -n scripts/build_and_run.sh scripts/release/sparkle-appcast.sh scripts/smoke/native-scroll-capture-macos.sh
- cargo metadata --format-version 1 --no-deps
- python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py --rev HEAD
- cargo make checks
- cargo make test-host-reset
- cargo make test-macos-native-host-stage
- SCROLL_START_METHOD=keyboard scripts/smoke/native-scroll-capture-macos.sh
- SCROLL_START_METHOD=toolbar scripts/smoke/native-scroll-capture-macos.sh
- SCROLL_START_METHOD=keyboard SCROLL_POINT_MODE=right_outside_selection MIN_SCROLL_COMMITS=4 MIN_EXPORT_GROWTH_PX=300 scripts/smoke/native-scroll-capture-macos.sh
- scripts/smoke/macos.sh
- scripts/perf/macos.sh

## Scroll smoke evidence
- keyboard: 58 commits, 6825px growth, preview_refreshes=11, toolbar_gap_p95=23.73ms, duration_p95=0.03ms, changed_gap_p95=67.61ms
- toolbar: 52 commits, 6763px growth, preview_refreshes=11, toolbar_gap_p95=23.01ms, duration_p95=0.03ms, changed_gap_p95=66.75ms
- right_outside_selection: 54 commits, 6829px growth, preview_refreshes=12, toolbar_gap_p95=22.79ms, duration_p95=0.03ms, changed_gap_p95=67.44ms