### PR TITLE
Release v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "color-eyre",
  "fast_image_resize",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.3"
+version     = "0.2.4"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -54,9 +54,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.2.3", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.3", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.2.3", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.2.4", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.4", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.2.4", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Prototype / in active development.
   `docs/spec/capture-session.md` is the current contract source of truth.
 - Menubar and Dock are not included in live window-outline targeting.
 - Windows support is planned (minimum Windows 10), but not implemented yet.
-- As of v0.2.3, the native-host release exposes Scroll Capture for dragged-region Frozen captures
+- As of v0.2.4, the native-host release exposes Scroll Capture for dragged-region Frozen captures
   on macOS. It uses ordered ScreenCaptureKit region frames, overlay-local wheel forwarding, and
   Rust-owned fail-closed stitching. Release readiness for broader target apps is governed by
   `docs/runbook/scroll-capture-recovery-plan.md`.
@@ -129,7 +129,7 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
 - Normal region/window/monitor capture does not require Accessibility or Input Monitoring.
 - The retained scroll-capture path uses Screen Recording-backed screenshots plus overlay-local
   wheel forwarding; it does not require Accessibility, Input Monitoring, Accessibility target
-  acquisition, app scripting, or browser/DOM access. The v0.2.3 native-host release exposes Scroll
+  acquisition, app scripting, or browser/DOM access. The v0.2.4 native-host release exposes Scroll
   Capture from dragged-region Frozen captures only.
 - macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when Rsnap bypasses the system picker.
 - Settings -> Permissions shows Screen Recording as the required capture permission.
@@ -166,7 +166,7 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
 
 ### Current scroll-capture status
 
-As of v0.2.3, Scroll Capture is exposed for dragged-region Frozen captures on macOS. It remains
+As of v0.2.4, Scroll Capture is exposed for dragged-region Frozen captures on macOS. It remains
 absent for window-click and fullscreen freezes. The retained Rust scroll-capture session,
 deterministic replay, and benchmark surfaces remain the validation authority for stitching behavior.
 

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -17,7 +17,7 @@ Depends on: `docs/runbook/performance-validation.md`; `docs/spec/performance.md`
 Covers: The current layer map for smoke/perf entrypoints, deterministic replay/bench surfaces,
 overlay runtime integration tests, and scroll-capture session semantics tests.
 
-Release exposure note: v0.2.3 exposes user-facing Scroll Capture for dragged-region Frozen captures
+Release exposure note: v0.2.4 exposes user-facing Scroll Capture for dragged-region Frozen captures
 in the native host. The scroll-capture entries in this reference remain the retained validation
 assets and recovery surfaces; follow `docs/runbook/scroll-capture-recovery-plan.md` before making a
 release-scope readiness claim for broader target apps.

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -17,7 +17,7 @@ Depends on: `docs/spec/performance.md`
 Outputs: A clear command choice for the regression class you are testing, plus a repeatable local
 baseline workflow for the committed Criterion benchmark targets.
 
-Current release status: v0.2.3 exposes user-facing Scroll Capture for dragged-region Frozen
+Current release status: v0.2.4 exposes user-facing Scroll Capture for dragged-region Frozen
 captures in the native host. The replay and benchmark commands in this runbook still own retained
 internal scroll-capture engine validation, but they do not replace the recovery plan or a final
 target-app acceptance run for broader release claims.

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -14,7 +14,7 @@ Depends on: `docs/spec/performance.md`
 Outputs: A repeatable local benchmark run, an optional saved Criterion baseline, and a clear
 understanding of what the synthetic fixture is intended to cover.
 
-Current release status: v0.2.3 exposes user-facing Scroll Capture for dragged-region Frozen
+Current release status: v0.2.4 exposes user-facing Scroll Capture for dragged-region Frozen
 captures in the native host. This runbook applies to the retained internal scroll-capture engine,
 replay, and stitching validation work; it is not release-readiness evidence by itself.
 

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -58,18 +58,19 @@ Validate these user-visible flows:
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
   Recognize Text, Scroll Capture, copy, and save.
-- For the v0.2.3 native-host release, Scroll Capture must stay absent for window-click and
+- For the v0.2.4 native-host release, Scroll Capture must stay absent for window-click and
   fullscreen freezes, remain available after dragged-region movement or auto-center, start from a
   dragged-region freeze via toolbar or plain `s`, and pass the functional scroll path in
   `docs/runbook/scroll-capture-recovery-plan.md`. Scroll toolbar Liquid Glass cadence, dynamic
   backdrop-change evidence, preview export latency, and cached copy/export timing are part of the
-  v0.2.3 publish gate.
+  v0.2.4 publish gate.
 - Light and dark appearance; Classic Glass and Liquid Glass where the OS and current build support
   Liquid Glass.
 - Settings -> About update rows: `Auto Update` and `Release Version` must use Title Case for row
   titles. The Auto Update mode control must show `Off`, `Notify`, and `Install`; secondary text must use
   sentence case, must not look like download progress, and the release-configured build must not
-  report that the Sparkle appcast is missing.
+  report that the Sparkle appcast is missing. The `Check` button must stay enabled after starting
+  an update from the status menu or while Sparkle has an active update session.
 - Settings -> Output frame rows: `Frame Preset` must include `Off`, selecting `Off` must disable
   `Apply To`, and selecting a background preset must re-enable `Apply To`.
 - Sparkle local update smoke:

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -145,6 +145,9 @@ Defines:
 - The About section must expose a Check for Updates action backed by Sparkle's standard check
   flow. When an installable update is available, Sparkle owns the native update window, download
   progress, install authorization if needed, and final install-and-relaunch action.
+- The Check for Updates action must remain user-available even while Sparkle reports that a
+  session is active, downloading, or preparing an update. That state must not gray out the user's
+  entry point back into the update flow.
 - The About section must expose one Auto Update mode control rather than separate Automatic Checks
   and Automatic Updates rows. The visible modes are Off, Notify, and Install.
 - Off must disable Sparkle automatic checks and automatic downloads. Notify must enable Sparkle

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -2383,8 +2383,8 @@ private struct UpdateCheckButtonGroup: View {
 			.rsnapGlassButton(prominent: false)
 			.controlSize(.small)
 			.disabled(
-				model.softwareUpdateSettings.isConfigured
-					&& !model.softwareUpdateSettings.canCheckForUpdates)
+				!SoftwareUpdateManualCheckAvailability.isEnabled(
+					sparkleCanCheckForUpdates: model.softwareUpdateSettings.canCheckForUpdates))
 		}
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSoftwareUpdater.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSoftwareUpdater.swift
@@ -201,3 +201,12 @@ final class NativeHostSoftwareUpdater {
 		return url
 	}
 }
+
+package enum SoftwareUpdateManualCheckAvailability {
+	package static func isEnabled(sparkleCanCheckForUpdates: Bool) -> Bool {
+		// Sparkle flips canCheckForUpdates off while a session is active, but Rsnap's
+		// Check action is the user's way back into that update flow.
+		_ = sparkleCanCheckForUpdates
+		return true
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -11,6 +11,7 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureFrameEffectExpandsExportCanvas()
 		assertScrollCaptureViewportPointAcceptsFlippedGlobalMouseCoordinates()
 		assertScrollCaptureObservedInputAcceptsSourceWindowGutter()
+		assertManualUpdateCheckRemainsAvailable()
 		let minimapExportSize = CGSize(width: 100, height: 200)
 		guard
 			let rightMinimap = scrollCaptureMinimapPlan(
@@ -65,6 +66,15 @@ enum RsnapNativeHostKitProbe {
 			"scroll minimap should fall back to the left when the right side is constrained"
 		)
 		assertLaunchAtLoginStateMapping()
+	}
+
+	private static func assertManualUpdateCheckRemainsAvailable() {
+		guard
+			SoftwareUpdateManualCheckAvailability.isEnabled(sparkleCanCheckForUpdates: true),
+			SoftwareUpdateManualCheckAvailability.isEnabled(sparkleCanCheckForUpdates: false)
+		else {
+			fatalError("manual update check should stay available across Sparkle session states")
+		}
 	}
 
 	private static func assertRectEqual(_ actual: CGRect, _ expected: CGRect, _ message: String) {

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -75,7 +75,7 @@ APP_VERSION="${RSNAP_NATIVE_HOST_APP_VERSION:-}"
 if [[ -z "$APP_VERSION" ]]; then
 	APP_VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -n 1)"
 fi
-APP_VERSION="${APP_VERSION:-0.2.3}"
+APP_VERSION="${APP_VERSION:-0.2.4}"
 
 require_liquid_glass_capable_swift_for_release() {
 	[[ "$SWIFT_CONFIGURATION" == "release" ]] || return 0


### PR DESCRIPTION
## Summary
- release v0.2.4 in Cargo metadata, build fallback, and release docs
- keep Settings -> About -> Check available even when Sparkle reports an active update session
- add native-host probe coverage for manual update check availability

## Verification
- cargo make fmt
- cargo make test-macos-native-host
- cargo make checks
- cargo make test-host-reset
- cargo make test-macos-native-host-stage
- scripts/smoke/sparkle-update-local.sh --self-check
- scripts/smoke/sparkle-update-local.sh --prepare-only
- scripts/smoke/macos.sh
- scripts/perf/macos.sh after rerunning one transient HUD event-delivery flake
- EXPECT_SCROLL_COPY_CACHE_HIT=1 SCROLL_START_METHOD=keyboard scripts/smoke/native-scroll-capture-macos.sh
- EXPECT_SCROLL_COPY_CACHE_HIT=1 SCROLL_START_METHOD=toolbar scripts/smoke/native-scroll-capture-macos.sh
- bash -n scripts/build_and_run.sh scripts/release/sparkle-appcast.sh scripts/smoke/native-scroll-capture-macos.sh scripts/smoke/sparkle-update-local.sh
- semantic drift audit reviewed as pass: update-check availability and v0.2.4 release claims map to executable policy/probe/version evidence

Manual Sparkle install/relaunch was not run in this PR; local Sparkle self-check and prepare-only packaging/appcast checks passed.