### PR TITLE
Fix native selection size badge label

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -1928,8 +1928,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func drawSelectionSizeBadge(for rect: CGRect, in context: CGContext) {
-		let scale = window?.screen?.backingScaleFactor ?? 1
-		let text = "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))"
+		let text = selectionSizeText(for: rect)
 		let font = Self.hudLayoutMetrics.font
 		let textSize = text.size(using: font)
 		let badgeFrame = CaptureChrome.selectionSizeBadgeFrame(
@@ -3286,7 +3285,13 @@ final class CaptureHostView: NSView {
 
 	private func selectionSizeText(for rect: CGRect) -> String {
 		let scale = window?.screen?.backingScaleFactor ?? 1
-		return "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))"
+		let sizeText = "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))px"
+
+		if abs(scale - 1) <= 0.005 {
+			return sizeText
+		}
+
+		return "\(sizeText) @\(String(format: "%g", Double(scale)))x"
 	}
 
 	private func currentPositionDisplay() -> LivePositionDisplay {

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -1269,30 +1269,8 @@ impl WindowRenderer {
 		size_points: RectPoints,
 	) -> String {
 		let size_pixels = monitor.local_rect_to_pixels(size_points);
-		let size_text = format!("{}x{} px", size_pixels.width, size_pixels.height);
 
-		if monitor.scale_factor_x1000 == 1_000 {
-			return size_text;
-		}
-
-		format!("{} @{}x", size_text, Self::selection_size_badge_scale_text(monitor))
-	}
-
-	fn selection_size_badge_scale_text(monitor: MonitorRect) -> String {
-		let scale_integer = monitor.scale_factor_x1000 / 1_000;
-		let scale_fraction = monitor.scale_factor_x1000 % 1_000;
-
-		if scale_fraction == 0 {
-			return scale_integer.to_string();
-		}
-
-		let mut scale_fraction_text = format!("{scale_fraction:03}");
-
-		while scale_fraction_text.ends_with('0') {
-			scale_fraction_text.pop();
-		}
-
-		format!("{scale_integer}.{scale_fraction_text}")
+		format!("{}x{}", size_pixels.width, size_pixels.height)
 	}
 
 	fn selection_size_badge_visual_overflow(pixels_per_point: f32) -> SelectionSizeBadgePadding {

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/capture_affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/capture_affordances.rs
@@ -306,34 +306,18 @@ fn selection_size_badge_reserved_rect_accepts_overlap_when_no_non_overlapping_sl
 
 #[test]
 fn selection_size_badge_text_uses_monitor_pixel_dimensions() {
+	let monitor = tests::test_monitor_with_scale(1_000, 800, 2_000);
+
 	assert_eq!(
-		WindowRenderer::selection_size_badge_text(
-			tests::test_monitor_with_scale(1_000, 800, 2_000),
-			RectPoints::new(10, 20, 120, 80),
-		),
-		"240x160 px @2x"
-	);
-	assert_eq!(
-		WindowRenderer::selection_size_badge_text(
-			tests::test_monitor_with_scale(1_000, 800, 1_500),
-			RectPoints::new(10, 20, 120, 80),
-		),
-		"180x120 px @1.5x"
-	);
-	assert_eq!(
-		WindowRenderer::selection_size_badge_text(
-			tests::test_monitor_with_scale(1_000, 800, 1_000),
-			RectPoints::new(10, 20, 120, 80),
-		),
-		"120x80 px"
+		WindowRenderer::selection_size_badge_text(monitor, RectPoints::new(10, 20, 120, 80)),
+		"240x160"
 	);
 }
 
 #[test]
 fn selection_size_badge_layout_keeps_visual_bounds_inside_badge_rect() {
 	let ctx = tests::test_egui_context();
-	let layout =
-		WindowRenderer::selection_size_badge_layout(&ctx, "240x160 px @2x", HudTheme::Light, 1.0);
+	let layout = WindowRenderer::selection_size_badge_layout(&ctx, "240x160", HudTheme::Light, 1.0);
 	let screen_rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
 
 	for (label, capture_rect) in [


### PR DESCRIPTION
## Summary
- Update the native macOS selection size badge to show explicit output pixel units, e.g. `1806x898px @2x`.
- Keep 1x displays compact by omitting `@1x`.
- Restore the Rust overlay badge text expectations from the earlier mis-targeted display change; the PNG density/export behavior from #231 is unchanged.

## Verification
- `cargo make fmt-check`
- `cargo make check-vstyle`
- `cargo make check-rust`
- `cargo make check-swift`
- `cargo test -p rsnap-overlay selection_size_badge_text_uses_monitor_pixel_dimensions`
- `git diff --check`
- `scripts/build_and_run.sh --verify` (release/prod staged app launched for manual UI check)