### PR TITLE
Bump workspace version to v0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "color-eyre",
  "fast_image_resize",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.6"
+version     = "0.2.7"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -54,9 +54,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.2.6", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.6", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.2.6", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.2.7", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.7", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.2.7", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"


### PR DESCRIPTION
## Summary
- Bump the workspace package version to 0.2.7.
- Sync internal workspace dependency constraints and Cargo.lock package entries.

## Validation
- cargo make checks
- cargo make test-host-reset
- cargo make test-macos-native-host-stage
- scripts/smoke/macos.sh
- scripts/perf/macos.sh