### PR TITLE
Focus Sparkle update alerts

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -108,7 +108,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	private var selfCaptureRegistrationWindow: NSWindow?
 	private var didBootstrap = false
 	private var didPresentLaunchPermissionOnboarding = false
-	private let softwareUpdater = NativeHostSoftwareUpdater()
+	private lazy var softwareUpdater = NativeHostSoftwareUpdater()
 	@objc public dynamic var window: NSWindow?
 	private lazy var sessionController: CaptureSessionController = {
 		let controller = CaptureSessionController(settingsStore: settingsStore)
@@ -145,6 +145,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		)
 		Self.applyApplicationIcon()
 		configureStatusItem()
+		_ = softwareUpdater
 		configureGlobalHotKeys()
 		showSelfCaptureRegistrationWindow()
 		NotificationCenter.default.addObserver(

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSoftwareUpdater.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSoftwareUpdater.swift
@@ -3,7 +3,7 @@ import Foundation
 import Sparkle
 
 @MainActor
-final class NativeHostSoftwareUpdater {
+final class NativeHostSoftwareUpdater: NSObject {
 	enum Mode: String, CaseIterable {
 		case off
 		case check
@@ -60,14 +60,15 @@ final class NativeHostSoftwareUpdater {
 		host: "github.com",
 		path: "/hack-ink/rsnap/releases/latest")
 
-	private let updaterController: SPUStandardUpdaterController?
+	private var updaterController: SPUStandardUpdaterController?
 
-	init() {
+	override init() {
+		super.init()
 		if Self.hasSparkleConfiguration {
 			let controller = SPUStandardUpdaterController(
 				startingUpdater: true,
 				updaterDelegate: nil,
-				userDriverDelegate: nil)
+				userDriverDelegate: self)
 			updaterController = controller
 			NativeHostTelemetry.lifecycleEvent("native_host.sparkle_updater_started")
 			requestImmediateLaunchUpdateCheckIfEnabled(using: controller.updater)
@@ -177,6 +178,11 @@ final class NativeHostSoftwareUpdater {
 		return trimmed.isEmpty ? nil : trimmed
 	}
 
+	private func showUpdateAlertInFront() {
+		NSApp.setActivationPolicy(.regular)
+		NSRunningApplication.current.activate(options: [.activateAllWindows])
+	}
+
 	private static func httpsURL(host: String, path: String) -> URL {
 		var components = URLComponents()
 		components.scheme = "https"
@@ -186,6 +192,33 @@ final class NativeHostSoftwareUpdater {
 			preconditionFailure("Invalid static Rsnap update URL: \(host)\(path)")
 		}
 		return url
+	}
+}
+
+extension NativeHostSoftwareUpdater: @preconcurrency SPUStandardUserDriverDelegate {
+	var supportsGentleScheduledUpdateReminders: Bool {
+		true
+	}
+
+	func standardUserDriverShouldHandleShowingScheduledUpdate(
+		_: SUAppcastItem,
+		andInImmediateFocus _: Bool
+	) -> Bool {
+		true
+	}
+
+	func standardUserDriverWillHandleShowingUpdate(
+		_ handleShowingUpdate: Bool,
+		forUpdate _: SUAppcastItem,
+		state _: SPUUserUpdateState
+	) {
+		guard handleShowingUpdate else {
+			return
+		}
+		showUpdateAlertInFront()
+		NativeHostTelemetry.lifecycleEvent(
+			"native_host.sparkle_update_alert_focused",
+			detail: "source=standard_driver")
 	}
 }
 


### PR DESCRIPTION
## Summary
- register Rsnap's Sparkle updater as the standard user-driver delegate for scheduled update prompts
- bring the standard Sparkle update alert to the foreground when Sparkle handles an available update
- initialize the updater after the status item is configured, without adding any Update Available menu state

## Verification
- cargo make fmt-swift
- cargo make test-macos-native-host
- cargo make test-macos-native-host-stage
- scripts/smoke/sparkle-update-local.sh --self-check
- cargo make check-swift
- git diff --check