### PR TITLE
Prepare v0.2.8 dependency roll

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -59,12 +59,12 @@ jobs:
         run: rustup toolchain install nightly --component rustfmt
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
+        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
         with:
           tool: cargo-make
 
       - name: Install nextest
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
+        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
         with:
           tool: nextest
 
@@ -105,7 +105,7 @@ jobs:
           rustflags: ''
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
+        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
         with:
           tool: cargo-make
 
@@ -140,12 +140,12 @@ jobs:
           rustflags: ''
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
+        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
         with:
           tool: cargo-make
 
       - name: Install taplo
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
+        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
         with:
           tool: taplo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "emath"
@@ -1887,12 +1887,13 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kurbo"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
  "arrayvec",
  "euclid",
+ "polycool",
  "smallvec",
 ]
 
@@ -2224,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2914,9 +2915,9 @@ dependencies = [
 
 [[package]]
 name = "peniko"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
 dependencies = [
  "bytemuck",
  "color",
@@ -2933,18 +2934,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,6 +3069,15 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3375,7 +3385,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3388,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "color-eyre",
  "fast_image_resize",
@@ -3399,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3407,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",
@@ -3449,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "color-eyre",
  "image",
@@ -3594,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5218,9 +5228,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -5546,9 +5556,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.7"
+version     = "0.2.8"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -54,9 +54,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.2.7", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.7", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.2.7", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.2.8", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.8", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.2.8", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"

--- a/native/macos-host/Package.resolved
+++ b/native/macos-host/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9c05e994e9f87c939c8cda211d145e263758e49e626a3bf1ca423d96a5e990be",
+  "originHash" : "4747a218392e344df35a09732cb96b958ac55a069fed1067d00f9fb4c72a73bf",
   "pins" : [
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
-        "version" : "2.9.1"
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
       }
     },
     {

--- a/native/macos-host/Package.swift
+++ b/native/macos-host/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.executable(name: "RsnapNativeHost", targets: ["RsnapNativeHost"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.1"),
+		.package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.2"),
 		.package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: "0.63.2"),
 	],
 	targets: [


### PR DESCRIPTION
## Summary
- bump the Rsnap workspace and internal path dependency versions to `0.2.8` for the next release PR
- refresh Cargo and SwiftPM dependency locks, including `serde_json` to `1.0.150` and Sparkle to `2.9.2`
- roll `taiki-e/install-action` to `v2.79.4` while preserving the repo full-SHA GitHub Actions pinning style

## Dependency notes
- Cargo lock refresh updated the latest Rust 1.95-compatible graph; `target-lexicon` remains at `0.13.3` because `cfg-expr v0.20.7` requires exactly that version through the `xcap`/PipeWire dependency path.
- Open Dependabot signals covered by this PR: #242 (`serde_json 1.0.150`) and #241 (`taiki-e/install-action`, superseded to latest `v2.79.4`).
- No release tag is created here; the checked-in release runbook still owns tag publishing after PR merge and RC validation.

## Verification
- `cargo make fmt-toml-check`
- `actionlint`
- external workflow ref full-SHA pin check
- `cargo make check-rust`
- `cargo make check-swift`
- `cargo make test-rust` (682 passed)
- `cargo make test-macos-native-host`
- `cargo make fmt-rust-check`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-rust`
- `cargo make check-vstyle-swift`
- `cargo make test-macos-native-host-stage`
- `git diff --check`
- staged app `CFBundleShortVersionString` and `CFBundleVersion` both read back as `0.2.8`
