### PR TITLE
Unify screenshot menu copy

### DIFF
--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -41,7 +41,7 @@ product level rather than binding itself to a particular window toolkit or shell
    closing Settings must return Rsnap to the background menubar shell.
 2. Global hotkey starts capture session (default `Alt+X`, macOS: Option+X) and can be customized
    from Settings.
-3. The status menu's New Capture item must use the configured capture shortcut. Shortcut display
+3. The status menu's New Screenshot item must use the configured capture shortcut. Shortcut display
    strings must use platform-native names such as `Option-X`, not raw event names such as
    `alt+KeyX`.
 4. The status menu must not expose Cancel Capture or Permissions entries. Capture cancellation is

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -38,7 +38,7 @@ Defines:
 
 ## Status Menu
 
-- The status menu must expose New Capture, Open Screenshots Folder, Check for Updates, Settings,
+- The status menu must expose New Screenshot, Open Screenshots Folder, Check for Updates, Settings,
   and Quit.
 - Open Screenshots Folder must open the configured output directory, creating it first when needed.
 - Check for Updates must invoke the same Sparkle-backed update check flow as the About section.
@@ -46,7 +46,7 @@ Defines:
   `Esc` and secondary click in both live and Frozen modes.
 - The status menu must not expose Permissions as a separate menu item. Permission status and
   recovery live in Settings.
-- New Capture must use the same configured shortcut as the global capture hotkey.
+- New Screenshot must use the same configured shortcut as the global capture hotkey.
 
 ## Settings Window
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -367,7 +367,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 
 		let menu = NSMenu(title: NativeHostBrand.displayName)
 		let captureItem = menu.addItem(
-			withTitle: "New Capture",
+			withTitle: "New Screenshot",
 			action: #selector(startCapture(_:)),
 			keyEquivalent: ""
 		)

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -2002,7 +2002,7 @@ private struct CaptureSettingsPanel: View {
 		VStack(spacing: 8) {
 			SettingsHeroControlTile(
 				symbolName: "keyboard",
-				title: "New Capture Shortcut",
+				title: "New Screenshot Shortcut",
 				subtitle: "Current: \(shortcutPresentation.displayTitle)."
 			) {
 				CaptureHotKeyField(model: model)

--- a/packages/rsnap-overlay/src/frozen_export.rs
+++ b/packages/rsnap-overlay/src/frozen_export.rs
@@ -266,7 +266,7 @@ pub fn render_frozen_overlay_export_rgba(
 fn rgba_image_from_bytes(width: u32, height: u32, rgba: &[u8]) -> Result<RgbaImage> {
 	let expected_len = usize::try_from(width)
 		.ok()
-		.and_then(|width| usize::try_from(height).ok().map(|height| (width, height)))
+		.zip(usize::try_from(height).ok())
 		.and_then(|(width, height)| width.checked_mul(height))
 		.and_then(|pixels| pixels.checked_mul(4))
 		.ok_or_else(|| eyre::eyre!("frozen-overlay export dimensions overflow"))?;

--- a/packages/rsnap-overlay/src/lib.rs
+++ b/packages/rsnap-overlay/src/lib.rs
@@ -172,7 +172,7 @@ pub mod scroll_stitching {
 	fn rgba_image_from_bytes(width: u32, height: u32, rgba: &[u8]) -> Result<RgbaImage> {
 		let expected_len = usize::try_from(width)
 			.ok()
-			.and_then(|width| usize::try_from(height).ok().map(|height| (width, height)))
+			.zip(usize::try_from(height).ok())
 			.and_then(|(width, height)| width.checked_mul(height))
 			.and_then(|pixels| pixels.checked_mul(4))
 			.ok_or_else(|| eyre::eyre!("scroll-capture frame dimensions overflow"))?;

--- a/scripts/smoke/lib/live-hud.sh
+++ b/scripts/smoke/lib/live-hud.sh
@@ -250,13 +250,13 @@ tell application "System Events"
         tell process "RsnapNativeHost"
             click menu bar item 1 of menu bar 1
             delay 0.06
-            click menu item "New Capture" of menu 1 of menu bar item 1 of menu bar 1
+            click menu item "New Screenshot" of menu 1 of menu bar item 1 of menu bar 1
         end tell
     else
         tell process "Rsnap"
             click menu bar item 1 of menu bar 1
             delay 0.06
-            click menu item "New Capture" of menu 1 of menu bar item 1 of menu bar 1
+            click menu item "New Screenshot" of menu 1 of menu bar item 1 of menu bar 1
         end tell
     end if
 end tell


### PR DESCRIPTION
Summary:
- Rename the status menu action from New Capture to New Screenshot.
- Rename the Settings shortcut label to New Screenshot Shortcut.
- Update specs and live HUD smoke automation to match the new menu copy.
- Fix Rust 1.96 Clippy manual_option_zip lints that blocked the PR Rust check.

Verification:
- cargo make check-swift
- cargo make fmt-swift-check
- bash -n scripts/smoke/lib/live-hud.sh
- git diff --check
- semantic_drift_audit.py: no stale phrase hits
- Runtime menu readback via System Events: New Screenshot, Quick Screenshot, Open Screenshots Folder, Check for Updates…, Settings…, Quit
- cargo make fmt-rust-check
- cargo make check-rust
- cargo make test-rust: 682 passed