### PR TITLE
Prepare v0.2.9 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,7 +3385,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "color-eyre",
  "directories",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "color-eyre",
  "fast_image_resize",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "rsnap-capture-core",
  "rsnap-overlay",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-overlay"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "block2 0.6.2",
  "color-eyre",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.8"
+version     = "0.2.9"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -54,9 +54,9 @@ wgpu                     = { version = "29.0" }
 winit                    = { version = "0.30", features = ["rwh_06"] }
 xcap                     = { version = "0.9" }
 
-rsnap-capture-core = { version = "0.2.8", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.8", path = "packages/rsnap-host-ffi" }
-rsnap-overlay      = { version = "0.2.8", path = "packages/rsnap-overlay" }
+rsnap-capture-core = { version = "0.2.9", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.9", path = "packages/rsnap-host-ffi" }
+rsnap-overlay      = { version = "0.2.9", path = "packages/rsnap-overlay" }
 
 [profile.final-release]
 inherits = "release"


### PR DESCRIPTION
## Summary
- bump workspace/package versions from 0.2.8 to 0.2.9
- refresh Cargo.lock package versions for the release

## Verification
- cargo metadata --locked --no-deps --format-version 1
- python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py --rev origin/main
- rg -n '0\.2\.8|v0\.2\.8' (no matches)
- cargo make checks
- cargo make test-host-reset
- cargo make test-macos-native-host-stage
- scripts/smoke/macos.sh
- scripts/perf/macos.sh