### PR TITLE
Modularize overlay session bootstrap

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -27,6 +27,7 @@ mod scroll_capture_runtime;
 mod scroll_input_runtime;
 mod scroll_preview_runtime;
 mod scroll_runtime;
+mod session_bootstrap_runtime;
 mod session_state;
 mod toolbar_runtime;
 mod trace_recording;
@@ -174,6 +175,7 @@ use self::runtime_model::{
 	HudTheme, LiveCaptureInteraction, OverlayEventLoopPhase, PngAction, ScrollCaptureFrameSource,
 	SelectionFlowStyle, SurfaceFrameSkipReason, WindowRendererPath,
 };
+use self::session_bootstrap_runtime::InitialSessionRuntime;
 #[cfg(all(target_os = "macos", test))]
 use self::session_state::InflightScrollCaptureObservation;
 use self::session_state::{
@@ -904,10 +906,6 @@ impl OverlaySession {
 		Self::with_config(OverlayConfig::default())
 	}
 
-	fn initial_timing() -> (Duration, Duration, Instant) {
-		(Duration::from_millis(500), LIVE_WINDOW_LIST_REFRESH_INTERVAL, Instant::now())
-	}
-
 	#[must_use]
 	/// Creates a new overlay session with the provided runtime configuration.
 	pub fn with_config(config: OverlayConfig) -> Self {
@@ -1078,39 +1076,6 @@ impl OverlaySession {
 			#[cfg(target_os = "macos")] pending_startup_aux_live_stream_filter_upgrade: false,
 			response_waker: None,
 		}
-	}
-
-	fn apply_initial_session_runtime(&mut self, runtime: InitialSessionRuntime) {
-		self.state = runtime.state;
-		self.last_hud_window_move_at = runtime.now;
-		self.last_loupe_window_move_at = runtime.now;
-		self.last_toolbar_window_move_at = runtime.now;
-		self.last_present_at = runtime.now;
-		self.last_live_cursor_poll_at = runtime.now - CURSOR_POLL_INTERVAL_MIN;
-		self.last_frozen_cursor_poll_at = runtime.now - CURSOR_POLL_INTERVAL_MIN;
-		self.last_window_list_refresh_request_at =
-			runtime.now - runtime.window_list_refresh_interval;
-		self.window_list_refresh_interval = runtime.window_list_refresh_interval;
-		self.last_live_bg_request_at = runtime.now - runtime.live_bg_request_interval;
-		self.live_bg_request_interval = runtime.live_bg_request_interval;
-		self.event_loop_last_progress_at = runtime.now;
-		self.loupe_patch_width_px = runtime.loupe_sample_side_px;
-		self.loupe_patch_height_px = runtime.loupe_sample_side_px;
-	}
-
-	fn overlay_state_with_loupe_patch(loupe_sample_side_px: u32) -> OverlayState {
-		let mut state = OverlayState::new();
-
-		state.reset_for_start(loupe_sample_side_px);
-
-		state
-	}
-
-	fn overlay_state_with_config(config: &OverlayConfig) -> (u32, OverlayState) {
-		let loupe_sample_side_px =
-			Self::normalized_loupe_sample_side_px(config.loupe_sample_side_px);
-
-		(loupe_sample_side_px, Self::overlay_state_with_loupe_patch(loupe_sample_side_px))
 	}
 
 	fn note_startup_overlay_frame_presented(&mut self) {
@@ -1916,19 +1881,6 @@ impl OverlaySession {
 			screen_rect,
 			toolbar_pos,
 		);
-	}
-
-	fn initial_session_runtime(config: &OverlayConfig) -> InitialSessionRuntime {
-		let (live_bg_request_interval, window_list_refresh_interval, now) = Self::initial_timing();
-		let (loupe_sample_side_px, state) = Self::overlay_state_with_config(config);
-
-		InitialSessionRuntime {
-			live_bg_request_interval,
-			window_list_refresh_interval,
-			now,
-			loupe_sample_side_px,
-			state,
-		}
 	}
 
 	fn refresh_frozen_helper_windows_for_transition(&mut self, monitor: MonitorRect) {
@@ -3784,14 +3736,6 @@ impl<'a> OverlayExitMetadata<'a> {
 
 		self
 	}
-}
-
-struct InitialSessionRuntime {
-	live_bg_request_interval: Duration,
-	window_list_refresh_interval: Duration,
-	now: Instant,
-	loupe_sample_side_px: u32,
-	state: OverlayState,
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/session_bootstrap_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/session_bootstrap_runtime.rs
@@ -1,0 +1,66 @@
+use std::time::{Duration, Instant};
+
+use crate::overlay::{
+	CURSOR_POLL_INTERVAL_MIN, LIVE_WINDOW_LIST_REFRESH_INTERVAL, OverlayConfig, OverlaySession,
+	OverlayState,
+};
+
+pub(super) struct InitialSessionRuntime {
+	live_bg_request_interval: Duration,
+	window_list_refresh_interval: Duration,
+	now: Instant,
+	loupe_sample_side_px: u32,
+	state: OverlayState,
+}
+
+impl OverlaySession {
+	fn initial_timing() -> (Duration, Duration, Instant) {
+		(Duration::from_millis(500), LIVE_WINDOW_LIST_REFRESH_INTERVAL, Instant::now())
+	}
+
+	pub(super) fn apply_initial_session_runtime(&mut self, runtime: InitialSessionRuntime) {
+		self.state = runtime.state;
+		self.last_hud_window_move_at = runtime.now;
+		self.last_loupe_window_move_at = runtime.now;
+		self.last_toolbar_window_move_at = runtime.now;
+		self.last_present_at = runtime.now;
+		self.last_live_cursor_poll_at = runtime.now - CURSOR_POLL_INTERVAL_MIN;
+		self.last_frozen_cursor_poll_at = runtime.now - CURSOR_POLL_INTERVAL_MIN;
+		self.last_window_list_refresh_request_at =
+			runtime.now - runtime.window_list_refresh_interval;
+		self.window_list_refresh_interval = runtime.window_list_refresh_interval;
+		self.last_live_bg_request_at = runtime.now - runtime.live_bg_request_interval;
+		self.live_bg_request_interval = runtime.live_bg_request_interval;
+		self.event_loop_last_progress_at = runtime.now;
+		self.loupe_patch_width_px = runtime.loupe_sample_side_px;
+		self.loupe_patch_height_px = runtime.loupe_sample_side_px;
+	}
+
+	fn overlay_state_with_loupe_patch(loupe_sample_side_px: u32) -> OverlayState {
+		let mut state = OverlayState::new();
+
+		state.reset_for_start(loupe_sample_side_px);
+
+		state
+	}
+
+	fn overlay_state_with_config(config: &OverlayConfig) -> (u32, OverlayState) {
+		let loupe_sample_side_px =
+			Self::normalized_loupe_sample_side_px(config.loupe_sample_side_px);
+
+		(loupe_sample_side_px, Self::overlay_state_with_loupe_patch(loupe_sample_side_px))
+	}
+
+	pub(super) fn initial_session_runtime(config: &OverlayConfig) -> InitialSessionRuntime {
+		let (live_bg_request_interval, window_list_refresh_interval, now) = Self::initial_timing();
+		let (loupe_sample_side_px, state) = Self::overlay_state_with_config(config);
+
+		InitialSessionRuntime {
+			live_bg_request_interval,
+			window_list_refresh_interval,
+			now,
+			loupe_sample_side_px,
+			state,
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- move overlay startup runtime construction into overlay/session_bootstrap_runtime.rs
- keep InitialSessionRuntime as a private bootstrap data carrier
- preserve normal Rust module boundaries with no include!/path split

## Validation
- cargo make fmt-rust-check
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo make check-rust
- git diff --check
- cargo test -p rsnap-overlay
- cargo make test-rust