### PR TITLE
Modularize toolbar layout model

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -31,6 +31,7 @@ mod scroll_preview_runtime;
 mod scroll_runtime;
 mod session_bootstrap_runtime;
 mod session_state;
+mod toolbar_layout_model;
 mod toolbar_runtime;
 mod trace_recording;
 mod window_position_runtime;
@@ -2826,12 +2827,18 @@ impl OverlaySession {
 
 		self.toolbar_state.default_slot_position = Some(current_default_pos);
 
-		if frozen_toolbar_matches_default_slot(toolbar_pos, previous_default_pos) {
+		if toolbar_layout_model::frozen_toolbar_matches_default_slot(
+			toolbar_pos,
+			previous_default_pos,
+		) {
 			self.toolbar_state.floating_position = Some(current_default_pos);
 
 			self.sync_frozen_annotation_style_capsule_placement(monitor);
 
-			return !frozen_toolbar_matches_default_slot(toolbar_pos, current_default_pos);
+			return !toolbar_layout_model::frozen_toolbar_matches_default_slot(
+				toolbar_pos,
+				current_default_pos,
+			);
 		}
 
 		self.sync_frozen_annotation_style_capsule_placement(monitor);
@@ -3162,13 +3169,16 @@ impl OverlaySession {
 
 	#[cfg(any(target_os = "macos", test))]
 	fn advance_frozen_toolbar_readiness_sample(&mut self, screen_rect: Rect) -> bool {
-		advance_frozen_toolbar_readiness_sample_state(&mut self.toolbar_state, screen_rect)
+		toolbar_layout_model::advance_frozen_toolbar_readiness_sample_state(
+			&mut self.toolbar_state,
+			screen_rect,
+		)
 	}
 
 	#[cfg(any(not(target_os = "macos"), test))]
 	fn frozen_toolbar_ready_for_draw(&self, screen_rect: Rect) -> bool {
 		let screen_size_points = screen_rect.size();
-		let needs_new_sample = frozen_toolbar_needs_new_sample(
+		let needs_new_sample = toolbar_layout_model::frozen_toolbar_needs_new_sample(
 			self.toolbar_state.layout_last_screen_size_points,
 			screen_size_points,
 		);
@@ -3476,76 +3486,6 @@ impl MacOSNativeCaptureInputDispatch {
 	}
 }
 
-pub(super) fn frozen_toolbar_corner_radius_u8(toolbar_height_points: f32) -> u8 {
-	if toolbar_height_points <= TOOLBAR_EXPANDED_HEIGHT_PX + 0.5 {
-		(toolbar_height_points * 0.5).round().clamp(1.0, f32::from(u8::MAX)) as u8
-	} else {
-		HUD_PILL_CORNER_RADIUS_POINTS
-	}
-}
-
-pub(super) fn frozen_toolbar_corner_radius_points(toolbar_height_points: f32) -> f64 {
-	f64::from(frozen_toolbar_corner_radius_u8(toolbar_height_points))
-}
-
-#[cfg(target_os = "macos")]
-pub(in crate::overlay) fn frozen_toolbar_window_primary_origin() -> Pos2 {
-	Pos2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
-}
-
-fn frozen_toolbar_window_startup_size_points() -> Vec2 {
-	[
-		FrozenToolbarState::default(),
-		FrozenToolbarState {
-			selected_tool: FrozenToolbarTool::Pen,
-			..FrozenToolbarState::default()
-		},
-		FrozenToolbarState {
-			selected_tool: FrozenToolbarTool::Arrow,
-			..FrozenToolbarState::default()
-		},
-		FrozenToolbarState {
-			selected_tool: FrozenToolbarTool::Text,
-			..FrozenToolbarState::default()
-		},
-		FrozenToolbarState { auto_center_available: true, ..FrozenToolbarState::default() },
-		FrozenToolbarState { scroll_capture_available: true, ..FrozenToolbarState::default() },
-		FrozenToolbarState {
-			auto_center_available: true,
-			scroll_capture_available: true,
-			..FrozenToolbarState::default()
-		},
-		FrozenToolbarState {
-			selected_tool: FrozenToolbarTool::Pen,
-			auto_center_available: true,
-			scroll_capture_available: true,
-			..FrozenToolbarState::default()
-		},
-		FrozenToolbarState {
-			selected_tool: FrozenToolbarTool::Arrow,
-			auto_center_available: true,
-			scroll_capture_available: true,
-			..FrozenToolbarState::default()
-		},
-		FrozenToolbarState {
-			selected_tool: FrozenToolbarTool::Text,
-			auto_center_available: true,
-			scroll_capture_available: true,
-			..FrozenToolbarState::default()
-		},
-		FrozenToolbarState {
-			scroll_capture_active: true,
-			scroll_capture_available: true,
-			..FrozenToolbarState::default()
-		},
-	]
-	.into_iter()
-	.map(|toolbar_state| WindowRenderer::frozen_toolbar_size(&toolbar_state))
-	.fold(Vec2::new(0.0, TOOLBAR_EXPANDED_HEIGHT_PX), |max_size, size| {
-		Vec2::new(max_size.x.max(size.x), max_size.y.max(size.y))
-	}) + Vec2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
-}
-
 #[cfg(target_os = "macos")]
 fn overlay_cursor_rect_icon_at_point(
 	rects: &[OverlayCursorRect],
@@ -3595,53 +3535,6 @@ fn should_request_overlay_redraw_after_surface_skip(
 			},
 		},
 	}
-}
-
-fn frozen_toolbar_needs_new_sample(
-	last_screen_size_points: Option<Vec2>,
-	screen_size_points: Vec2,
-) -> bool {
-	match last_screen_size_points {
-		None => true,
-		Some(last) => {
-			let dx = (last.x - screen_size_points.x).abs();
-			let dy = (last.y - screen_size_points.y).abs();
-
-			dx > 0.5 || dy > 0.5
-		},
-	}
-}
-
-fn advance_frozen_toolbar_readiness_sample_state(
-	toolbar_state: &mut FrozenToolbarState,
-	screen_rect: Rect,
-) -> bool {
-	let screen_size_points = screen_rect.size();
-
-	if frozen_toolbar_needs_new_sample(
-		toolbar_state.layout_last_screen_size_points,
-		screen_size_points,
-	) {
-		toolbar_state.layout_last_screen_size_points = Some(screen_size_points);
-		toolbar_state.layout_stable_frames = 0;
-
-		return false;
-	}
-	if toolbar_state.layout_stable_frames < 1 {
-		toolbar_state.layout_stable_frames = toolbar_state.layout_stable_frames.saturating_add(1);
-
-		return false;
-	}
-
-	true
-}
-
-fn frozen_toolbar_matches_default_slot(toolbar_pos: Pos2, default_pos: Pos2) -> bool {
-	let dx = (toolbar_pos.x - default_pos.x).abs();
-	let dy = (toolbar_pos.y - default_pos.y).abs();
-
-	dx <= TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS
-		&& dy <= TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/config_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/config_runtime.rs
@@ -5,8 +5,10 @@ use winit::window::WindowId;
 #[cfg(target_os = "macos")]
 use crate::backend;
 #[cfg(target_os = "macos")]
+use crate::overlay;
+#[cfg(target_os = "macos")]
 use crate::overlay::OverlayWorker;
-use crate::overlay::{self, toolbar_layout_model};
+use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	Arc, Instant, LOUPE_TILE_CORNER_RADIUS_POINTS, OverlayConfig, OverlayMode, OverlaySession,
 	WindowRenderer,

--- a/packages/rsnap-overlay/src/overlay/config_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/config_runtime.rs
@@ -4,9 +4,9 @@ use winit::window::WindowId;
 
 #[cfg(target_os = "macos")]
 use crate::backend;
-use crate::overlay;
 #[cfg(target_os = "macos")]
 use crate::overlay::OverlayWorker;
+use crate::overlay::{self, toolbar_layout_model};
 use crate::overlay::{
 	Arc, Instant, LOUPE_TILE_CORNER_RADIUS_POINTS, OverlayConfig, OverlayMode, OverlaySession,
 	WindowRenderer,
@@ -184,7 +184,9 @@ impl OverlaySession {
 
 			self.configure_hud_window_common(
 				window.as_ref(),
-				Some(overlay::frozen_toolbar_corner_radius_points(toolbar_height_points)),
+				Some(toolbar_layout_model::frozen_toolbar_corner_radius_points(
+					toolbar_height_points,
+				)),
 			);
 		}
 	}

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use image::{Rgba, RgbaImage};
 
 use crate::overlay::LIVE_DRAG_START_THRESHOLD_PX;
+use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	CursorIcon, FrozenCaptureSource, FrozenMosaicDragState, FrozenSelectionCorner,
 	FrozenSelectionDragState, FrozenSelectionInteractionKind, FrozenToolbarTool, GlobalPoint,
@@ -1087,7 +1088,10 @@ impl OverlaySession {
 			self.toolbar_state.default_slot_position,
 		) {
 			(Some(floating_pos), Some(default_pos))
-				if !super::frozen_toolbar_matches_default_slot(floating_pos, default_pos) =>
+				if !toolbar_layout_model::frozen_toolbar_matches_default_slot(
+					floating_pos,
+					default_pos,
+				) =>
 			{
 				floating_pos
 			},

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -10,6 +10,7 @@ use winit::keyboard::ModifiersState;
 use crate::overlay::FrozenGlobalHotkey;
 #[cfg(target_os = "macos")]
 use crate::overlay::SLOW_OP_WARN_CURSOR_LOCATION;
+use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource, ElementState,
 	FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
@@ -155,7 +156,7 @@ impl OverlaySession {
 
 	fn toolbar_primary_rect_contains(&self, cursor_local: Pos2) -> bool {
 		#[cfg(target_os = "macos")]
-		let toolbar_primary_origin = super::frozen_toolbar_window_primary_origin();
+		let toolbar_primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 		#[cfg(not(target_os = "macos"))]
 		let toolbar_primary_origin = Pos2::ZERO;
 

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -10,6 +10,7 @@ use winit::keyboard::ModifiersState;
 use crate::overlay::FrozenGlobalHotkey;
 #[cfg(target_os = "macos")]
 use crate::overlay::SLOW_OP_WARN_CURSOR_LOCATION;
+#[cfg(target_os = "macos")]
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource, ElementState,

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -19,7 +19,7 @@ use crate::overlay::rendering::{
 };
 use crate::overlay::session_state::FrozenAnnotationStyleCapsulePlacement;
 use crate::overlay::{
-	self, Align, Align2, Area, Color32, CornerRadius, FROZEN_BRUSH_RENDER_SAMPLE_STEP_POINTS,
+	Align, Align2, Area, Color32, CornerRadius, FROZEN_BRUSH_RENDER_SAMPLE_STEP_POINTS,
 	FROZEN_SELECTION_DASHED_BORDER_WIDTH_PX,
 	FROZEN_SELECTION_RESIZE_HANDLE_CENTER_DOT_RADIUS_POINTS,
 	FROZEN_SELECTION_RESIZE_HANDLE_CORNER_KEEPOUT_POINTS,
@@ -49,7 +49,7 @@ use crate::overlay::{
 	SELECTION_SIZE_BADGE_SCREEN_MARGIN_PX, SELECTION_SIZE_BADGE_TEXT_OUTSET_POINTS,
 	SelectionFlowStyle, Sense, Shape, Stroke, StrokeKind, TOOLBAR_CAPTURE_GAP_PX,
 	TOOLBAR_EXPANDED_HEIGHT_PX, TOOLBAR_PILL_INNER_MARGIN_Y_POINTS, TOOLBAR_SCREEN_MARGIN_PX,
-	ToolbarPlacement, Ui, UiBuilder, Vec2,
+	ToolbarPlacement, Ui, UiBuilder, Vec2, toolbar_layout_model,
 };
 
 const FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS: f32 = 4.0;
@@ -1249,7 +1249,7 @@ impl WindowRenderer {
 		);
 		let toolbar_pos = toolbar_state.floating_position.unwrap_or(default_pos);
 
-		if !overlay::frozen_toolbar_matches_default_slot(toolbar_pos, default_pos) {
+		if !toolbar_layout_model::frozen_toolbar_matches_default_slot(toolbar_pos, default_pos) {
 			return None;
 		}
 
@@ -2629,7 +2629,10 @@ impl WindowRenderer {
 
 		#[cfg(any(not(target_os = "macos"), test))]
 		{
-			if !overlay::advance_frozen_toolbar_readiness_sample_state(toolbar_state, screen_rect) {
+			if !toolbar_layout_model::advance_frozen_toolbar_readiness_sample_state(
+				toolbar_state,
+				screen_rect,
+			) {
 				ctx.request_repaint();
 
 				return;
@@ -2864,7 +2867,7 @@ impl WindowRenderer {
 			"Frozen toolbar birth attempt."
 		);
 
-		let needs_new_sample = overlay::frozen_toolbar_needs_new_sample(
+		let needs_new_sample = toolbar_layout_model::frozen_toolbar_needs_new_sample(
 			toolbar_state.layout_last_screen_size_points,
 			screen_size_points,
 		);
@@ -3107,7 +3110,7 @@ impl WindowRenderer {
 
 			*hud_pill_out = Some(HudPillGeometry {
 				rect: window_rect,
-				radius_points: f32::from(overlay::frozen_toolbar_corner_radius_u8(
+				radius_points: f32::from(toolbar_layout_model::frozen_toolbar_corner_radius_u8(
 					window_rect.height(),
 				)),
 			});
@@ -3125,7 +3128,7 @@ impl WindowRenderer {
 		hud_milk_amount: f32,
 		hud_tint_hue: f32,
 	) {
-		let corner_radius = overlay::frozen_toolbar_corner_radius_u8(rect.height());
+		let corner_radius = toolbar_layout_model::frozen_toolbar_corner_radius_u8(rect.height());
 		let body_fill = Self::tinted_hud_body_fill(
 			theme,
 			hud_blur_active,

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/freeze_handoff.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/freeze_handoff.rs
@@ -8,7 +8,7 @@ use crate::overlay::tests::rendering_behaviors::{
 	OverlayMode, OverlaySession, OverlayState, PngAction, Pos2, RawInput, Rect, RectPoints,
 	SelectionDashedBorderCache, SelectionFlowGeometryCache, TOOLBAR_CAPTURE_GAP_PX,
 	TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Ui, Vec2, WindowFreezeCaptureTarget,
-	WindowRenderer, WorkerErrorSource, WorkerResponse, overlay, tests,
+	WindowRenderer, WorkerErrorSource, WorkerResponse, overlay::toolbar_layout_model, tests,
 };
 
 #[cfg(target_os = "macos")]
@@ -438,7 +438,7 @@ fn frozen_annotation_toolbar_hud_pill_keeps_standard_corner_radius() {
 
 	assert_eq!(
 		hud_pill.radius_points,
-		f32::from(overlay::frozen_toolbar_corner_radius_u8(hud_pill.rect.height())),
+		f32::from(toolbar_layout_model::frozen_toolbar_corner_radius_u8(hud_pill.rect.height())),
 	);
 }
 
@@ -629,7 +629,7 @@ fn frozen_annotation_capsule_flip_keeps_native_toolbar_outer_position_stable() {
 	let monitor = tests::test_monitor();
 	let screen_rect =
 		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
-	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_size = toolbar_layout_model::frozen_toolbar_window_startup_size_points();
 	let mut session = OverlaySession::new();
 
 	session.toolbar_inner_size_points =

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/toolbar_layout.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/toolbar_layout.rs
@@ -4,14 +4,14 @@ use crate::overlay::tests::rendering_behaviors::{
 	FrozenToolbarState, FrozenToolbarTool, GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, HudTheme,
 	MonitorRect, OverlayMode, OverlaySession, OverlayState, Pos2, RawInput, Rect, RectPoints,
 	TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Ui, Vec2, WindowRenderer,
-	overlay, tests,
+	overlay::toolbar_layout_model, tests,
 };
 
 #[test]
 fn toolbar_position_update_queues_pending_move_without_window() {
 	let monitor = tests::test_monitor();
 	#[cfg(target_os = "macos")]
-	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 	let mut session = OverlaySession::new();
 
 	session.toolbar_inner_size_points = Some((460, 54));
@@ -32,7 +32,7 @@ fn toolbar_position_update_queues_pending_move_without_window() {
 fn toolbar_window_position_sync_updates_runtime_state_without_requeueing_in_bounds_move() {
 	let monitor = tests::test_monitor();
 	#[cfg(target_os = "macos")]
-	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 	let mut session = OverlaySession::new();
 
 	session.toolbar_inner_size_points = Some((460, 54));
@@ -56,10 +56,10 @@ fn toolbar_position_update_near_edge_clamps_with_runtime_positioning_geometry() 
 	let desired = Pos2::new(900.0, 760.0);
 	let screen_rect =
 		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
-	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_size = toolbar_layout_model::frozen_toolbar_window_startup_size_points();
 	let positioning_size = WindowRenderer::frozen_toolbar_positioning_size(&session.toolbar_state);
 	#[cfg(target_os = "macos")]
-	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 	#[cfg(not(target_os = "macos"))]
 	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
 
@@ -106,10 +106,10 @@ fn toolbar_window_position_sync_near_edge_clamps_with_runtime_positioning_geomet
 	let desired_local = Pos2::new(desired_outer.x as f32, desired_outer.y as f32);
 	let screen_rect =
 		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
-	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_size = toolbar_layout_model::frozen_toolbar_window_startup_size_points();
 	let positioning_size = WindowRenderer::frozen_toolbar_positioning_size(&session.toolbar_state);
 	#[cfg(target_os = "macos")]
-	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 	#[cfg(not(target_os = "macos"))]
 	let startup_window_size = Vec2::new(startup_size.x, startup_size.y);
 
@@ -158,7 +158,7 @@ fn toolbar_position_update_clamps_scroll_mode_pen_from_primary_anchor_width() {
 	let desired = Pos2::new(900.0, 160.0);
 	let screen_rect =
 		Rect::from_min_size(Pos2::ZERO, Vec2::new(monitor.width as f32, monitor.height as f32));
-	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_size = toolbar_layout_model::frozen_toolbar_window_startup_size_points();
 	let primary_toolbar_state = FrozenToolbarState {
 		selected_tool: FrozenToolbarTool::Pen,
 		scroll_capture_active: true,
@@ -167,7 +167,7 @@ fn toolbar_position_update_clamps_scroll_mode_pen_from_primary_anchor_width() {
 	let primary_size = WindowRenderer::frozen_toolbar_primary_size(&primary_toolbar_state);
 	let full_toolbar_size = WindowRenderer::frozen_toolbar_size(&primary_toolbar_state);
 	#[cfg(target_os = "macos")]
-	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 	let mut session = OverlaySession::new();
 
 	assert!(
@@ -214,7 +214,7 @@ fn toolbar_event_outer_position_uses_best_available_source() {
 	let cached_outer_pos = Some(GlobalPoint::new(340, 420));
 	let floating_position = Some(Pos2::new(80.4, 90.6));
 	#[cfg(target_os = "macos")]
-	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 	#[cfg(target_os = "macos")]
 	let floating_outer_pos = GlobalPoint::new(80, (90.6 - primary_origin.y).round() as i32);
 	#[cfg(not(target_os = "macos"))]
@@ -334,7 +334,7 @@ fn render_frozen_toolbar_ui_keeps_runtime_drag_when_pointer_snapshot_is_missing(
 fn seeded_frozen_toolbar_default_slot_uses_positioning_window_size() {
 	let monitor = tests::test_monitor();
 	let capture_rect = RectPoints::new(760, 160, 160, 240);
-	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_size = toolbar_layout_model::frozen_toolbar_window_startup_size_points();
 	let mut session = OverlaySession::new();
 
 	session.toolbar_inner_size_points =
@@ -970,11 +970,15 @@ fn auto_center_toolbar_tool_only_appears_when_available() {
 
 #[test]
 fn toolbar_window_startup_size_covers_every_tool_permutation() {
-	let startup_size = overlay::frozen_toolbar_window_startup_size_points();
+	let startup_size = toolbar_layout_model::frozen_toolbar_window_startup_size_points();
 	let toolbar_states = [
 		FrozenToolbarState::default(),
 		FrozenToolbarState {
 			selected_tool: FrozenToolbarTool::Pen,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Arrow,
 			..FrozenToolbarState::default()
 		},
 		FrozenToolbarState {
@@ -990,6 +994,12 @@ fn toolbar_window_startup_size_covers_every_tool_permutation() {
 		},
 		FrozenToolbarState {
 			selected_tool: FrozenToolbarTool::Pen,
+			auto_center_available: true,
+			scroll_capture_available: true,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Arrow,
 			auto_center_available: true,
 			scroll_capture_available: true,
 			..FrozenToolbarState::default()

--- a/packages/rsnap-overlay/src/overlay/tests/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/toolbar_runtime.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "macos")]
-use crate::overlay::tests::overlay;
+use crate::overlay::tests::overlay::toolbar_layout_model;
 use crate::overlay::tests::{
 	self, FrozenToolbarTool, GlobalPoint, HudTheme, OverlaySession, Pos2, Rect,
 	TOOLBAR_SCREEN_MARGIN_PX, Vec2, WindowRenderer,
@@ -33,7 +33,7 @@ fn toolbar_cursor_left_during_drag_keeps_drag_session_alive() {
 #[test]
 fn toolbar_drag_start_eligibility_uses_live_cursor_then_cached_pointer() {
 	#[cfg(target_os = "macos")]
-	let primary_origin = overlay::frozen_toolbar_window_primary_origin();
+	let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 	#[cfg(not(target_os = "macos"))]
 	let primary_origin = Pos2::ZERO;
 	let primary_rect = WindowRenderer::frozen_toolbar_primary_rect(

--- a/packages/rsnap-overlay/src/overlay/toolbar_layout_model.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_layout_model.rs
@@ -1,0 +1,124 @@
+use egui::{Pos2, Rect, Vec2};
+
+use crate::overlay::rendering::WindowRenderer;
+use crate::overlay::{
+	FrozenToolbarState, FrozenToolbarTool, HUD_PILL_CORNER_RADIUS_POINTS,
+	TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS, TOOLBAR_EXPANDED_HEIGHT_PX,
+};
+
+pub(super) fn frozen_toolbar_corner_radius_u8(toolbar_height_points: f32) -> u8 {
+	if toolbar_height_points <= TOOLBAR_EXPANDED_HEIGHT_PX + 0.5 {
+		(toolbar_height_points * 0.5).round().clamp(1.0, f32::from(u8::MAX)) as u8
+	} else {
+		HUD_PILL_CORNER_RADIUS_POINTS
+	}
+}
+
+pub(super) fn frozen_toolbar_corner_radius_points(toolbar_height_points: f32) -> f64 {
+	f64::from(frozen_toolbar_corner_radius_u8(toolbar_height_points))
+}
+
+pub(super) fn frozen_toolbar_window_startup_size_points() -> Vec2 {
+	[
+		FrozenToolbarState::default(),
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Pen,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Arrow,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Text,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState { auto_center_available: true, ..FrozenToolbarState::default() },
+		FrozenToolbarState { scroll_capture_available: true, ..FrozenToolbarState::default() },
+		FrozenToolbarState {
+			auto_center_available: true,
+			scroll_capture_available: true,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Pen,
+			auto_center_available: true,
+			scroll_capture_available: true,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Arrow,
+			auto_center_available: true,
+			scroll_capture_available: true,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			selected_tool: FrozenToolbarTool::Text,
+			auto_center_available: true,
+			scroll_capture_available: true,
+			..FrozenToolbarState::default()
+		},
+		FrozenToolbarState {
+			scroll_capture_active: true,
+			scroll_capture_available: true,
+			..FrozenToolbarState::default()
+		},
+	]
+	.into_iter()
+	.map(|toolbar_state| WindowRenderer::frozen_toolbar_size(&toolbar_state))
+	.fold(Vec2::new(0.0, TOOLBAR_EXPANDED_HEIGHT_PX), |max_size, size| {
+		Vec2::new(max_size.x.max(size.x), max_size.y.max(size.y))
+	}) + Vec2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
+}
+
+pub(super) fn frozen_toolbar_needs_new_sample(
+	last_screen_size_points: Option<Vec2>,
+	screen_size_points: Vec2,
+) -> bool {
+	match last_screen_size_points {
+		None => true,
+		Some(last) => {
+			let dx = (last.x - screen_size_points.x).abs();
+			let dy = (last.y - screen_size_points.y).abs();
+
+			dx > 0.5 || dy > 0.5
+		},
+	}
+}
+
+pub(super) fn advance_frozen_toolbar_readiness_sample_state(
+	toolbar_state: &mut FrozenToolbarState,
+	screen_rect: Rect,
+) -> bool {
+	let screen_size_points = screen_rect.size();
+
+	if frozen_toolbar_needs_new_sample(
+		toolbar_state.layout_last_screen_size_points,
+		screen_size_points,
+	) {
+		toolbar_state.layout_last_screen_size_points = Some(screen_size_points);
+		toolbar_state.layout_stable_frames = 0;
+
+		return false;
+	}
+	if toolbar_state.layout_stable_frames < 1 {
+		toolbar_state.layout_stable_frames = toolbar_state.layout_stable_frames.saturating_add(1);
+
+		return false;
+	}
+
+	true
+}
+
+pub(super) fn frozen_toolbar_matches_default_slot(toolbar_pos: Pos2, default_pos: Pos2) -> bool {
+	let dx = (toolbar_pos.x - default_pos.x).abs();
+	let dy = (toolbar_pos.y - default_pos.y).abs();
+
+	dx <= TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS
+		&& dy <= TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn frozen_toolbar_window_primary_origin() -> Pos2 {
+	Pos2::new(0.0, WindowRenderer::frozen_toolbar_window_top_padding_points())
+}

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -1,3 +1,4 @@
+use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
 	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
@@ -344,8 +345,8 @@ impl OverlaySession {
 		window_toolbar_outer_pos.or(cached_toolbar_outer_pos).or_else(|| {
 			floating_position.map(|floating_position| {
 				#[cfg(target_os = "macos")]
-				let floating_position =
-					floating_position - super::frozen_toolbar_window_primary_origin().to_vec2();
+				let floating_position = floating_position
+					- toolbar_layout_model::frozen_toolbar_window_primary_origin().to_vec2();
 
 				GlobalPoint::new(
 					monitor.origin.x.saturating_add(floating_position.x.round() as i32),
@@ -467,7 +468,9 @@ impl OverlaySession {
 
 				self.configure_hud_window_common(
 					window.as_ref(),
-					Some(overlay::frozen_toolbar_corner_radius_points(toolbar_height_points)),
+					Some(overlay::toolbar_layout_model::frozen_toolbar_corner_radius_points(
+						toolbar_height_points,
+					)),
 				);
 
 				OverlayControl::Continue
@@ -545,7 +548,7 @@ impl OverlaySession {
 			let frozen_arrow_preview = self.active_frozen_arrow_preview();
 
 			self.toolbar_state.floating_position =
-				Some(super::frozen_toolbar_window_primary_origin());
+				Some(toolbar_layout_model::frozen_toolbar_window_primary_origin());
 
 			let Some(toolbar_window) = self.toolbar_window.as_mut() else {
 				return Ok(());
@@ -790,7 +793,7 @@ impl OverlaySession {
 		let cursor_local =
 			Self::toolbar_cursor_local_position_from_outer(toolbar_outer_pos, cursor_global);
 		#[cfg(target_os = "macos")]
-		let toolbar_primary_origin = super::frozen_toolbar_window_primary_origin();
+		let toolbar_primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 		#[cfg(not(target_os = "macos"))]
 		let toolbar_primary_origin = Pos2::ZERO;
 

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -1,7 +1,7 @@
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
-	self, Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant,
-	MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
+	Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant, MonitorRect,
+	OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
 	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
 	WindowRenderer,
 };
@@ -468,7 +468,7 @@ impl OverlaySession {
 
 				self.configure_hud_window_common(
 					window.as_ref(),
-					Some(overlay::toolbar_layout_model::frozen_toolbar_corner_radius_points(
+					Some(toolbar_layout_model::frozen_toolbar_corner_radius_points(
 						toolbar_height_points,
 					)),
 				);

--- a/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, MonitorRect, OverlayMode, OverlaySession, Pos2, Rect,

--- a/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
@@ -1,3 +1,4 @@
+use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, MonitorRect, OverlayMode, OverlaySession, Pos2, Rect,
 	TOOLBAR_SCREEN_MARGIN_PX, Vec2, WindowRenderer,
@@ -14,7 +15,7 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		primary_anchor: Pos2,
 	) -> GlobalPoint {
-		let primary_origin = super::frozen_toolbar_window_primary_origin();
+		let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 
 		GlobalPoint::new(
 			monitor.origin.x.saturating_add((primary_anchor.x - primary_origin.x).round() as i32),
@@ -28,7 +29,7 @@ impl OverlaySession {
 		monitor: MonitorRect,
 		outer_position: GlobalPoint,
 	) -> Pos2 {
-		let primary_origin = super::frozen_toolbar_window_primary_origin();
+		let primary_origin = toolbar_layout_model::frozen_toolbar_window_primary_origin();
 
 		Pos2::new(
 			outer_position.x as f32 - monitor.origin.x as f32 + primary_origin.x,

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -12,6 +12,7 @@ use winit::window::{Window, WindowId};
 use crate::backend;
 #[cfg(target_os = "macos")]
 use crate::overlay::MacOSHudWindowConfigState;
+use crate::overlay::toolbar_layout_model;
 use crate::overlay::{self, CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED};
 use crate::overlay::{
 	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LOUPE_TILE_CORNER_RADIUS_POINTS,
@@ -894,7 +895,7 @@ impl OverlaySession {
 	}
 
 	fn create_toolbar_window(&mut self, event_loop: &ActiveEventLoop) -> Result<(), String> {
-		let startup_size = super::frozen_toolbar_window_startup_size_points();
+		let startup_size = toolbar_layout_model::frozen_toolbar_window_startup_size_points();
 		let attrs = Window::default_attributes()
 			.with_title("rsnap-toolbar")
 			.with_decorations(false)
@@ -919,7 +920,7 @@ impl OverlaySession {
 		window.set_transparent(true);
 		self.configure_hud_window_common(
 			window.as_ref(),
-			Some(overlay::frozen_toolbar_corner_radius_points(
+			Some(overlay::toolbar_layout_model::frozen_toolbar_corner_radius_points(
 				WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state).y,
 			)),
 		);

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -920,7 +920,7 @@ impl OverlaySession {
 		window.set_transparent(true);
 		self.configure_hud_window_common(
 			window.as_ref(),
-			Some(overlay::toolbar_layout_model::frozen_toolbar_corner_radius_points(
+			Some(toolbar_layout_model::frozen_toolbar_corner_radius_points(
 				WindowRenderer::frozen_toolbar_primary_size(&self.toolbar_state).y,
 			)),
 		);

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -11,9 +11,11 @@ use winit::window::{Window, WindowId};
 
 use crate::backend;
 #[cfg(target_os = "macos")]
+use crate::overlay;
+use crate::overlay::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
+#[cfg(target_os = "macos")]
 use crate::overlay::MacOSHudWindowConfigState;
 use crate::overlay::toolbar_layout_model;
-use crate::overlay::{self, CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED};
 use crate::overlay::{
 	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LOUPE_TILE_CORNER_RADIUS_POINTS,
 	LiveSampleApplyResult, LogicalPosition, LogicalSize, MonitorRect, OverlayMode, OverlaySession,


### PR DESCRIPTION
## Summary
- move frozen toolbar layout/readiness helpers out of overlay.rs into overlay/toolbar_layout_model.rs
- update callers to use the new module boundary and keep visibility internal to overlay
- expand startup-size coverage for Arrow toolbar permutations

## Validation
- cargo make fmt-rust-check
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo make check-rust
- cargo test -p rsnap-overlay
- git diff --check
- cargo make test-rust
- rg -n "include!|#\[path" packages apps (no matches)