### PR TITLE
Modularize macOS cursor runtime

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -22,6 +22,8 @@ mod hud_runtime;
 mod image_helpers;
 mod input_runtime;
 #[cfg(target_os = "macos")]
+mod macos_cursor_runtime;
+#[cfg(target_os = "macos")]
 mod macos_native_capture_shell_runtime;
 mod rendering;
 mod runtime_model;
@@ -51,8 +53,6 @@ use std::panic;
 use std::process;
 use std::ptr;
 use std::slice;
-#[cfg(target_os = "macos")]
-use std::sync::OnceLock;
 #[cfg(target_os = "macos")]
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
@@ -86,17 +86,7 @@ use image::RgbaImage;
 #[cfg(target_os = "macos")]
 use image::imageops;
 #[cfg(target_os = "macos")]
-use objc::declare::ClassDecl;
-#[cfg(target_os = "macos")]
-use objc::runtime::{BOOL, Class, NO, Object, Sel, YES};
-#[cfg(target_os = "macos")]
-use objc::{Encode, Encoding};
-#[cfg(target_os = "macos")]
-use objc2::MainThreadMarker;
-#[cfg(target_os = "macos")]
-use objc2_app_kit::NSScreen;
-#[cfg(target_os = "macos")]
-use objc2_foundation::{NSPoint, NSRect, NSSize};
+use objc::runtime::{BOOL, NO, Object, YES};
 #[cfg(target_os = "macos")]
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use serde::{Deserialize, Serialize};
@@ -3338,72 +3328,6 @@ impl OverlayKeyboardInputEvent {
 	}
 }
 
-#[cfg(target_os = "macos")]
-pub(super) struct MacOSOverlayCursorRectSupport {
-	view_key: usize,
-}
-#[cfg(target_os = "macos")]
-impl MacOSOverlayCursorRectSupport {
-	const fn new(view_key: usize) -> Self {
-		Self { view_key }
-	}
-
-	fn sync_cursor_rects(&self, window: &Window, rects: &[OverlayCursorRect]) {
-		macos_resize_overlay_cursor_view(window, self.view_key);
-
-		if macos_set_overlay_view_cursor_rects(self.view_key, rects) {
-			macos_invalidate_overlay_cursor_rects(self.view_key);
-		}
-
-		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
-	}
-
-	fn apply_cursor_for_current_pointer(&self) {
-		tracing::trace!(
-			op = "overlay.macos_overlay_cursor_rect_support_apply_current_pointer",
-			view_key = self.view_key,
-			"Applying macOS overlay cursor rect authority for current pointer."
-		);
-
-		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
-	}
-
-	fn apply_cursor_for_current_pointer_or_fallback(&self, fallback_icon: CursorIcon) {
-		if macos_overlay_view_cursor_rect_entries(self.view_key).is_none() {
-			tracing::trace!(
-				op = "overlay.macos_overlay_cursor_rect_support_apply_fallback",
-				view_key = self.view_key,
-				icon = ?fallback_icon,
-				"Fell back to the session cursor icon because the render cursor rects are not ready yet."
-			);
-
-			macos_set_cursor_icon(fallback_icon);
-
-			return;
-		}
-
-		self.apply_cursor_for_current_pointer();
-	}
-}
-
-#[cfg(target_os = "macos")]
-impl Drop for MacOSOverlayCursorRectSupport {
-	fn drop(&mut self) {
-		let rects = macos_overlay_view_cursor_rects();
-
-		match rects.lock() {
-			Ok(mut guard) => {
-				guard.remove(&self.view_key);
-			},
-			Err(poisoned) => {
-				poisoned.into_inner().remove(&self.view_key);
-			},
-		}
-
-		macos_remove_overlay_cursor_view(self.view_key);
-	}
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct LiveClickCaptureTarget {
 	capture_rect: Option<RectPoints>,
@@ -3433,37 +3357,10 @@ struct MacOSFrontmostApplication {
 }
 
 #[cfg(target_os = "macos")]
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct OverlayCursorRect {
-	rect: Rect,
-	icon: CursorIcon,
-}
-#[cfg(target_os = "macos")]
-impl OverlayCursorRect {
-	const fn new(rect: Rect, icon: CursorIcon) -> Self {
-		Self { rect, icon }
-	}
-}
-
-#[cfg(target_os = "macos")]
 #[repr(C)]
 struct MacOSCGPoint {
 	x: f64,
 	y: f64,
-}
-
-#[cfg(target_os = "macos")]
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct MacOSOverlayPoint {
-	x: f64,
-	y: f64,
-}
-#[cfg(target_os = "macos")]
-unsafe impl Encode for MacOSOverlayPoint {
-	fn encode() -> Encoding {
-		unsafe { Encoding::from_str("{CGPoint=dd}") }
-	}
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -3484,34 +3381,6 @@ impl MacOSNativeCaptureInputDispatch {
 	fn enqueue(&self, event: MacOSNativeCaptureInputEvent) {
 		(self.sink)(event);
 	}
-}
-
-#[cfg(target_os = "macos")]
-fn overlay_cursor_rect_icon_at_point(
-	rects: &[OverlayCursorRect],
-	point: Pos2,
-) -> Option<CursorIcon> {
-	rects.iter().find(|entry| entry.rect.contains(point)).map(|entry| entry.icon)
-}
-
-#[cfg(target_os = "macos")]
-fn sort_unique_axis_values(values: &mut Vec<f32>) {
-	values.sort_by(f32::total_cmp);
-	values.dedup_by(|a, b| (*a - *b).abs() <= f32::EPSILON);
-}
-
-#[cfg(target_os = "macos")]
-fn trim_rect_min_edge(min: f32, max: f32) -> f32 {
-	let trimmed = min.next_up();
-
-	if trimmed < max { trimmed } else { max }
-}
-
-#[cfg(target_os = "macos")]
-fn trim_rect_max_edge(max: f32, min: f32) -> f32 {
-	let trimmed = max.next_down();
-
-	if trimmed > min { trimmed } else { min }
 }
 
 fn should_request_overlay_redraw_after_surface_skip(
@@ -3581,40 +3450,6 @@ unsafe extern "C" {
 }
 
 #[cfg(target_os = "macos")]
-fn macos_install_overlay_cursor_rect_support(
-	window: &Window,
-) -> std::result::Result<MacOSOverlayCursorRectSupport, String> {
-	let _ = MainThreadMarker::new().ok_or_else(|| {
-		String::from("Installing macOS overlay cursor rect support requires the main thread.")
-	})?;
-	let Some(host_view) = macos_overlay_window_ns_view(window) else {
-		return Err(String::from("Overlay cursor rect support requires an AppKit window handle."));
-	};
-	let bounds: NSRect = unsafe { objc::msg_send![host_view, bounds] };
-	let overlay_class = macos_overlay_cursor_view_class();
-	let overlay_view: *mut Object = unsafe {
-		let overlay_view: *mut Object = objc::msg_send![overlay_class, alloc];
-
-		objc::msg_send![overlay_view, initWithFrame: bounds]
-	};
-
-	if overlay_view.is_null() {
-		return Err(String::from("Failed to create macOS overlay cursor view."));
-	}
-
-	unsafe {
-		const NS_VIEW_WIDTH_SIZABLE: usize = 2;
-		const NS_VIEW_HEIGHT_SIZABLE: usize = 16;
-
-		let _: () = objc::msg_send![overlay_view, setAutoresizingMask: NS_VIEW_WIDTH_SIZABLE | NS_VIEW_HEIGHT_SIZABLE];
-		let _: () = objc::msg_send![host_view, addSubview: overlay_view];
-		let _: () = objc::msg_send![overlay_view, release];
-	}
-
-	Ok(MacOSOverlayCursorRectSupport::new(overlay_view as usize))
-}
-
-#[cfg(target_os = "macos")]
 fn macos_mouse_location() -> Option<GlobalPoint> {
 	let event = unsafe { CGEventCreate(ptr::null()) };
 
@@ -3630,195 +3465,6 @@ fn macos_mouse_location() -> Option<GlobalPoint> {
 }
 
 #[cfg(target_os = "macos")]
-fn macos_overlay_view_cursor_rects() -> &'static Mutex<HashMap<usize, Vec<OverlayCursorRect>>> {
-	static RECTS: OnceLock<Mutex<HashMap<usize, Vec<OverlayCursorRect>>>> = OnceLock::new();
-
-	RECTS.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-#[cfg(target_os = "macos")]
-fn macos_set_overlay_view_cursor_rects(view_key: usize, rects: &[OverlayCursorRect]) -> bool {
-	let rects_by_view = macos_overlay_view_cursor_rects();
-
-	match rects_by_view.lock() {
-		Ok(mut guard) => {
-			let unchanged =
-				guard.get(&view_key).is_some_and(|existing| existing.as_slice() == rects);
-
-			if unchanged || (rects.is_empty() && !guard.contains_key(&view_key)) {
-				return false;
-			}
-			if rects.is_empty() {
-				guard.remove(&view_key);
-			} else {
-				guard.insert(view_key, rects.to_vec());
-			}
-		},
-		Err(poisoned) => {
-			let mut guard = poisoned.into_inner();
-			let unchanged =
-				guard.get(&view_key).is_some_and(|existing| existing.as_slice() == rects);
-
-			if unchanged || (rects.is_empty() && !guard.contains_key(&view_key)) {
-				return false;
-			}
-			if rects.is_empty() {
-				guard.remove(&view_key);
-			} else {
-				guard.insert(view_key, rects.to_vec());
-			}
-		},
-	}
-
-	true
-}
-
-#[cfg(target_os = "macos")]
-fn macos_overlay_view_cursor_rect_entries(view_key: usize) -> Option<Vec<OverlayCursorRect>> {
-	let rects = macos_overlay_view_cursor_rects();
-
-	match rects.lock() {
-		Ok(guard) => guard.get(&view_key).cloned(),
-		Err(poisoned) => poisoned.into_inner().get(&view_key).cloned(),
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_cursor_object_for_icon(icon: CursorIcon) -> *mut Object {
-	let cursor_class = objc::class!(NSCursor);
-
-	match icon {
-		CursorIcon::Crosshair => unsafe { objc::msg_send![cursor_class, crosshairCursor] },
-		CursorIcon::Grab => unsafe { objc::msg_send![cursor_class, openHandCursor] },
-		CursorIcon::Grabbing => unsafe { objc::msg_send![cursor_class, closedHandCursor] },
-		CursorIcon::Text => unsafe { objc::msg_send![cursor_class, IBeamCursor] },
-		CursorIcon::NeswResize => unsafe {
-			let responds: bool = objc::msg_send![cursor_class, respondsToSelector: objc::sel!(_windowResizeNorthEastSouthWestCursor)];
-
-			if responds {
-				objc::msg_send![cursor_class, performSelector: objc::sel!(_windowResizeNorthEastSouthWestCursor)]
-			} else {
-				objc::msg_send![cursor_class, arrowCursor]
-			}
-		},
-		CursorIcon::NwseResize => unsafe {
-			let responds: bool = objc::msg_send![cursor_class, respondsToSelector: objc::sel!(_windowResizeNorthWestSouthEastCursor)];
-
-			if responds {
-				objc::msg_send![cursor_class, performSelector: objc::sel!(_windowResizeNorthWestSouthEastCursor)]
-			} else {
-				objc::msg_send![cursor_class, arrowCursor]
-			}
-		},
-		_ => unsafe { objc::msg_send![cursor_class, arrowCursor] },
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_set_cursor_icon(icon: CursorIcon) {
-	let cursor = macos_cursor_object_for_icon(icon);
-
-	if cursor.is_null() {
-		tracing::trace!(
-			op = "overlay.macos_set_cursor_icon",
-			icon = ?icon,
-			cursor_available = false,
-			"Skipped macOS cursor update because no cursor object was available."
-		);
-
-		return;
-	}
-
-	tracing::trace!(
-		op = "overlay.macos_set_cursor_icon",
-		icon = ?icon,
-		cursor_available = true,
-		"Setting macOS cursor icon."
-	);
-
-	unsafe {
-		let _: () = objc::msg_send![cursor, set];
-	}
-}
-
-#[cfg(target_os = "macos")]
-extern "C" fn macos_overlay_cursor_view_is_flipped(_this: &Object, _cmd: Sel) -> BOOL {
-	let _ = _cmd;
-
-	YES
-}
-
-#[cfg(target_os = "macos")]
-extern "C" fn macos_overlay_cursor_view_hit_test(
-	_this: &Object,
-	_cmd: Sel,
-	_point: MacOSOverlayPoint,
-) -> *mut Object {
-	let _ = (_cmd, _point);
-
-	ptr::null_mut()
-}
-
-#[cfg(target_os = "macos")]
-extern "C" fn macos_overlay_cursor_view_reset_cursor_rects(this: &Object, _cmd: Sel) {
-	let _ = _cmd;
-	let view_key = (this as *const Object) as usize;
-	let Some(entries) = macos_overlay_view_cursor_rect_entries(view_key) else {
-		return;
-	};
-
-	for entry in entries {
-		let cursor = macos_cursor_object_for_icon(entry.icon);
-
-		if cursor.is_null() {
-			continue;
-		}
-
-		let rect = NSRect::new(
-			NSPoint::new(f64::from(entry.rect.min.x), f64::from(entry.rect.min.y)),
-			NSSize::new(f64::from(entry.rect.width()), f64::from(entry.rect.height())),
-		);
-
-		unsafe {
-			let _: () = objc::msg_send![this, addCursorRect: rect cursor: cursor];
-		}
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_overlay_cursor_view_class() -> *const Class {
-	static CLASS: OnceLock<usize> = OnceLock::new();
-
-	(*CLASS.get_or_init(|| {
-		if let Some(class) = Class::get("RsnapOverlayCursorView") {
-			return class as *const Class as usize;
-		}
-
-		let superclass = objc::class!(NSView);
-		let mut decl = ClassDecl::new("RsnapOverlayCursorView", superclass)
-			.expect("cursor overlay view class");
-
-		unsafe {
-			decl.add_method(
-				objc::sel!(isFlipped),
-				macos_overlay_cursor_view_is_flipped as extern "C" fn(&Object, Sel) -> BOOL,
-			);
-			decl.add_method(
-				objc::sel!(hitTest:),
-				macos_overlay_cursor_view_hit_test
-					as extern "C" fn(&Object, Sel, MacOSOverlayPoint) -> *mut Object,
-			);
-			decl.add_method(
-				objc::sel!(resetCursorRects),
-				macos_overlay_cursor_view_reset_cursor_rects as extern "C" fn(&Object, Sel),
-			);
-		}
-
-		decl.register() as *const Class as usize
-	})) as *const Class
-}
-
-#[cfg(target_os = "macos")]
 fn macos_overlay_window_ns_view(window: &Window) -> Option<*mut Object> {
 	let Ok(handle) = window.window_handle() else {
 		return None;
@@ -3828,155 +3474,6 @@ fn macos_overlay_window_ns_view(window: &Window) -> Option<*mut Object> {
 	};
 
 	Some(appkit.ns_view.as_ptr().cast::<Object>())
-}
-
-#[cfg(target_os = "macos")]
-fn macos_resize_overlay_cursor_view(window: &Window, overlay_view_key: usize) {
-	let Some(ns_view) = macos_overlay_window_ns_view(window) else {
-		return;
-	};
-	let overlay_view = overlay_view_key as *mut Object;
-
-	if overlay_view.is_null() {
-		return;
-	}
-
-	let bounds: NSRect = unsafe { objc::msg_send![ns_view, bounds] };
-
-	unsafe {
-		let _: () = objc::msg_send![overlay_view, setFrame: bounds];
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_invalidate_overlay_cursor_rects(overlay_view_key: usize) {
-	let overlay_view = overlay_view_key as *mut Object;
-
-	if overlay_view.is_null() {
-		return;
-	}
-
-	unsafe {
-		let ns_window: *mut Object = objc::msg_send![overlay_view, window];
-
-		if ns_window.is_null() {
-			return;
-		}
-
-		let _: () = objc::msg_send![ns_window, invalidateCursorRectsForView: overlay_view];
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_overlay_view_current_local_point(overlay_view_key: usize) -> Option<Pos2> {
-	let overlay_view = overlay_view_key as *mut Object;
-
-	if overlay_view.is_null() {
-		return None;
-	}
-
-	unsafe {
-		let ns_window: *mut Object = objc::msg_send![overlay_view, window];
-
-		if ns_window.is_null() {
-			return None;
-		}
-
-		let window_point: NSPoint = objc::msg_send![ns_window, mouseLocationOutsideOfEventStream];
-		let local_point: NSPoint = objc::msg_send![overlay_view, convertPoint: window_point fromView: ptr::null_mut::<Object>()];
-
-		Some(Pos2::new(local_point.x as f32, local_point.y as f32))
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_overlay_view_bounds(overlay_view_key: usize) -> Option<Rect> {
-	let overlay_view = overlay_view_key as *mut Object;
-
-	if overlay_view.is_null() {
-		return None;
-	}
-
-	unsafe {
-		let bounds: NSRect = objc::msg_send![overlay_view, bounds];
-
-		Some(Rect::from_min_size(
-			Pos2::new(bounds.origin.x as f32, bounds.origin.y as f32),
-			Vec2::new(bounds.size.width as f32, bounds.size.height as f32),
-		))
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn macos_cursor_icon_for_current_pointer(
-	entries: Option<&[OverlayCursorRect]>,
-	local_point: Option<Pos2>,
-	overlay_bounds: Option<Rect>,
-) -> Option<CursorIcon> {
-	let local_point = local_point?;
-	let overlay_bounds = overlay_bounds?;
-
-	if !overlay_bounds.contains(local_point) {
-		return None;
-	}
-
-	Some(match entries {
-		Some(entries) => {
-			overlay_cursor_rect_icon_at_point(entries, local_point).unwrap_or(CursorIcon::Default)
-		},
-		None => CursorIcon::Default,
-	})
-}
-
-#[cfg(target_os = "macos")]
-fn macos_apply_overlay_cursor_for_current_pointer(overlay_view_key: usize) {
-	let entries = macos_overlay_view_cursor_rect_entries(overlay_view_key);
-	let local_point = macos_overlay_view_current_local_point(overlay_view_key);
-	let overlay_bounds = macos_overlay_view_bounds(overlay_view_key);
-	let Some(icon) =
-		macos_cursor_icon_for_current_pointer(entries.as_deref(), local_point, overlay_bounds)
-	else {
-		tracing::trace!(
-			op = "overlay.macos_apply_overlay_cursor_for_current_pointer",
-			view_key = overlay_view_key,
-			entry_count = entries.as_ref().map_or(0, Vec::len),
-			local_point = ?local_point,
-			overlay_bounds = ?overlay_bounds,
-			icon = ?"none",
-			"Skipped macOS overlay cursor apply because the pointer is not within an active cursor rect."
-		);
-
-		return;
-	};
-
-	tracing::trace!(
-		op = "overlay.macos_apply_overlay_cursor_for_current_pointer",
-		view_key = overlay_view_key,
-		entry_count = entries.as_ref().map_or(0, Vec::len),
-		local_point = ?local_point,
-		overlay_bounds = ?overlay_bounds,
-		icon = ?icon,
-		"Resolved macOS overlay cursor icon for current pointer."
-	);
-
-	macos_set_cursor_icon(icon);
-}
-
-#[cfg(target_os = "macos")]
-fn macos_remove_overlay_cursor_view(overlay_view_key: usize) {
-	let overlay_view = overlay_view_key as *mut Object;
-
-	if overlay_view.is_null() {
-		return;
-	}
-
-	unsafe {
-		let superview: *mut Object = objc::msg_send![overlay_view, superview];
-
-		if !superview.is_null() {
-			let _: () = objc::msg_send![overlay_view, removeFromSuperview];
-		}
-	}
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -3,6 +3,8 @@ use std::time::{Duration, Instant};
 use image::{Rgba, RgbaImage};
 
 use crate::overlay::LIVE_DRAG_START_THRESHOLD_PX;
+#[cfg(target_os = "macos")]
+use crate::overlay::macos_cursor_runtime::{self, OverlayCursorRect};
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	CursorIcon, FrozenCaptureSource, FrozenMosaicDragState, FrozenSelectionCorner,
@@ -11,9 +13,7 @@ use crate::overlay::{
 	OverlaySession, Pos2, RectPoints, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{
-	FROZEN_SELECTION_RESIZE_HANDLE_INTERIOR_REACH_MAX_POINTS, OverlayCursorRect, Rect, Vec2,
-};
+use crate::overlay::{FROZEN_SELECTION_RESIZE_HANDLE_INTERIOR_REACH_MAX_POINTS, Rect, Vec2};
 
 impl OverlaySession {
 	#[cfg(target_os = "macos")]
@@ -38,7 +38,7 @@ impl OverlaySession {
 				&& matches!(self.state.mode, OverlayMode::Live)
 				&& !self.windows.is_empty()
 			{
-				super::macos_set_cursor_icon(CursorIcon::Crosshair);
+				macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Crosshair);
 			}
 
 			return;
@@ -663,8 +663,8 @@ impl OverlaySession {
 			y_edges.push(handle.hit_rect.max.y);
 		}
 
-		super::sort_unique_axis_values(&mut x_edges);
-		super::sort_unique_axis_values(&mut y_edges);
+		macos_cursor_runtime::sort_unique_axis_values(&mut x_edges);
+		macos_cursor_runtime::sort_unique_axis_values(&mut y_edges);
 
 		let mut rects = Vec::new();
 
@@ -705,28 +705,32 @@ impl OverlaySession {
 					Pos2::new(rect.min.x, point.y),
 				) != Some(corner)
 				{
-					adjusted_min.x = super::trim_rect_min_edge(adjusted_min.x, adjusted_max.x);
+					adjusted_min.x =
+						macos_cursor_runtime::trim_rect_min_edge(adjusted_min.x, adjusted_max.x);
 				}
 				if WindowRenderer::frozen_selection_resize_hit_test(
 					capture_rect,
 					Pos2::new(rect.max.x, point.y),
 				) != Some(corner)
 				{
-					adjusted_max.x = super::trim_rect_max_edge(adjusted_max.x, adjusted_min.x);
+					adjusted_max.x =
+						macos_cursor_runtime::trim_rect_max_edge(adjusted_max.x, adjusted_min.x);
 				}
 				if WindowRenderer::frozen_selection_resize_hit_test(
 					capture_rect,
 					Pos2::new(point.x, rect.min.y),
 				) != Some(corner)
 				{
-					adjusted_min.y = super::trim_rect_min_edge(adjusted_min.y, adjusted_max.y);
+					adjusted_min.y =
+						macos_cursor_runtime::trim_rect_min_edge(adjusted_min.y, adjusted_max.y);
 				}
 				if WindowRenderer::frozen_selection_resize_hit_test(
 					capture_rect,
 					Pos2::new(point.x, rect.max.y),
 				) != Some(corner)
 				{
-					adjusted_max.y = super::trim_rect_max_edge(adjusted_max.y, adjusted_min.y);
+					adjusted_max.y =
+						macos_cursor_runtime::trim_rect_max_edge(adjusted_max.y, adjusted_min.y);
 				}
 				if adjusted_max.x <= adjusted_min.x || adjusted_max.y <= adjusted_min.y {
 					continue;

--- a/packages/rsnap-overlay/src/overlay/macos_cursor_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_cursor_runtime.rs
@@ -1,0 +1,476 @@
+use std::collections::HashMap;
+use std::ptr;
+use std::sync::{Mutex, OnceLock};
+
+use egui::{Pos2, Rect, Vec2};
+use objc::declare::ClassDecl;
+use objc::runtime::{BOOL, Class, Object, Sel, YES};
+use objc::{Encode, Encoding, sel, sel_impl};
+use objc2::MainThreadMarker;
+use objc2_foundation::{NSPoint, NSRect, NSSize};
+use winit::window::{CursorIcon, Window};
+
+pub(super) struct MacOSOverlayCursorRectSupport {
+	view_key: usize,
+}
+impl MacOSOverlayCursorRectSupport {
+	const fn new(view_key: usize) -> Self {
+		Self { view_key }
+	}
+
+	pub(super) fn sync_cursor_rects(&self, window: &Window, rects: &[OverlayCursorRect]) {
+		macos_resize_overlay_cursor_view(window, self.view_key);
+
+		if macos_set_overlay_view_cursor_rects(self.view_key, rects) {
+			macos_invalidate_overlay_cursor_rects(self.view_key);
+		}
+
+		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
+	}
+
+	pub(super) fn apply_cursor_for_current_pointer(&self) {
+		tracing::trace!(
+			op = "overlay.macos_overlay_cursor_rect_support_apply_current_pointer",
+			view_key = self.view_key,
+			"Applying macOS overlay cursor rect authority for current pointer."
+		);
+
+		macos_apply_overlay_cursor_for_current_pointer(self.view_key);
+	}
+
+	pub(super) fn apply_cursor_for_current_pointer_or_fallback(&self, fallback_icon: CursorIcon) {
+		if macos_overlay_view_cursor_rect_entries(self.view_key).is_none() {
+			tracing::trace!(
+				op = "overlay.macos_overlay_cursor_rect_support_apply_fallback",
+				view_key = self.view_key,
+				icon = ?fallback_icon,
+				"Fell back to the session cursor icon because the render cursor rects are not ready yet."
+			);
+
+			macos_set_cursor_icon(fallback_icon);
+
+			return;
+		}
+
+		self.apply_cursor_for_current_pointer();
+	}
+}
+
+impl Drop for MacOSOverlayCursorRectSupport {
+	fn drop(&mut self) {
+		let rects = macos_overlay_view_cursor_rects();
+
+		match rects.lock() {
+			Ok(mut guard) => {
+				guard.remove(&self.view_key);
+			},
+			Err(poisoned) => {
+				poisoned.into_inner().remove(&self.view_key);
+			},
+		}
+
+		macos_remove_overlay_cursor_view(self.view_key);
+	}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct OverlayCursorRect {
+	pub(super) rect: Rect,
+	pub(super) icon: CursorIcon,
+}
+impl OverlayCursorRect {
+	pub(super) const fn new(rect: Rect, icon: CursorIcon) -> Self {
+		Self { rect, icon }
+	}
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub(super) struct MacOSOverlayPoint {
+	pub(super) x: f64,
+	pub(super) y: f64,
+}
+unsafe impl Encode for MacOSOverlayPoint {
+	fn encode() -> Encoding {
+		unsafe { Encoding::from_str("{CGPoint=dd}") }
+	}
+}
+
+pub(super) fn overlay_cursor_rect_icon_at_point(
+	rects: &[OverlayCursorRect],
+	point: Pos2,
+) -> Option<CursorIcon> {
+	rects.iter().find(|entry| entry.rect.contains(point)).map(|entry| entry.icon)
+}
+
+pub(super) fn sort_unique_axis_values(values: &mut Vec<f32>) {
+	values.sort_by(f32::total_cmp);
+	values.dedup_by(|a, b| (*a - *b).abs() <= f32::EPSILON);
+}
+
+pub(super) fn trim_rect_min_edge(min: f32, max: f32) -> f32 {
+	let trimmed = min.next_up();
+
+	if trimmed < max { trimmed } else { max }
+}
+
+pub(super) fn trim_rect_max_edge(max: f32, min: f32) -> f32 {
+	let trimmed = max.next_down();
+
+	if trimmed > min { trimmed } else { min }
+}
+
+pub(super) fn macos_install_overlay_cursor_rect_support(
+	window: &Window,
+) -> std::result::Result<MacOSOverlayCursorRectSupport, String> {
+	let _ = MainThreadMarker::new().ok_or_else(|| {
+		String::from("Installing macOS overlay cursor rect support requires the main thread.")
+	})?;
+	let Some(host_view) = super::macos_overlay_window_ns_view(window) else {
+		return Err(String::from("Overlay cursor rect support requires an AppKit window handle."));
+	};
+	let bounds: NSRect = unsafe { objc::msg_send![host_view, bounds] };
+	let overlay_class = macos_overlay_cursor_view_class();
+	let overlay_view: *mut Object = unsafe {
+		let overlay_view: *mut Object = objc::msg_send![overlay_class, alloc];
+
+		objc::msg_send![overlay_view, initWithFrame: bounds]
+	};
+
+	if overlay_view.is_null() {
+		return Err(String::from("Failed to create macOS overlay cursor view."));
+	}
+
+	unsafe {
+		const NS_VIEW_WIDTH_SIZABLE: usize = 2;
+		const NS_VIEW_HEIGHT_SIZABLE: usize = 16;
+
+		let _: () = objc::msg_send![overlay_view, setAutoresizingMask: NS_VIEW_WIDTH_SIZABLE | NS_VIEW_HEIGHT_SIZABLE];
+		let _: () = objc::msg_send![host_view, addSubview: overlay_view];
+		let _: () = objc::msg_send![overlay_view, release];
+	}
+
+	Ok(MacOSOverlayCursorRectSupport::new(overlay_view as usize))
+}
+
+pub(super) fn macos_cursor_object_for_icon(icon: CursorIcon) -> *mut Object {
+	let cursor_class = objc::class!(NSCursor);
+
+	match icon {
+		CursorIcon::Crosshair => unsafe { objc::msg_send![cursor_class, crosshairCursor] },
+		CursorIcon::Grab => unsafe { objc::msg_send![cursor_class, openHandCursor] },
+		CursorIcon::Grabbing => unsafe { objc::msg_send![cursor_class, closedHandCursor] },
+		CursorIcon::Text => unsafe { objc::msg_send![cursor_class, IBeamCursor] },
+		CursorIcon::NeswResize => unsafe {
+			let responds: bool = objc::msg_send![cursor_class, respondsToSelector: objc::sel!(_windowResizeNorthEastSouthWestCursor)];
+
+			if responds {
+				objc::msg_send![cursor_class, performSelector: objc::sel!(_windowResizeNorthEastSouthWestCursor)]
+			} else {
+				objc::msg_send![cursor_class, arrowCursor]
+			}
+		},
+		CursorIcon::NwseResize => unsafe {
+			let responds: bool = objc::msg_send![cursor_class, respondsToSelector: objc::sel!(_windowResizeNorthWestSouthEastCursor)];
+
+			if responds {
+				objc::msg_send![cursor_class, performSelector: objc::sel!(_windowResizeNorthWestSouthEastCursor)]
+			} else {
+				objc::msg_send![cursor_class, arrowCursor]
+			}
+		},
+		_ => unsafe { objc::msg_send![cursor_class, arrowCursor] },
+	}
+}
+
+pub(super) fn macos_set_cursor_icon(icon: CursorIcon) {
+	let cursor = macos_cursor_object_for_icon(icon);
+
+	if cursor.is_null() {
+		tracing::trace!(
+			op = "overlay.macos_set_cursor_icon",
+			icon = ?icon,
+			cursor_available = false,
+			"Skipped macOS cursor update because no cursor object was available."
+		);
+
+		return;
+	}
+
+	tracing::trace!(
+		op = "overlay.macos_set_cursor_icon",
+		icon = ?icon,
+		cursor_available = true,
+		"Setting macOS cursor icon."
+	);
+
+	unsafe {
+		let _: () = objc::msg_send![cursor, set];
+	}
+}
+
+pub(super) fn macos_cursor_icon_for_current_pointer(
+	entries: Option<&[OverlayCursorRect]>,
+	local_point: Option<Pos2>,
+	overlay_bounds: Option<Rect>,
+) -> Option<CursorIcon> {
+	let local_point = local_point?;
+	let overlay_bounds = overlay_bounds?;
+
+	if !overlay_bounds.contains(local_point) {
+		return None;
+	}
+
+	Some(match entries {
+		Some(entries) => {
+			overlay_cursor_rect_icon_at_point(entries, local_point).unwrap_or(CursorIcon::Default)
+		},
+		None => CursorIcon::Default,
+	})
+}
+
+fn macos_overlay_view_cursor_rects() -> &'static Mutex<HashMap<usize, Vec<OverlayCursorRect>>> {
+	static RECTS: OnceLock<Mutex<HashMap<usize, Vec<OverlayCursorRect>>>> = OnceLock::new();
+
+	RECTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn macos_set_overlay_view_cursor_rects(view_key: usize, rects: &[OverlayCursorRect]) -> bool {
+	let rects_by_view = macos_overlay_view_cursor_rects();
+
+	match rects_by_view.lock() {
+		Ok(mut guard) => {
+			let unchanged =
+				guard.get(&view_key).is_some_and(|existing| existing.as_slice() == rects);
+
+			if unchanged || (rects.is_empty() && !guard.contains_key(&view_key)) {
+				return false;
+			}
+			if rects.is_empty() {
+				guard.remove(&view_key);
+			} else {
+				guard.insert(view_key, rects.to_vec());
+			}
+		},
+		Err(poisoned) => {
+			let mut guard = poisoned.into_inner();
+			let unchanged =
+				guard.get(&view_key).is_some_and(|existing| existing.as_slice() == rects);
+
+			if unchanged || (rects.is_empty() && !guard.contains_key(&view_key)) {
+				return false;
+			}
+			if rects.is_empty() {
+				guard.remove(&view_key);
+			} else {
+				guard.insert(view_key, rects.to_vec());
+			}
+		},
+	}
+
+	true
+}
+
+fn macos_overlay_view_cursor_rect_entries(view_key: usize) -> Option<Vec<OverlayCursorRect>> {
+	let rects = macos_overlay_view_cursor_rects();
+
+	match rects.lock() {
+		Ok(guard) => guard.get(&view_key).cloned(),
+		Err(poisoned) => poisoned.into_inner().get(&view_key).cloned(),
+	}
+}
+
+extern "C" fn macos_overlay_cursor_view_is_flipped(_this: &Object, _cmd: Sel) -> BOOL {
+	let _ = _cmd;
+
+	YES
+}
+
+extern "C" fn macos_overlay_cursor_view_hit_test(
+	_this: &Object,
+	_cmd: Sel,
+	_point: MacOSOverlayPoint,
+) -> *mut Object {
+	let _ = (_cmd, _point);
+
+	ptr::null_mut()
+}
+
+extern "C" fn macos_overlay_cursor_view_reset_cursor_rects(this: &Object, _cmd: Sel) {
+	let _ = _cmd;
+	let view_key = (this as *const Object) as usize;
+	let Some(entries) = macos_overlay_view_cursor_rect_entries(view_key) else {
+		return;
+	};
+
+	for entry in entries {
+		let cursor = macos_cursor_object_for_icon(entry.icon);
+
+		if cursor.is_null() {
+			continue;
+		}
+
+		let rect = NSRect::new(
+			NSPoint::new(f64::from(entry.rect.min.x), f64::from(entry.rect.min.y)),
+			NSSize::new(f64::from(entry.rect.width()), f64::from(entry.rect.height())),
+		);
+
+		unsafe {
+			let _: () = objc::msg_send![this, addCursorRect: rect cursor: cursor];
+		}
+	}
+}
+
+fn macos_overlay_cursor_view_class() -> *const Class {
+	static CLASS: OnceLock<usize> = OnceLock::new();
+
+	(*CLASS.get_or_init(|| {
+		if let Some(class) = Class::get("RsnapOverlayCursorView") {
+			return class as *const Class as usize;
+		}
+
+		let superclass = objc::class!(NSView);
+		let mut decl = ClassDecl::new("RsnapOverlayCursorView", superclass)
+			.expect("cursor overlay view class");
+
+		unsafe {
+			decl.add_method(
+				objc::sel!(isFlipped),
+				macos_overlay_cursor_view_is_flipped as extern "C" fn(&Object, Sel) -> BOOL,
+			);
+			decl.add_method(
+				objc::sel!(hitTest:),
+				macos_overlay_cursor_view_hit_test
+					as extern "C" fn(&Object, Sel, MacOSOverlayPoint) -> *mut Object,
+			);
+			decl.add_method(
+				objc::sel!(resetCursorRects),
+				macos_overlay_cursor_view_reset_cursor_rects as extern "C" fn(&Object, Sel),
+			);
+		}
+
+		decl.register() as *const Class as usize
+	})) as *const Class
+}
+
+fn macos_resize_overlay_cursor_view(window: &Window, overlay_view_key: usize) {
+	let Some(ns_view) = super::macos_overlay_window_ns_view(window) else {
+		return;
+	};
+	let overlay_view = overlay_view_key as *mut Object;
+
+	if overlay_view.is_null() {
+		return;
+	}
+
+	let bounds: NSRect = unsafe { objc::msg_send![ns_view, bounds] };
+
+	unsafe {
+		let _: () = objc::msg_send![overlay_view, setFrame: bounds];
+	}
+}
+
+fn macos_invalidate_overlay_cursor_rects(overlay_view_key: usize) {
+	let overlay_view = overlay_view_key as *mut Object;
+
+	if overlay_view.is_null() {
+		return;
+	}
+
+	unsafe {
+		let ns_window: *mut Object = objc::msg_send![overlay_view, window];
+
+		if ns_window.is_null() {
+			return;
+		}
+
+		let _: () = objc::msg_send![ns_window, invalidateCursorRectsForView: overlay_view];
+	}
+}
+
+fn macos_overlay_view_current_local_point(overlay_view_key: usize) -> Option<Pos2> {
+	let overlay_view = overlay_view_key as *mut Object;
+
+	if overlay_view.is_null() {
+		return None;
+	}
+
+	unsafe {
+		let ns_window: *mut Object = objc::msg_send![overlay_view, window];
+
+		if ns_window.is_null() {
+			return None;
+		}
+
+		let window_point: NSPoint = objc::msg_send![ns_window, mouseLocationOutsideOfEventStream];
+		let local_point: NSPoint = objc::msg_send![overlay_view, convertPoint: window_point fromView: ptr::null_mut::<Object>()];
+
+		Some(Pos2::new(local_point.x as f32, local_point.y as f32))
+	}
+}
+
+fn macos_overlay_view_bounds(overlay_view_key: usize) -> Option<Rect> {
+	let overlay_view = overlay_view_key as *mut Object;
+
+	if overlay_view.is_null() {
+		return None;
+	}
+
+	unsafe {
+		let bounds: NSRect = objc::msg_send![overlay_view, bounds];
+
+		Some(Rect::from_min_size(
+			Pos2::new(bounds.origin.x as f32, bounds.origin.y as f32),
+			Vec2::new(bounds.size.width as f32, bounds.size.height as f32),
+		))
+	}
+}
+
+fn macos_apply_overlay_cursor_for_current_pointer(overlay_view_key: usize) {
+	let entries = macos_overlay_view_cursor_rect_entries(overlay_view_key);
+	let local_point = macos_overlay_view_current_local_point(overlay_view_key);
+	let overlay_bounds = macos_overlay_view_bounds(overlay_view_key);
+	let Some(icon) =
+		macos_cursor_icon_for_current_pointer(entries.as_deref(), local_point, overlay_bounds)
+	else {
+		tracing::trace!(
+			op = "overlay.macos_apply_overlay_cursor_for_current_pointer",
+			view_key = overlay_view_key,
+			entry_count = entries.as_ref().map_or(0, Vec::len),
+			local_point = ?local_point,
+			overlay_bounds = ?overlay_bounds,
+			icon = ?"none",
+			"Skipped macOS overlay cursor apply because the pointer is not within an active cursor rect."
+		);
+
+		return;
+	};
+
+	tracing::trace!(
+		op = "overlay.macos_apply_overlay_cursor_for_current_pointer",
+		view_key = overlay_view_key,
+		entry_count = entries.as_ref().map_or(0, Vec::len),
+		local_point = ?local_point,
+		overlay_bounds = ?overlay_bounds,
+		icon = ?icon,
+		"Resolved macOS overlay cursor icon for current pointer."
+	);
+
+	macos_set_cursor_icon(icon);
+}
+
+fn macos_remove_overlay_cursor_view(overlay_view_key: usize) {
+	let overlay_view = overlay_view_key as *mut Object;
+
+	if overlay_view.is_null() {
+		return;
+	}
+
+	unsafe {
+		let superview: *mut Object = objc::msg_send![overlay_view, superview];
+
+		if !superview.is_null() {
+			let _: () = objc::msg_send![overlay_view, removeFromSuperview];
+		}
+	}
+}

--- a/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs
@@ -13,6 +13,7 @@ use winit::event::{ElementState, Ime, MouseButton};
 use winit::keyboard::{Key, ModifiersState, NamedKey, NativeKey};
 
 use crate::overlay::MacOSFrontmostApplication;
+use crate::overlay::macos_cursor_runtime::{self, MacOSOverlayPoint};
 use crate::overlay::{
 	CursorIcon, GlobalPoint, MacOSNativeCaptureInputDispatch, MacOSNativeCaptureInputEvent,
 	MacOSNativeCaptureScrollDelta, MonitorRect, OverlayKeyboardInputEvent, OverlayMode,
@@ -446,7 +447,7 @@ impl From<NSSize> for MacOSSize {
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct MacOSRect {
-	origin: super::MacOSOverlayPoint,
+	origin: MacOSOverlayPoint,
 	size: MacOSSize,
 }
 unsafe impl Encode for MacOSRect {
@@ -458,7 +459,7 @@ unsafe impl Encode for MacOSRect {
 impl From<NSRect> for MacOSRect {
 	fn from(value: NSRect) -> Self {
 		Self {
-			origin: super::MacOSOverlayPoint { x: value.origin.x, y: value.origin.y },
+			origin: MacOSOverlayPoint { x: value.origin.x, y: value.origin.y },
 			size: MacOSSize::from(value.size),
 		}
 	}
@@ -1065,7 +1066,7 @@ fn macos_passive_shell_view_class() -> *const Class {
 			decl.add_method(
 				objc::sel!(hitTest:),
 				macos_passive_shell_view_hit_test
-					as extern "C" fn(&Object, Sel, super::MacOSOverlayPoint) -> *mut Object,
+					as extern "C" fn(&Object, Sel, MacOSOverlayPoint) -> *mut Object,
 			);
 			decl.add_method(
 				objc::sel!(drawRect:),
@@ -1212,7 +1213,7 @@ fn macos_key_focus_shell_view_class() -> *const Class {
 			decl.add_method(
 				objc::sel!(characterIndexForPoint:),
 				macos_key_focus_shell_view_character_index_for_point
-					as extern "C" fn(&Object, Sel, super::MacOSOverlayPoint) -> usize,
+					as extern "C" fn(&Object, Sel, MacOSOverlayPoint) -> usize,
 			);
 			decl.add_method(
 				objc::sel!(firstRectForCharacterRange:actualRange:),
@@ -1266,7 +1267,7 @@ extern "C" fn macos_passive_shell_view_accepts_first_mouse(
 extern "C" fn macos_passive_shell_view_hit_test(
 	this: &Object,
 	_cmd: Sel,
-	_point: super::MacOSOverlayPoint,
+	_point: MacOSOverlayPoint,
 ) -> *mut Object {
 	this as *const Object as *mut Object
 }
@@ -1298,10 +1299,10 @@ extern "C" fn macos_passive_shell_view_reset_cursor_rects(this: &Object, _cmd: S
 	};
 	let cursor = match callback {
 		MacOSPassiveShellCallback::Overlay { .. } => {
-			super::macos_cursor_object_for_icon(CursorIcon::Crosshair)
+			macos_cursor_runtime::macos_cursor_object_for_icon(CursorIcon::Crosshair)
 		},
 		MacOSPassiveShellCallback::Toolbar { .. } | MacOSPassiveShellCallback::KeyFocus { .. } => {
-			super::macos_cursor_object_for_icon(CursorIcon::Default)
+			macos_cursor_runtime::macos_cursor_object_for_icon(CursorIcon::Default)
 		},
 	};
 
@@ -1342,10 +1343,10 @@ extern "C" fn macos_passive_shell_view_cursor_update(
 
 	match callback {
 		MacOSPassiveShellCallback::Overlay { .. } => {
-			super::macos_set_cursor_icon(CursorIcon::Crosshair);
+			macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Crosshair);
 		},
 		MacOSPassiveShellCallback::Toolbar { .. } => {
-			super::macos_set_cursor_icon(CursorIcon::Default);
+			macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Default);
 		},
 		MacOSPassiveShellCallback::KeyFocus { .. } => {},
 	}
@@ -1742,7 +1743,7 @@ extern "C" fn macos_key_focus_shell_view_attributed_substring_for_proposed_range
 extern "C" fn macos_key_focus_shell_view_character_index_for_point(
 	_this: &Object,
 	_cmd: Sel,
-	_point: super::MacOSOverlayPoint,
+	_point: MacOSOverlayPoint,
 ) -> usize {
 	0
 }
@@ -1849,12 +1850,12 @@ fn macos_dispatch_shell_pointer_moved(this: &Object, event: *mut Object) {
 				Some(local_point),
 			);
 
-			super::macos_set_cursor_icon(CursorIcon::Crosshair);
+			macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Crosshair);
 		},
 		MacOSPassiveShellCallback::Toolbar { .. } => {
 			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
 
-			super::macos_set_cursor_icon(CursorIcon::Default);
+			macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Default);
 		},
 		MacOSPassiveShellCallback::KeyFocus { .. } => {
 			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
@@ -1879,12 +1880,12 @@ fn macos_dispatch_shell_mouse_input(
 		MacOSPassiveShellCallback::Overlay { .. } => {
 			macos_update_passive_shell_cursor_point(this as *const Object as usize, local_point);
 
-			super::macos_set_cursor_icon(CursorIcon::Crosshair);
+			macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Crosshair);
 		},
 		MacOSPassiveShellCallback::Toolbar { .. } => {
 			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
 
-			super::macos_set_cursor_icon(CursorIcon::Default);
+			macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Default);
 		},
 		MacOSPassiveShellCallback::KeyFocus { .. } => {
 			macos_update_passive_shell_cursor_point(this as *const Object as usize, None);
@@ -1935,7 +1936,7 @@ fn macos_shell_scroll_delta(event: *mut Object) -> Option<MacOSNativeCaptureScro
 }
 
 fn macos_set_crosshair_cursor() {
-	super::macos_set_cursor_icon(CursorIcon::Crosshair);
+	macos_cursor_runtime::macos_set_cursor_icon(CursorIcon::Crosshair);
 }
 
 fn macos_passive_shell_cursor_points() -> &'static Mutex<HashMap<usize, Option<NSPoint>>> {

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -32,9 +32,9 @@ use winit::window::Window;
 use self::hud_rendering::LiveLoupeTexture;
 use self::hud_surface::{HudBg, HudBlurUniformRaw};
 #[cfg(target_os = "macos")]
-use crate::overlay::MacOSOverlayCursorRectSupport;
-#[cfg(target_os = "macos")]
 use crate::overlay::macos_configure_hud_window;
+#[cfg(target_os = "macos")]
+use crate::overlay::macos_cursor_runtime::MacOSOverlayCursorRectSupport;
 use crate::overlay::{
 	self, AcquiredSurfaceFrame, Adapter, AddressMode, Arc, BindGroupLayout, BindingResource,
 	BindingType, BlendState, Buffer, BufferBindingType, BufferSize, BufferUsages, ClippedPrimitive,

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/annotation_rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/annotation_rendering.rs
@@ -8,7 +8,7 @@ use crate::overlay::tests::rendering_behaviors::{
 	SelectionDashedBorderCache, SelectionFlowGeometryCache, Ui, Vec2, WindowRenderer, tests,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::tests::rendering_behaviors::{CursorIcon, overlay};
+use crate::overlay::tests::rendering_behaviors::{CursorIcon, overlay::macos_cursor_runtime};
 
 #[test]
 fn frozen_mosaic_drag_waits_for_final_capture_ready() {
@@ -492,10 +492,13 @@ fn frozen_mosaic_cursor_rects_preserve_crosshair_hover_and_drag() {
 	let rects = session.frozen_selection_cursor_rects_for_monitor(monitor);
 
 	assert_eq!(
-		overlay::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(150.0, 180.0)),
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(150.0, 180.0)),
 		Some(CursorIcon::Crosshair)
 	);
-	assert_eq!(overlay::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(80.0, 100.0)), None);
+	assert_eq!(
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(80.0, 100.0)),
+		None
+	);
 
 	session.frozen_mosaic_drag.active = true;
 

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/cursor_rects.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/cursor_rects.rs
@@ -4,7 +4,7 @@ use crate::overlay::tests::rendering_behaviors::{
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::rendering_behaviors::{Object, frozen_selection_runtime};
 #[cfg(target_os = "macos")]
-use crate::overlay::tests::rendering_behaviors::{Rect, Vec2, overlay};
+use crate::overlay::tests::rendering_behaviors::{Rect, Vec2, overlay::macos_cursor_runtime};
 
 #[test]
 fn toolbar_cursor_global_position_from_outer_uses_cached_toolbar_origin() {
@@ -63,7 +63,7 @@ fn macos_live_cursor_sync_keeps_render_rects_active_during_native_shell_input() 
 #[cfg(target_os = "macos")]
 #[test]
 fn macos_cursor_object_maps_crosshair_icon() {
-	let actual = overlay::macos_cursor_object_for_icon(CursorIcon::Crosshair) as usize;
+	let actual = macos_cursor_runtime::macos_cursor_object_for_icon(CursorIcon::Crosshair) as usize;
 	let expected: *mut Object = unsafe { objc::msg_send![objc::class!(NSCursor), crosshairCursor] };
 
 	assert_eq!(actual, expected as usize);
@@ -73,7 +73,7 @@ fn macos_cursor_object_maps_crosshair_icon() {
 #[test]
 fn macos_cursor_icon_defaults_without_active_rect_entries() {
 	assert_eq!(
-		overlay::macos_cursor_icon_for_current_pointer(
+		macos_cursor_runtime::macos_cursor_icon_for_current_pointer(
 			None,
 			Some(Pos2::new(150.0, 180.0)),
 			Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(400.0, 300.0))),
@@ -86,7 +86,7 @@ fn macos_cursor_icon_defaults_without_active_rect_entries() {
 #[test]
 fn macos_cursor_icon_skips_windows_outside_pointer_bounds() {
 	assert_eq!(
-		overlay::macos_cursor_icon_for_current_pointer(
+		macos_cursor_runtime::macos_cursor_icon_for_current_pointer(
 			None,
 			Some(Pos2::new(450.0, 180.0)),
 			Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(400.0, 300.0))),

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/selection_runtime.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use image::{Rgba, RgbaImage};
 
 #[cfg(target_os = "macos")]
-use crate::overlay::tests::rendering_behaviors::overlay;
+use crate::overlay::tests::rendering_behaviors::overlay::macos_cursor_runtime;
 use crate::overlay::tests::rendering_behaviors::{
 	CursorIcon, ElementState, FrozenCaptureSource, FrozenSelectionCorner, FrozenSelectionDragState,
 	FrozenSelectionInteractionKind, FrozenToolbarState, FrozenToolbarTool, GlobalPoint,
@@ -526,15 +526,15 @@ fn frozen_selection_cursor_rects_use_native_handle_hover_and_full_window_resize_
 	let rects = session.frozen_selection_cursor_rects_for_monitor(monitor);
 
 	assert_eq!(
-		overlay::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(95.0, 115.0)),
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(95.0, 115.0)),
 		Some(CursorIcon::NwseResize)
 	);
 	assert_eq!(
-		overlay::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(305.0, 115.0)),
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(305.0, 115.0)),
 		Some(CursorIcon::NeswResize)
 	);
 	assert_eq!(
-		overlay::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(150.0, 180.0)),
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, Pos2::new(150.0, 180.0)),
 		Some(CursorIcon::Grab)
 	);
 
@@ -611,7 +611,7 @@ fn frozen_selection_cursor_rects_match_resize_hit_test_for_tiny_overlapping_hand
 		Some(FrozenSelectionCorner::TopRight)
 	);
 	assert_eq!(
-		overlay::overlay_cursor_rect_icon_at_point(&rects, top_overlap),
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, top_overlap),
 		Some(CursorIcon::NeswResize)
 	);
 	assert_eq!(
@@ -619,12 +619,12 @@ fn frozen_selection_cursor_rects_match_resize_hit_test_for_tiny_overlapping_hand
 		Some(FrozenSelectionCorner::TopLeft)
 	);
 	assert_eq!(
-		overlay::overlay_cursor_rect_icon_at_point(&rects, top_overlap_midline_tie),
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, top_overlap_midline_tie),
 		Some(CursorIcon::NwseResize)
 	);
 	assert_eq!(WindowRenderer::frozen_selection_resize_hit_test(capture_rect, center_inside), None);
 	assert_eq!(
-		overlay::overlay_cursor_rect_icon_at_point(&rects, center_inside),
+		macos_cursor_runtime::overlay_cursor_rect_icon_at_point(&rects, center_inside),
 		Some(CursorIcon::Grab)
 	);
 }

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -6,24 +6,28 @@ use std::time::Duration;
 use std::time::Instant;
 
 #[cfg(target_os = "macos")]
+use objc2::MainThreadMarker;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::NSScreen;
+#[cfg(target_os = "macos")]
 use objc2_foundation::NSArray;
 use winit::window::{Window, WindowId};
 
 use crate::backend;
-#[cfg(target_os = "macos")]
-use crate::overlay;
 use crate::overlay::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
+#[cfg(target_os = "macos")]
+use crate::overlay::MacLiveFrameStream;
 #[cfg(target_os = "macos")]
 use crate::overlay::MacOSHudWindowConfigState;
 use crate::overlay::toolbar_layout_model;
+#[cfg(target_os = "macos")]
+use crate::overlay::{self, macos_cursor_runtime};
 use crate::overlay::{
 	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LOUPE_TILE_CORNER_RADIUS_POINTS,
 	LiveSampleApplyResult, LogicalPosition, LogicalSize, MonitorRect, OverlayMode, OverlaySession,
 	OverlayWindow, OverlayWorker, Result, ScrollPreviewWindow, TOOLBAR_EXPANDED_HEIGHT_PX,
 	WindowLevel, WindowRenderer, hud_helpers,
 };
-#[cfg(target_os = "macos")]
-use crate::overlay::{MacLiveFrameStream, MainThreadMarker, NSScreen};
 
 impl OverlaySession {
 	/// Starts the core session runtime and prepares the render windows and surfaces that the
@@ -726,7 +730,8 @@ impl OverlaySession {
 			overlay::macos_configure_overlay_window_mouse_moved_events(window.as_ref());
 
 			#[cfg(target_os = "macos")]
-			let cursor_rects = overlay::macos_install_overlay_cursor_rect_support(window.as_ref())?;
+			let cursor_rects =
+				macos_cursor_runtime::macos_install_overlay_cursor_rect_support(window.as_ref())?;
 
 			if visible {
 				window.request_redraw();


### PR DESCRIPTION
## Summary
- move macOS cursor-rect and AppKit cursor authority into overlay/macos_cursor_runtime.rs
- keep overlay.rs as the module root while callers use the new normal Rust module boundary
- update macOS cursor tests to target the new module owner

## Validation
- cargo make fmt-rust-check
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo make check-rust
- cargo test -p rsnap-overlay
- cargo make test-rust
- git diff --cached --check
- rg -n "include!|#\[path" packages apps (no matches)