### PR TITLE
Modularize host FFI scroll session

### DIFF
--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod abi;
 mod frozen_overlay;
+mod scroll_session;
 
 #[cfg(target_os = "macos")]
 pub use self::abi::RsnapLiveSamplerHandle;
@@ -36,6 +37,13 @@ pub use self::frozen_overlay::{
 	rsnap_frozen_overlay_edit_session_undo, rsnap_frozen_overlay_edit_session_update,
 	rsnap_frozen_overlay_edit_snapshot_release, rsnap_frozen_overlay_export_render_rgba,
 };
+pub use self::scroll_session::{
+	rsnap_scroll_session_create, rsnap_scroll_session_destroy,
+	rsnap_scroll_session_observe_downward_frame,
+	rsnap_scroll_session_observe_downward_frame_with_motion_hint,
+	rsnap_scroll_session_take_export_rgba, rsnap_scroll_session_take_preview_rgba,
+	rsnap_scroll_session_undo_last_append,
+};
 
 use std::ffi::CStr;
 use std::mem;
@@ -62,9 +70,6 @@ use rsnap_capture_core::{
 };
 #[cfg(target_os = "macos")]
 use rsnap_overlay::host_live_sampling_macos::HostMacLiveSampler;
-use rsnap_overlay::scroll_stitching::{
-	ScrollStitchImage, ScrollStitchObserveOutcome, ScrollStitchSession,
-};
 
 /// Creates a new opaque session handle.
 ///
@@ -78,239 +83,6 @@ pub unsafe extern "C" fn rsnap_session_create(
 	let session = CaptureSessionCore::with_config(decode_session_config(config));
 
 	Box::into_raw(Box::new(RsnapSessionHandle { session }))
-}
-
-/// Creates a scroll-capture stitcher from the first frozen viewport frame.
-///
-/// # Safety
-///
-/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
-/// row-major RGBA data. The returned pointer must be released by calling
-/// `rsnap_scroll_session_destroy`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_scroll_session_create(
-	width: u32,
-	height: u32,
-	rgba: *const u8,
-	rgba_len: usize,
-	preview_width_px: u32,
-) -> *mut RsnapScrollSessionHandle {
-	let Some(bytes) = (unsafe { rgba_bytes(rgba, rgba_len) }) else {
-		return ptr::null_mut();
-	};
-	let Ok(session) = ScrollStitchSession::new_from_rgba(width, height, bytes, preview_width_px)
-	else {
-		return ptr::null_mut();
-	};
-
-	Box::into_raw(Box::new(RsnapScrollSessionHandle { session }))
-}
-
-/// Destroys a scroll-capture stitcher returned by `rsnap_scroll_session_create`.
-///
-/// # Safety
-///
-/// The pointer must either be null or a pointer returned by
-/// `rsnap_scroll_session_create` that has not already been destroyed.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_scroll_session_destroy(handle: *mut RsnapScrollSessionHandle) {
-	if handle.is_null() {
-		return;
-	}
-
-	unsafe {
-		drop(Box::from_raw(handle));
-	}
-}
-
-/// Observes one discrete viewport screenshot for downward scroll-capture stitching.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`.
-/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
-/// row-major RGBA data, and `out_result` must be writable.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_scroll_session_observe_downward_frame(
-	handle: *mut RsnapScrollSessionHandle,
-	width: u32,
-	height: u32,
-	rgba: *const u8,
-	rgba_len: usize,
-	out_result: *mut RsnapScrollObserveResult,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_result.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let Some(bytes) = (unsafe { rgba_bytes(rgba, rgba_len) }) else {
-		return RsnapStatus::InvalidInput;
-	};
-	let outcome = match handle.session.observe_worker_pairwise_rgba(width, height, bytes) {
-		Ok(outcome) => outcome,
-		Err(_err) => return RsnapStatus::InvalidInput,
-	};
-	let (export_width, export_height) = handle.session.export_dimensions();
-
-	unsafe {
-		ptr::write(
-			out_result,
-			encode_scroll_observe_result(outcome, export_width, export_height, &handle.session),
-		);
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Observes one discrete viewport screenshot with an optional downward motion hint.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`.
-/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
-/// row-major RGBA data, and `out_result` must be writable.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_scroll_session_observe_downward_frame_with_motion_hint(
-	handle: *mut RsnapScrollSessionHandle,
-	width: u32,
-	height: u32,
-	rgba: *const u8,
-	rgba_len: usize,
-	motion_rows_hint: u32,
-	allow_burst_search: u8,
-	out_result: *mut RsnapScrollObserveResult,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_result.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let Some(bytes) = (unsafe { rgba_bytes(rgba, rgba_len) }) else {
-		return RsnapStatus::InvalidInput;
-	};
-	let hint = (motion_rows_hint > 0).then_some(motion_rows_hint);
-	let outcome = match handle.session.observe_downward_rgba_with_motion_hint(
-		width,
-		height,
-		bytes,
-		hint,
-		allow_burst_search != 0,
-	) {
-		Ok(outcome) => outcome,
-		Err(_err) => return RsnapStatus::InvalidInput,
-	};
-	let (export_width, export_height) = handle.session.export_dimensions();
-
-	unsafe {
-		ptr::write(
-			out_result,
-			encode_scroll_observe_result(outcome, export_width, export_height, &handle.session),
-		);
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Copies the current committed scroll-capture export into a Rust-owned RGBA buffer.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
-/// `out_region` must be writable. The returned buffer must be released with
-/// `rsnap_owned_rgba_region_release`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_scroll_session_take_export_rgba(
-	handle: *mut RsnapScrollSessionHandle,
-	out_region: *mut RsnapOwnedRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let export = handle.session.export_image();
-
-	unsafe {
-		ptr::write(out_region, owned_region_from_scroll_image(export));
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Copies the current committed scroll-capture preview into a Rust-owned RGBA buffer.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
-/// `out_region` must be writable. The returned buffer must be released with
-/// `rsnap_owned_rgba_region_release`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_scroll_session_take_preview_rgba(
-	handle: *mut RsnapScrollSessionHandle,
-	out_region: *mut RsnapOwnedRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let preview = handle.session.preview_image();
-
-	unsafe {
-		ptr::write(out_region, owned_region_from_scroll_image(preview));
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Reverts the most recent committed scroll-capture append when possible.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
-/// `out_result` must be writable.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_scroll_session_undo_last_append(
-	handle: *mut RsnapScrollSessionHandle,
-	out_result: *mut RsnapScrollObserveResult,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { scroll_session_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_result.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let did_undo = handle.session.undo_last_append();
-	let (export_width, export_height) = handle.session.export_dimensions();
-	let kind = if did_undo {
-		ScrollStitchObserveOutcome::PreviewUpdated
-	} else {
-		ScrollStitchObserveOutcome::NoChange
-	};
-
-	unsafe {
-		ptr::write(
-			out_result,
-			encode_scroll_observe_result(kind, export_width, export_height, &handle.session),
-		);
-	}
-
-	RsnapStatus::Ok
 }
 
 /// Encodes a full RGBA export image as lossless PNG through the Rust product core.
@@ -1789,12 +1561,6 @@ unsafe fn handle_ref<'a>(handle: *const RsnapSessionHandle) -> Option<&'a RsnapS
 	unsafe { handle.as_ref() }
 }
 
-unsafe fn scroll_session_handle_mut<'a>(
-	handle: *mut RsnapScrollSessionHandle,
-) -> Option<&'a mut RsnapScrollSessionHandle> {
-	unsafe { handle.as_mut() }
-}
-
 #[cfg(target_os = "macos")]
 unsafe fn live_sampler_handle_mut<'a>(
 	handle: *mut RsnapLiveSamplerHandle,
@@ -2265,38 +2031,6 @@ fn encode_host_request(request: HostRequest) -> RsnapHostRequestValue {
 			..RsnapHostRequestValue::default()
 		},
 	}
-}
-
-fn encode_scroll_observe_result(
-	outcome: ScrollStitchObserveOutcome,
-	export_width: u32,
-	export_height: u32,
-	session: &ScrollStitchSession,
-) -> RsnapScrollObserveResult {
-	let (kind, growth_rows) = match outcome {
-		ScrollStitchObserveOutcome::NoChange => (RsnapScrollObserveOutcomeKind::NoChange, 0),
-		ScrollStitchObserveOutcome::PreviewUpdated => {
-			(RsnapScrollObserveOutcomeKind::PreviewUpdated, 0)
-		},
-		ScrollStitchObserveOutcome::Committed { growth_rows } => {
-			(RsnapScrollObserveOutcomeKind::Committed, growth_rows)
-		},
-		ScrollStitchObserveOutcome::UnsupportedDirection => {
-			(RsnapScrollObserveOutcomeKind::UnsupportedDirection, 0)
-		},
-	};
-
-	RsnapScrollObserveResult {
-		kind: kind as u32,
-		growth_rows,
-		export_width,
-		export_height,
-		current_viewport_top_y: session.current_viewport_top_y(),
-	}
-}
-
-fn owned_region_from_scroll_image(image: ScrollStitchImage) -> RsnapOwnedRgbaRegion {
-	owned_region_from_raw_rgba(image.width, image.height, image.rgba)
 }
 
 fn owned_bytes_from_vec(mut bytes: Vec<u8>) -> RsnapOwnedBytes {

--- a/packages/rsnap-host-ffi/src/scroll_session.rs
+++ b/packages/rsnap-host-ffi/src/scroll_session.rs
@@ -1,0 +1,274 @@
+use std::ptr;
+
+use crate::abi::{
+	RsnapOwnedRgbaRegion, RsnapScrollObserveOutcomeKind, RsnapScrollObserveResult,
+	RsnapScrollSessionHandle, RsnapStatus,
+};
+use rsnap_overlay::scroll_stitching::{
+	ScrollStitchImage, ScrollStitchObserveOutcome, ScrollStitchSession,
+};
+
+/// Creates a scroll-capture stitcher from the first frozen viewport frame.
+///
+/// # Safety
+///
+/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
+/// row-major RGBA data. The returned pointer must be released by calling
+/// `rsnap_scroll_session_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_create(
+	width: u32,
+	height: u32,
+	rgba: *const u8,
+	rgba_len: usize,
+	preview_width_px: u32,
+) -> *mut RsnapScrollSessionHandle {
+	let Some(bytes) = (unsafe { crate::rgba_bytes(rgba, rgba_len) }) else {
+		return ptr::null_mut();
+	};
+	let Ok(session) = ScrollStitchSession::new_from_rgba(width, height, bytes, preview_width_px)
+	else {
+		return ptr::null_mut();
+	};
+
+	Box::into_raw(Box::new(RsnapScrollSessionHandle { session }))
+}
+
+/// Destroys a scroll-capture stitcher returned by `rsnap_scroll_session_create`.
+///
+/// # Safety
+///
+/// The pointer must either be null or a pointer returned by
+/// `rsnap_scroll_session_create` that has not already been destroyed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_destroy(handle: *mut RsnapScrollSessionHandle) {
+	if handle.is_null() {
+		return;
+	}
+
+	unsafe {
+		drop(Box::from_raw(handle));
+	}
+}
+
+/// Observes one discrete viewport screenshot for downward scroll-capture stitching.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`.
+/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
+/// row-major RGBA data, and `out_result` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_observe_downward_frame(
+	handle: *mut RsnapScrollSessionHandle,
+	width: u32,
+	height: u32,
+	rgba: *const u8,
+	rgba_len: usize,
+	out_result: *mut RsnapScrollObserveResult,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle.as_mut() }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_result.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let Some(bytes) = (unsafe { crate::rgba_bytes(rgba, rgba_len) }) else {
+		return RsnapStatus::InvalidInput;
+	};
+	let outcome = match handle.session.observe_worker_pairwise_rgba(width, height, bytes) {
+		Ok(outcome) => outcome,
+		Err(_err) => return RsnapStatus::InvalidInput,
+	};
+	let (export_width, export_height) = handle.session.export_dimensions();
+
+	unsafe {
+		ptr::write(
+			out_result,
+			encode_scroll_observe_result(outcome, export_width, export_height, &handle.session),
+		);
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Observes one discrete viewport screenshot with an optional downward motion hint.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`.
+/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
+/// row-major RGBA data, and `out_result` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_observe_downward_frame_with_motion_hint(
+	handle: *mut RsnapScrollSessionHandle,
+	width: u32,
+	height: u32,
+	rgba: *const u8,
+	rgba_len: usize,
+	motion_rows_hint: u32,
+	allow_burst_search: u8,
+	out_result: *mut RsnapScrollObserveResult,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle.as_mut() }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_result.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let Some(bytes) = (unsafe { crate::rgba_bytes(rgba, rgba_len) }) else {
+		return RsnapStatus::InvalidInput;
+	};
+	let hint = (motion_rows_hint > 0).then_some(motion_rows_hint);
+	let outcome = match handle.session.observe_downward_rgba_with_motion_hint(
+		width,
+		height,
+		bytes,
+		hint,
+		allow_burst_search != 0,
+	) {
+		Ok(outcome) => outcome,
+		Err(_err) => return RsnapStatus::InvalidInput,
+	};
+	let (export_width, export_height) = handle.session.export_dimensions();
+
+	unsafe {
+		ptr::write(
+			out_result,
+			encode_scroll_observe_result(outcome, export_width, export_height, &handle.session),
+		);
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Copies the current committed scroll-capture export into a Rust-owned RGBA buffer.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
+/// `out_region` must be writable. The returned buffer must be released with
+/// `rsnap_owned_rgba_region_release`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_take_export_rgba(
+	handle: *mut RsnapScrollSessionHandle,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle.as_mut() }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let export = handle.session.export_image();
+
+	unsafe {
+		ptr::write(out_region, owned_region_from_scroll_image(export));
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Copies the current committed scroll-capture preview into a Rust-owned RGBA buffer.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
+/// `out_region` must be writable. The returned buffer must be released with
+/// `rsnap_owned_rgba_region_release`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_take_preview_rgba(
+	handle: *mut RsnapScrollSessionHandle,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle.as_mut() }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let preview = handle.session.preview_image();
+
+	unsafe {
+		ptr::write(out_region, owned_region_from_scroll_image(preview));
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Reverts the most recent committed scroll-capture append when possible.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_scroll_session_create`, and
+/// `out_result` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_scroll_session_undo_last_append(
+	handle: *mut RsnapScrollSessionHandle,
+	out_result: *mut RsnapScrollObserveResult,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle.as_mut() }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_result.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let did_undo = handle.session.undo_last_append();
+	let (export_width, export_height) = handle.session.export_dimensions();
+	let kind = if did_undo {
+		ScrollStitchObserveOutcome::PreviewUpdated
+	} else {
+		ScrollStitchObserveOutcome::NoChange
+	};
+
+	unsafe {
+		ptr::write(
+			out_result,
+			encode_scroll_observe_result(kind, export_width, export_height, &handle.session),
+		);
+	}
+
+	RsnapStatus::Ok
+}
+
+fn encode_scroll_observe_result(
+	outcome: ScrollStitchObserveOutcome,
+	export_width: u32,
+	export_height: u32,
+	session: &ScrollStitchSession,
+) -> RsnapScrollObserveResult {
+	let (kind, growth_rows) = match outcome {
+		ScrollStitchObserveOutcome::NoChange => (RsnapScrollObserveOutcomeKind::NoChange, 0),
+		ScrollStitchObserveOutcome::PreviewUpdated => {
+			(RsnapScrollObserveOutcomeKind::PreviewUpdated, 0)
+		},
+		ScrollStitchObserveOutcome::Committed { growth_rows } => {
+			(RsnapScrollObserveOutcomeKind::Committed, growth_rows)
+		},
+		ScrollStitchObserveOutcome::UnsupportedDirection => {
+			(RsnapScrollObserveOutcomeKind::UnsupportedDirection, 0)
+		},
+	};
+
+	RsnapScrollObserveResult {
+		kind: kind as u32,
+		growth_rows,
+		export_width,
+		export_height,
+		current_viewport_top_y: session.current_viewport_top_y(),
+	}
+}
+
+fn owned_region_from_scroll_image(image: ScrollStitchImage) -> RsnapOwnedRgbaRegion {
+	crate::owned_region_from_raw_rgba(image.width, image.height, image.rgba)
+}


### PR DESCRIPTION
## Summary
- Move scroll-session FFI exports and result encoding into packages/rsnap-host-ffi/src/scroll_session.rs
- Keep rsnap_scroll_session_* C symbols and crate re-exports stable through lib.rs
- Use a normal Rust module boundary with no include!/#[path] split

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-host-ffi --all-targets --all-features
- cargo test -p rsnap-host-ffi --all-features scroll_session
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts (no matches)
- Fresh skeptic review: untracked module concern resolved by staging scroll_session.rs, then host FFI check/test rerun