### PR TITLE
Modularize host FFI live sampler

### DIFF
--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -7,6 +7,8 @@
 mod abi;
 mod capture_frame;
 mod frozen_overlay;
+#[cfg(target_os = "macos")]
+mod live_sampler;
 mod scroll_session;
 
 #[cfg(target_os = "macos")]
@@ -47,6 +49,16 @@ pub use self::frozen_overlay::{
 	rsnap_frozen_overlay_edit_session_undo, rsnap_frozen_overlay_edit_session_update,
 	rsnap_frozen_overlay_edit_snapshot_release, rsnap_frozen_overlay_export_render_rgba,
 };
+#[cfg(target_os = "macos")]
+pub use self::live_sampler::{
+	rsnap_live_sampler_create, rsnap_live_sampler_create_with_self_capture_exception_window_ids,
+	rsnap_live_sampler_destroy, rsnap_live_sampler_peek_latest_monitor_rgba,
+	rsnap_live_sampler_peek_region_rgba, rsnap_live_sampler_prime_monitor,
+	rsnap_live_sampler_reset, rsnap_live_sampler_sample_cursor,
+	rsnap_live_sampler_take_latest_monitor_rgba,
+	rsnap_live_sampler_take_next_region_rgba_after_seq,
+	rsnap_live_sampler_take_next_region_rgba_pixels_after_seq, rsnap_live_sampler_take_region_rgba,
+};
 pub use self::scroll_session::{
 	rsnap_scroll_session_create, rsnap_scroll_session_destroy,
 	rsnap_scroll_session_observe_downward_frame,
@@ -62,8 +74,6 @@ use std::slice;
 #[cfg(not(target_os = "macos"))]
 use rsnap_overlay as _;
 
-#[cfg(target_os = "macos")]
-use self::abi::RSNAP_LIVE_SAMPLE_PATCH_CAPACITY;
 use self::abi::{RSNAP_STATUS_MESSAGE_CAPACITY, RSNAP_TOOLBAR_ITEM_CAPACITY};
 use rsnap_capture_core::SceneModel;
 use rsnap_capture_core::{
@@ -73,8 +83,6 @@ use rsnap_capture_core::{
 	ScrollMinimapInput, ScrollMinimapPlan, SessionConfig, ToolbarItemKind, ToolbarItemModel,
 	WindowRect,
 };
-#[cfg(target_os = "macos")]
-use rsnap_overlay::host_live_sampling_macos::HostMacLiveSampler;
 
 /// Creates a new opaque session handle.
 ///
@@ -276,85 +284,6 @@ pub extern "C" fn rsnap_host_ffi_abi_version() -> u32 {
 	RSNAP_HOST_FFI_ABI_VERSION
 }
 
-/// Creates a new opaque live-sampler handle for the native host.
-///
-/// # Safety
-///
-/// The returned pointer must be released by calling `rsnap_live_sampler_destroy`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_create() -> *mut RsnapLiveSamplerHandle {
-	Box::into_raw(Box::new(RsnapLiveSamplerHandle { sampler: HostMacLiveSampler::new() }))
-}
-
-/// Creates a live sampler that keeps selected current-process windows capturable.
-///
-/// # Safety
-///
-/// `window_ids` must point to `window_id_count` valid `u32` values, or be null when
-/// `window_id_count` is zero. The returned pointer must be released by calling
-/// `rsnap_live_sampler_destroy`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_create_with_self_capture_exception_window_ids(
-	window_ids: *const u32,
-	window_id_count: usize,
-) -> *mut RsnapLiveSamplerHandle {
-	if window_id_count > 0 && window_ids.is_null() {
-		return ptr::null_mut();
-	}
-
-	let exception_window_ids = if window_id_count == 0 {
-		Vec::new()
-	} else {
-		unsafe { slice::from_raw_parts(window_ids, window_id_count) }.to_vec()
-	};
-
-	Box::into_raw(Box::new(RsnapLiveSamplerHandle {
-		sampler: HostMacLiveSampler::with_self_capture_exception_window_ids(exception_window_ids),
-	}))
-}
-
-/// Starts warming the live sampler for the requested monitor without blocking on the
-/// first captured frame.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_prime_monitor(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	handle.sampler.prime_monitor(decode_overlay_monitor(monitor));
-
-	RsnapStatus::Ok
-}
-
-/// Stops any active ScreenCaptureKit stream while retaining the live-sampler worker.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_reset(
-	handle: *mut RsnapLiveSamplerHandle,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	handle.sampler.reset();
-
-	RsnapStatus::Ok
-}
-
 /// Destroys an opaque session handle.
 ///
 /// # Safety
@@ -363,21 +292,6 @@ pub unsafe extern "C" fn rsnap_live_sampler_reset(
 /// has not already been destroyed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rsnap_session_destroy(handle: *mut RsnapSessionHandle) {
-	if let Some(handle) = NonNull::new(handle) {
-		unsafe {
-			drop(Box::from_raw(handle.as_ptr()));
-		}
-	}
-}
-
-/// Destroys an opaque live-sampler handle.
-///
-/// # Safety
-///
-/// The pointer must either be null or a pointer returned by `rsnap_live_sampler_create`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_destroy(handle: *mut RsnapLiveSamplerHandle) {
 	if let Some(handle) = NonNull::new(handle) {
 		unsafe {
 			drop(Box::from_raw(handle.as_ptr()));
@@ -492,428 +406,6 @@ pub unsafe extern "C" fn rsnap_session_take_next_request(
 	RsnapStatus::Ok
 }
 
-/// Samples the current live RGB value and optional loupe patch through the proven
-/// Rust ScreenCaptureKit path.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
-/// `out_sample` must be a valid writable pointer.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_sample_cursor(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-	point: RsnapPoint,
-	patch_width_px: u32,
-	patch_height_px: u32,
-	out_sample: *mut RsnapLiveSample,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_sample.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let sample = handle.sampler.sample_cursor_with_metadata(
-		decode_overlay_monitor(monitor),
-		decode_overlay_point(point),
-		patch_width_px,
-		patch_height_px,
-	);
-	let Some(sample) = sample else {
-		return RsnapStatus::Empty;
-	};
-	let mut out = RsnapLiveSample {
-		has_frame_metadata: 1,
-		frame_age_micros: sample.frame_age_micros,
-		frame_seq: sample.frame_seq,
-		stream_generation: sample.stream_generation,
-		..Default::default()
-	};
-
-	if let Some(rgb) = sample.sample.rgb {
-		out.rgb = RsnapRgb { r: rgb.r, g: rgb.g, b: rgb.b };
-		out.has_rgb = 1;
-	}
-	if let Some(patch) = sample.sample.patch {
-		let bytes = patch.as_raw();
-		let len = bytes.len().min(RSNAP_LIVE_SAMPLE_PATCH_CAPACITY);
-
-		out.patch_width = patch.width();
-		out.patch_height = patch.height();
-		out.patch_len = len as u32;
-
-		out.patch_rgba[..len].copy_from_slice(&bytes[..len]);
-	}
-
-	unsafe {
-		ptr::write(out_sample, out);
-	}
-
-	if out.has_rgb == 0 && out.patch_len == 0 {
-		return RsnapStatus::Empty;
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Peeks a cached RGBA region from the latest live sampler monitor frame without waiting
-/// for a new capture.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
-/// `out_region` must be a valid writable pointer. The caller may first call with a null
-/// `rgba` pointer and zero `capacity` to query the required size, then call again with a
-/// writable buffer to receive the bytes.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_peek_region_rgba(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-	rect: RsnapRect,
-	out_region: *mut RsnapRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let region = handle.sampler.peek_region_rgba(
-		decode_overlay_monitor(monitor),
-		decode_overlay_point(RsnapPoint { x: rect.x, y: rect.y }),
-		rect.width,
-		rect.height,
-	);
-	let Some(region) = region else {
-		unsafe {
-			ptr::write(out_region, RsnapRgbaRegion::default());
-		}
-
-		return RsnapStatus::Empty;
-	};
-	let requested = unsafe { &mut *out_region };
-	let len = region.rgba.len();
-
-	if !requested.rgba.is_null() && requested.capacity >= len {
-		unsafe {
-			ptr::copy_nonoverlapping(region.rgba.as_ptr(), requested.rgba, len);
-		}
-	}
-
-	unsafe {
-		ptr::write(
-			out_region,
-			RsnapRgbaRegion {
-				width: region.width,
-				height: region.height,
-				len,
-				capacity: requested.capacity,
-				rgba: requested.rgba,
-			},
-		);
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Transfers ownership of a cached RGBA region from the latest live sampler monitor frame
-/// to the caller.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
-/// `out_region` must be a valid writable pointer. The caller must later release the
-/// returned buffer with `rsnap_owned_rgba_region_release`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_take_region_rgba(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-	rect: RsnapRect,
-	out_region: *mut RsnapOwnedRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let region = handle.sampler.peek_region_rgba(
-		decode_overlay_monitor(monitor),
-		decode_overlay_point(RsnapPoint { x: rect.x, y: rect.y }),
-		rect.width,
-		rect.height,
-	);
-	let Some(region) = region else {
-		unsafe {
-			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
-		}
-
-		return RsnapStatus::Empty;
-	};
-	let mut rgba = region.rgba;
-	let out = RsnapOwnedRgbaRegion {
-		width: region.width,
-		height: region.height,
-		len: rgba.len(),
-		capacity: rgba.capacity(),
-		rgba: rgba.as_mut_ptr(),
-	};
-
-	mem::forget(rgba);
-
-	unsafe {
-		ptr::write(out_region, out);
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Transfers ownership of the oldest queued RGBA region newer than `after_frame_seq`
-/// to the caller, preserving live-stream frame order.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`,
-/// `out_frame_seq` and `out_frame_age_micros` must be valid writable pointers, and
-/// `out_region` must be a valid writable pointer. The caller must later release the
-/// returned region buffer with `rsnap_owned_rgba_region_release`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_take_next_region_rgba_after_seq(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-	rect: RsnapRect,
-	after_frame_seq: u64,
-	wait_for_fresh: u8,
-	out_frame_seq: *mut u64,
-	out_frame_age_micros: *mut u64,
-	out_region: *mut RsnapOwnedRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_frame_seq.is_null() || out_frame_age_micros.is_null() || out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let Some(frame) = handle.sampler.next_region_rgba_after_seq(
-		decode_overlay_monitor(monitor),
-		decode_overlay_point(RsnapPoint { x: rect.x, y: rect.y }),
-		rect.width,
-		rect.height,
-		after_frame_seq,
-		wait_for_fresh != 0,
-	) else {
-		unsafe {
-			ptr::write(out_frame_seq, after_frame_seq);
-			ptr::write(out_frame_age_micros, 0);
-			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
-		}
-
-		return RsnapStatus::Empty;
-	};
-	let mut rgba = frame.region.rgba;
-	let out = RsnapOwnedRgbaRegion {
-		width: frame.region.width,
-		height: frame.region.height,
-		len: rgba.len(),
-		capacity: rgba.capacity(),
-		rgba: rgba.as_mut_ptr(),
-	};
-
-	mem::forget(rgba);
-
-	unsafe {
-		ptr::write(out_frame_seq, frame.frame_seq);
-		ptr::write(out_frame_age_micros, frame.frame_age_micros);
-		ptr::write(out_region, out);
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Transfers ownership of the oldest queued RGBA region newer than `after_frame_seq`
-/// using a monitor-local pixel rectangle, preserving live-stream frame order.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`,
-/// `out_frame_seq` and `out_frame_age_micros` must be valid writable pointers, and
-/// `out_region` must be a valid writable pointer. The caller must later release the
-/// returned region buffer with `rsnap_owned_rgba_region_release`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_take_next_region_rgba_pixels_after_seq(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-	rect: RsnapPixelRect,
-	after_frame_seq: u64,
-	wait_for_fresh: u8,
-	out_frame_seq: *mut u64,
-	out_frame_age_micros: *mut u64,
-	out_region: *mut RsnapOwnedRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_frame_seq.is_null() || out_frame_age_micros.is_null() || out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let Some(frame) = handle.sampler.next_region_rgba_after_seq_pixels(
-		decode_overlay_monitor(monitor),
-		decode_pixel_rect(rect),
-		after_frame_seq,
-		wait_for_fresh != 0,
-	) else {
-		unsafe {
-			ptr::write(out_frame_seq, after_frame_seq);
-			ptr::write(out_frame_age_micros, 0);
-			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
-		}
-
-		return RsnapStatus::Empty;
-	};
-	let mut rgba = frame.region.rgba;
-	let out = RsnapOwnedRgbaRegion {
-		width: frame.region.width,
-		height: frame.region.height,
-		len: rgba.len(),
-		capacity: rgba.capacity(),
-		rgba: rgba.as_mut_ptr(),
-	};
-
-	mem::forget(rgba);
-
-	unsafe {
-		ptr::write(out_frame_seq, frame.frame_seq);
-		ptr::write(out_frame_age_micros, frame.frame_age_micros);
-		ptr::write(out_region, out);
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Peeks the latest cached full-monitor RGBA snapshot from the live sampler without waiting
-/// for a new capture.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
-/// `out_region` must be a valid writable pointer. The caller may first call with a null
-/// `rgba` pointer and zero `capacity` to query the required size, then call again with a
-/// writable buffer to receive the bytes.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_peek_latest_monitor_rgba(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-	out_region: *mut RsnapRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let region = handle.sampler.peek_latest_monitor_rgba(decode_overlay_monitor(monitor));
-	let Some(region) = region else {
-		unsafe {
-			ptr::write(out_region, RsnapRgbaRegion::default());
-		}
-
-		return RsnapStatus::Empty;
-	};
-	let requested = unsafe { &mut *out_region };
-	let len = region.rgba.len();
-
-	if !requested.rgba.is_null() && requested.capacity >= len {
-		unsafe {
-			ptr::copy_nonoverlapping(region.rgba.as_ptr(), requested.rgba, len);
-		}
-	}
-
-	unsafe {
-		ptr::write(
-			out_region,
-			RsnapRgbaRegion {
-				width: region.width,
-				height: region.height,
-				len,
-				capacity: requested.capacity,
-				rgba: requested.rgba,
-			},
-		);
-	}
-
-	RsnapStatus::Ok
-}
-
-/// Transfers ownership of the latest cached full-monitor RGBA snapshot buffer to the caller.
-///
-/// This cache-only payload does not expose the original frame age or sequence, so callers must not
-/// use it as the first frozen screenshot frame.
-///
-/// # Safety
-///
-/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
-/// `out_region` must be a valid writable pointer. The caller must later release the
-/// returned buffer with `rsnap_owned_rgba_region_release`.
-#[cfg(target_os = "macos")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_live_sampler_take_latest_monitor_rgba(
-	handle: *mut RsnapLiveSamplerHandle,
-	monitor: RsnapMonitorRect,
-	out_region: *mut RsnapOwnedRgbaRegion,
-) -> RsnapStatus {
-	let Some(handle) = (unsafe { live_sampler_handle_mut(handle) }) else {
-		return RsnapStatus::NullHandle;
-	};
-
-	if out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let Some(region) = handle.sampler.peek_latest_monitor_rgba(decode_overlay_monitor(monitor))
-	else {
-		unsafe {
-			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
-		}
-
-		return RsnapStatus::Empty;
-	};
-	let mut rgba = region.rgba;
-	let out = RsnapOwnedRgbaRegion {
-		width: region.width,
-		height: region.height,
-		len: rgba.len(),
-		capacity: rgba.capacity(),
-		rgba: rgba.as_mut_ptr(),
-	};
-
-	mem::forget(rgba);
-
-	unsafe {
-		ptr::write(out_region, out);
-	}
-
-	RsnapStatus::Ok
-}
-
 /// Releases a buffer previously returned by an RGBA export function.
 ///
 /// # Safety
@@ -1019,13 +511,6 @@ unsafe fn handle_mut<'a>(handle: *mut RsnapSessionHandle) -> Option<&'a mut Rsna
 
 unsafe fn handle_ref<'a>(handle: *const RsnapSessionHandle) -> Option<&'a RsnapSessionHandle> {
 	unsafe { handle.as_ref() }
-}
-
-#[cfg(target_os = "macos")]
-unsafe fn live_sampler_handle_mut<'a>(
-	handle: *mut RsnapLiveSamplerHandle,
-) -> Option<&'a mut RsnapLiveSamplerHandle> {
-	unsafe { handle.as_mut() }
 }
 
 fn decode_frozen_selection_transform_kind(
@@ -1414,10 +899,6 @@ fn decode_point(point: RsnapPoint) -> rsnap_capture_core::GlobalPoint {
 }
 
 #[cfg(target_os = "macos")]
-fn decode_overlay_point(point: RsnapPoint) -> rsnap_overlay::session::GlobalPoint {
-	rsnap_overlay::session::GlobalPoint::new(point.x, point.y)
-}
-
 fn encode_rgb(rgb: Rgb) -> RsnapRgb {
 	RsnapRgb { r: rgb.r, g: rgb.g, b: rgb.b }
 }
@@ -1437,16 +918,6 @@ fn encode_monitor(monitor: rsnap_capture_core::MonitorRect) -> RsnapMonitorRect 
 }
 
 #[cfg(target_os = "macos")]
-fn decode_overlay_monitor(monitor: RsnapMonitorRect) -> rsnap_overlay::session::MonitorRect {
-	rsnap_overlay::session::MonitorRect {
-		id: monitor.id,
-		origin: rsnap_overlay::session::GlobalPoint::new(monitor.origin.x, monitor.origin.y),
-		width: monitor.width,
-		height: monitor.height,
-		scale_factor_x1000: monitor.scale_factor_x1000,
-	}
-}
-
 fn encode_window(window: WindowRect) -> RsnapWindowRect {
 	RsnapWindowRect {
 		window_id: window.window_id.unwrap_or_default(),

--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -898,7 +898,6 @@ fn decode_point(point: RsnapPoint) -> rsnap_capture_core::GlobalPoint {
 	rsnap_capture_core::GlobalPoint::new(point.x, point.y)
 }
 
-#[cfg(target_os = "macos")]
 fn encode_rgb(rgb: Rgb) -> RsnapRgb {
 	RsnapRgb { r: rgb.r, g: rgb.g, b: rgb.b }
 }
@@ -917,7 +916,6 @@ fn encode_monitor(monitor: rsnap_capture_core::MonitorRect) -> RsnapMonitorRect 
 	}
 }
 
-#[cfg(target_os = "macos")]
 fn encode_window(window: WindowRect) -> RsnapWindowRect {
 	RsnapWindowRect {
 		window_id: window.window_id.unwrap_or_default(),

--- a/packages/rsnap-host-ffi/src/live_sampler.rs
+++ b/packages/rsnap-host-ffi/src/live_sampler.rs
@@ -1,0 +1,546 @@
+use std::mem;
+use std::ptr::{self, NonNull};
+use std::slice;
+
+use crate::abi::{
+	RSNAP_LIVE_SAMPLE_PATCH_CAPACITY, RsnapLiveSample, RsnapLiveSamplerHandle, RsnapMonitorRect,
+	RsnapOwnedRgbaRegion, RsnapPixelRect, RsnapPoint, RsnapRect, RsnapRgb, RsnapRgbaRegion,
+	RsnapStatus,
+};
+use rsnap_overlay::host_live_sampling_macos::HostMacLiveSampler;
+
+/// Creates a new opaque live-sampler handle for the native host.
+///
+/// # Safety
+///
+/// The returned pointer must be released by calling `rsnap_live_sampler_destroy`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_create() -> *mut RsnapLiveSamplerHandle {
+	Box::into_raw(Box::new(RsnapLiveSamplerHandle { sampler: HostMacLiveSampler::new() }))
+}
+
+/// Creates a live sampler that keeps selected current-process windows capturable.
+///
+/// # Safety
+///
+/// `window_ids` must point to `window_id_count` valid `u32` values, or be null when
+/// `window_id_count` is zero. The returned pointer must be released by calling
+/// `rsnap_live_sampler_destroy`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_create_with_self_capture_exception_window_ids(
+	window_ids: *const u32,
+	window_id_count: usize,
+) -> *mut RsnapLiveSamplerHandle {
+	if window_id_count > 0 && window_ids.is_null() {
+		return ptr::null_mut();
+	}
+
+	let exception_window_ids = if window_id_count == 0 {
+		Vec::new()
+	} else {
+		unsafe { slice::from_raw_parts(window_ids, window_id_count) }.to_vec()
+	};
+
+	Box::into_raw(Box::new(RsnapLiveSamplerHandle {
+		sampler: HostMacLiveSampler::with_self_capture_exception_window_ids(exception_window_ids),
+	}))
+}
+
+/// Starts warming the live sampler for the requested monitor without blocking on the
+/// first captured frame.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_prime_monitor(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	handle.sampler.prime_monitor(decode_overlay_monitor(monitor));
+
+	RsnapStatus::Ok
+}
+
+/// Stops any active ScreenCaptureKit stream while retaining the live-sampler worker.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_reset(
+	handle: *mut RsnapLiveSamplerHandle,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	handle.sampler.reset();
+
+	RsnapStatus::Ok
+}
+
+/// Destroys an opaque live-sampler handle.
+///
+/// # Safety
+///
+/// The pointer must either be null or a pointer returned by `rsnap_live_sampler_create`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_destroy(handle: *mut RsnapLiveSamplerHandle) {
+	if let Some(handle) = NonNull::new(handle) {
+		unsafe {
+			drop(Box::from_raw(handle.as_ptr()));
+		}
+	}
+}
+
+/// Samples the current live RGB value and optional loupe patch through the proven
+/// Rust ScreenCaptureKit path.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
+/// `out_sample` must be a valid writable pointer.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_sample_cursor(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+	point: RsnapPoint,
+	patch_width_px: u32,
+	patch_height_px: u32,
+	out_sample: *mut RsnapLiveSample,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_sample.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let sample = handle.sampler.sample_cursor_with_metadata(
+		decode_overlay_monitor(monitor),
+		decode_overlay_point(point),
+		patch_width_px,
+		patch_height_px,
+	);
+	let Some(sample) = sample else {
+		return RsnapStatus::Empty;
+	};
+	let mut out = RsnapLiveSample {
+		has_frame_metadata: 1,
+		frame_age_micros: sample.frame_age_micros,
+		frame_seq: sample.frame_seq,
+		stream_generation: sample.stream_generation,
+		..Default::default()
+	};
+
+	if let Some(rgb) = sample.sample.rgb {
+		out.rgb = RsnapRgb { r: rgb.r, g: rgb.g, b: rgb.b };
+		out.has_rgb = 1;
+	}
+	if let Some(patch) = sample.sample.patch {
+		let bytes = patch.as_raw();
+		let len = bytes.len().min(RSNAP_LIVE_SAMPLE_PATCH_CAPACITY);
+
+		out.patch_width = patch.width();
+		out.patch_height = patch.height();
+		out.patch_len = len as u32;
+
+		out.patch_rgba[..len].copy_from_slice(&bytes[..len]);
+	}
+
+	unsafe {
+		ptr::write(out_sample, out);
+	}
+
+	if out.has_rgb == 0 && out.patch_len == 0 {
+		return RsnapStatus::Empty;
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Peeks a cached RGBA region from the latest live sampler monitor frame without waiting
+/// for a new capture.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
+/// `out_region` must be a valid writable pointer. The caller may first call with a null
+/// `rgba` pointer and zero `capacity` to query the required size, then call again with a
+/// writable buffer to receive the bytes.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_peek_region_rgba(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+	rect: RsnapRect,
+	out_region: *mut RsnapRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let region = handle.sampler.peek_region_rgba(
+		decode_overlay_monitor(monitor),
+		decode_overlay_point(RsnapPoint { x: rect.x, y: rect.y }),
+		rect.width,
+		rect.height,
+	);
+	let Some(region) = region else {
+		unsafe {
+			ptr::write(out_region, RsnapRgbaRegion::default());
+		}
+
+		return RsnapStatus::Empty;
+	};
+	let requested = unsafe { &mut *out_region };
+	let len = region.rgba.len();
+
+	if !requested.rgba.is_null() && requested.capacity >= len {
+		unsafe {
+			ptr::copy_nonoverlapping(region.rgba.as_ptr(), requested.rgba, len);
+		}
+	}
+
+	unsafe {
+		ptr::write(
+			out_region,
+			RsnapRgbaRegion {
+				width: region.width,
+				height: region.height,
+				len,
+				capacity: requested.capacity,
+				rgba: requested.rgba,
+			},
+		);
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Transfers ownership of a cached RGBA region from the latest live sampler monitor frame
+/// to the caller.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
+/// `out_region` must be a valid writable pointer. The caller must later release the
+/// returned buffer with `rsnap_owned_rgba_region_release`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_take_region_rgba(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+	rect: RsnapRect,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let region = handle.sampler.peek_region_rgba(
+		decode_overlay_monitor(monitor),
+		decode_overlay_point(RsnapPoint { x: rect.x, y: rect.y }),
+		rect.width,
+		rect.height,
+	);
+	let Some(region) = region else {
+		unsafe {
+			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
+		}
+
+		return RsnapStatus::Empty;
+	};
+	let mut rgba = region.rgba;
+	let out = RsnapOwnedRgbaRegion {
+		width: region.width,
+		height: region.height,
+		len: rgba.len(),
+		capacity: rgba.capacity(),
+		rgba: rgba.as_mut_ptr(),
+	};
+
+	mem::forget(rgba);
+
+	unsafe {
+		ptr::write(out_region, out);
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Transfers ownership of the oldest queued RGBA region newer than `after_frame_seq`
+/// to the caller, preserving live-stream frame order.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`,
+/// `out_frame_seq` and `out_frame_age_micros` must be valid writable pointers, and
+/// `out_region` must be a valid writable pointer. The caller must later release the
+/// returned region buffer with `rsnap_owned_rgba_region_release`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_take_next_region_rgba_after_seq(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+	rect: RsnapRect,
+	after_frame_seq: u64,
+	wait_for_fresh: u8,
+	out_frame_seq: *mut u64,
+	out_frame_age_micros: *mut u64,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_frame_seq.is_null() || out_frame_age_micros.is_null() || out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let Some(frame) = handle.sampler.next_region_rgba_after_seq(
+		decode_overlay_monitor(monitor),
+		decode_overlay_point(RsnapPoint { x: rect.x, y: rect.y }),
+		rect.width,
+		rect.height,
+		after_frame_seq,
+		wait_for_fresh != 0,
+	) else {
+		unsafe {
+			ptr::write(out_frame_seq, after_frame_seq);
+			ptr::write(out_frame_age_micros, 0);
+			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
+		}
+
+		return RsnapStatus::Empty;
+	};
+	let mut rgba = frame.region.rgba;
+	let out = RsnapOwnedRgbaRegion {
+		width: frame.region.width,
+		height: frame.region.height,
+		len: rgba.len(),
+		capacity: rgba.capacity(),
+		rgba: rgba.as_mut_ptr(),
+	};
+
+	mem::forget(rgba);
+
+	unsafe {
+		ptr::write(out_frame_seq, frame.frame_seq);
+		ptr::write(out_frame_age_micros, frame.frame_age_micros);
+		ptr::write(out_region, out);
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Transfers ownership of the oldest queued RGBA region newer than `after_frame_seq`
+/// using a monitor-local pixel rectangle, preserving live-stream frame order.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`,
+/// `out_frame_seq` and `out_frame_age_micros` must be valid writable pointers, and
+/// `out_region` must be a valid writable pointer. The caller must later release the
+/// returned region buffer with `rsnap_owned_rgba_region_release`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_take_next_region_rgba_pixels_after_seq(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+	rect: RsnapPixelRect,
+	after_frame_seq: u64,
+	wait_for_fresh: u8,
+	out_frame_seq: *mut u64,
+	out_frame_age_micros: *mut u64,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_frame_seq.is_null() || out_frame_age_micros.is_null() || out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let Some(frame) = handle.sampler.next_region_rgba_after_seq_pixels(
+		decode_overlay_monitor(monitor),
+		crate::decode_pixel_rect(rect),
+		after_frame_seq,
+		wait_for_fresh != 0,
+	) else {
+		unsafe {
+			ptr::write(out_frame_seq, after_frame_seq);
+			ptr::write(out_frame_age_micros, 0);
+			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
+		}
+
+		return RsnapStatus::Empty;
+	};
+	let mut rgba = frame.region.rgba;
+	let out = RsnapOwnedRgbaRegion {
+		width: frame.region.width,
+		height: frame.region.height,
+		len: rgba.len(),
+		capacity: rgba.capacity(),
+		rgba: rgba.as_mut_ptr(),
+	};
+
+	mem::forget(rgba);
+
+	unsafe {
+		ptr::write(out_frame_seq, frame.frame_seq);
+		ptr::write(out_frame_age_micros, frame.frame_age_micros);
+		ptr::write(out_region, out);
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Peeks the latest cached full-monitor RGBA snapshot from the live sampler without waiting
+/// for a new capture.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
+/// `out_region` must be a valid writable pointer. The caller may first call with a null
+/// `rgba` pointer and zero `capacity` to query the required size, then call again with a
+/// writable buffer to receive the bytes.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_peek_latest_monitor_rgba(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+	out_region: *mut RsnapRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let region = handle.sampler.peek_latest_monitor_rgba(decode_overlay_monitor(monitor));
+	let Some(region) = region else {
+		unsafe {
+			ptr::write(out_region, RsnapRgbaRegion::default());
+		}
+
+		return RsnapStatus::Empty;
+	};
+	let requested = unsafe { &mut *out_region };
+	let len = region.rgba.len();
+
+	if !requested.rgba.is_null() && requested.capacity >= len {
+		unsafe {
+			ptr::copy_nonoverlapping(region.rgba.as_ptr(), requested.rgba, len);
+		}
+	}
+
+	unsafe {
+		ptr::write(
+			out_region,
+			RsnapRgbaRegion {
+				width: region.width,
+				height: region.height,
+				len,
+				capacity: requested.capacity,
+				rgba: requested.rgba,
+			},
+		);
+	}
+
+	RsnapStatus::Ok
+}
+
+/// Transfers ownership of the latest cached full-monitor RGBA snapshot buffer to the caller.
+///
+/// This cache-only payload does not expose the original frame age or sequence, so callers must not
+/// use it as the first frozen screenshot frame.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `rsnap_live_sampler_create`, and
+/// `out_region` must be a valid writable pointer. The caller must later release the
+/// returned buffer with `rsnap_owned_rgba_region_release`.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_live_sampler_take_latest_monitor_rgba(
+	handle: *mut RsnapLiveSamplerHandle,
+	monitor: RsnapMonitorRect,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	let Some(handle) = (unsafe { handle_mut(handle) }) else {
+		return RsnapStatus::NullHandle;
+	};
+
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let Some(region) = handle.sampler.peek_latest_monitor_rgba(decode_overlay_monitor(monitor))
+	else {
+		unsafe {
+			ptr::write(out_region, RsnapOwnedRgbaRegion::default());
+		}
+
+		return RsnapStatus::Empty;
+	};
+	let mut rgba = region.rgba;
+	let out = RsnapOwnedRgbaRegion {
+		width: region.width,
+		height: region.height,
+		len: rgba.len(),
+		capacity: rgba.capacity(),
+		rgba: rgba.as_mut_ptr(),
+	};
+
+	mem::forget(rgba);
+
+	unsafe {
+		ptr::write(out_region, out);
+	}
+
+	RsnapStatus::Ok
+}
+
+unsafe fn handle_mut<'a>(
+	handle: *mut RsnapLiveSamplerHandle,
+) -> Option<&'a mut RsnapLiveSamplerHandle> {
+	unsafe { handle.as_mut() }
+}
+
+fn decode_overlay_point(point: RsnapPoint) -> rsnap_overlay::session::GlobalPoint {
+	rsnap_overlay::session::GlobalPoint::new(point.x, point.y)
+}
+
+fn decode_overlay_monitor(monitor: RsnapMonitorRect) -> rsnap_overlay::session::MonitorRect {
+	rsnap_overlay::session::MonitorRect {
+		id: monitor.id,
+		origin: rsnap_overlay::session::GlobalPoint::new(monitor.origin.x, monitor.origin.y),
+		width: monitor.width,
+		height: monitor.height,
+		scale_factor_x1000: monitor.scale_factor_x1000,
+	}
+}


### PR DESCRIPTION
## Summary
- Move macOS live sampler FFI exports and overlay coordinate helpers into packages/rsnap-host-ffi/src/live_sampler.rs
- Keep rsnap_live_sampler_* C symbol names and macOS crate re-exports stable through lib.rs
- Preserve the non-macOS cfg surface while using a normal Rust module boundary with no include!/#[path] split

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-host-ffi --all-targets --all-features
- cargo test -p rsnap-host-ffi --all-features
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts (no matches)
- Fresh skeptic review: untracked module concern resolved by staging live_sampler.rs, then host FFI check rerun