### PR TITLE
Move scroll preview geometry constants to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -34,6 +34,7 @@ mod rendering;
 mod runtime_model;
 mod scroll_capture_runtime;
 mod scroll_input_runtime;
+mod scroll_preview_geometry;
 mod scroll_preview_runtime;
 mod scroll_runtime;
 mod session_bootstrap_runtime;
@@ -326,9 +327,6 @@ const TOOLBAR_WINDOW_WARMUP_REDRAWS: u8 = 30;
 const LOUPE_WINDOW_WARMUP_REDRAWS: u8 = 30;
 const LIVE_DRAG_START_THRESHOLD_PX: f32 = 6.0;
 const INTERACTIVE_REPAINT_TARGET_FPS: f32 = 120.0;
-const SCROLL_PREVIEW_WINDOW_WIDTH_POINTS: f64 = 260.0;
-const SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS: f64 = 360.0;
-const SCROLL_PREVIEW_WINDOW_MARGIN_POINTS: i32 = 16;
 #[cfg(target_os = "macos")]
 const SCROLL_CAPTURE_SAMPLE_INTERVAL: Duration = Duration::from_millis(250);
 #[cfg(not(target_os = "macos"))]
@@ -337,7 +335,6 @@ const SCROLL_CAPTURE_SAMPLE_INTERVAL: Duration = Duration::from_millis(50);
 const SCROLL_CAPTURE_DUPLICATE_WORKER_FRAME_RETRY_INTERVAL: Duration = Duration::from_millis(60);
 #[cfg(target_os = "macos")]
 const SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE: Duration = Duration::from_millis(180);
-const SCROLL_CAPTURE_PREVIEW_WIDTH_PX: u32 = 320;
 /// Transitional Rust-core session controller that owns product state, rendering,
 /// explicit host requests, and host-sync state consumed by the native app host.
 pub struct OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/image_helpers.rs
+++ b/packages/rsnap-overlay/src/overlay/image_helpers.rs
@@ -5,7 +5,7 @@ use image::{
 	imageops::{self, FilterType},
 };
 
-use crate::overlay::SCROLL_CAPTURE_PREVIEW_WIDTH_PX;
+use crate::overlay::scroll_preview_geometry::SCROLL_CAPTURE_PREVIEW_WIDTH_PX;
 
 pub(super) fn resize_scroll_preview_segment(segment: &RgbaImage) -> RgbaImage {
 	if segment.width() <= SCROLL_CAPTURE_PREVIEW_WIDTH_PX {

--- a/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
@@ -8,11 +8,13 @@ use wgpu::SurfaceConfiguration;
 
 use crate::overlay::rendering::overlay::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
 use crate::overlay::rendering::{GpuContext, ScrollPreviewView, WindowRenderer};
+use crate::overlay::scroll_preview_geometry::{
+	SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS, SCROLL_PREVIEW_WINDOW_WIDTH_POINTS,
+};
 use crate::overlay::{
 	AcquiredSurfaceFrame, ActiveEventLoop, Align, Arc, CentralPanel, Color32, ColorImage,
 	CornerRadius, CurrentSurfaceTexture, FontDefinitions, Frame, FullOutput, HudTheme, Layout,
-	LoadOp, LogicalSize, Margin, PhysicalSize, Renderer, Result, RgbaImage,
-	SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS, SCROLL_PREVIEW_WINDOW_WIDTH_POINTS, ScreenDescriptor,
+	LoadOp, LogicalSize, Margin, PhysicalSize, Renderer, Result, RgbaImage, ScreenDescriptor,
 	StoreOp, Stroke, Surface, SurfaceFrameSkipReason, TextureHandle, TextureOptions,
 	TextureViewDescriptor, Vec2, ViewportId, Visuals, WindowEvent, WindowLevel, WrapErr, eyre,
 	image_helpers,

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -9,6 +9,8 @@ use image::RgbaImage;
 
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::MacLiveFrameStream;
+#[cfg(target_os = "macos")]
+use crate::overlay::scroll_preview_geometry::SCROLL_CAPTURE_PREVIEW_WIDTH_PX;
 use crate::overlay::{
 	FrozenCaptureSource, Key, MonitorRect, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
 	OverlayMode, OverlaySession, PngAction, Pos2, Rect, SCROLL_CAPTURE_INPUT_FRESHNESS,
@@ -16,8 +18,8 @@ use crate::overlay::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
-	MacOSScrollPixelResidual, RectPoints, SCROLL_CAPTURE_PREVIEW_WIDTH_PX,
-	ScrollCaptureHostStartRequest, ScrollCaptureState, ScrollCaptureTraceRecorder, ScrollSession,
+	MacOSScrollPixelResidual, RectPoints, ScrollCaptureHostStartRequest, ScrollCaptureState,
+	ScrollCaptureTraceRecorder, ScrollSession,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/scroll_preview_geometry.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_preview_geometry.rs
@@ -1,0 +1,4 @@
+pub(in crate::overlay) const SCROLL_CAPTURE_PREVIEW_WIDTH_PX: u32 = 320;
+pub(in crate::overlay) const SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS: f64 = 360.0;
+pub(in crate::overlay) const SCROLL_PREVIEW_WINDOW_MARGIN_POINTS: i32 = 16;
+pub(in crate::overlay) const SCROLL_PREVIEW_WINDOW_WIDTH_POINTS: f64 = 260.0;

--- a/packages/rsnap-overlay/src/overlay/scroll_preview_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_preview_runtime.rs
@@ -1,8 +1,10 @@
+use crate::overlay::scroll_preview_geometry::{
+	SCROLL_CAPTURE_PREVIEW_WIDTH_PX, SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS,
+	SCROLL_PREVIEW_WINDOW_MARGIN_POINTS, SCROLL_PREVIEW_WINDOW_WIDTH_POINTS,
+};
 use crate::overlay::{
 	ElementState, MonitorRect, MouseButton, OverlayControl, OverlayExit, OverlaySession, Pos2,
-	Rect, RgbaImage, SCROLL_CAPTURE_PREVIEW_WIDTH_PX, SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS,
-	SCROLL_PREVIEW_WINDOW_MARGIN_POINTS, SCROLL_PREVIEW_WINDOW_WIDTH_POINTS, ScrollPreviewView,
-	Vec2, WindowEvent, WindowId, hud_helpers, scroll_capture,
+	Rect, RgbaImage, ScrollPreviewView, Vec2, WindowEvent, WindowId, hud_helpers, scroll_capture,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{LogicalPosition, LogicalSize};


### PR DESCRIPTION
## Summary
- move scroll preview window and preview-width constants into overlay::scroll_preview_geometry
- keep sibling modules importing the constants through the owner module with restricted visibility
- leave scroll runtime behavior unchanged

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features scroll_preview
- git diff --check
- ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

Skeptic review: no blockers.