### PR TITLE
Move scroll input constants to runtime owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -252,16 +252,6 @@ type Result<T, E = Report> = std::result::Result<T, E>;
 
 pub(crate) const CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED: bool = false;
 
-#[cfg(target_os = "macos")]
-const KCG_SCROLL_EVENT_UNIT_PIXEL: u32 = 0;
-#[cfg(target_os = "macos")]
-const KCG_SCROLL_EVENT_UNIT_LINE: u32 = 1;
-#[cfg(target_os = "macos")]
-const MACOS_SCROLL_PIXEL_WRAP_MODULUS: f64 = 4_294_967_296.0;
-#[cfg(target_os = "macos")]
-const MACOS_SCROLL_PIXEL_WRAP_THRESHOLD: f64 = 1_000_000.0;
-#[cfg(target_os = "macos")]
-const MACOS_SCROLL_PIXEL_DELTA_CLAMP: f64 = 240.0;
 const HUD_PILL_BODY_FILL_DARK_SRGBA8: [u8; 4] = [28, 28, 32, 156];
 const HUD_PILL_BODY_FILL_LIGHT_SRGBA8: [u8; 4] = [232, 236, 243, 176];
 const HUD_PILL_BLUR_TINT_ALPHA_DARK: f32 = 0.18;

--- a/packages/rsnap-overlay/src/overlay/scroll_input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_input_runtime.rs
@@ -7,12 +7,22 @@ use crate::overlay::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
-	KCG_SCROLL_EVENT_UNIT_LINE, KCG_SCROLL_EVENT_UNIT_PIXEL, MACOS_SCROLL_PIXEL_DELTA_CLAMP,
-	MACOS_SCROLL_PIXEL_WRAP_MODULUS, MACOS_SCROLL_PIXEL_WRAP_THRESHOLD, MacOSScrollPixelResidual,
-	MacOSScrollWheelEvent, MonitorRect, RectPoints,
+	MacOSScrollPixelResidual, MacOSScrollWheelEvent, MonitorRect, RectPoints,
 	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
 	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
 };
+
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const KCG_SCROLL_EVENT_UNIT_LINE: u32 = 1;
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const KCG_SCROLL_EVENT_UNIT_PIXEL: u32 = 0;
+
+#[cfg(target_os = "macos")]
+const MACOS_SCROLL_PIXEL_DELTA_CLAMP: f64 = 240.0;
+#[cfg(target_os = "macos")]
+const MACOS_SCROLL_PIXEL_WRAP_MODULUS: f64 = 4_294_967_296.0;
+#[cfg(target_os = "macos")]
+const MACOS_SCROLL_PIXEL_WRAP_THRESHOLD: f64 = 1_000_000.0;
 
 impl OverlaySession {
 	pub(super) fn handle_scroll_mouse_wheel(

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -64,11 +64,11 @@ use crate::overlay::{
 #[cfg(target_os = "macos")]
 use crate::overlay::{
 	HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, InflightScrollCaptureObservation,
-	KCG_SCROLL_EVENT_UNIT_PIXEL, LiveSampleApplyResult, LiveStreamStaleGrace,
-	MacOSScrollPixelResidual, OverlayExit, SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
-	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES,
-	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE, ScrollCaptureFrameSource,
-	ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError, StartupLiveRgbPlan,
+	LiveSampleApplyResult, LiveStreamStaleGrace, MacOSScrollPixelResidual, OverlayExit,
+	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW, SCROLL_CAPTURE_INPUT_FRESHNESS,
+	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES, SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
+	ScrollCaptureFrameSource, ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
+	StartupLiveRgbPlan,
 };
 use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/scroll_capture_runtime.rs
@@ -18,14 +18,16 @@ use image::{Rgba, RgbaImage};
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::MacLiveFrameStream;
 #[cfg(target_os = "macos")]
+use crate::overlay::scroll_input_runtime::KCG_SCROLL_EVENT_UNIT_PIXEL;
+#[cfg(target_os = "macos")]
 use crate::overlay::session_state::ScrollCaptureLiveFrame;
 use crate::overlay::tests::{self, GlobalPoint, MonitorRect, OverlaySession, RectPoints};
 #[cfg(not(target_os = "macos"))]
 use crate::overlay::tests::{FrozenCaptureSource, OverlayMode};
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::{
-	FrozenToolbarTool, KCG_SCROLL_EVENT_UNIT_PIXEL, LiveStreamStaleGrace, MacOSScrollPixelResidual,
-	MouseScrollDelta, OverlayControl, PhysicalPosition, SCROLL_CAPTURE_INPUT_FRESHNESS,
+	FrozenToolbarTool, LiveStreamStaleGrace, MacOSScrollPixelResidual, MouseScrollDelta,
+	OverlayControl, PhysicalPosition, SCROLL_CAPTURE_INPUT_FRESHNESS,
 	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES, ScrollCaptureFrameSource,
 	ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
 };


### PR DESCRIPTION
## Summary
- move macOS scroll wheel unit and pixel normalization constants into overlay::scroll_input_runtime
- keep test-only pixel unit access scoped through the runtime owner
- leave scroll input behavior unchanged

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features scroll_input_runtime
- git diff --check
- ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

Skeptic review: no blockers.