### PR TITLE
Move HUD loupe geometry constants to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -18,6 +18,7 @@ mod frozen_selection_runtime;
 mod frozen_spotlight_runtime;
 mod frozen_text_runtime;
 mod frozen_transition_runtime;
+mod hud_geometry;
 mod hud_helpers;
 mod hud_runtime;
 mod image_helpers;
@@ -159,6 +160,7 @@ use winit::{
 use self::frozen_export_model::{FrozenExportTransform, FrozenImagePatch, FrozenMosaicEdit};
 use self::frozen_text_runtime::{FrozenTextInputSource, FrozenTextRecentInput};
 use self::frozen_transition_runtime::FrozenTransitionRuntime;
+use self::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
 #[cfg(target_os = "macos")]
 use self::macos_capture_host::ExternalScrollInputDrainReader;
 #[cfg(all(test, target_os = "macos"))]
@@ -256,8 +258,6 @@ const HUD_PILL_BODY_FILL_DARK_SRGBA8: [u8; 4] = [28, 28, 32, 156];
 const HUD_PILL_BODY_FILL_LIGHT_SRGBA8: [u8; 4] = [232, 236, 243, 176];
 const HUD_PILL_BLUR_TINT_ALPHA_DARK: f32 = 0.18;
 const HUD_PILL_BLUR_TINT_ALPHA_LIGHT: f32 = 0.22;
-const LOUPE_TILE_CORNER_RADIUS_POINTS: f64 = 12.0;
-const HUD_LOUPE_STRIP_GAP_POINTS: i32 = 8;
 const FROZEN_TOOLBAR_BUTTON_SIZE_POINTS: f32 = 24.0;
 const FROZEN_TOOLBAR_ITEM_SPACING_POINTS: f32 = 4.0;
 const TOOLBAR_PILL_INNER_MARGIN_Y_POINTS: f32 = 6.0;

--- a/packages/rsnap-overlay/src/overlay/config_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/config_runtime.rs
@@ -8,11 +8,9 @@ use crate::backend;
 use crate::overlay;
 #[cfg(target_os = "macos")]
 use crate::overlay::OverlayWorker;
+use crate::overlay::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
 use crate::overlay::toolbar_layout_model;
-use crate::overlay::{
-	Arc, Instant, LOUPE_TILE_CORNER_RADIUS_POINTS, OverlayConfig, OverlayMode, OverlaySession,
-	WindowRenderer,
-};
+use crate::overlay::{Arc, Instant, OverlayConfig, OverlayMode, OverlaySession, WindowRenderer};
 #[cfg(target_os = "macos")]
 use crate::overlay::{
 	FrozenCaptureWorkerState, MacLiveFrameStream, MacOSHudWindowConfigState,

--- a/packages/rsnap-overlay/src/overlay/hud_geometry.rs
+++ b/packages/rsnap-overlay/src/overlay/hud_geometry.rs
@@ -1,0 +1,2 @@
+pub(in crate::overlay) const HUD_LOUPE_STRIP_GAP_POINTS: i32 = 8;
+pub(in crate::overlay) const LOUPE_TILE_CORNER_RADIUS_POINTS: f64 = 12.0;

--- a/packages/rsnap-overlay/src/overlay/rendering/hud_rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/hud_rendering.rs
@@ -1,8 +1,9 @@
 use egui::Context;
 
+use crate::overlay::hud_geometry::HUD_LOUPE_STRIP_GAP_POINTS;
 use crate::overlay::rendering::WindowRenderer;
 use crate::overlay::{
-	Align, Area, Color32, ColorImage, CornerRadius, Frame, GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS,
+	Align, Area, Color32, ColorImage, CornerRadius, Frame, GlobalPoint,
 	HUD_PILL_CORNER_RADIUS_POINTS, HudAnchor, HudPillGeometry, HudTheme, Id, Layout, Margin,
 	MonitorRect, Order, OverlayMode, OverlayState, Pos2, Rect, RichText, Sense, Stroke, StrokeKind,
 	TextureHandle, TextureId, TextureOptions, Ui, Vec2, hud_helpers,

--- a/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/hud_surface.rs
@@ -9,13 +9,14 @@ use wgpu::TexelCopyTextureInfo;
 use wgpu::TextureDescriptor;
 use wgpu::{BindGroup, TextureFormat};
 
+use crate::overlay::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
 use crate::overlay::rendering::{GpuContext, WindowRenderer, WindowRendererPhaseTimings};
 use crate::overlay::{
 	Area, BindingResource, Color32, CornerRadius, Frame, FullOutput, HudDrawConfig, HudTheme, Id,
-	Instant, LOUPE_TILE_CORNER_RADIUS_POINTS, Margin, MonitorRect, Order, Origin3d, OverlayMode,
-	OverlayState, PhysicalSize, Pos2, Rect, Result, Rgb, RgbaImage, Stroke, StrokeKind, Texture,
-	TextureAspect, TextureDimension, TextureUsages, TextureView, TextureViewDescriptor, ThemeMode,
-	Vec2, WindowRendererPath, hud_helpers, image_helpers, mem, ptr, slice,
+	Instant, Margin, MonitorRect, Order, Origin3d, OverlayMode, OverlayState, PhysicalSize, Pos2,
+	Rect, Result, Rgb, RgbaImage, Stroke, StrokeKind, Texture, TextureAspect, TextureDimension,
+	TextureUsages, TextureView, TextureViewDescriptor, ThemeMode, Vec2, WindowRendererPath,
+	hud_helpers, image_helpers, mem, ptr, slice,
 };
 
 impl WindowRenderer {

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -54,7 +54,7 @@ use crate::overlay::{
 	FrozenBrushModelState, FrozenBrushStroke, FrozenCommittedOverlay, FrozenEditKind,
 	FrozenExportTransform, FrozenImagePatch, FrozenMosaicEdit, FrozenSelectionDragState,
 	FrozenSpotlightAnnotation, FrozenTextAnnotation, FrozenTextEditState, FrozenTextInputSource,
-	FrozenToolbarState, FrozenToolbarTool, HUD_LOUPE_STRIP_GAP_POINTS, HudRedrawSummary, HudTheme,
+	FrozenToolbarState, FrozenToolbarTool, HudRedrawSummary, HudTheme,
 	OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, OutputNaming, OverlayControl, OverlaySession, Pos2,
 	PreparedHostEffectRequest, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL, SelectionDashedBorderCache,
 	SelectionFlowGeometryCache, SelectionSizeBadgeTarget, SurfaceFrameSkipReason,

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors.rs
@@ -33,9 +33,9 @@ use crate::overlay::session_state::{
 };
 use crate::overlay::tests::{
 	self, ElementState, FrozenCaptureSource, FrozenSelectionDragState, FrozenToolbarState,
-	FrozenToolbarTool, GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, HudTheme, MonitorRect,
-	MonitorRectPoints, MouseButton, OverlayMode, OverlaySession, OverlayState, PngAction, Pos2,
-	Rect, RectPoints, Rgba, ScrollSession, SelectionDashedBorderCache, SelectionFlowGeometryCache,
+	FrozenToolbarTool, GlobalPoint, HudTheme, MonitorRect, MonitorRectPoints, MouseButton,
+	OverlayMode, OverlaySession, OverlayState, PngAction, Pos2, Rect, RectPoints, Rgba,
+	ScrollSession, SelectionDashedBorderCache, SelectionFlowGeometryCache,
 	SelectionSizeBadgeTarget, TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement,
 	Vec2, WindowRenderer, overlay,
 };

--- a/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/toolbar_layout.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/rendering_behaviors/toolbar_layout.rs
@@ -1,9 +1,10 @@
+use crate::overlay::hud_geometry::HUD_LOUPE_STRIP_GAP_POINTS;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::rendering_behaviors::FrozenCaptureSource;
 use crate::overlay::tests::rendering_behaviors::{
-	FrozenToolbarState, FrozenToolbarTool, GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, HudTheme,
-	MonitorRect, OverlayMode, OverlaySession, OverlayState, Pos2, RawInput, Rect, RectPoints,
-	TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Ui, Vec2, WindowRenderer,
+	FrozenToolbarState, FrozenToolbarTool, GlobalPoint, HudTheme, MonitorRect, OverlayMode,
+	OverlaySession, OverlayState, Pos2, RawInput, Rect, RectPoints, TOOLBAR_CAPTURE_GAP_PX,
+	TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Ui, Vec2, WindowRenderer,
 	overlay::toolbar_layout_model, tests,
 };
 

--- a/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
@@ -1,8 +1,9 @@
+use crate::overlay::hud_geometry::HUD_LOUPE_STRIP_GAP_POINTS;
 #[cfg(target_os = "macos")]
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
-	GlobalPoint, HUD_LOUPE_STRIP_GAP_POINTS, MonitorRect, OverlayMode, OverlaySession, Pos2, Rect,
-	TOOLBAR_SCREEN_MARGIN_PX, Vec2, WindowRenderer,
+	GlobalPoint, MonitorRect, OverlayMode, OverlaySession, Pos2, Rect, TOOLBAR_SCREEN_MARGIN_PX,
+	Vec2, WindowRenderer,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -19,14 +19,15 @@ use crate::overlay::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
 use crate::overlay::MacLiveFrameStream;
 #[cfg(target_os = "macos")]
 use crate::overlay::MacOSHudWindowConfigState;
+use crate::overlay::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
 use crate::overlay::toolbar_layout_model;
 #[cfg(target_os = "macos")]
 use crate::overlay::{self, macos_cursor_runtime};
 use crate::overlay::{
-	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LOUPE_TILE_CORNER_RADIUS_POINTS,
-	LiveSampleApplyResult, LogicalPosition, LogicalSize, MonitorRect, OverlayMode, OverlaySession,
-	OverlayWindow, OverlayWorker, Result, ScrollPreviewWindow, TOOLBAR_EXPANDED_HEIGHT_PX,
-	WindowLevel, WindowRenderer, hud_helpers,
+	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LiveSampleApplyResult,
+	LogicalPosition, LogicalSize, MonitorRect, OverlayMode, OverlaySession, OverlayWindow,
+	OverlayWorker, Result, ScrollPreviewWindow, TOOLBAR_EXPANDED_HEIGHT_PX, WindowLevel,
+	WindowRenderer, hud_helpers,
 };
 
 impl OverlaySession {


### PR DESCRIPTION
## Summary
- move HUD/loupe placement and tile-radius constants into overlay::hud_geometry
- keep callers importing the values through the geometry owner module
- leave HUD/loupe behavior unchanged

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features rendering_behaviors::toolbar_layout
- cargo test -p rsnap-overlay --all-features session_runtime::tinted_hud_body_fill
- git diff --check
- ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

Skeptic review: no blockers.