### PR TITLE
Move HUD pill constants to style owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -20,6 +20,7 @@ mod frozen_text_runtime;
 mod frozen_transition_runtime;
 mod hud_geometry;
 mod hud_helpers;
+mod hud_pill_style;
 mod hud_runtime;
 mod image_helpers;
 mod input_runtime;
@@ -161,6 +162,7 @@ use self::frozen_export_model::{FrozenExportTransform, FrozenImagePatch, FrozenM
 use self::frozen_text_runtime::{FrozenTextInputSource, FrozenTextRecentInput};
 use self::frozen_transition_runtime::FrozenTransitionRuntime;
 use self::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
+use self::hud_pill_style::HUD_PILL_STROKE_WIDTH_POINTS;
 #[cfg(target_os = "macos")]
 use self::macos_capture_host::ExternalScrollInputDrainReader;
 #[cfg(all(test, target_os = "macos"))]
@@ -254,10 +256,6 @@ type Result<T, E = Report> = std::result::Result<T, E>;
 
 pub(crate) const CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED: bool = false;
 
-const HUD_PILL_BODY_FILL_DARK_SRGBA8: [u8; 4] = [28, 28, 32, 156];
-const HUD_PILL_BODY_FILL_LIGHT_SRGBA8: [u8; 4] = [232, 236, 243, 176];
-const HUD_PILL_BLUR_TINT_ALPHA_DARK: f32 = 0.18;
-const HUD_PILL_BLUR_TINT_ALPHA_LIGHT: f32 = 0.22;
 const FROZEN_TOOLBAR_BUTTON_SIZE_POINTS: f32 = 24.0;
 const FROZEN_TOOLBAR_ITEM_SPACING_POINTS: f32 = 4.0;
 const TOOLBAR_PILL_INNER_MARGIN_Y_POINTS: f32 = 6.0;
@@ -302,15 +300,12 @@ const SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES: u8 = 5;
 const SCROLL_CAPTURE_DUPLICATE_STREAM_STALL_THRESHOLD: u8 = 3;
 #[cfg(target_os = "macos")]
 const SCROLL_CAPTURE_DUPLICATE_STREAM_REFRESH_INTERVAL: Duration = Duration::from_millis(80);
-const HUD_PILL_INNER_MARGIN_X_POINTS: f32 = 12.0;
-const HUD_PILL_STROKE_WIDTH_POINTS: f32 = 1.0;
 const TOOLBAR_EXPANDED_HEIGHT_PX: f32 = FROZEN_TOOLBAR_BUTTON_SIZE_POINTS
 	+ 2.0 * TOOLBAR_PILL_INNER_MARGIN_Y_POINTS
 	+ 2.0 * HUD_PILL_STROKE_WIDTH_POINTS;
 const TOOLBAR_CAPTURE_GAP_PX: f32 = 10.0;
 const TOOLBAR_SCREEN_MARGIN_PX: f32 = 10.0;
 const TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS: f32 = 1.0;
-const HUD_PILL_CORNER_RADIUS_POINTS: u8 = 18;
 const TOOLBAR_DRAG_START_THRESHOLD_PX: f32 = 6.0;
 #[cfg(target_os = "macos")]
 const TOOLBAR_WINDOW_WARMUP_REDRAWS: u8 = 30;

--- a/packages/rsnap-overlay/src/overlay/hud_helpers.rs
+++ b/packages/rsnap-overlay/src/overlay/hud_helpers.rs
@@ -1,9 +1,10 @@
 use winit::window::Theme;
 
-use crate::overlay::{
+use crate::overlay::hud_pill_style::{
 	HUD_PILL_BLUR_TINT_ALPHA_DARK, HUD_PILL_BLUR_TINT_ALPHA_LIGHT, HUD_PILL_BODY_FILL_DARK_SRGBA8,
-	HUD_PILL_BODY_FILL_LIGHT_SRGBA8, HudTheme, ThemeMode,
+	HUD_PILL_BODY_FILL_LIGHT_SRGBA8,
 };
+use crate::overlay::{HudTheme, ThemeMode};
 use crate::state::{GlobalPoint, MonitorRect, OverlayState, Rgb};
 
 pub(super) fn srgb8_to_linear_f32(x: u8) -> f32 {

--- a/packages/rsnap-overlay/src/overlay/hud_pill_style.rs
+++ b/packages/rsnap-overlay/src/overlay/hud_pill_style.rs
@@ -1,0 +1,8 @@
+pub(in crate::overlay) const HUD_PILL_BLUR_TINT_ALPHA_DARK: f32 = 0.18;
+pub(in crate::overlay) const HUD_PILL_BLUR_TINT_ALPHA_LIGHT: f32 = 0.22;
+pub(in crate::overlay) const HUD_PILL_BODY_FILL_DARK_SRGBA8: [u8; 4] = [28, 28, 32, 156];
+pub(in crate::overlay) const HUD_PILL_BODY_FILL_LIGHT_SRGBA8: [u8; 4] = [232, 236, 243, 176];
+pub(in crate::overlay) const HUD_PILL_CORNER_RADIUS_POINTS: u8 = 18;
+pub(in crate::overlay) const HUD_PILL_INNER_MARGIN_X_POINTS: i8 = 12;
+pub(in crate::overlay) const HUD_PILL_INNER_MARGIN_Y_POINTS: i8 = 8;
+pub(in crate::overlay) const HUD_PILL_STROKE_WIDTH_POINTS: f32 = 1.0;

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances/toolbar.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances/toolbar.rs
@@ -2,16 +2,19 @@ mod annotation_style;
 
 use egui::Context;
 
+use crate::overlay::hud_pill_style::{
+	HUD_PILL_INNER_MARGIN_X_POINTS, HUD_PILL_STROKE_WIDTH_POINTS,
+};
 use crate::overlay::rendering::{FrozenToolbarButtonStyle, WindowRenderer};
 use crate::overlay::session_state::FrozenAnnotationStyleCapsulePlacement;
 use crate::overlay::{
 	Align, Align2, Area, Color32, CornerRadius, FROZEN_TOOLBAR_BUTTON_SIZE_POINTS,
 	FROZEN_TOOLBAR_ITEM_SPACING_POINTS, FontFamily, FontId, FrozenAnnotationColor,
-	FrozenToolbarPointerState, FrozenToolbarState, FrozenToolbarTool,
-	HUD_PILL_INNER_MARGIN_X_POINTS, HUD_PILL_STROKE_WIDTH_POINTS, HudPillGeometry, HudTheme, Id,
-	Layout, MonitorRect, Order, OverlayMode, OverlayState, Pos2, Rect, Sense, Stroke, StrokeKind,
-	TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_EXPANDED_HEIGHT_PX, TOOLBAR_PILL_INNER_MARGIN_Y_POINTS,
-	TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Ui, UiBuilder, Vec2, toolbar_layout_model,
+	FrozenToolbarPointerState, FrozenToolbarState, FrozenToolbarTool, HudPillGeometry, HudTheme,
+	Id, Layout, MonitorRect, Order, OverlayMode, OverlayState, Pos2, Rect, Sense, Stroke,
+	StrokeKind, TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_EXPANDED_HEIGHT_PX,
+	TOOLBAR_PILL_INNER_MARGIN_Y_POINTS, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Ui, UiBuilder,
+	Vec2, toolbar_layout_model,
 };
 use annotation_style::{
 	FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS, FROZEN_ANNOTATION_TOOLBAR_SECTION_HEIGHT_POINTS,
@@ -294,7 +297,7 @@ impl WindowRenderer {
 		let spacing_count = (tool_count - 1.0).max(0.0);
 		let width = tool_count * FROZEN_TOOLBAR_BUTTON_SIZE_POINTS
 			+ spacing_count * FROZEN_TOOLBAR_ITEM_SPACING_POINTS
-			+ 2.0 * HUD_PILL_INNER_MARGIN_X_POINTS
+			+ 2.0 * f32::from(HUD_PILL_INNER_MARGIN_X_POINTS)
 			+ 2.0 * HUD_PILL_STROKE_WIDTH_POINTS;
 		let height = toolbar_state.pill_height_points.unwrap_or(TOOLBAR_EXPANDED_HEIGHT_PX);
 
@@ -317,7 +320,7 @@ impl WindowRenderer {
 			+ (swatch_count - 1.0).max(0.0) * FROZEN_ANNOTATION_TOOLBAR_SWATCH_GAP_POINTS;
 		let content_width = style_kind.size_control_width() + 4.0 + swatches_width;
 		let width = content_width
-			+ 2.0 * HUD_PILL_INNER_MARGIN_X_POINTS
+			+ 2.0 * f32::from(HUD_PILL_INNER_MARGIN_X_POINTS)
 			+ 2.0 * HUD_PILL_STROKE_WIDTH_POINTS;
 		let height = toolbar_state.pill_height_points.unwrap_or(TOOLBAR_EXPANDED_HEIGHT_PX);
 
@@ -673,7 +676,7 @@ impl WindowRenderer {
 			);
 
 			let toolbar_inner_rect = toolbar_rect.shrink2(egui::vec2(
-				HUD_PILL_INNER_MARGIN_X_POINTS,
+				f32::from(HUD_PILL_INNER_MARGIN_X_POINTS),
 				TOOLBAR_PILL_INNER_MARGIN_Y_POINTS,
 			));
 			let _ = ui.scope_builder(UiBuilder::new().max_rect(toolbar_inner_rect), |ui| {
@@ -698,7 +701,7 @@ impl WindowRenderer {
 				);
 
 				let style_inner_rect = style_rect.shrink2(egui::vec2(
-					HUD_PILL_INNER_MARGIN_X_POINTS,
+					f32::from(HUD_PILL_INNER_MARGIN_X_POINTS),
 					TOOLBAR_PILL_INNER_MARGIN_Y_POINTS,
 				));
 				let _ = ui.scope_builder(UiBuilder::new().max_rect(style_inner_rect), |ui| {
@@ -762,12 +765,12 @@ impl WindowRenderer {
 			HudTheme::Dark => Color32::from_rgba_unmultiplied(0, 0, 0, 44),
 			HudTheme::Light => Color32::from_rgba_unmultiplied(255, 255, 255, 140),
 		};
-		let inner_rect = rect.shrink(1.0);
+		let inner_rect = rect.shrink(HUD_PILL_STROKE_WIDTH_POINTS);
 
 		ui.painter().rect_stroke(
 			inner_rect,
 			CornerRadius::same(corner_radius.saturating_sub(1)),
-			Stroke::new(1.0, inner_stroke_color),
+			Stroke::new(HUD_PILL_STROKE_WIDTH_POINTS, inner_stroke_color),
 			StrokeKind::Inside,
 		);
 	}

--- a/packages/rsnap-overlay/src/overlay/rendering/hud_rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/hud_rendering.rs
@@ -1,12 +1,16 @@
 use egui::Context;
 
 use crate::overlay::hud_geometry::HUD_LOUPE_STRIP_GAP_POINTS;
+use crate::overlay::hud_pill_style::{
+	HUD_PILL_CORNER_RADIUS_POINTS, HUD_PILL_INNER_MARGIN_X_POINTS, HUD_PILL_INNER_MARGIN_Y_POINTS,
+	HUD_PILL_STROKE_WIDTH_POINTS,
+};
 use crate::overlay::rendering::WindowRenderer;
 use crate::overlay::{
-	Align, Area, Color32, ColorImage, CornerRadius, Frame, GlobalPoint,
-	HUD_PILL_CORNER_RADIUS_POINTS, HudAnchor, HudPillGeometry, HudTheme, Id, Layout, Margin,
-	MonitorRect, Order, OverlayMode, OverlayState, Pos2, Rect, RichText, Sense, Stroke, StrokeKind,
-	TextureHandle, TextureId, TextureOptions, Ui, Vec2, hud_helpers,
+	Align, Area, Color32, ColorImage, CornerRadius, Frame, GlobalPoint, HudAnchor, HudPillGeometry,
+	HudTheme, Id, Layout, Margin, MonitorRect, Order, OverlayMode, OverlayState, Pos2, Rect,
+	RichText, Sense, Stroke, StrokeKind, TextureHandle, TextureId, TextureOptions, Ui, Vec2,
+	hud_helpers,
 };
 use crate::state::LoupeSample;
 
@@ -127,8 +131,8 @@ impl WindowRenderer {
 			HudTheme::Dark => Color32::from_rgba_unmultiplied(0, 0, 0, 44),
 			HudTheme::Light => Color32::from_rgba_unmultiplied(255, 255, 255, 140),
 		};
-		let inner_stroke = Stroke::new(1.0, inner_stroke_color);
-		let inner_rect = pill_rect.shrink(1.0);
+		let inner_stroke = Stroke::new(HUD_PILL_STROKE_WIDTH_POINTS, inner_stroke_color);
+		let inner_rect = pill_rect.shrink(HUD_PILL_STROKE_WIDTH_POINTS);
 
 		ui.painter().rect_stroke(
 			inner_rect,
@@ -177,10 +181,13 @@ impl WindowRenderer {
 
 		Frame {
 			fill: body_fill,
-			stroke: Stroke::new(1.0, outer_stroke_color),
+			stroke: Stroke::new(HUD_PILL_STROKE_WIDTH_POINTS, outer_stroke_color),
 			shadow: pill_shadow,
 			corner_radius: CornerRadius::same(HUD_PILL_CORNER_RADIUS_POINTS),
-			inner_margin: Margin::symmetric(12, 8),
+			inner_margin: Margin::symmetric(
+				HUD_PILL_INNER_MARGIN_X_POINTS,
+				HUD_PILL_INNER_MARGIN_Y_POINTS,
+			),
 			..Frame::default()
 		}
 	}

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -63,12 +63,11 @@ use crate::overlay::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
-	HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, InflightScrollCaptureObservation,
-	LiveSampleApplyResult, LiveStreamStaleGrace, MacOSScrollPixelResidual, OverlayExit,
-	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW, SCROLL_CAPTURE_INPUT_FRESHNESS,
-	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES, SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
-	ScrollCaptureFrameSource, ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError,
-	StartupLiveRgbPlan,
+	HudPillGeometry, InflightScrollCaptureObservation, LiveSampleApplyResult, LiveStreamStaleGrace,
+	MacOSScrollPixelResidual, OverlayExit, SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
+	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES,
+	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE, ScrollCaptureFrameSource,
+	ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError, StartupLiveRgbPlan,
 };
 use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -24,6 +24,8 @@ use crate::overlay::MacOSNativeCaptureInputEvent;
 use crate::overlay::OverlayKeyboardInputEvent;
 #[cfg(target_os = "macos")]
 use crate::overlay::PENDING_CLICK_HIT_TEST_TIMEOUT;
+#[cfg(target_os = "macos")]
+use crate::overlay::hud_pill_style::HUD_PILL_CORNER_RADIUS_POINTS;
 use crate::overlay::tests;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::WorkerResponse;
@@ -34,9 +36,8 @@ use crate::overlay::tests::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::{
-	HUD_PILL_CORNER_RADIUS_POINTS, HudPillGeometry, Ime, Key, LiveCursorSample,
-	LiveSampleApplyResult, ModifiersState, NamedKey, OverlayExit, StartupLiveRgbPlan, WindowId,
-	WindowListSnapshot,
+	HudPillGeometry, Ime, Key, LiveCursorSample, LiveSampleApplyResult, ModifiersState, NamedKey,
+	OverlayExit, StartupLiveRgbPlan, WindowId, WindowListSnapshot,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{FrozenGlobalHotkey, PngAction};

--- a/packages/rsnap-overlay/src/overlay/toolbar_layout_model.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_layout_model.rs
@@ -1,9 +1,10 @@
 use egui::{Pos2, Rect, Vec2};
 
+use crate::overlay::hud_pill_style::HUD_PILL_CORNER_RADIUS_POINTS;
 use crate::overlay::rendering::WindowRenderer;
 use crate::overlay::{
-	FrozenToolbarState, FrozenToolbarTool, HUD_PILL_CORNER_RADIUS_POINTS,
-	TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS, TOOLBAR_EXPANDED_HEIGHT_PX,
+	FrozenToolbarState, FrozenToolbarTool, TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS,
+	TOOLBAR_EXPANDED_HEIGHT_PX,
 };
 
 pub(super) fn frozen_toolbar_corner_radius_u8(toolbar_height_points: f32) -> u8 {


### PR DESCRIPTION
## Summary
- move HUD pill style constants into the overlay hud_pill_style module
- update HUD and toolbar rendering/layout callers to consume the style owner
- keep overlay-scoped visibility without include/path splitting

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features rendering_behaviors::toolbar_layout
- cargo test -p rsnap-overlay --all-features session_runtime::tinted_hud_body_fill
- git diff --check
- ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check
- Fresh skeptic review: no code blocker found