### PR TITLE
Move toolbar geometry constants to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -42,6 +42,7 @@ mod scroll_runtime;
 mod session_bootstrap_runtime;
 mod session_contracts;
 mod session_state;
+mod toolbar_geometry;
 mod toolbar_layout_model;
 mod toolbar_runtime;
 mod trace_recording;
@@ -162,7 +163,6 @@ use self::frozen_export_model::{FrozenExportTransform, FrozenImagePatch, FrozenM
 use self::frozen_text_runtime::{FrozenTextInputSource, FrozenTextRecentInput};
 use self::frozen_transition_runtime::FrozenTransitionRuntime;
 use self::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
-use self::hud_pill_style::HUD_PILL_STROKE_WIDTH_POINTS;
 #[cfg(target_os = "macos")]
 use self::macos_capture_host::ExternalScrollInputDrainReader;
 #[cfg(all(test, target_os = "macos"))]
@@ -211,6 +211,8 @@ use self::session_state::{
 	MacOSScrollWheelEvent,
 };
 #[cfg(target_os = "macos")]
+use self::toolbar_geometry::TOOLBAR_WINDOW_WARMUP_REDRAWS;
+#[cfg(target_os = "macos")]
 use self::trace_recording::ScrollCaptureTraceInputRecord;
 use self::trace_recording::{
 	ScrollCaptureTraceFrameRecord, ScrollCaptureTraceRecorder, ScrollCaptureTraceSessionSnapshot,
@@ -256,9 +258,6 @@ type Result<T, E = Report> = std::result::Result<T, E>;
 
 pub(crate) const CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED: bool = false;
 
-const FROZEN_TOOLBAR_BUTTON_SIZE_POINTS: f32 = 24.0;
-const FROZEN_TOOLBAR_ITEM_SPACING_POINTS: f32 = 4.0;
-const TOOLBAR_PILL_INNER_MARGIN_Y_POINTS: f32 = 6.0;
 const LIVE_EVENT_CURSOR_CACHE_TTL: Duration = Duration::from_millis(120);
 const CURSOR_EVENT_TICK_TTL: Duration = Duration::from_millis(24);
 const LIVE_HOVER_HIT_TEST_INTERVAL: Duration = Duration::from_millis(60);
@@ -300,15 +299,6 @@ const SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES: u8 = 5;
 const SCROLL_CAPTURE_DUPLICATE_STREAM_STALL_THRESHOLD: u8 = 3;
 #[cfg(target_os = "macos")]
 const SCROLL_CAPTURE_DUPLICATE_STREAM_REFRESH_INTERVAL: Duration = Duration::from_millis(80);
-const TOOLBAR_EXPANDED_HEIGHT_PX: f32 = FROZEN_TOOLBAR_BUTTON_SIZE_POINTS
-	+ 2.0 * TOOLBAR_PILL_INNER_MARGIN_Y_POINTS
-	+ 2.0 * HUD_PILL_STROKE_WIDTH_POINTS;
-const TOOLBAR_CAPTURE_GAP_PX: f32 = 10.0;
-const TOOLBAR_SCREEN_MARGIN_PX: f32 = 10.0;
-const TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS: f32 = 1.0;
-const TOOLBAR_DRAG_START_THRESHOLD_PX: f32 = 6.0;
-#[cfg(target_os = "macos")]
-const TOOLBAR_WINDOW_WARMUP_REDRAWS: u8 = 30;
 const LOUPE_WINDOW_WARMUP_REDRAWS: u8 = 30;
 const LIVE_DRAG_START_THRESHOLD_PX: f32 = 6.0;
 const INTERACTIVE_REPAINT_TARGET_FPS: f32 = 120.0;

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances/toolbar.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances/toolbar.rs
@@ -7,14 +7,15 @@ use crate::overlay::hud_pill_style::{
 };
 use crate::overlay::rendering::{FrozenToolbarButtonStyle, WindowRenderer};
 use crate::overlay::session_state::FrozenAnnotationStyleCapsulePlacement;
+use crate::overlay::toolbar_geometry::{
+	FROZEN_TOOLBAR_BUTTON_SIZE_POINTS, FROZEN_TOOLBAR_ITEM_SPACING_POINTS, TOOLBAR_CAPTURE_GAP_PX,
+	TOOLBAR_EXPANDED_HEIGHT_PX, TOOLBAR_PILL_INNER_MARGIN_Y_POINTS, TOOLBAR_SCREEN_MARGIN_PX,
+};
 use crate::overlay::{
-	Align, Align2, Area, Color32, CornerRadius, FROZEN_TOOLBAR_BUTTON_SIZE_POINTS,
-	FROZEN_TOOLBAR_ITEM_SPACING_POINTS, FontFamily, FontId, FrozenAnnotationColor,
+	Align, Align2, Area, Color32, CornerRadius, FontFamily, FontId, FrozenAnnotationColor,
 	FrozenToolbarPointerState, FrozenToolbarState, FrozenToolbarTool, HudPillGeometry, HudTheme,
 	Id, Layout, MonitorRect, Order, OverlayMode, OverlayState, Pos2, Rect, Sense, Stroke,
-	StrokeKind, TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_EXPANDED_HEIGHT_PX,
-	TOOLBAR_PILL_INNER_MARGIN_Y_POINTS, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Ui, UiBuilder,
-	Vec2, toolbar_layout_model,
+	StrokeKind, ToolbarPlacement, Ui, UiBuilder, Vec2, toolbar_layout_model,
 };
 use annotation_style::{
 	FROZEN_ANNOTATION_TOOLBAR_SECTION_GAP_POINTS, FROZEN_ANNOTATION_TOOLBAR_SECTION_HEIGHT_POINTS,

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -49,6 +49,7 @@ use crate::overlay::session_state::{
 	FrozenBrushStyle, FrozenCaptureSessionState, FrozenCaptureWorkerState,
 	FrozenExportSessionState, WindowFreezeCaptureTarget,
 };
+use crate::overlay::toolbar_geometry::{TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX};
 use crate::overlay::{
 	self, ActiveFrozenBrushStroke, FrozenAnnotationColor, FrozenArrowAnnotation,
 	FrozenBrushModelState, FrozenBrushStroke, FrozenCommittedOverlay, FrozenEditKind,
@@ -57,9 +58,8 @@ use crate::overlay::{
 	FrozenToolbarState, FrozenToolbarTool, HudRedrawSummary, HudTheme,
 	OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, OutputNaming, OverlayControl, OverlaySession, Pos2,
 	PreparedHostEffectRequest, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL, SelectionDashedBorderCache,
-	SelectionFlowGeometryCache, SelectionSizeBadgeTarget, SurfaceFrameSkipReason,
-	TOOLBAR_CAPTURE_GAP_PX, TOOLBAR_SCREEN_MARGIN_PX, ToolbarPlacement, Vec2,
-	WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
+	SelectionFlowGeometryCache, SelectionSizeBadgeTarget, SurfaceFrameSkipReason, ToolbarPlacement,
+	Vec2, WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{

--- a/packages/rsnap-overlay/src/overlay/tests/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/toolbar_runtime.rs
@@ -1,9 +1,10 @@
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::overlay::toolbar_layout_model;
 use crate::overlay::tests::{
-	self, FrozenToolbarTool, GlobalPoint, HudTheme, OverlaySession, Pos2, Rect,
-	TOOLBAR_SCREEN_MARGIN_PX, Vec2, WindowRenderer,
+	self, FrozenToolbarTool, GlobalPoint, HudTheme, OverlaySession, Pos2, Rect, Vec2,
+	WindowRenderer,
 };
+use crate::overlay::toolbar_geometry::TOOLBAR_SCREEN_MARGIN_PX;
 
 #[test]
 fn toolbar_cursor_left_during_drag_keeps_drag_session_alive() {

--- a/packages/rsnap-overlay/src/overlay/toolbar_geometry.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_geometry.rs
@@ -1,0 +1,14 @@
+use crate::overlay::hud_pill_style::HUD_PILL_STROKE_WIDTH_POINTS;
+
+pub(in crate::overlay) const FROZEN_TOOLBAR_BUTTON_SIZE_POINTS: f32 = 24.0;
+pub(in crate::overlay) const FROZEN_TOOLBAR_ITEM_SPACING_POINTS: f32 = 4.0;
+pub(in crate::overlay) const TOOLBAR_CAPTURE_GAP_PX: f32 = 10.0;
+pub(in crate::overlay) const TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS: f32 = 1.0;
+pub(in crate::overlay) const TOOLBAR_DRAG_START_THRESHOLD_PX: f32 = 6.0;
+pub(in crate::overlay) const TOOLBAR_EXPANDED_HEIGHT_PX: f32 = FROZEN_TOOLBAR_BUTTON_SIZE_POINTS
+	+ 2.0 * TOOLBAR_PILL_INNER_MARGIN_Y_POINTS
+	+ 2.0 * HUD_PILL_STROKE_WIDTH_POINTS;
+pub(in crate::overlay) const TOOLBAR_PILL_INNER_MARGIN_Y_POINTS: f32 = 6.0;
+pub(in crate::overlay) const TOOLBAR_SCREEN_MARGIN_PX: f32 = 10.0;
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const TOOLBAR_WINDOW_WARMUP_REDRAWS: u8 = 30;

--- a/packages/rsnap-overlay/src/overlay/toolbar_layout_model.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_layout_model.rs
@@ -2,10 +2,10 @@ use egui::{Pos2, Rect, Vec2};
 
 use crate::overlay::hud_pill_style::HUD_PILL_CORNER_RADIUS_POINTS;
 use crate::overlay::rendering::WindowRenderer;
-use crate::overlay::{
-	FrozenToolbarState, FrozenToolbarTool, TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS,
-	TOOLBAR_EXPANDED_HEIGHT_PX,
+use crate::overlay::toolbar_geometry::{
+	TOOLBAR_DEFAULT_SLOT_POSITION_EPSILON_POINTS, TOOLBAR_EXPANDED_HEIGHT_PX,
 };
+use crate::overlay::{FrozenToolbarState, FrozenToolbarTool};
 
 pub(super) fn frozen_toolbar_corner_radius_u8(toolbar_height_points: f32) -> u8 {
 	if toolbar_height_points <= TOOLBAR_EXPANDED_HEIGHT_PX + 0.5 {

--- a/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/toolbar_runtime.rs
@@ -1,12 +1,14 @@
+use crate::overlay::toolbar_geometry::TOOLBAR_DRAG_START_THRESHOLD_PX;
+#[cfg(target_os = "macos")]
+use crate::overlay::toolbar_geometry::TOOLBAR_WINDOW_WARMUP_REDRAWS;
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	Arc, Duration, FrozenToolbarPointerState, GlobalPoint, HudOverlayWindow, Instant, MonitorRect,
 	OverlayControl, OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession,
-	PhysicalPosition, PhysicalSize, Pos2, Result, TOOLBAR_DRAG_START_THRESHOLD_PX, Vec2, WindowId,
-	WindowRenderer,
+	PhysicalPosition, PhysicalSize, Pos2, Result, Vec2, WindowId, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
-use crate::overlay::{FrozenCaptureSource, HudAnchor, TOOLBAR_WINDOW_WARMUP_REDRAWS};
+use crate::overlay::{FrozenCaptureSource, HudAnchor};
 
 impl OverlaySession {
 	pub(super) fn handle_toolbar_window_moved(

--- a/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_position_runtime.rs
@@ -1,9 +1,9 @@
 use crate::overlay::hud_geometry::HUD_LOUPE_STRIP_GAP_POINTS;
+use crate::overlay::toolbar_geometry::TOOLBAR_SCREEN_MARGIN_PX;
 #[cfg(target_os = "macos")]
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
-	GlobalPoint, MonitorRect, OverlayMode, OverlaySession, Pos2, Rect, TOOLBAR_SCREEN_MARGIN_PX,
-	Vec2, WindowRenderer,
+	GlobalPoint, MonitorRect, OverlayMode, OverlaySession, Pos2, Rect, Vec2, WindowRenderer,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -20,14 +20,14 @@ use crate::overlay::MacLiveFrameStream;
 #[cfg(target_os = "macos")]
 use crate::overlay::MacOSHudWindowConfigState;
 use crate::overlay::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
+use crate::overlay::toolbar_geometry::TOOLBAR_EXPANDED_HEIGHT_PX;
 use crate::overlay::toolbar_layout_model;
 #[cfg(target_os = "macos")]
 use crate::overlay::{self, macos_cursor_runtime};
 use crate::overlay::{
 	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LiveSampleApplyResult,
 	LogicalPosition, LogicalSize, MonitorRect, OverlayMode, OverlaySession, OverlayWindow,
-	OverlayWorker, Result, ScrollPreviewWindow, TOOLBAR_EXPANDED_HEIGHT_PX, WindowLevel,
-	WindowRenderer, hud_helpers,
+	OverlayWorker, Result, ScrollPreviewWindow, WindowLevel, WindowRenderer, hud_helpers,
 };
 
 impl OverlaySession {


### PR DESCRIPTION
## Summary
- move toolbar geometry constants from overlay.rs into overlay/toolbar_geometry.rs
- update toolbar render/layout/runtime callers to import from the owner module
- keep overlay-scoped visibility without include/path splitting

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features rendering_behaviors::toolbar_layout
- cargo test -p rsnap-overlay --all-features toolbar_runtime
- git diff --check
- ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check
- Fresh skeptic review: no code structure blocker after staging the new module