### PR TITLE
Move runtime timing constants to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -34,6 +34,7 @@ mod macos_native_capture_shell_runtime;
 mod macos_window_bridge;
 mod rendering;
 mod runtime_model;
+mod runtime_timing;
 mod scroll_capture_runtime;
 mod scroll_input_runtime;
 mod scroll_preview_geometry;
@@ -193,6 +194,7 @@ use self::runtime_model::{
 	HudTheme, LiveCaptureInteraction, OverlayEventLoopPhase, PngAction, ScrollCaptureFrameSource,
 	SelectionFlowStyle, SurfaceFrameSkipReason, WindowRendererPath,
 };
+use self::runtime_timing::{OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, SLOW_OP_WARN_WINDOW_EVENT};
 use self::session_bootstrap_runtime::InitialSessionRuntime;
 #[cfg(all(target_os = "macos", test))]
 use self::session_state::InflightScrollCaptureObservation;
@@ -277,17 +279,6 @@ const SCROLL_CAPTURE_STREAM_BACKLOG_MAX_FRAMES: usize = 12;
 #[cfg(target_os = "macos")]
 const SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW: Duration =
 	Duration::from_millis(320);
-const OVERLAY_EVENT_LOOP_STALL_THRESHOLD: Duration = Duration::from_millis(250);
-#[cfg(target_os = "macos")]
-const SLOW_OP_WARN_CURSOR_LOCATION: Duration = Duration::from_millis(8);
-#[cfg(target_os = "macos")]
-const SLOW_OP_WARN_HUD_CONFIG: Duration = Duration::from_millis(40);
-const SLOW_OP_WARN_OUTER_POSITION: Duration = Duration::from_millis(24);
-const SLOW_OP_WARN_RENDER: Duration = Duration::from_millis(24);
-const SLOW_OP_WARN_WINDOW_EVENT: Duration = Duration::from_millis(40);
-const SLOW_OP_WARN_INTERVAL: Duration = Duration::from_secs(1);
-const OCCLUDED_FRAME_REDRAW_RETRY_WINDOW: Duration = Duration::from_secs(2);
-const REDRAW_SUBSTEP_CONTRIBUTION_FLOOR: Duration = Duration::from_millis(4);
 // macOS trackpad/wheel sequences can keep delivering usable follow-up frames after the
 // initiating input event. Keep the observation window wide enough for the capture pipeline
 // to pair those frames before declaring the input stale.

--- a/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
@@ -1,9 +1,11 @@
 use crate::overlay::frozen_text_runtime::FROZEN_TEXT_CARET_REPAINT_INTERVAL;
+use crate::overlay::runtime_timing::{
+	OVERLAY_EVENT_LOOP_STALL_THRESHOLD, SLOW_OP_WARN_INTERVAL, SLOW_OP_WARN_OUTER_POSITION,
+};
 use crate::overlay::{
 	Duration, GlobalPoint, HUD_LOUPE_MOVE_INTERVAL_MIN, INTERACTIVE_REPAINT_TARGET_FPS, Instant,
-	LOUPE_WINDOW_WARMUP_REDRAWS, LogicalPosition, MonitorRect, MonitorRectPoints,
-	OVERLAY_EVENT_LOOP_STALL_THRESHOLD, OverlayControl, OverlayEventLoopPhase, OverlayMode,
-	OverlaySession, SLOW_OP_WARN_INTERVAL, SLOW_OP_WARN_OUTER_POSITION, WindowEvent,
+	LOUPE_WINDOW_WARMUP_REDRAWS, LogicalPosition, MonitorRect, MonitorRectPoints, OverlayControl,
+	OverlayEventLoopPhase, OverlayMode, OverlaySession, WindowEvent,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/config_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/config_runtime.rs
@@ -9,13 +9,12 @@ use crate::overlay;
 #[cfg(target_os = "macos")]
 use crate::overlay::OverlayWorker;
 use crate::overlay::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
+#[cfg(target_os = "macos")]
+use crate::overlay::runtime_timing::SLOW_OP_WARN_HUD_CONFIG;
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{Arc, Instant, OverlayConfig, OverlayMode, OverlaySession, WindowRenderer};
 #[cfg(target_os = "macos")]
-use crate::overlay::{
-	FrozenCaptureWorkerState, MacLiveFrameStream, MacOSHudWindowConfigState,
-	SLOW_OP_WARN_HUD_CONFIG,
-};
+use crate::overlay::{FrozenCaptureWorkerState, MacLiveFrameStream, MacOSHudWindowConfigState};
 
 impl OverlaySession {
 	/// Applies updated runtime configuration to an existing session.

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -9,7 +9,7 @@ use winit::keyboard::ModifiersState;
 #[cfg(target_os = "macos")]
 use crate::overlay::FrozenGlobalHotkey;
 #[cfg(target_os = "macos")]
-use crate::overlay::SLOW_OP_WARN_CURSOR_LOCATION;
+use crate::overlay::runtime_timing::SLOW_OP_WARN_CURSOR_LOCATION;
 #[cfg(target_os = "macos")]
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{

--- a/packages/rsnap-overlay/src/overlay/rendering/window_surface.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/window_surface.rs
@@ -31,13 +31,14 @@ use crate::overlay::rendering::hud_surface::HudBlurUniformRaw;
 use crate::overlay::rendering::{
 	self, GpuContext, SelectionDashedBorderCache, SelectionFlowGeometryCache, WindowRenderer,
 };
+use crate::overlay::runtime_timing::SLOW_OP_WARN_RENDER;
 use crate::overlay::{
 	AcquiredSurfaceFrame, AddressMode, Arc, BindGroupLayout, BindingResource, BindingType,
 	BlendState, BufferBindingType, BufferSize, ClippedPrimitive, ColorWrites, CompositeAlphaMode,
 	Cow, CurrentSurfaceTexture, FilterMode, FontDefinitions, FrontFace, MipmapFilterMode,
 	MultisampleState, Mutex, PhysicalSize, PipelineCompilationOptions, PolygonMode, PresentMode,
-	PrimitiveTopology, RenderPipeline, Renderer, Result, SLOW_OP_WARN_RENDER, Sampler,
-	SamplerBindingType, ScreenDescriptor, ShaderSource, ShaderStages, SlowOperationLogger, StoreOp,
+	PrimitiveTopology, RenderPipeline, Renderer, Result, Sampler, SamplerBindingType,
+	ScreenDescriptor, ShaderSource, ShaderStages, SlowOperationLogger, StoreOp,
 	SurfaceCapabilities, SurfaceFrameSkipReason, SurfaceTexture, Texture, TextureAspect,
 	TextureSampleType, TextureUsages, TextureViewDescriptor, TextureViewDimension, WrapErr, eyre,
 	mem,

--- a/packages/rsnap-overlay/src/overlay/runtime_timing.rs
+++ b/packages/rsnap-overlay/src/overlay/runtime_timing.rs
@@ -1,0 +1,14 @@
+use std::time::Duration;
+
+pub(in crate::overlay) const OCCLUDED_FRAME_REDRAW_RETRY_WINDOW: Duration = Duration::from_secs(2);
+pub(in crate::overlay) const OVERLAY_EVENT_LOOP_STALL_THRESHOLD: Duration =
+	Duration::from_millis(250);
+pub(in crate::overlay) const REDRAW_SUBSTEP_CONTRIBUTION_FLOOR: Duration = Duration::from_millis(4);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SLOW_OP_WARN_CURSOR_LOCATION: Duration = Duration::from_millis(8);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SLOW_OP_WARN_HUD_CONFIG: Duration = Duration::from_millis(40);
+pub(in crate::overlay) const SLOW_OP_WARN_INTERVAL: Duration = Duration::from_secs(1);
+pub(in crate::overlay) const SLOW_OP_WARN_OUTER_POSITION: Duration = Duration::from_millis(24);
+pub(in crate::overlay) const SLOW_OP_WARN_RENDER: Duration = Duration::from_millis(24);
+pub(in crate::overlay) const SLOW_OP_WARN_WINDOW_EVENT: Duration = Duration::from_millis(40);

--- a/packages/rsnap-overlay/src/overlay/session_state.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state.rs
@@ -7,11 +7,11 @@ use std::{
 
 use image::RgbaImage;
 
+use crate::overlay::runtime_timing::{REDRAW_SUBSTEP_CONTRIBUTION_FLOOR, SLOW_OP_WARN_INTERVAL};
 use crate::overlay::{
 	Color32, DeviceCursorPointSource, FrozenSelectionInteractionKind, FrozenToolbarTool,
 	GlobalPoint, LIVE_PRESENT_INTERVAL_MIN, MonitorRect, MouseScrollDelta, PhysicalPosition, Pos2,
-	REDRAW_SUBSTEP_CONTRIBUTION_FLOOR, RectPoints, SLOW_OP_WARN_INTERVAL,
-	ScrollCaptureTraceRecorder, ScrollDirection, ScrollSession, Vec2, WindowId,
+	RectPoints, ScrollCaptureTraceRecorder, ScrollDirection, ScrollSession, Vec2, WindowId,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{ExternalScrollInputDrainReader, MacLiveFrameStream};

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -55,11 +55,11 @@ use crate::overlay::{
 	FrozenBrushModelState, FrozenBrushStroke, FrozenCommittedOverlay, FrozenEditKind,
 	FrozenExportTransform, FrozenImagePatch, FrozenMosaicEdit, FrozenSelectionDragState,
 	FrozenSpotlightAnnotation, FrozenTextAnnotation, FrozenTextEditState, FrozenTextInputSource,
-	FrozenToolbarState, FrozenToolbarTool, HudRedrawSummary, HudTheme,
-	OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, OutputNaming, OverlayControl, OverlaySession, Pos2,
-	PreparedHostEffectRequest, Rect, SCROLL_CAPTURE_SAMPLE_INTERVAL, SelectionDashedBorderCache,
-	SelectionFlowGeometryCache, SelectionSizeBadgeTarget, SurfaceFrameSkipReason, ToolbarPlacement,
-	Vec2, WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
+	FrozenToolbarState, FrozenToolbarTool, HudRedrawSummary, HudTheme, OutputNaming,
+	OverlayControl, OverlaySession, Pos2, PreparedHostEffectRequest, Rect,
+	SCROLL_CAPTURE_SAMPLE_INTERVAL, SelectionDashedBorderCache, SelectionFlowGeometryCache,
+	SelectionSizeBadgeTarget, SurfaceFrameSkipReason, ToolbarPlacement, Vec2,
+	WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{

--- a/packages/rsnap-overlay/src/overlay/tests/session_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/session_runtime.rs
@@ -7,11 +7,12 @@ use image::{Rgba, RgbaImage};
 use crate::live_frame_stream_macos::MacLiveFrameStream;
 #[cfg(not(target_os = "macos"))]
 use crate::overlay::OverlayConfig;
+use crate::overlay::runtime_timing::OCCLUDED_FRAME_REDRAW_RETRY_WINDOW;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::GlobalPoint;
 use crate::overlay::tests::{
-	self, HudTheme, OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, OverlayMode, OverlaySession,
-	SurfaceFrameSkipReason, WindowRenderer, hud_helpers, overlay,
+	self, HudTheme, OverlayMode, OverlaySession, SurfaceFrameSkipReason, WindowRenderer,
+	hud_helpers, overlay,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::{LiveCaptureInteraction, ModifiersState};


### PR DESCRIPTION
## Summary
- move slow-op, event-loop stall, and redraw retry timing constants into overlay/runtime_timing.rs
- update runtime, rendering, and session test callers to import from the timing owner
- keep overlay-scoped visibility without include/path splitting

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features session_runtime
- git diff --check
- ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check
- Fresh skeptic review: no code structure blocker after staging the new module