### PR TITLE
Move scroll capture timing constants to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -36,6 +36,7 @@ mod rendering;
 mod runtime_model;
 mod runtime_timing;
 mod scroll_capture_runtime;
+mod scroll_capture_timing;
 mod scroll_input_runtime;
 mod scroll_preview_geometry;
 mod scroll_preview_runtime;
@@ -270,37 +271,9 @@ const DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT: Duration = Duration::from_millis(600);
 const LIVE_PRESENT_INTERVAL_MIN: Duration = Duration::from_nanos(8_333_333);
 const HUD_LOUPE_MOVE_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
 const CURSOR_POLL_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_STREAM_EVENT_FALLBACK_POLL_INTERVAL: Duration = Duration::from_millis(40);
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_STREAM_POLL_INTERVAL: Duration = Duration::from_millis(8);
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_STREAM_BACKLOG_MAX_FRAMES: usize = 12;
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW: Duration =
-	Duration::from_millis(320);
-// macOS trackpad/wheel sequences can keep delivering usable follow-up frames after the
-// initiating input event. Keep the observation window wide enough for the capture pipeline
-// to pair those frames before declaring the input stale.
-const SCROLL_CAPTURE_INPUT_FRESHNESS: Duration = Duration::from_millis(600);
-const SCROLL_CAPTURE_INPUT_MOTION_PRIOR_ROWS_MAX: f64 = 4_096.0;
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES: u8 = 5;
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_DUPLICATE_STREAM_STALL_THRESHOLD: u8 = 3;
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_DUPLICATE_STREAM_REFRESH_INTERVAL: Duration = Duration::from_millis(80);
 const LOUPE_WINDOW_WARMUP_REDRAWS: u8 = 30;
 const LIVE_DRAG_START_THRESHOLD_PX: f32 = 6.0;
 const INTERACTIVE_REPAINT_TARGET_FPS: f32 = 120.0;
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_SAMPLE_INTERVAL: Duration = Duration::from_millis(250);
-#[cfg(not(target_os = "macos"))]
-const SCROLL_CAPTURE_SAMPLE_INTERVAL: Duration = Duration::from_millis(50);
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_DUPLICATE_WORKER_FRAME_RETRY_INTERVAL: Duration = Duration::from_millis(60);
-#[cfg(target_os = "macos")]
-const SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE: Duration = Duration::from_millis(180);
 /// Transitional Rust-core session controller that owns product state, rendering,
 /// explicit host requests, and host-sync state consumed by the native app host.
 pub struct OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_runtime.rs
@@ -9,12 +9,15 @@ use image::RgbaImage;
 
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::MacLiveFrameStream;
+use crate::overlay::scroll_capture_timing::{
+	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_SAMPLE_INTERVAL,
+};
 #[cfg(target_os = "macos")]
 use crate::overlay::scroll_preview_geometry::SCROLL_CAPTURE_PREVIEW_WIDTH_PX;
 use crate::overlay::{
 	FrozenCaptureSource, Key, MonitorRect, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
-	OverlayMode, OverlaySession, PngAction, Pos2, Rect, SCROLL_CAPTURE_INPUT_FRESHNESS,
-	SCROLL_CAPTURE_SAMPLE_INTERVAL, ScrollDirection, ScrollObserveOutcome, Vec2, WindowRenderer,
+	OverlayMode, OverlaySession, PngAction, Pos2, Rect, ScrollDirection, ScrollObserveOutcome,
+	Vec2, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{

--- a/packages/rsnap-overlay/src/overlay/scroll_capture_timing.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_capture_timing.rs
@@ -1,0 +1,35 @@
+use std::time::Duration;
+
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_STREAM_EVENT_FALLBACK_POLL_INTERVAL: Duration =
+	Duration::from_millis(40);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_STREAM_POLL_INTERVAL: Duration =
+	Duration::from_millis(8);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_STREAM_BACKLOG_MAX_FRAMES: usize = 12;
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW: Duration =
+	Duration::from_millis(320);
+// macOS trackpad/wheel sequences can keep delivering usable follow-up frames after the
+// initiating input event. Keep the observation window wide enough for the capture pipeline
+// to pair those frames before declaring the input stale.
+pub(in crate::overlay) const SCROLL_CAPTURE_INPUT_FRESHNESS: Duration = Duration::from_millis(600);
+pub(in crate::overlay) const SCROLL_CAPTURE_INPUT_MOTION_PRIOR_ROWS_MAX: f64 = 4_096.0;
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES: u8 = 5;
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_DUPLICATE_STREAM_STALL_THRESHOLD: u8 = 3;
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_DUPLICATE_STREAM_REFRESH_INTERVAL: Duration =
+	Duration::from_millis(80);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_SAMPLE_INTERVAL: Duration = Duration::from_millis(250);
+#[cfg(not(target_os = "macos"))]
+pub(in crate::overlay) const SCROLL_CAPTURE_SAMPLE_INTERVAL: Duration = Duration::from_millis(50);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_DUPLICATE_WORKER_FRAME_RETRY_INTERVAL: Duration =
+	Duration::from_millis(60);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE: Duration =
+	Duration::from_millis(180);

--- a/packages/rsnap-overlay/src/overlay/scroll_input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_input_runtime.rs
@@ -1,16 +1,19 @@
 use std::time::Instant;
 
-use crate::overlay::{
-	GlobalPoint, MouseScrollDelta, OverlayControl, OverlaySession, SCROLL_CAPTURE_INPUT_FRESHNESS,
-	SCROLL_CAPTURE_INPUT_MOTION_PRIOR_ROWS_MAX, ScrollCaptureTraceSessionSnapshot, ScrollDirection,
-	ScrollObserveOutcome, WindowId,
-};
 #[cfg(target_os = "macos")]
-use crate::overlay::{
-	MacOSScrollPixelResidual, MacOSScrollWheelEvent, MonitorRect, RectPoints,
+use crate::overlay::scroll_capture_timing::{
 	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
 	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
 };
+use crate::overlay::scroll_capture_timing::{
+	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_INPUT_MOTION_PRIOR_ROWS_MAX,
+};
+use crate::overlay::{
+	GlobalPoint, MouseScrollDelta, OverlayControl, OverlaySession,
+	ScrollCaptureTraceSessionSnapshot, ScrollDirection, ScrollObserveOutcome, WindowId,
+};
+#[cfg(target_os = "macos")]
+use crate::overlay::{MacOSScrollPixelResidual, MacOSScrollWheelEvent, MonitorRect, RectPoints};
 
 #[cfg(target_os = "macos")]
 pub(in crate::overlay) const KCG_SCROLL_EVENT_UNIT_LINE: u32 = 1;

--- a/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/scroll_runtime.rs
@@ -8,25 +8,27 @@ use image::RgbaImage;
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::MacLiveFrameStream;
 #[cfg(target_os = "macos")]
-use crate::overlay::SCROLL_CAPTURE_DUPLICATE_WORKER_FRAME_RETRY_INTERVAL;
-use crate::overlay::SCROLL_CAPTURE_SAMPLE_INTERVAL;
-#[cfg(target_os = "macos")]
-use crate::overlay::SCROLL_CAPTURE_STREAM_BACKLOG_MAX_FRAMES;
+use crate::overlay::LiveStreamStaleGrace;
 #[cfg(target_os = "macos")]
 use crate::overlay::ScrollCaptureHostFrameRequestError;
 #[cfg(target_os = "macos")]
 use crate::overlay::ScrollCaptureTraceInputRecord;
 #[cfg(target_os = "macos")]
-use crate::overlay::session_state::InflightScrollCaptureObservation;
+use crate::overlay::scroll_capture_timing::SCROLL_CAPTURE_DUPLICATE_WORKER_FRAME_RETRY_INTERVAL;
+use crate::overlay::scroll_capture_timing::SCROLL_CAPTURE_SAMPLE_INTERVAL;
 #[cfg(target_os = "macos")]
-use crate::overlay::session_state::ScrollCaptureLiveFrame;
+use crate::overlay::scroll_capture_timing::SCROLL_CAPTURE_STREAM_BACKLOG_MAX_FRAMES;
 #[cfg(target_os = "macos")]
-use crate::overlay::{
-	LiveStreamStaleGrace, SCROLL_CAPTURE_DUPLICATE_STREAM_REFRESH_INTERVAL,
+use crate::overlay::scroll_capture_timing::{
+	SCROLL_CAPTURE_DUPLICATE_STREAM_REFRESH_INTERVAL,
 	SCROLL_CAPTURE_DUPLICATE_STREAM_STALL_THRESHOLD, SCROLL_CAPTURE_INPUT_FRESHNESS,
 	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES,
 	SCROLL_CAPTURE_STREAM_EVENT_FALLBACK_POLL_INTERVAL, SCROLL_CAPTURE_STREAM_POLL_INTERVAL,
 };
+#[cfg(target_os = "macos")]
+use crate::overlay::session_state::InflightScrollCaptureObservation;
+#[cfg(target_os = "macos")]
+use crate::overlay::session_state::ScrollCaptureLiveFrame;
 use crate::overlay::{MonitorRect, RectPoints};
 use crate::overlay::{
 	OverlayControl, OverlaySession, ScrollCaptureFrameSource, ScrollCaptureTraceFrameRecord,

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -43,6 +43,12 @@ use crate::overlay::PngAction;
 use crate::overlay::frozen_edit_history_runtime::FROZEN_EDIT_HISTORY_LIMIT;
 use crate::overlay::frozen_text_runtime::FROZEN_TEXT_CARET_REPAINT_INTERVAL;
 use crate::overlay::rendering;
+use crate::overlay::scroll_capture_timing::SCROLL_CAPTURE_SAMPLE_INTERVAL;
+#[cfg(target_os = "macos")]
+use crate::overlay::scroll_capture_timing::{
+	SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW, SCROLL_CAPTURE_INPUT_FRESHNESS,
+	SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES, SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE,
+};
 #[cfg(target_os = "macos")]
 use crate::overlay::session_state::ScrollCaptureLiveFrame;
 use crate::overlay::session_state::{
@@ -57,17 +63,15 @@ use crate::overlay::{
 	FrozenSpotlightAnnotation, FrozenTextAnnotation, FrozenTextEditState, FrozenTextInputSource,
 	FrozenToolbarState, FrozenToolbarTool, HudRedrawSummary, HudTheme, OutputNaming,
 	OverlayControl, OverlaySession, Pos2, PreparedHostEffectRequest, Rect,
-	SCROLL_CAPTURE_SAMPLE_INTERVAL, SelectionDashedBorderCache, SelectionFlowGeometryCache,
-	SelectionSizeBadgeTarget, SurfaceFrameSkipReason, ToolbarPlacement, Vec2,
-	WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
+	SelectionDashedBorderCache, SelectionFlowGeometryCache, SelectionSizeBadgeTarget,
+	SurfaceFrameSkipReason, ToolbarPlacement, Vec2, WindowCaptureAlphaMode, WindowRenderer,
+	hud_helpers,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{
 	HudPillGeometry, InflightScrollCaptureObservation, LiveSampleApplyResult, LiveStreamStaleGrace,
-	MacOSScrollPixelResidual, OverlayExit, SCROLL_CAPTURE_ACTIVE_GESTURE_STALE_REFRESH_DEAD_WINDOW,
-	SCROLL_CAPTURE_INPUT_FRESHNESS, SCROLL_CAPTURE_LIVE_STREAM_STALE_GRACE_FRAMES,
-	SCROLL_CAPTURE_MOUSE_PASSTHROUGH_IDLE_GRACE, ScrollCaptureFrameSource,
-	ScrollCaptureHostAdapter, ScrollCaptureHostFrameRequestError, StartupLiveRgbPlan,
+	MacOSScrollPixelResidual, OverlayExit, ScrollCaptureFrameSource, ScrollCaptureHostAdapter,
+	ScrollCaptureHostFrameRequestError, StartupLiveRgbPlan,
 };
 use crate::scroll_capture::{ScrollDirection, ScrollObserveOutcome, ScrollSession};
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- move scroll capture timing constants into overlay/scroll_capture_timing.rs
- update scroll runtime and test imports to use the timing owner module
- keep cfg-gated platform timing semantics unchanged

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features scroll_capture_runtime
- cargo test -p rsnap-overlay --all-features scroll_input_runtime
- cargo test -p rsnap-overlay --all-features stream_refresh_runtime
- cargo test -p rsnap-overlay --all-features worker_tick_runtime
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check