### PR TITLE
Move live runtime timing constants to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -195,7 +195,9 @@ use self::runtime_model::{
 	HudTheme, LiveCaptureInteraction, OverlayEventLoopPhase, PngAction, ScrollCaptureFrameSource,
 	SelectionFlowStyle, SurfaceFrameSkipReason, WindowRendererPath,
 };
-use self::runtime_timing::{OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, SLOW_OP_WARN_WINDOW_EVENT};
+use self::runtime_timing::{
+	CURSOR_POLL_INTERVAL_MIN, OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, SLOW_OP_WARN_WINDOW_EVENT,
+};
 use self::session_bootstrap_runtime::InitialSessionRuntime;
 #[cfg(all(target_os = "macos", test))]
 use self::session_state::InflightScrollCaptureObservation;
@@ -261,19 +263,7 @@ type Result<T, E = Report> = std::result::Result<T, E>;
 
 pub(crate) const CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED: bool = false;
 
-const LIVE_EVENT_CURSOR_CACHE_TTL: Duration = Duration::from_millis(120);
-const CURSOR_EVENT_TICK_TTL: Duration = Duration::from_millis(24);
-const LIVE_HOVER_HIT_TEST_INTERVAL: Duration = Duration::from_millis(60);
-const LIVE_WINDOW_LIST_REFRESH_INTERVAL: Duration = Duration::from_millis(120);
-const PENDING_CLICK_HIT_TEST_TIMEOUT: Duration = Duration::from_millis(250);
-#[cfg(target_os = "macos")]
-const DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT: Duration = Duration::from_millis(600);
-const LIVE_PRESENT_INTERVAL_MIN: Duration = Duration::from_nanos(8_333_333);
-const HUD_LOUPE_MOVE_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
-const CURSOR_POLL_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
-const LOUPE_WINDOW_WARMUP_REDRAWS: u8 = 30;
 const LIVE_DRAG_START_THRESHOLD_PX: f32 = 6.0;
-const INTERACTIVE_REPAINT_TARGET_FPS: f32 = 120.0;
 /// Transitional Rust-core session controller that owns product state, rendering,
 /// explicit host requests, and host-sync state consumed by the native app host.
 pub struct OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/aux_window_runtime.rs
@@ -1,11 +1,11 @@
 use crate::overlay::frozen_text_runtime::FROZEN_TEXT_CARET_REPAINT_INTERVAL;
 use crate::overlay::runtime_timing::{
+	HUD_LOUPE_MOVE_INTERVAL_MIN, INTERACTIVE_REPAINT_TARGET_FPS, LOUPE_WINDOW_WARMUP_REDRAWS,
 	OVERLAY_EVENT_LOOP_STALL_THRESHOLD, SLOW_OP_WARN_INTERVAL, SLOW_OP_WARN_OUTER_POSITION,
 };
 use crate::overlay::{
-	Duration, GlobalPoint, HUD_LOUPE_MOVE_INTERVAL_MIN, INTERACTIVE_REPAINT_TARGET_FPS, Instant,
-	LOUPE_WINDOW_WARMUP_REDRAWS, LogicalPosition, MonitorRect, MonitorRectPoints, OverlayControl,
-	OverlayEventLoopPhase, OverlayMode, OverlaySession, WindowEvent,
+	Duration, GlobalPoint, Instant, LogicalPosition, MonitorRect, MonitorRectPoints,
+	OverlayControl, OverlayEventLoopPhase, OverlayMode, OverlaySession, WindowEvent,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/cursor_context_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/cursor_context_runtime.rs
@@ -1,8 +1,9 @@
+use crate::overlay::runtime_timing::LIVE_EVENT_CURSOR_CACHE_TTL;
 #[cfg(target_os = "macos")]
 use crate::overlay::{CursorSampleRequest, StartupLiveRgbPlan};
 use crate::overlay::{
-	DeviceCursorPointSource, FreezeCaptureTarget, GlobalPoint, Instant,
-	LIVE_EVENT_CURSOR_CACHE_TTL, MonitorRect, OverlayMode, OverlaySession,
+	DeviceCursorPointSource, FreezeCaptureTarget, GlobalPoint, Instant, MonitorRect, OverlayMode,
+	OverlaySession,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/cursor_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/cursor_runtime.rs
@@ -1,6 +1,7 @@
+use crate::overlay::runtime_timing::{CURSOR_POLL_INTERVAL_MIN, LIVE_HOVER_HIT_TEST_INTERVAL};
 use crate::overlay::{
-	CURSOR_POLL_INTERVAL_MIN, DeviceCursorPointSource, Duration, GlobalPoint, Instant,
-	LIVE_HOVER_HIT_TEST_INTERVAL, MonitorRect, OverlayMode, OverlaySession,
+	DeviceCursorPointSource, Duration, GlobalPoint, Instant, MonitorRect, OverlayMode,
+	OverlaySession,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_capture_backend_adapter.rs
@@ -4,10 +4,11 @@ use image::RgbaImage;
 #[cfg(target_os = "macos")]
 use crate::live_frame_stream_macos::STREAM_REGION_FRAME_MAX_AGE;
 #[cfg(target_os = "macos")]
+use crate::overlay::runtime_timing::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT;
+#[cfg(target_os = "macos")]
 use crate::overlay::{
-	Arc, DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT, FreezeCaptureTarget, FrozenCaptureWorkerState,
-	GlobalPoint, Instant, MonitorRect, OverlayMode, OverlaySession, WindowCaptureAlphaMode,
-	WindowFreezeCaptureTarget,
+	Arc, FreezeCaptureTarget, FrozenCaptureWorkerState, GlobalPoint, Instant, MonitorRect,
+	OverlayMode, OverlaySession, WindowCaptureAlphaMode, WindowFreezeCaptureTarget,
 };
 #[cfg(target_os = "macos")]
 use crate::state::MonitorImageSnapshot;

--- a/packages/rsnap-overlay/src/overlay/hud_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/hud_runtime.rs
@@ -1,9 +1,10 @@
 use winit::window::Window;
 
+use crate::overlay::runtime_timing::LIVE_PRESENT_INTERVAL_MIN;
 use crate::overlay::{
 	Duration, FrozenCaptureSource, GlobalPoint, HudAnchor, HudPillGeometry, HudRedrawSummary,
-	Instant, LIVE_PRESENT_INTERVAL_MIN, LogicalSize, MonitorRect, OverlayControl,
-	OverlayEventLoopPhase, OverlayExit, OverlayMode, OverlaySession, Pos2, Rect, Result, eyre,
+	Instant, LogicalSize, MonitorRect, OverlayControl, OverlayEventLoopPhase, OverlayExit,
+	OverlayMode, OverlaySession, Pos2, Rect, Result, eyre,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -8,17 +8,17 @@ use winit::keyboard::ModifiersState;
 
 #[cfg(target_os = "macos")]
 use crate::overlay::FrozenGlobalHotkey;
+use crate::overlay::runtime_timing::CURSOR_EVENT_TICK_TTL;
 #[cfg(target_os = "macos")]
 use crate::overlay::runtime_timing::SLOW_OP_WARN_CURSOR_LOCATION;
 #[cfg(target_os = "macos")]
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
-	CURSOR_EVENT_TICK_TTL, CursorMoveTrace, DeviceCursorPointSource, ElementState,
-	FrozenSelectionDragCursorMoveTiming, FrozenTextEditState, FrozenTextInputSource,
-	FrozenToolbarTool, GlobalPoint, Ime, Key, LiveCaptureInteraction, LiveClickCaptureTarget,
-	Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl, OverlayKeyboardInputEvent,
-	OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId,
-	WindowRenderer,
+	CursorMoveTrace, DeviceCursorPointSource, ElementState, FrozenSelectionDragCursorMoveTiming,
+	FrozenTextEditState, FrozenTextInputSource, FrozenToolbarTool, GlobalPoint, Ime, Key,
+	LiveCaptureInteraction, LiveClickCaptureTarget, Modifiers, MonitorRect, MouseScrollDelta,
+	NamedKey, OverlayControl, OverlayKeyboardInputEvent, OverlayMode, OverlaySession,
+	PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId, WindowRenderer,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/runtime_timing.rs
+++ b/packages/rsnap-overlay/src/overlay/runtime_timing.rs
@@ -1,5 +1,19 @@
 use std::time::Duration;
 
+pub(in crate::overlay) const LIVE_EVENT_CURSOR_CACHE_TTL: Duration = Duration::from_millis(120);
+pub(in crate::overlay) const CURSOR_EVENT_TICK_TTL: Duration = Duration::from_millis(24);
+pub(in crate::overlay) const LIVE_HOVER_HIT_TEST_INTERVAL: Duration = Duration::from_millis(60);
+pub(in crate::overlay) const LIVE_WINDOW_LIST_REFRESH_INTERVAL: Duration =
+	Duration::from_millis(120);
+pub(in crate::overlay) const PENDING_CLICK_HIT_TEST_TIMEOUT: Duration = Duration::from_millis(250);
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) const DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT: Duration =
+	Duration::from_millis(600);
+pub(in crate::overlay) const LIVE_PRESENT_INTERVAL_MIN: Duration = Duration::from_nanos(8_333_333);
+pub(in crate::overlay) const HUD_LOUPE_MOVE_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
+pub(in crate::overlay) const CURSOR_POLL_INTERVAL_MIN: Duration = LIVE_PRESENT_INTERVAL_MIN;
+pub(in crate::overlay) const LOUPE_WINDOW_WARMUP_REDRAWS: u8 = 30;
+pub(in crate::overlay) const INTERACTIVE_REPAINT_TARGET_FPS: f32 = 120.0;
 pub(in crate::overlay) const OCCLUDED_FRAME_REDRAW_RETRY_WINDOW: Duration = Duration::from_secs(2);
 pub(in crate::overlay) const OVERLAY_EVENT_LOOP_STALL_THRESHOLD: Duration =
 	Duration::from_millis(250);

--- a/packages/rsnap-overlay/src/overlay/session_bootstrap_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/session_bootstrap_runtime.rs
@@ -1,9 +1,7 @@
 use std::time::{Duration, Instant};
 
-use crate::overlay::{
-	CURSOR_POLL_INTERVAL_MIN, LIVE_WINDOW_LIST_REFRESH_INTERVAL, OverlayConfig, OverlaySession,
-	OverlayState,
-};
+use crate::overlay::runtime_timing::{CURSOR_POLL_INTERVAL_MIN, LIVE_WINDOW_LIST_REFRESH_INTERVAL};
+use crate::overlay::{OverlayConfig, OverlaySession, OverlayState};
 
 pub(super) struct InitialSessionRuntime {
 	live_bg_request_interval: Duration,

--- a/packages/rsnap-overlay/src/overlay/session_state.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state.rs
@@ -7,11 +7,13 @@ use std::{
 
 use image::RgbaImage;
 
-use crate::overlay::runtime_timing::{REDRAW_SUBSTEP_CONTRIBUTION_FLOOR, SLOW_OP_WARN_INTERVAL};
+use crate::overlay::runtime_timing::{
+	LIVE_PRESENT_INTERVAL_MIN, REDRAW_SUBSTEP_CONTRIBUTION_FLOOR, SLOW_OP_WARN_INTERVAL,
+};
 use crate::overlay::{
 	Color32, DeviceCursorPointSource, FrozenSelectionInteractionKind, FrozenToolbarTool,
-	GlobalPoint, LIVE_PRESENT_INTERVAL_MIN, MonitorRect, MouseScrollDelta, PhysicalPosition, Pos2,
-	RectPoints, ScrollCaptureTraceRecorder, ScrollDirection, ScrollSession, Vec2, WindowId,
+	GlobalPoint, MonitorRect, MouseScrollDelta, PhysicalPosition, Pos2, RectPoints,
+	ScrollCaptureTraceRecorder, ScrollDirection, ScrollSession, Vec2, WindowId,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{ExternalScrollInputDrainReader, MacLiveFrameStream};

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -23,9 +23,9 @@ use crate::overlay::MacOSNativeCaptureInputEvent;
 #[cfg(target_os = "macos")]
 use crate::overlay::OverlayKeyboardInputEvent;
 #[cfg(target_os = "macos")]
-use crate::overlay::PENDING_CLICK_HIT_TEST_TIMEOUT;
-#[cfg(target_os = "macos")]
 use crate::overlay::hud_pill_style::HUD_PILL_CORNER_RADIUS_POINTS;
+#[cfg(target_os = "macos")]
+use crate::overlay::runtime_timing::PENDING_CLICK_HIT_TEST_TIMEOUT;
 use crate::overlay::tests;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::WorkerResponse;

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -5,13 +5,13 @@ use std::ptr;
 use image::{Rgba, RgbaImage};
 
 #[cfg(target_os = "macos")]
-use crate::overlay::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT;
-#[cfg(target_os = "macos")]
 use crate::overlay::LiveClickCaptureTarget;
 #[cfg(target_os = "macos")]
 use crate::overlay::OverlayMode;
 #[cfg(target_os = "macos")]
 use crate::overlay::RectPoints;
+#[cfg(target_os = "macos")]
+use crate::overlay::runtime_timing::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::WorkerRequestSendError;
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -1,10 +1,9 @@
-use crate::overlay::PENDING_CLICK_HIT_TEST_TIMEOUT;
+use crate::overlay::runtime_timing::{CURSOR_POLL_INTERVAL_MIN, PENDING_CLICK_HIT_TEST_TIMEOUT};
 use crate::overlay::{
-	Arc, CURSOR_POLL_INTERVAL_MIN, CapturedMonitorRegionResult, Duration, FrozenCaptureWorkerState,
-	GlobalPoint, Instant, LiveCaptureInteraction, LiveClickCaptureTarget, LiveCursorSample,
-	LiveSampleApplyResult, MonitorRect, OverlayControl, OverlayMode, OverlaySession,
-	WindowFreezeCaptureTarget, WindowHit, WindowListSnapshot, WorkerErrorSource,
-	WorkerRequestSendError, WorkerResponse,
+	Arc, CapturedMonitorRegionResult, Duration, FrozenCaptureWorkerState, GlobalPoint, Instant,
+	LiveCaptureInteraction, LiveClickCaptureTarget, LiveCursorSample, LiveSampleApplyResult,
+	MonitorRect, OverlayControl, OverlayMode, OverlaySession, WindowFreezeCaptureTarget, WindowHit,
+	WindowListSnapshot, WorkerErrorSource, WorkerRequestSendError, WorkerResponse,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{CursorSampleRequest, mem};
@@ -36,7 +35,7 @@ impl OverlaySession {
 		tracing::warn!(
 			request_id,
 			elapsed_ms = elapsed.as_millis(),
-			timeout_ms = crate::overlay::PENDING_CLICK_HIT_TEST_TIMEOUT.as_millis(),
+			timeout_ms = PENDING_CLICK_HIT_TEST_TIMEOUT.as_millis(),
 			"Pending click hit test timed out."
 		);
 


### PR DESCRIPTION
## Summary
- move live/runtime cadence constants from overlay.rs into overlay/runtime_timing.rs
- update runtime and test imports to use the timing owner module
- preserve macOS cfg gates and timing values

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features live_runtime
- cargo test -p rsnap-overlay --all-features self_capture_runtime
- cargo test -p rsnap-overlay --all-features session_runtime
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check