### PR TITLE
Move selection drag threshold to geometry owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -13,6 +13,7 @@ mod frozen_edit_history_runtime;
 mod frozen_export_model;
 mod frozen_export_runtime;
 mod frozen_mosaic_runtime;
+mod frozen_selection_geometry;
 mod frozen_selection_handles;
 mod frozen_selection_runtime;
 mod frozen_spotlight_runtime;
@@ -263,7 +264,6 @@ type Result<T, E = Report> = std::result::Result<T, E>;
 
 pub(crate) const CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED: bool = false;
 
-const LIVE_DRAG_START_THRESHOLD_PX: f32 = 6.0;
 /// Transitional Rust-core session controller that owns product state, rendering,
 /// explicit host requests, and host-sync state consumed by the native app host.
 pub struct OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_geometry.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_geometry.rs
@@ -1,0 +1,1 @@
+pub(in crate::overlay) const LIVE_DRAG_START_THRESHOLD_PX: f32 = 6.0;

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use image::{Rgba, RgbaImage};
 
-use crate::overlay::LIVE_DRAG_START_THRESHOLD_PX;
+use crate::overlay::frozen_selection_geometry::LIVE_DRAG_START_THRESHOLD_PX;
 #[cfg(target_os = "macos")]
 use crate::overlay::frozen_selection_handles;
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances.rs
@@ -14,6 +14,7 @@ use egui::RawInput;
 use egui::text::CCursor;
 
 use crate::overlay::frozen_brush_runtime::FROZEN_BRUSH_RENDER_SAMPLE_STEP_POINTS;
+use crate::overlay::frozen_selection_geometry::LIVE_DRAG_START_THRESHOLD_PX;
 use crate::overlay::frozen_selection_handles::{
 	self, FrozenSelectionResizeHandleGeometry, RESIZE_HANDLE_CENTER_DOT_RADIUS_POINTS,
 	RESIZE_HANDLE_OUTER_RADIUS_POINTS, RESIZE_HANDLE_STROKE_WIDTH_POINTS,
@@ -26,9 +27,8 @@ use crate::overlay::{
 	Color32, FontId, FrozenAnnotationColor, FrozenArrowAnnotation, FrozenBrushState,
 	FrozenCaptureSource, FrozenCommittedOverlay, FrozenEditKind, FrozenSelectionCorner,
 	FrozenSpotlightAnnotation, FrozenTextAnnotation, FrozenTextEditState, FrozenTextStyle,
-	HudTheme, Id, LIVE_DRAG_START_THRESHOLD_PX, LayerId, MonitorRect, Order, OverlayMode,
-	OverlaySession, OverlayState, Painter, Pos2, Rect, RectPoints, SelectionFlowStyle, Shape,
-	Stroke, Vec2,
+	HudTheme, Id, LayerId, MonitorRect, Order, OverlayMode, OverlaySession, OverlayState, Painter,
+	Pos2, Rect, RectPoints, SelectionFlowStyle, Shape, Stroke, Vec2,
 };
 
 const FROZEN_TEXT_PREVIEW_PLACEHOLDER: &str = "Type";

--- a/packages/rsnap-overlay/src/overlay/rendering/affordances/selection_flow.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/affordances/selection_flow.rs
@@ -3,12 +3,12 @@ use std::f32::consts::PI;
 
 use egui::Context;
 
+use crate::overlay::frozen_selection_geometry::LIVE_DRAG_START_THRESHOLD_PX;
 use crate::overlay::rendering::{
 	SelectionFlowGeometryCache, SelectionFlowGeometryCacheKey, WindowRenderer,
 };
 use crate::overlay::{
-	Color32, HudTheme, LIVE_DRAG_START_THRESHOLD_PX, Mesh, Painter, Pos2, Rect, SelectionFlowStyle,
-	Shape, Vec2,
+	Color32, HudTheme, Mesh, Painter, Pos2, Rect, SelectionFlowStyle, Shape, Vec2,
 };
 
 const SELECTION_FLOW_CORNER_RADIUS_PX: f32 = 9.0;


### PR DESCRIPTION
## Summary
- move the live drag start threshold out of overlay.rs into overlay/frozen_selection_geometry.rs
- update selection runtime and rendering imports to use the geometry owner module
- keep content-protection root constant unchanged

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features live_runtime
- cargo test -p rsnap-overlay --all-features rendering_behaviors::selection_runtime
- cargo test -p rsnap-overlay --all-features rendering_behaviors::scroll_preview
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check