### PR TITLE
Move window content policy to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -49,6 +49,7 @@ mod toolbar_geometry;
 mod toolbar_layout_model;
 mod toolbar_runtime;
 mod trace_recording;
+mod window_content_policy;
 mod window_position_runtime;
 mod window_runtime;
 mod worker_runtime;
@@ -261,8 +262,6 @@ macro_rules! sel_impl {
 }
 
 type Result<T, E = Report> = std::result::Result<T, E>;
-
-pub(crate) const CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED: bool = false;
 
 /// Transitional Rust-core session controller that owns product state, rendering,
 /// explicit host requests, and host-sync state consumed by the native app host.

--- a/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
@@ -6,11 +6,11 @@ use wgpu::RenderPassColorAttachment;
 use wgpu::RenderPassDescriptor;
 use wgpu::SurfaceConfiguration;
 
-use crate::overlay::rendering::overlay::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
 use crate::overlay::rendering::{GpuContext, ScrollPreviewView, WindowRenderer};
 use crate::overlay::scroll_preview_geometry::{
 	SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS, SCROLL_PREVIEW_WINDOW_WIDTH_POINTS,
 };
+use crate::overlay::window_content_policy::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
 use crate::overlay::{
 	AcquiredSurfaceFrame, ActiveEventLoop, Align, Arc, CentralPanel, Color32, ColorImage,
 	CornerRadius, CurrentSurfaceTexture, FontDefinitions, Frame, FullOutput, HudTheme, Layout,

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -826,7 +826,7 @@ fn authoritative_freeze_capture_hides_overlay_windows_on_macos() {
 #[test]
 #[allow(clippy::assertions_on_constants)]
 fn capture_windows_are_not_content_protected_on_macos() {
-	assert!(!super::super::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED);
+	assert!(!super::super::window_content_policy::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED);
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/window_content_policy.rs
+++ b/packages/rsnap-overlay/src/overlay/window_content_policy.rs
@@ -1,0 +1,1 @@
+pub(in crate::overlay) const CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED: bool = false;

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -14,7 +14,6 @@ use objc2_foundation::NSArray;
 use winit::window::{Window, WindowId};
 
 use crate::backend;
-use crate::overlay::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
 #[cfg(target_os = "macos")]
 use crate::overlay::MacLiveFrameStream;
 #[cfg(target_os = "macos")]
@@ -22,6 +21,7 @@ use crate::overlay::MacOSHudWindowConfigState;
 use crate::overlay::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
 use crate::overlay::toolbar_geometry::TOOLBAR_EXPANDED_HEIGHT_PX;
 use crate::overlay::toolbar_layout_model;
+use crate::overlay::window_content_policy::CAPTURE_WINDOW_CONTENT_PROTECTION_ENABLED;
 #[cfg(target_os = "macos")]
 use crate::overlay::{self, macos_cursor_runtime};
 use crate::overlay::{


### PR DESCRIPTION
## Summary
- Move the capture window content-protection policy out of overlay.rs into overlay/window_content_policy.rs.
- Import the policy from window runtime and scroll preview window code, keeping visibility scoped to the overlay module.
- Update the macOS self-capture assertion to use the new owner module.

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features self_capture_runtime
- cargo test -p rsnap-overlay --all-features scroll_preview
- cargo test -p rsnap-overlay --all-features window_runtime
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh read-only skeptic reviewed the module boundary and found one blocker: the new module file was untracked. The file is now staged and committed as an added file.