### PR TITLE
Move live click capture target to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -25,6 +25,7 @@ mod hud_pill_style;
 mod hud_runtime;
 mod image_helpers;
 mod input_runtime;
+mod live_capture_target;
 #[cfg(target_os = "macos")]
 mod macos_capture_host;
 #[cfg(target_os = "macos")]
@@ -227,7 +228,7 @@ use crate::worker::CapturedMonitorRegionResult;
 use crate::{
 	state::{
 		GlobalPoint, MonitorRect, MonitorRectPoints, OverlayMode, OverlayState, RectPoints, Rgb,
-		WindowHit, WindowListSnapshot,
+		WindowListSnapshot,
 	},
 	worker::{
 		FreezeCaptureTarget, OverlayWorker, WorkerErrorSource, WorkerRequestSendError,
@@ -2643,28 +2644,6 @@ impl OverlaySession {
 impl Default for OverlaySession {
 	fn default() -> Self {
 		Self::new()
-	}
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct LiveClickCaptureTarget {
-	capture_rect: Option<RectPoints>,
-	window_target: Option<WindowFreezeCaptureTarget>,
-}
-impl LiveClickCaptureTarget {
-	fn fullscreen_fallback() -> Self {
-		Self { capture_rect: None, window_target: None }
-	}
-
-	fn from_window_hit(monitor: MonitorRect, hit: WindowHit) -> Self {
-		Self {
-			capture_rect: Some(hit.rect),
-			window_target: hit.window_id.map(|window_id| WindowFreezeCaptureTarget {
-				monitor,
-				window_id,
-				rect: hit.rect,
-			}),
-		}
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_selection_runtime.rs
@@ -5,14 +5,15 @@ use image::{Rgba, RgbaImage};
 use crate::overlay::frozen_selection_geometry::LIVE_DRAG_START_THRESHOLD_PX;
 #[cfg(target_os = "macos")]
 use crate::overlay::frozen_selection_handles;
+use crate::overlay::live_capture_target::LiveClickCaptureTarget;
 #[cfg(target_os = "macos")]
 use crate::overlay::macos_cursor_runtime::{self, OverlayCursorRect};
 use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	CursorIcon, FrozenCaptureSource, FrozenMosaicDragState, FrozenSelectionCorner,
 	FrozenSelectionDragState, FrozenSelectionInteractionKind, FrozenToolbarTool, GlobalPoint,
-	LiveCaptureInteraction, LiveClickCaptureTarget, MonitorRect, MonitorRectPoints, OverlayMode,
-	OverlaySession, Pos2, RectPoints, WindowRenderer,
+	LiveCaptureInteraction, MonitorRect, MonitorRectPoints, OverlayMode, OverlaySession, Pos2,
+	RectPoints, WindowRenderer,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{Rect, Vec2};

--- a/packages/rsnap-overlay/src/overlay/frozen_transition_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_transition_runtime.rs
@@ -1,8 +1,7 @@
 use std::time::Instant;
 
-use crate::overlay::{
-	LiveClickCaptureTarget, MonitorRect, OverlaySession, RectPoints, WindowFreezeCaptureTarget,
-};
+use crate::overlay::live_capture_target::LiveClickCaptureTarget;
+use crate::overlay::{MonitorRect, OverlaySession, RectPoints, WindowFreezeCaptureTarget};
 
 #[derive(Debug, Default)]
 pub(super) struct FrozenTransitionRuntime {

--- a/packages/rsnap-overlay/src/overlay/input_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/input_runtime.rs
@@ -8,6 +8,7 @@ use winit::keyboard::ModifiersState;
 
 #[cfg(target_os = "macos")]
 use crate::overlay::FrozenGlobalHotkey;
+use crate::overlay::live_capture_target::LiveClickCaptureTarget;
 use crate::overlay::runtime_timing::CURSOR_EVENT_TICK_TTL;
 #[cfg(target_os = "macos")]
 use crate::overlay::runtime_timing::SLOW_OP_WARN_CURSOR_LOCATION;
@@ -16,9 +17,9 @@ use crate::overlay::toolbar_layout_model;
 use crate::overlay::{
 	CursorMoveTrace, DeviceCursorPointSource, ElementState, FrozenSelectionDragCursorMoveTiming,
 	FrozenTextEditState, FrozenTextInputSource, FrozenToolbarTool, GlobalPoint, Ime, Key,
-	LiveCaptureInteraction, LiveClickCaptureTarget, Modifiers, MonitorRect, MouseScrollDelta,
-	NamedKey, OverlayControl, OverlayKeyboardInputEvent, OverlayMode, OverlaySession,
-	PhysicalPosition, PhysicalSize, PngAction, Pos2, Vec2, WindowId, WindowRenderer,
+	LiveCaptureInteraction, Modifiers, MonitorRect, MouseScrollDelta, NamedKey, OverlayControl,
+	OverlayKeyboardInputEvent, OverlayMode, OverlaySession, PhysicalPosition, PhysicalSize,
+	PngAction, Pos2, Vec2, WindowId, WindowRenderer,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/live_capture_target.rs
+++ b/packages/rsnap-overlay/src/overlay/live_capture_target.rs
@@ -1,0 +1,24 @@
+use crate::overlay::session_state::WindowFreezeCaptureTarget;
+use crate::state::{MonitorRect, RectPoints, WindowHit};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::overlay) struct LiveClickCaptureTarget {
+	pub(in crate::overlay) capture_rect: Option<RectPoints>,
+	pub(in crate::overlay) window_target: Option<WindowFreezeCaptureTarget>,
+}
+impl LiveClickCaptureTarget {
+	pub(in crate::overlay) fn fullscreen_fallback() -> Self {
+		Self { capture_rect: None, window_target: None }
+	}
+
+	pub(in crate::overlay) fn from_window_hit(monitor: MonitorRect, hit: WindowHit) -> Self {
+		Self {
+			capture_rect: Some(hit.rect),
+			window_target: hit.window_id.map(|window_id| WindowFreezeCaptureTarget {
+				monitor,
+				window_id,
+				rect: hit.rect,
+			}),
+		}
+	}
+}

--- a/packages/rsnap-overlay/src/overlay/runtime_model.rs
+++ b/packages/rsnap-overlay/src/overlay/runtime_model.rs
@@ -8,9 +8,10 @@ use egui_phosphor::regular::{
 };
 use wgpu::SurfaceTexture;
 
+use crate::overlay::live_capture_target::LiveClickCaptureTarget;
 use crate::overlay::{
 	FrozenArrowAnnotation, FrozenBrushStroke, FrozenTextAnnotation, FrozenToolbarState,
-	GlobalPoint, LiveClickCaptureTarget, MonitorRect, RectPoints,
+	GlobalPoint, MonitorRect, RectPoints,
 };
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/live_runtime.rs
@@ -24,6 +24,7 @@ use crate::overlay::MacOSNativeCaptureInputEvent;
 use crate::overlay::OverlayKeyboardInputEvent;
 #[cfg(target_os = "macos")]
 use crate::overlay::hud_pill_style::HUD_PILL_CORNER_RADIUS_POINTS;
+use crate::overlay::live_capture_target::LiveClickCaptureTarget;
 #[cfg(target_os = "macos")]
 use crate::overlay::runtime_timing::PENDING_CLICK_HIT_TEST_TIMEOUT;
 use crate::overlay::tests;
@@ -41,7 +42,7 @@ use crate::overlay::tests::{
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{FrozenGlobalHotkey, PngAction};
-use crate::overlay::{LiveCaptureInteraction, LiveClickCaptureTarget, OverlayControl};
+use crate::overlay::{LiveCaptureInteraction, OverlayControl};
 #[cfg(target_os = "macos")]
 use crate::state::{WindowHit, WindowRect};
 

--- a/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/self_capture_runtime.rs
@@ -5,11 +5,11 @@ use std::ptr;
 use image::{Rgba, RgbaImage};
 
 #[cfg(target_os = "macos")]
-use crate::overlay::LiveClickCaptureTarget;
-#[cfg(target_os = "macos")]
 use crate::overlay::OverlayMode;
 #[cfg(target_os = "macos")]
 use crate::overlay::RectPoints;
+#[cfg(target_os = "macos")]
+use crate::overlay::live_capture_target::LiveClickCaptureTarget;
 #[cfg(target_os = "macos")]
 use crate::overlay::runtime_timing::DISPLAY_FIRST_FREEZE_LIVE_TIMEOUT;
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/worker_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/worker_runtime.rs
@@ -1,13 +1,14 @@
+use crate::overlay::live_capture_target::LiveClickCaptureTarget;
 use crate::overlay::runtime_timing::{CURSOR_POLL_INTERVAL_MIN, PENDING_CLICK_HIT_TEST_TIMEOUT};
 use crate::overlay::{
 	Arc, CapturedMonitorRegionResult, Duration, FrozenCaptureWorkerState, GlobalPoint, Instant,
-	LiveCaptureInteraction, LiveClickCaptureTarget, LiveCursorSample, LiveSampleApplyResult,
-	MonitorRect, OverlayControl, OverlayMode, OverlaySession, WindowFreezeCaptureTarget, WindowHit,
-	WindowListSnapshot, WorkerErrorSource, WorkerRequestSendError, WorkerResponse,
+	LiveCaptureInteraction, LiveCursorSample, LiveSampleApplyResult, MonitorRect, OverlayControl,
+	OverlayMode, OverlaySession, WindowFreezeCaptureTarget, WindowListSnapshot, WorkerErrorSource,
+	WorkerRequestSendError, WorkerResponse,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{CursorSampleRequest, mem};
-use crate::state::LoupeSample;
+use crate::state::{LoupeSample, WindowHit};
 
 pub(super) const FREEZE_CAPTURE_SEND_FULL_RETRY_LIMIT: u64 = 8;
 


### PR DESCRIPTION
## Summary
- Move `LiveClickCaptureTarget` out of `overlay.rs` into `overlay/live_capture_target.rs`.
- Keep the target and fields scoped to the overlay module, and update sibling runtime/test imports to use the owner module.
- Remove the stale root `WindowHit` import from `overlay.rs`.

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features live_runtime
- cargo test -p rsnap-overlay --all-features self_capture_runtime
- cargo test -p rsnap-overlay --all-features rendering_behaviors::selection_runtime
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh read-only skeptic found one blocker: the new owner module was untracked. The file is now staged, tracked, and included in the commit.