### PR TITLE
Move frozen arrow geometry to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -2647,14 +2647,6 @@ impl Default for OverlaySession {
 	}
 }
 
-#[derive(Clone, Copy, Debug)]
-struct FrozenArrowGeometry {
-	shaft_end: Pos2,
-	tip: Pos2,
-	head_left: Pos2,
-	head_right: Pos2,
-}
-
 fn should_request_overlay_redraw_after_surface_skip(
 	reason: SurfaceFrameSkipReason,
 	now: Instant,

--- a/packages/rsnap-overlay/src/overlay/frozen_arrow_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/frozen_arrow_runtime.rs
@@ -1,6 +1,6 @@
 use crate::overlay::{
-	FrozenArrowAnnotation, FrozenArrowDragState, FrozenArrowGeometry, FrozenEditKind,
-	FrozenToolbarTool, GlobalPoint, OverlaySession, Pos2, Vec2,
+	FrozenArrowAnnotation, FrozenArrowDragState, FrozenEditKind, FrozenToolbarTool, GlobalPoint,
+	OverlaySession, Pos2, Vec2,
 };
 
 const FROZEN_ARROW_MIN_LENGTH_POINTS: f32 = 6.0;
@@ -12,6 +12,14 @@ const FROZEN_ARROW_HEAD_LENGTH_MULTIPLIER: f32 = 4.2;
 const FROZEN_ARROW_HEAD_WIDTH_MULTIPLIER: f32 = 3.2;
 const FROZEN_ARROW_HEAD_LENGTH_MIN_POINTS: f32 = 16.0;
 const FROZEN_ARROW_HEAD_WIDTH_MIN_POINTS: f32 = 14.0;
+
+#[derive(Clone, Copy, Debug)]
+pub(in crate::overlay) struct FrozenArrowGeometry {
+	pub(in crate::overlay) shaft_end: Pos2,
+	pub(in crate::overlay) tip: Pos2,
+	pub(in crate::overlay) head_left: Pos2,
+	pub(in crate::overlay) head_right: Pos2,
+}
 
 impl OverlaySession {
 	pub(super) fn frozen_arrow_stroke_width_points(stroke_width_points: f32) -> f32 {


### PR DESCRIPTION
## Summary
- Move FrozenArrowGeometry from overlay.rs into overlay/frozen_arrow_runtime.rs, where geometry calculation is owned.
- Keep the type and fields scoped to the overlay module tree with pub(in crate::overlay).
- Preserve normal Rust module boundaries; no include! or #[path] splitting.

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features annotation_runtime
- cargo test -p rsnap-overlay --all-features rendering_behaviors::annotation_rendering
- cargo test -p rsnap-overlay --all-features export_actions
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Skeptic Review
- Fresh read-only skeptic found the code shape and visibility plausible.
- Its branch-artifact objection was resolved by staging and committing the two intended files; git diff --name-status origin/main...HEAD now contains only those files.
- Its validation-evidence objection is resolved by the local validation listed above, including rsnap-overlay all-target compile coverage and full cargo make check.
