### PR TITLE
Move redraw skip policy to runtime timing

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -194,9 +194,9 @@ use self::runtime_model::{
 	AcquiredSurfaceFrame, DeviceCursorPointSource, FrozenCaptureSource, FrozenCommittedOverlay,
 	FrozenEditKind, FrozenSelectionCorner, FrozenSelectionInteractionKind, FrozenToolbarTool,
 	HudTheme, LiveCaptureInteraction, OverlayEventLoopPhase, PngAction, ScrollCaptureFrameSource,
-	SelectionFlowStyle, SurfaceFrameSkipReason, WindowRendererPath,
+	SelectionFlowStyle, WindowRendererPath,
 };
-use self::runtime_timing::{OCCLUDED_FRAME_REDRAW_RETRY_WINDOW, SLOW_OP_WARN_WINDOW_EVENT};
+use self::runtime_timing::SLOW_OP_WARN_WINDOW_EVENT;
 #[cfg(all(target_os = "macos", test))]
 use self::session_state::InflightScrollCaptureObservation;
 use self::session_state::{
@@ -2644,29 +2644,6 @@ impl OverlaySession {
 impl Default for OverlaySession {
 	fn default() -> Self {
 		Self::new()
-	}
-}
-
-fn should_request_overlay_redraw_after_surface_skip(
-	reason: SurfaceFrameSkipReason,
-	now: Instant,
-	occluded_redraw_retry_until: &mut Option<Instant>,
-) -> bool {
-	match reason {
-		SurfaceFrameSkipReason::Timeout => true,
-		SurfaceFrameSkipReason::Occluded => match occluded_redraw_retry_until {
-			Some(deadline) if now >= *deadline => {
-				*occluded_redraw_retry_until = None;
-
-				false
-			},
-			Some(_) => true,
-			None => {
-				*occluded_redraw_retry_until = Some(now + OCCLUDED_FRAME_REDRAW_RETRY_WINDOW);
-
-				true
-			},
-		},
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -24,6 +24,7 @@ use self::hud_surface::HudBg;
 use crate::overlay::macos_configure_hud_window;
 #[cfg(target_os = "macos")]
 use crate::overlay::macos_cursor_runtime::MacOSOverlayCursorRectSupport;
+use crate::overlay::runtime_timing;
 use crate::overlay::{
 	self, AcquiredSurfaceFrame, Adapter, Arc, BindGroupLayout, Buffer, ClippedPrimitive, Color32,
 	Device, Duration, Event, ExperimentalFeatures, Features, FontDefinitions, FontFamily,
@@ -667,7 +668,7 @@ impl WindowRenderer {
 					"Skipped overlay window frame acquisition."
 				);
 
-				if overlay::should_request_overlay_redraw_after_surface_skip(
+				if runtime_timing::should_request_overlay_redraw_after_surface_skip(
 					reason,
 					Instant::now(),
 					&mut self.occluded_redraw_retry_until,

--- a/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/scroll_preview_window.rs
@@ -7,6 +7,7 @@ use wgpu::RenderPassDescriptor;
 use wgpu::SurfaceConfiguration;
 
 use crate::overlay::rendering::{GpuContext, ScrollPreviewView, WindowRenderer};
+use crate::overlay::runtime_model::SurfaceFrameSkipReason;
 use crate::overlay::scroll_preview_geometry::{
 	SCROLL_PREVIEW_WINDOW_HEIGHT_POINTS, SCROLL_PREVIEW_WINDOW_WIDTH_POINTS,
 };
@@ -15,9 +16,8 @@ use crate::overlay::{
 	AcquiredSurfaceFrame, ActiveEventLoop, Align, Arc, CentralPanel, Color32, ColorImage,
 	CornerRadius, CurrentSurfaceTexture, FontDefinitions, Frame, FullOutput, HudTheme, Layout,
 	LoadOp, LogicalSize, Margin, PhysicalSize, Renderer, Result, RgbaImage, ScreenDescriptor,
-	StoreOp, Stroke, Surface, SurfaceFrameSkipReason, TextureHandle, TextureOptions,
-	TextureViewDescriptor, Vec2, ViewportId, Visuals, WindowEvent, WindowLevel, WrapErr, eyre,
-	image_helpers,
+	StoreOp, Stroke, Surface, TextureHandle, TextureOptions, TextureViewDescriptor, Vec2,
+	ViewportId, Visuals, WindowEvent, WindowLevel, WrapErr, eyre, image_helpers,
 };
 
 pub(in crate::overlay) struct ScrollPreviewWindow {

--- a/packages/rsnap-overlay/src/overlay/rendering/window_surface.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering/window_surface.rs
@@ -31,6 +31,7 @@ use crate::overlay::rendering::hud_surface::HudBlurUniformRaw;
 use crate::overlay::rendering::{
 	self, GpuContext, SelectionDashedBorderCache, SelectionFlowGeometryCache, WindowRenderer,
 };
+use crate::overlay::runtime_model::SurfaceFrameSkipReason;
 use crate::overlay::runtime_timing::SLOW_OP_WARN_RENDER;
 use crate::overlay::{
 	AcquiredSurfaceFrame, AddressMode, Arc, BindGroupLayout, BindingResource, BindingType,
@@ -39,9 +40,8 @@ use crate::overlay::{
 	MultisampleState, Mutex, PhysicalSize, PipelineCompilationOptions, PolygonMode, PresentMode,
 	PrimitiveTopology, RenderPipeline, Renderer, Result, Sampler, SamplerBindingType,
 	ScreenDescriptor, ShaderSource, ShaderStages, SlowOperationLogger, StoreOp,
-	SurfaceCapabilities, SurfaceFrameSkipReason, SurfaceTexture, Texture, TextureAspect,
-	TextureSampleType, TextureUsages, TextureViewDescriptor, TextureViewDimension, WrapErr, eyre,
-	mem,
+	SurfaceCapabilities, SurfaceTexture, Texture, TextureAspect, TextureSampleType, TextureUsages,
+	TextureViewDescriptor, TextureViewDimension, WrapErr, eyre, mem,
 };
 
 impl WindowRenderer {

--- a/packages/rsnap-overlay/src/overlay/runtime_timing.rs
+++ b/packages/rsnap-overlay/src/overlay/runtime_timing.rs
@@ -1,4 +1,6 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+use crate::overlay::runtime_model::SurfaceFrameSkipReason;
 
 pub(in crate::overlay) const LIVE_EVENT_CURSOR_CACHE_TTL: Duration = Duration::from_millis(120);
 pub(in crate::overlay) const CURSOR_EVENT_TICK_TTL: Duration = Duration::from_millis(24);
@@ -26,3 +28,26 @@ pub(in crate::overlay) const SLOW_OP_WARN_INTERVAL: Duration = Duration::from_se
 pub(in crate::overlay) const SLOW_OP_WARN_OUTER_POSITION: Duration = Duration::from_millis(24);
 pub(in crate::overlay) const SLOW_OP_WARN_RENDER: Duration = Duration::from_millis(24);
 pub(in crate::overlay) const SLOW_OP_WARN_WINDOW_EVENT: Duration = Duration::from_millis(40);
+
+pub(in crate::overlay) fn should_request_overlay_redraw_after_surface_skip(
+	reason: SurfaceFrameSkipReason,
+	now: Instant,
+	occluded_redraw_retry_until: &mut Option<Instant>,
+) -> bool {
+	match reason {
+		SurfaceFrameSkipReason::Timeout => true,
+		SurfaceFrameSkipReason::Occluded => match occluded_redraw_retry_until {
+			Some(deadline) if now >= *deadline => {
+				*occluded_redraw_retry_until = None;
+
+				false
+			},
+			Some(_) => true,
+			None => {
+				*occluded_redraw_retry_until = Some(now + OCCLUDED_FRAME_REDRAW_RETRY_WINDOW);
+
+				true
+			},
+		},
+	}
+}

--- a/packages/rsnap-overlay/src/overlay/tests.rs
+++ b/packages/rsnap-overlay/src/overlay/tests.rs
@@ -43,6 +43,7 @@ use crate::overlay::PngAction;
 use crate::overlay::frozen_edit_history_runtime::FROZEN_EDIT_HISTORY_LIMIT;
 use crate::overlay::frozen_text_runtime::FROZEN_TEXT_CARET_REPAINT_INTERVAL;
 use crate::overlay::rendering;
+use crate::overlay::runtime_model::SurfaceFrameSkipReason;
 use crate::overlay::scroll_capture_timing::SCROLL_CAPTURE_SAMPLE_INTERVAL;
 #[cfg(target_os = "macos")]
 use crate::overlay::scroll_capture_timing::{
@@ -64,8 +65,7 @@ use crate::overlay::{
 	FrozenToolbarState, FrozenToolbarTool, HudRedrawSummary, HudTheme, OutputNaming,
 	OverlayControl, OverlaySession, Pos2, PreparedHostEffectRequest, Rect,
 	SelectionDashedBorderCache, SelectionFlowGeometryCache, SelectionSizeBadgeTarget,
-	SurfaceFrameSkipReason, ToolbarPlacement, Vec2, WindowCaptureAlphaMode, WindowRenderer,
-	hud_helpers,
+	ToolbarPlacement, Vec2, WindowCaptureAlphaMode, WindowRenderer, hud_helpers,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::{

--- a/packages/rsnap-overlay/src/overlay/tests/session_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/tests/session_runtime.rs
@@ -7,12 +7,12 @@ use image::{Rgba, RgbaImage};
 use crate::live_frame_stream_macos::MacLiveFrameStream;
 #[cfg(not(target_os = "macos"))]
 use crate::overlay::OverlayConfig;
-use crate::overlay::runtime_timing::OCCLUDED_FRAME_REDRAW_RETRY_WINDOW;
+use crate::overlay::runtime_timing;
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::GlobalPoint;
 use crate::overlay::tests::{
 	self, HudTheme, OverlayMode, OverlaySession, SurfaceFrameSkipReason, WindowRenderer,
-	hud_helpers, overlay,
+	hud_helpers,
 };
 #[cfg(target_os = "macos")]
 use crate::overlay::tests::{LiveCaptureInteraction, ModifiersState};
@@ -354,20 +354,20 @@ fn occluded_surface_skip_requests_redraw_until_retry_window_expires() {
 	let now = Instant::now();
 	let mut retry_until = None;
 
-	assert!(overlay::should_request_overlay_redraw_after_surface_skip(
+	assert!(runtime_timing::should_request_overlay_redraw_after_surface_skip(
 		SurfaceFrameSkipReason::Occluded,
 		now,
 		&mut retry_until,
 	));
-	assert_eq!(retry_until, Some(now + OCCLUDED_FRAME_REDRAW_RETRY_WINDOW));
-	assert!(overlay::should_request_overlay_redraw_after_surface_skip(
+	assert_eq!(retry_until, Some(now + runtime_timing::OCCLUDED_FRAME_REDRAW_RETRY_WINDOW));
+	assert!(runtime_timing::should_request_overlay_redraw_after_surface_skip(
 		SurfaceFrameSkipReason::Occluded,
 		now + Duration::from_millis(500),
 		&mut retry_until,
 	));
-	assert!(!overlay::should_request_overlay_redraw_after_surface_skip(
+	assert!(!runtime_timing::should_request_overlay_redraw_after_surface_skip(
 		SurfaceFrameSkipReason::Occluded,
-		now + OCCLUDED_FRAME_REDRAW_RETRY_WINDOW,
+		now + runtime_timing::OCCLUDED_FRAME_REDRAW_RETRY_WINDOW,
 		&mut retry_until,
 	));
 	assert_eq!(retry_until, None);
@@ -379,7 +379,7 @@ fn timeout_surface_skip_always_requests_redraw_without_touching_occluded_retry_w
 	let retry_deadline = now + Duration::from_millis(250);
 	let mut retry_until = Some(retry_deadline);
 
-	assert!(overlay::should_request_overlay_redraw_after_surface_skip(
+	assert!(runtime_timing::should_request_overlay_redraw_after_surface_skip(
 		SurfaceFrameSkipReason::Timeout,
 		now,
 		&mut retry_until,


### PR DESCRIPTION
## Summary
- Move overlay frame-skip redraw retry policy from overlay.rs into overlay/runtime_timing.rs.
- Keep callers on normal Rust module paths and update tests to exercise the runtime_timing owner directly.
- Route SurfaceFrameSkipReason imports to runtime_model owners instead of relying on overlay.rs root scope.

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features session_runtime
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Skeptic Review
- Fresh read-only skeptic found the module move structurally sound and runtime_timing a defensible owner.
- Its branch-artifact objection was resolved by staging and committing the intended files; branch is ahead by one commit.
- Its validation-evidence objection is resolved by the local validation listed above, including rsnap-overlay all-target compile coverage and full cargo make check.
