### PR TITLE
Move coordinate geometry helper to owner

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -3,6 +3,7 @@ pub(crate) mod replay_support;
 mod aux_window_runtime;
 mod capture_window_runtime;
 mod config_runtime;
+mod coordinate_geometry;
 mod cursor_context_runtime;
 mod cursor_runtime;
 mod exit_runtime;
@@ -1912,8 +1913,11 @@ impl OverlaySession {
 		self.toolbar_left_button_went_down = false;
 		self.toolbar_left_button_went_up = false;
 
-		let cursor_local = toolbar_cursor_local_override
-			.or_else(|| self.state.cursor.and_then(|cursor| global_to_local(cursor, monitor)))?;
+		let cursor_local = toolbar_cursor_local_override.or_else(|| {
+			self.state
+				.cursor
+				.and_then(|cursor| coordinate_geometry::global_to_local(cursor, monitor))
+		})?;
 
 		Some(FrozenToolbarPointerState {
 			cursor_local,
@@ -2645,12 +2649,6 @@ impl Default for OverlaySession {
 	fn default() -> Self {
 		Self::new()
 	}
-}
-
-fn global_to_local(cursor: GlobalPoint, monitor: MonitorRect) -> Option<Pos2> {
-	let (x, y) = monitor.local_u32(cursor)?;
-
-	Some(Pos2::new(x as f32, y as f32))
 }
 
 #[cfg(target_os = "macos")]

--- a/packages/rsnap-overlay/src/overlay/coordinate_geometry.rs
+++ b/packages/rsnap-overlay/src/overlay/coordinate_geometry.rs
@@ -1,0 +1,10 @@
+use crate::overlay::{GlobalPoint, MonitorRect, Pos2};
+
+pub(in crate::overlay) fn global_to_local(
+	cursor: GlobalPoint,
+	monitor: MonitorRect,
+) -> Option<Pos2> {
+	let (x, y) = monitor.local_u32(cursor)?;
+
+	Some(Pos2::new(x as f32, y as f32))
+}

--- a/packages/rsnap-overlay/src/overlay/rendering.rs
+++ b/packages/rsnap-overlay/src/overlay/rendering.rs
@@ -20,14 +20,15 @@ use winit::window::Window;
 
 use self::hud_rendering::LiveLoupeTexture;
 use self::hud_surface::HudBg;
+use crate::overlay::coordinate_geometry;
 #[cfg(target_os = "macos")]
 use crate::overlay::macos_configure_hud_window;
 #[cfg(target_os = "macos")]
 use crate::overlay::macos_cursor_runtime::MacOSOverlayCursorRectSupport;
 use crate::overlay::runtime_timing;
 use crate::overlay::{
-	self, AcquiredSurfaceFrame, Adapter, Arc, BindGroupLayout, Buffer, ClippedPrimitive, Color32,
-	Device, Duration, Event, ExperimentalFeatures, Features, FontDefinitions, FontFamily,
+	AcquiredSurfaceFrame, Adapter, Arc, BindGroupLayout, Buffer, ClippedPrimitive, Color32, Device,
+	Duration, Event, ExperimentalFeatures, Features, FontDefinitions, FontFamily,
 	FrozenArrowAnnotation, FrozenBrushState, FrozenCaptureSource, FrozenEditKind,
 	FrozenSpotlightAnnotation, FrozenTextAnnotation, FrozenTextEditState, FrozenTextStyle,
 	FrozenToolbarPointerState, FrozenToolbarState, FullOutput, HudAnchor, HudDrawConfig, HudTheme,
@@ -377,7 +378,7 @@ impl WindowRenderer {
 		let hud_data = if can_draw_hud {
 			state.cursor.and_then(|cursor| {
 				let local_cursor = hud_local_cursor_override
-					.or_else(|| overlay::global_to_local(cursor, monitor))?;
+					.or_else(|| coordinate_geometry::global_to_local(cursor, monitor))?;
 
 				Some((cursor, local_cursor))
 			})


### PR DESCRIPTION
## Summary
- Move overlay global-to-local coordinate conversion out of overlay.rs into overlay/coordinate_geometry.rs.
- Keep helper visibility constrained to the overlay module tree with pub(in crate::overlay).
- Update HUD and toolbar cursor callers to use the coordinate_geometry module path.

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features session_runtime
- cargo test -p rsnap-overlay --all-features live_runtime
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Skeptic Review
- Fresh read-only skeptic found the module shape and scoped visibility appropriate.
- Its untracked-file objection was resolved by staging and committing coordinate_geometry.rs with the caller updates.
- Its validation-evidence objection is resolved by the local validation listed above, including rsnap-overlay all-target compile coverage and full cargo make check.
