### PR TITLE
Move unix timestamp helper to runtime timing

### DIFF
--- a/packages/rsnap-overlay/src/overlay.rs
+++ b/packages/rsnap-overlay/src/overlay.rs
@@ -71,8 +71,6 @@ pub use self::session_contracts::{
 use std::mem;
 use std::ptr;
 use std::slice;
-#[cfg(target_os = "macos")]
-use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
 	borrow::Cow,
 	collections::{HashMap, HashSet},
@@ -1933,7 +1931,7 @@ impl OverlaySession {
 		&mut self,
 		request_id: u64,
 	) -> Option<DeferredTextRecognitionRequest> {
-		let requested_at_unix_ms = current_unix_millis();
+		let requested_at_unix_ms = runtime_timing::current_unix_millis();
 
 		if self.scroll_capture.active {
 			let image = self.scroll_capture.session.as_ref()?.export_image().clone();
@@ -2648,14 +2646,6 @@ impl OverlaySession {
 impl Default for OverlaySession {
 	fn default() -> Self {
 		Self::new()
-	}
-}
-
-#[cfg(target_os = "macos")]
-fn current_unix_millis() -> u64 {
-	match SystemTime::now().duration_since(UNIX_EPOCH) {
-		Ok(duration) => duration.as_millis().try_into().unwrap_or(u64::MAX),
-		Err(_err) => 0,
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/runtime_timing.rs
+++ b/packages/rsnap-overlay/src/overlay/runtime_timing.rs
@@ -1,4 +1,6 @@
 use std::time::{Duration, Instant};
+#[cfg(target_os = "macos")]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::overlay::runtime_model::SurfaceFrameSkipReason;
 
@@ -28,6 +30,14 @@ pub(in crate::overlay) const SLOW_OP_WARN_INTERVAL: Duration = Duration::from_se
 pub(in crate::overlay) const SLOW_OP_WARN_OUTER_POSITION: Duration = Duration::from_millis(24);
 pub(in crate::overlay) const SLOW_OP_WARN_RENDER: Duration = Duration::from_millis(24);
 pub(in crate::overlay) const SLOW_OP_WARN_WINDOW_EVENT: Duration = Duration::from_millis(40);
+
+#[cfg(target_os = "macos")]
+pub(in crate::overlay) fn current_unix_millis() -> u64 {
+	match SystemTime::now().duration_since(UNIX_EPOCH) {
+		Ok(duration) => duration.as_millis().try_into().unwrap_or(u64::MAX),
+		Err(_err) => 0,
+	}
+}
 
 pub(in crate::overlay) fn should_request_overlay_redraw_after_surface_skip(
 	reason: SurfaceFrameSkipReason,


### PR DESCRIPTION
## Summary
- Move the macOS current_unix_millis helper from overlay.rs into overlay/runtime_timing.rs.
- Keep the helper cfg-gated to macOS and scoped to the overlay module tree.
- Update deferred OCR request creation to use the runtime_timing owner path.

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features export_actions
- git diff --check && ! rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Skeptic Review
- Fresh read-only skeptic found runtime_timing a defensible owner and cfg handling clean.
- Its branch-artifact objection was resolved by staging and committing the intended two files.
- Its validation-evidence objection is resolved by the local validation listed above, including export_actions and full cargo make check.
