### PR TITLE
Move downward candidate selection

### DIFF
--- a/packages/rsnap-overlay/src/scroll_capture.rs
+++ b/packages/rsnap-overlay/src/scroll_capture.rs
@@ -1,5 +1,6 @@
 pub mod bench_support;
 
+mod downward_candidates;
 mod downward_recovery;
 mod downward_resolution;
 mod fingerprint;

--- a/packages/rsnap-overlay/src/scroll_capture/downward_candidates.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/downward_candidates.rs
@@ -1,0 +1,124 @@
+use crate::scroll_capture::{
+	DIRECTION_WARNING_MARGIN_X100, DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS, DownwardViewportCandidate,
+	DownwardViewportCandidateSource, DownwardViewportResolution,
+};
+
+pub(super) fn select_downward_viewport_candidate(
+	candidates: &mut [DownwardViewportCandidate],
+) -> DownwardViewportResolution {
+	if candidates.is_empty() {
+		return DownwardViewportResolution::NoMatch;
+	}
+
+	if let Some(preferred_local) = prefer_local_downward_viewport_candidate(candidates) {
+		let ambiguity_margin = downward_viewport_competing_margin(candidates, preferred_local);
+		let competing = candidates.iter().copied().find(|candidate| {
+			candidate != &preferred_local
+				&& candidate.viewport_top_y.abs_diff(preferred_local.viewport_top_y)
+					>= DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS
+				&& candidate.mean_abs_diff_x100
+					<= preferred_local.mean_abs_diff_x100.saturating_add(ambiguity_margin)
+		});
+
+		return match competing {
+			Some(competing) => {
+				DownwardViewportResolution::Ambiguous { preferred: preferred_local, competing }
+			},
+			None => DownwardViewportResolution::Selected(preferred_local),
+		};
+	}
+
+	candidates.sort_by(|left, right| {
+		left.mean_abs_diff_x100
+			.cmp(&right.mean_abs_diff_x100)
+			.then(left.source.priority().cmp(&right.source.priority()))
+			.then(left.motion_rows.cmp(&right.motion_rows))
+	});
+
+	let preferred = candidates[0];
+	let ambiguity_margin = downward_viewport_competing_margin(candidates, preferred);
+	let competing = candidates.iter().copied().skip(1).find(|candidate| {
+		candidate.viewport_top_y.abs_diff(preferred.viewport_top_y)
+			>= DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS
+			&& candidate.mean_abs_diff_x100
+				<= preferred.mean_abs_diff_x100.saturating_add(ambiguity_margin)
+	});
+
+	match competing {
+		Some(competing) => DownwardViewportResolution::Ambiguous { preferred, competing },
+		None => DownwardViewportResolution::Selected(preferred),
+	}
+}
+
+pub(super) fn format_downward_viewport_candidates(
+	candidates: &[DownwardViewportCandidate],
+) -> String {
+	candidates
+		.iter()
+		.map(|candidate| {
+			format!(
+				"{:?}@{}/{}:{}",
+				candidate.source,
+				candidate.viewport_top_y,
+				candidate.motion_rows,
+				candidate.mean_abs_diff_x100
+			)
+		})
+		.collect::<Vec<_>>()
+		.join(",")
+}
+
+pub(super) fn best_local_downward_viewport_candidate(
+	candidates: &[DownwardViewportCandidate],
+) -> Option<DownwardViewportCandidate> {
+	candidates
+		.iter()
+		.copied()
+		.filter(|candidate| candidate.source != DownwardViewportCandidateSource::CommittedKeyframe)
+		.min_by(|left, right| {
+			left.mean_abs_diff_x100
+				.cmp(&right.mean_abs_diff_x100)
+				.then(left.source.priority().cmp(&right.source.priority()))
+				.then(left.motion_rows.cmp(&right.motion_rows))
+		})
+}
+
+fn downward_viewport_competing_margin(
+	candidates: &[DownwardViewportCandidate],
+	preferred: DownwardViewportCandidate,
+) -> u32 {
+	let exact_corroborated = candidates.iter().any(|candidate| {
+		candidate != &preferred
+			&& candidate.viewport_top_y == preferred.viewport_top_y
+			&& candidate.motion_rows == preferred.motion_rows
+			&& candidate.mean_abs_diff_x100
+				<= preferred.mean_abs_diff_x100.saturating_add(DIRECTION_WARNING_MARGIN_X100)
+	});
+
+	if exact_corroborated { 0 } else { DIRECTION_WARNING_MARGIN_X100 }
+}
+
+fn prefer_local_downward_viewport_candidate(
+	candidates: &[DownwardViewportCandidate],
+) -> Option<DownwardViewportCandidate> {
+	let local = best_local_downward_viewport_candidate(candidates)?;
+	let committed = candidates
+		.iter()
+		.copied()
+		.filter(|candidate| candidate.source == DownwardViewportCandidateSource::CommittedKeyframe)
+		.min_by(|left, right| {
+			left.mean_abs_diff_x100
+				.cmp(&right.mean_abs_diff_x100)
+				.then(left.motion_rows.cmp(&right.motion_rows))
+		});
+	let Some(committed) = committed else {
+		return Some(local);
+	};
+	let committed_is_nearby = committed.viewport_top_y.abs_diff(local.viewport_top_y)
+		< DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS;
+	let committed_is_only_modestly_better =
+		committed.mean_abs_diff_x100.saturating_add(DIRECTION_WARNING_MARGIN_X100)
+			>= local.mean_abs_diff_x100;
+
+	if committed_is_nearby && committed_is_only_modestly_better { Some(local) } else { None }
+}

--- a/packages/rsnap-overlay/src/scroll_capture/downward_recovery.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/downward_recovery.rs
@@ -1,4 +1,4 @@
-use crate::scroll_capture::support;
+use crate::scroll_capture::downward_candidates;
 use crate::scroll_capture::{
 	BlockedPreviewOnlyLocalCandidate, DIRECTION_WARNING_MARGIN_X100,
 	DOWNWARD_COMMITTED_KEYFRAME_LOCAL_OVERRUN_MAX_ROWS, DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS,
@@ -354,7 +354,8 @@ impl ScrollSession {
 		let has_committed_candidate = candidates.iter().any(|candidate| {
 			candidate.source == DownwardViewportCandidateSource::CommittedKeyframe
 		});
-		let mut local_anchor = support::best_local_downward_viewport_candidate(candidates);
+		let mut local_anchor =
+			downward_candidates::best_local_downward_viewport_candidate(candidates);
 
 		if local_anchor.is_some_and(|anchor| {
 			has_committed_candidate
@@ -376,7 +377,7 @@ impl ScrollSession {
 				candidate.source != DownwardViewportCandidateSource::PreviewOnlyLocalSample
 			});
 
-			local_anchor = support::best_local_downward_viewport_candidate(candidates);
+			local_anchor = downward_candidates::best_local_downward_viewport_candidate(candidates);
 		}
 
 		let Some(local_anchor) = local_anchor else {

--- a/packages/rsnap-overlay/src/scroll_capture/downward_resolution.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/downward_resolution.rs
@@ -1,6 +1,5 @@
 use color_eyre::eyre::Result;
 
-use crate::scroll_capture::support;
 use crate::scroll_capture::{
 	CommittedDownwardViewportCandidateMode, DIRECTION_WARNING_MARGIN_X100,
 	DOWNWARD_KEYFRAME_MIN_OVERLAP_DIVISOR, DOWNWARD_KEYFRAME_SEARCH_LIMIT,
@@ -17,6 +16,7 @@ use crate::scroll_capture::{
 	TRANSIENT_BURST_UNDERCONSUMED_HINT_MIN_ROWS, UNDERCONSUMED_OBSERVED_BURST_RECOVERY_GAP_ROWS,
 	eyre,
 };
+use crate::scroll_capture::{downward_candidates, support};
 
 impl ScrollSession {
 	pub(super) fn evaluate_reference_overlap_direction(
@@ -518,7 +518,7 @@ impl ScrollSession {
 		let candidates_before_prune = candidates.clone();
 
 		self.last_downward_viewport_candidates_before_prune =
-			Some(support::format_downward_viewport_candidates(&candidates));
+			Some(downward_candidates::format_downward_viewport_candidates(&candidates));
 
 		self.prune_committed_keyframe_candidates_outside_local_continuity(&mut candidates);
 		self.restore_repeated_small_preview_only_local_candidate_after_empty_prune(
@@ -544,9 +544,9 @@ impl ScrollSession {
 
 		self.last_downward_viewport_candidate_count = Some(candidates.len());
 		self.last_downward_viewport_candidates_after_prune =
-			Some(support::format_downward_viewport_candidates(&candidates));
+			Some(downward_candidates::format_downward_viewport_candidates(&candidates));
 
-		support::select_downward_viewport_candidate(&mut candidates)
+		downward_candidates::select_downward_viewport_candidate(&mut candidates)
 	}
 
 	pub(super) fn collect_committed_downward_viewport_candidates(
@@ -834,7 +834,7 @@ impl ScrollSession {
 
 		self.collect_fallback_downward_viewport_candidates(&frame, &mut candidates);
 
-		match support::select_downward_viewport_candidate(&mut candidates) {
+		match downward_candidates::select_downward_viewport_candidate(&mut candidates) {
 			DownwardViewportResolution::NoMatch => {
 				self.record_transient_burst_missing_downward_candidate_frame(preview_changed);
 				self.refresh_preview_only_downward_local_sample(

--- a/packages/rsnap-overlay/src/scroll_capture/support.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/support.rs
@@ -10,11 +10,9 @@ use image::{
 use crate::scroll_capture::OverlapMatch;
 use crate::scroll_capture::{
 	DIRECTION_WARNING_MARGIN_X100, DOWNWARD_REGISTRATION_AMBIGUOUS_GAP_ROWS,
-	DOWNWARD_REGISTRATION_MIN_OVERLAP_DIVISOR, DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS,
-	DirectionMatch, DownwardRegistration, DownwardViewportCandidate,
-	DownwardViewportCandidateSource, DownwardViewportResolution, InformativeSpan,
-	OverlapSearchConfig, RESUME_DIRECT_PROOF_MAX_MEAN_ABS_DIFF_X100, ScrollDirection,
-	ScrollFrameFingerprint, ScrollObserveOutcome,
+	DOWNWARD_REGISTRATION_MIN_OVERLAP_DIVISOR, DirectionMatch, DownwardRegistration,
+	InformativeSpan, OverlapSearchConfig, RESUME_DIRECT_PROOF_MAX_MEAN_ABS_DIFF_X100,
+	ScrollDirection, ScrollFrameFingerprint, ScrollObserveOutcome,
 };
 
 const INFORMATIVE_SPAN_ROW_SAMPLES: u32 = 24;
@@ -124,86 +122,6 @@ pub(crate) fn compose_provisional_preview_image(
 	let preview_strip = resize_strip_to_preview_width(&strip, preview_width_px);
 
 	append_vertical_image(base_preview, &preview_strip).unwrap_or_else(|_| base_preview.clone())
-}
-
-pub(super) fn select_downward_viewport_candidate(
-	candidates: &mut [DownwardViewportCandidate],
-) -> DownwardViewportResolution {
-	if candidates.is_empty() {
-		return DownwardViewportResolution::NoMatch;
-	}
-
-	if let Some(preferred_local) = prefer_local_downward_viewport_candidate(candidates) {
-		let ambiguity_margin = downward_viewport_competing_margin(candidates, preferred_local);
-		let competing = candidates.iter().copied().find(|candidate| {
-			candidate != &preferred_local
-				&& candidate.viewport_top_y.abs_diff(preferred_local.viewport_top_y)
-					>= DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS
-				&& candidate.mean_abs_diff_x100
-					<= preferred_local.mean_abs_diff_x100.saturating_add(ambiguity_margin)
-		});
-
-		return match competing {
-			Some(competing) => {
-				DownwardViewportResolution::Ambiguous { preferred: preferred_local, competing }
-			},
-			None => DownwardViewportResolution::Selected(preferred_local),
-		};
-	}
-
-	candidates.sort_by(|left, right| {
-		left.mean_abs_diff_x100
-			.cmp(&right.mean_abs_diff_x100)
-			.then(left.source.priority().cmp(&right.source.priority()))
-			.then(left.motion_rows.cmp(&right.motion_rows))
-	});
-
-	let preferred = candidates[0];
-	let ambiguity_margin = downward_viewport_competing_margin(candidates, preferred);
-	let competing = candidates.iter().copied().skip(1).find(|candidate| {
-		candidate.viewport_top_y.abs_diff(preferred.viewport_top_y)
-			>= DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS
-			&& candidate.mean_abs_diff_x100
-				<= preferred.mean_abs_diff_x100.saturating_add(ambiguity_margin)
-	});
-
-	match competing {
-		Some(competing) => DownwardViewportResolution::Ambiguous { preferred, competing },
-		None => DownwardViewportResolution::Selected(preferred),
-	}
-}
-
-pub(super) fn format_downward_viewport_candidates(
-	candidates: &[DownwardViewportCandidate],
-) -> String {
-	candidates
-		.iter()
-		.map(|candidate| {
-			format!(
-				"{:?}@{}/{}:{}",
-				candidate.source,
-				candidate.viewport_top_y,
-				candidate.motion_rows,
-				candidate.mean_abs_diff_x100
-			)
-		})
-		.collect::<Vec<_>>()
-		.join(",")
-}
-
-pub(super) fn best_local_downward_viewport_candidate(
-	candidates: &[DownwardViewportCandidate],
-) -> Option<DownwardViewportCandidate> {
-	candidates
-		.iter()
-		.copied()
-		.filter(|candidate| candidate.source != DownwardViewportCandidateSource::CommittedKeyframe)
-		.min_by(|left, right| {
-			left.mean_abs_diff_x100
-				.cmp(&right.mean_abs_diff_x100)
-				.then(left.source.priority().cmp(&right.source.priority()))
-				.then(left.motion_rows.cmp(&right.motion_rows))
-		})
 }
 
 pub(super) fn evaluate_overlap_direction(
@@ -622,46 +540,6 @@ pub(super) fn evenly_spaced_sample(start: u32, end_exclusive: u32, index: u32, c
 		(u64::from(index) * u64::from(span.saturating_sub(1))) / u64::from(count.saturating_sub(1));
 
 	start.saturating_add(numerator as u32).min(end_exclusive.saturating_sub(1))
-}
-
-fn downward_viewport_competing_margin(
-	candidates: &[DownwardViewportCandidate],
-	preferred: DownwardViewportCandidate,
-) -> u32 {
-	let exact_corroborated = candidates.iter().any(|candidate| {
-		candidate != &preferred
-			&& candidate.viewport_top_y == preferred.viewport_top_y
-			&& candidate.motion_rows == preferred.motion_rows
-			&& candidate.mean_abs_diff_x100
-				<= preferred.mean_abs_diff_x100.saturating_add(DIRECTION_WARNING_MARGIN_X100)
-	});
-
-	if exact_corroborated { 0 } else { DIRECTION_WARNING_MARGIN_X100 }
-}
-
-fn prefer_local_downward_viewport_candidate(
-	candidates: &[DownwardViewportCandidate],
-) -> Option<DownwardViewportCandidate> {
-	let local = best_local_downward_viewport_candidate(candidates)?;
-	let committed = candidates
-		.iter()
-		.copied()
-		.filter(|candidate| candidate.source == DownwardViewportCandidateSource::CommittedKeyframe)
-		.min_by(|left, right| {
-			left.mean_abs_diff_x100
-				.cmp(&right.mean_abs_diff_x100)
-				.then(left.motion_rows.cmp(&right.motion_rows))
-		});
-	let Some(committed) = committed else {
-		return Some(local);
-	};
-	let committed_is_nearby = committed.viewport_top_y.abs_diff(local.viewport_top_y)
-		< DOWNWARD_VIEWPORT_AUTHORITY_GAP_ROWS;
-	let committed_is_only_modestly_better =
-		committed.mean_abs_diff_x100.saturating_add(DIRECTION_WARNING_MARGIN_X100)
-			>= local.mean_abs_diff_x100;
-
-	if committed_is_nearby && committed_is_only_modestly_better { Some(local) } else { None }
 }
 
 #[cfg(test)]

--- a/packages/rsnap-overlay/src/scroll_capture/tests.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/tests.rs
@@ -4,7 +4,7 @@ use crate::scroll_capture::{
 	self, DirectionMatch, DownwardRegistration, DownwardViewportCandidate,
 	DownwardViewportCandidateSource, DownwardViewportResolution, MotionObservation,
 	OverlapSearchConfig, PreviewOnlyDownwardLocalSample, ScrollDirection, ScrollFrameFingerprint,
-	ScrollObserveOutcome, ScrollSession, pairwise_shift, support, test_support,
+	ScrollObserveOutcome, ScrollSession, downward_candidates, pairwise_shift, test_support,
 };
 
 fn make_test_image(width: u32, rows: &[[u8; 4]]) -> image::RgbaImage {
@@ -1680,7 +1680,7 @@ fn viewport_selection_fails_closed_when_observed_and_committed_authority_conflic
 	let mut candidates = [observed, committed];
 
 	assert_eq!(
-		support::select_downward_viewport_candidate(&mut candidates),
+		downward_candidates::select_downward_viewport_candidate(&mut candidates),
 		DownwardViewportResolution::Ambiguous { preferred: committed, competing: observed }
 	);
 }
@@ -1798,7 +1798,7 @@ fn nearby_local_candidate_wins_when_committed_is_only_modestly_better() {
 	let mut candidates = [observed, committed];
 
 	assert_eq!(
-		support::select_downward_viewport_candidate(&mut candidates),
+		downward_candidates::select_downward_viewport_candidate(&mut candidates),
 		DownwardViewportResolution::Selected(observed)
 	);
 }


### PR DESCRIPTION
## Summary
- extract downward viewport candidate selection and formatting into scroll_capture/downward_candidates.rs
- update downward resolution, recovery, and tests to depend on the dedicated candidate module
- keep generic scroll_capture/support.rs focused on overlap/image helpers

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features scroll_capture::tests
- cargo test -p rsnap-overlay --all-features worker_tick_runtime
- cargo test -p rsnap-overlay --all-features worker_observation_runtime
- git diff --check
- no include!/#[path] matches under packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check