### PR TITLE
Move scroll capture image stacking

### DIFF
--- a/packages/rsnap-overlay/src/scroll_capture.rs
+++ b/packages/rsnap-overlay/src/scroll_capture.rs
@@ -4,6 +4,7 @@ mod downward_candidates;
 mod downward_recovery;
 mod downward_resolution;
 mod fingerprint;
+mod image_stack;
 mod logging;
 mod pairwise_shift;
 mod resume_frontier;
@@ -16,9 +17,10 @@ mod upward_input;
 mod worker_pairwise;
 
 pub(crate) use self::fingerprint::ScrollFrameFingerprint;
+pub(crate) use self::image_stack::compose_provisional_preview_image;
+pub(crate) use self::support::scroll_capture_fingerprint;
 #[cfg(any(test, target_os = "macos"))]
 pub(crate) use self::support::scroll_capture_fingerprint_delta;
-pub(crate) use self::support::{compose_provisional_preview_image, scroll_capture_fingerprint};
 #[cfg(test)]
 pub(crate) use self::types::OverlapMatch;
 pub(crate) use self::types::{
@@ -134,7 +136,7 @@ impl ScrollSession {
 	pub(crate) fn new(base_frame: RgbaImage, preview_width_px: u32) -> Result<Self> {
 		let fingerprint = scroll_capture_fingerprint(&base_frame);
 		let anchor_preview =
-			self::support::resize_strip_to_preview_width(&base_frame, preview_width_px.max(1));
+			self::image_stack::resize_strip_to_preview_width(&base_frame, preview_width_px.max(1));
 
 		Ok(Self {
 			anchor_frame: base_frame.clone(),

--- a/packages/rsnap-overlay/src/scroll_capture/downward_resolution.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/downward_resolution.rs
@@ -16,7 +16,7 @@ use crate::scroll_capture::{
 	TRANSIENT_BURST_UNDERCONSUMED_HINT_MIN_ROWS, UNDERCONSUMED_OBSERVED_BURST_RECOVERY_GAP_ROWS,
 	eyre,
 };
-use crate::scroll_capture::{downward_candidates, support};
+use crate::scroll_capture::{downward_candidates, image_stack, support};
 
 impl ScrollSession {
 	pub(super) fn evaluate_reference_overlap_direction(
@@ -940,12 +940,14 @@ impl ScrollSession {
 		previous_motion_rows_hint: Option<u32>,
 	) -> Result<ScrollObserveOutcome> {
 		let fingerprint = support::scroll_capture_fingerprint(&frame);
-		let strip = support::crop_bottom_rows(&frame, growth_rows)
+		let strip = image_stack::crop_bottom_rows(&frame, growth_rows)
 			.ok_or_else(|| eyre::eyre!("failed to extract growth strip"))?;
-		let preview_strip = support::resize_strip_to_preview_width(&strip, self.preview_width_px);
+		let preview_strip =
+			image_stack::resize_strip_to_preview_width(&strip, self.preview_width_px);
 
-		self.export_image = support::append_vertical_image(&self.export_image, &strip)?;
-		self.preview_image = support::append_vertical_image(&self.preview_image, &preview_strip)?;
+		self.export_image = image_stack::append_vertical_image(&self.export_image, &strip)?;
+		self.preview_image =
+			image_stack::append_vertical_image(&self.preview_image, &preview_strip)?;
 
 		self.bottom_segments.push(strip);
 		self.bottom_preview_segments.push(preview_strip);
@@ -1042,7 +1044,7 @@ impl ScrollSession {
 			ordered.push(strip);
 		}
 
-		support::stack_vertical_images(&ordered)
+		image_stack::stack_vertical_images(&ordered)
 	}
 
 	pub(super) fn rebuild_preview_image(&self) -> Result<RgbaImage> {
@@ -1054,6 +1056,6 @@ impl ScrollSession {
 			ordered.push(strip);
 		}
 
-		support::stack_vertical_images(&ordered)
+		image_stack::stack_vertical_images(&ordered)
 	}
 }

--- a/packages/rsnap-overlay/src/scroll_capture/image_stack.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/image_stack.rs
@@ -1,0 +1,97 @@
+use color_eyre::eyre::{self, Result};
+use image::{
+	RgbaImage,
+	imageops::{self, FilterType},
+};
+
+pub(crate) fn compose_provisional_preview_image(
+	base_preview: &RgbaImage,
+	latest_frame: Option<&RgbaImage>,
+	motion_rows_hint: Option<u32>,
+	preview_width_px: u32,
+) -> RgbaImage {
+	let Some(frame) = latest_frame else {
+		return base_preview.clone();
+	};
+	let Some(motion_rows_hint) = motion_rows_hint else {
+		return base_preview.clone();
+	};
+	let hinted_growth_rows = motion_rows_hint.min(frame.height());
+
+	if hinted_growth_rows == 0 {
+		return base_preview.clone();
+	}
+
+	let Some(strip) = crop_bottom_rows(frame, hinted_growth_rows) else {
+		return base_preview.clone();
+	};
+	let preview_strip = resize_strip_to_preview_width(&strip, preview_width_px);
+
+	append_vertical_image(base_preview, &preview_strip).unwrap_or_else(|_| base_preview.clone())
+}
+
+pub(super) fn resize_strip_to_preview_width(strip: &RgbaImage, preview_width_px: u32) -> RgbaImage {
+	if strip.width() <= preview_width_px {
+		return strip.clone();
+	}
+
+	let preview_height = ((strip.height() as f32 / strip.width() as f32) * preview_width_px as f32)
+		.round()
+		.max(1.0) as u32;
+
+	imageops::resize(strip, preview_width_px, preview_height, FilterType::Triangle)
+}
+
+pub(super) fn crop_bottom_rows(frame: &RgbaImage, rows: u32) -> Option<RgbaImage> {
+	let rows = rows.min(frame.height());
+
+	if rows == 0 {
+		return None;
+	}
+
+	let start_y = frame.height().saturating_sub(rows);
+
+	Some(imageops::crop_imm(frame, 0, start_y, frame.width(), rows).to_image())
+}
+
+pub(super) fn stack_vertical_images(images: &[&RgbaImage]) -> Result<RgbaImage> {
+	let Some(first) = images.first() else {
+		return Err(eyre::eyre!("cannot stack an empty image list"));
+	};
+	let width = first.width();
+	let total_height = images.iter().try_fold(0_u32, |acc, image| {
+		if image.width() != width {
+			return Err(eyre::eyre!(
+				"image width mismatch while stacking: expected {} got {}",
+				width,
+				image.width()
+			));
+		}
+
+		acc.checked_add(image.height()).ok_or_else(|| eyre::eyre!("stacked image height overflow"))
+	})?;
+	let total_bytes = images.iter().try_fold(0_usize, |acc, image| {
+		acc.checked_add(image.as_raw().len())
+			.ok_or_else(|| eyre::eyre!("stacked image byte length overflow"))
+	})?;
+	let mut raw = Vec::with_capacity(total_bytes);
+
+	for image in images {
+		raw.extend_from_slice(image.as_raw());
+	}
+
+	RgbaImage::from_raw(width, total_height, raw)
+		.ok_or_else(|| eyre::eyre!("failed to construct stacked image buffer"))
+}
+
+pub(super) fn append_vertical_image(base: &RgbaImage, strip: &RgbaImage) -> Result<RgbaImage> {
+	if base.width() != strip.width() {
+		return Err(eyre::eyre!(
+			"image width mismatch while appending: expected {} got {}",
+			base.width(),
+			strip.width()
+		));
+	}
+
+	stack_vertical_images(&[base, strip])
+}

--- a/packages/rsnap-overlay/src/scroll_capture/support.rs
+++ b/packages/rsnap-overlay/src/scroll_capture/support.rs
@@ -1,10 +1,6 @@
 use std::ops::RangeInclusive;
 
-use color_eyre::eyre::{self, Result};
-use image::{
-	RgbaImage,
-	imageops::{self, FilterType},
-};
+use image::RgbaImage;
 
 #[cfg(test)]
 use crate::scroll_capture::OverlapMatch;
@@ -96,32 +92,6 @@ pub(crate) fn detect_vertical_overlap(
 		config,
 		overlap_global_informative_span(previous, next),
 	)
-}
-
-pub(crate) fn compose_provisional_preview_image(
-	base_preview: &RgbaImage,
-	latest_frame: Option<&RgbaImage>,
-	motion_rows_hint: Option<u32>,
-	preview_width_px: u32,
-) -> RgbaImage {
-	let Some(frame) = latest_frame else {
-		return base_preview.clone();
-	};
-	let Some(motion_rows_hint) = motion_rows_hint else {
-		return base_preview.clone();
-	};
-	let hinted_growth_rows = motion_rows_hint.min(frame.height());
-
-	if hinted_growth_rows == 0 {
-		return base_preview.clone();
-	}
-
-	let Some(strip) = crop_bottom_rows(frame, hinted_growth_rows) else {
-		return base_preview.clone();
-	};
-	let preview_strip = resize_strip_to_preview_width(&strip, preview_width_px);
-
-	append_vertical_image(base_preview, &preview_strip).unwrap_or_else(|_| base_preview.clone())
 }
 
 pub(super) fn evaluate_overlap_direction(
@@ -402,72 +372,6 @@ pub(super) fn max_directional_motion_rows(
 		if max_overlap <= config.min_overlap_rows { 1 } else { config.min_overlap_rows.max(1) };
 
 	max_overlap.saturating_sub(effective_min_overlap).max(1)
-}
-
-pub(super) fn resize_strip_to_preview_width(strip: &RgbaImage, preview_width_px: u32) -> RgbaImage {
-	if strip.width() <= preview_width_px {
-		return strip.clone();
-	}
-
-	let preview_height = ((strip.height() as f32 / strip.width() as f32) * preview_width_px as f32)
-		.round()
-		.max(1.0) as u32;
-
-	imageops::resize(strip, preview_width_px, preview_height, FilterType::Triangle)
-}
-
-pub(super) fn crop_bottom_rows(frame: &RgbaImage, rows: u32) -> Option<RgbaImage> {
-	let rows = rows.min(frame.height());
-
-	if rows == 0 {
-		return None;
-	}
-
-	let start_y = frame.height().saturating_sub(rows);
-
-	Some(imageops::crop_imm(frame, 0, start_y, frame.width(), rows).to_image())
-}
-
-pub(super) fn stack_vertical_images(images: &[&RgbaImage]) -> Result<RgbaImage> {
-	let Some(first) = images.first() else {
-		return Err(eyre::eyre!("cannot stack an empty image list"));
-	};
-	let width = first.width();
-	let total_height = images.iter().try_fold(0_u32, |acc, image| {
-		if image.width() != width {
-			return Err(eyre::eyre!(
-				"image width mismatch while stacking: expected {} got {}",
-				width,
-				image.width()
-			));
-		}
-
-		acc.checked_add(image.height()).ok_or_else(|| eyre::eyre!("stacked image height overflow"))
-	})?;
-	let total_bytes = images.iter().try_fold(0_usize, |acc, image| {
-		acc.checked_add(image.as_raw().len())
-			.ok_or_else(|| eyre::eyre!("stacked image byte length overflow"))
-	})?;
-	let mut raw = Vec::with_capacity(total_bytes);
-
-	for image in images {
-		raw.extend_from_slice(image.as_raw());
-	}
-
-	RgbaImage::from_raw(width, total_height, raw)
-		.ok_or_else(|| eyre::eyre!("failed to construct stacked image buffer"))
-}
-
-pub(super) fn append_vertical_image(base: &RgbaImage, strip: &RgbaImage) -> Result<RgbaImage> {
-	if base.width() != strip.width() {
-		return Err(eyre::eyre!(
-			"image width mismatch while appending: expected {} got {}",
-			base.width(),
-			strip.width()
-		));
-	}
-
-	stack_vertical_images(&[base, strip])
 }
 
 pub(super) fn informative_column_span(


### PR DESCRIPTION
## Summary
- extract scroll capture image composition and vertical stacking helpers into scroll_capture/image_stack.rs
- update scroll session initialization and downward growth paths to use the dedicated image stack module
- keep scroll_capture/support.rs focused on overlap and registration helpers

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features scroll_capture::tests
- cargo test -p rsnap-overlay --all-features worker_tick_runtime
- cargo test -p rsnap-overlay --all-features worker_observation_runtime
- git diff --check
- no include!/#[path] matches under packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check