### PR TITLE
Modularize replay summary finalization

### DIFF
--- a/packages/rsnap-overlay/src/overlay/replay_support.rs
+++ b/packages/rsnap-overlay/src/overlay/replay_support.rs
@@ -1,5 +1,6 @@
 mod model;
 mod semantic;
+mod summary;
 
 pub use model::{
 	RecordedScrollCaptureReplayFrameSource, RecordedScrollCaptureReplayMode,
@@ -61,7 +62,7 @@ pub fn replay_recorded_scroll_capture_trace_with_mode(
 	let (mut session, started_at) = initialize_replay_session(&trace)?;
 	let replay_stats = replay_trace_entries(&trace, &mut session, started_at, replay_mode)?;
 
-	finalize_replay_summary(trace, &session, replay_stats, replay_mode)
+	summary::finalize_replay_summary(trace, &session, replay_stats, replay_mode)
 }
 
 fn classify_replayed_outcome(
@@ -468,118 +469,6 @@ fn update_live_frame_gap(
 	}
 }
 
-fn finalize_replay_summary(
-	trace: LoadedScrollCaptureLiveTrace,
-	session: &OverlaySession,
-	replay_stats: ReplayStats,
-	replay_mode: RecordedScrollCaptureReplayMode,
-) -> Result<RecordedScrollCaptureReplaySummary> {
-	let final_session = session.scroll_capture.session.as_ref().ok_or_else(|| {
-		eyre::eyre!("scroll-capture session missing after replaying recorded live trace")
-	})?;
-	let first_outcome_divergence_frame = replay_stats
-		.step_results
-		.iter()
-		.find(|step| !recorded_step_outcome_matches_replayed(step))
-		.map(|step| step.frame_index);
-	let first_export_height_drift_frame = replay_stats
-		.step_results
-		.iter()
-		.find(|step| {
-			step.recorded_export_height.is_some_and(|recorded| recorded != step.export_height)
-		})
-		.map(|step| step.frame_index);
-	let first_preview_height_drift_frame = replay_stats
-		.step_results
-		.iter()
-		.find(|step| {
-			step.recorded_preview_height.is_some_and(|recorded| recorded != step.preview_height)
-		})
-		.map(|step| step.frame_index);
-	let first_semantic_issue_frame = replay_stats
-		.step_results
-		.iter()
-		.find(|step| step.semantic_issue.is_some())
-		.map(|step| step.frame_index);
-	let first_missed_downward_motion_frame = replay_stats
-		.step_results
-		.iter()
-		.find(|step| {
-			matches!(
-				step.semantic_issue,
-				Some(RecordedScrollCaptureSemanticIssue::MissedDownwardMotion)
-			)
-		})
-		.map(|step| step.frame_index);
-	let first_underconsumed_downward_motion_frame = replay_stats
-		.step_results
-		.iter()
-		.find(|step| {
-			matches!(
-				step.semantic_issue,
-				Some(RecordedScrollCaptureSemanticIssue::UnderconsumedDownwardMotion)
-			)
-		})
-		.map(|step| step.frame_index);
-	let first_growth_overshoot_frame = replay_stats
-		.step_results
-		.iter()
-		.find(|step| {
-			matches!(
-				step.semantic_issue,
-				Some(RecordedScrollCaptureSemanticIssue::GrowthExceedsRecordedShift)
-			)
-		})
-		.map(|step| step.frame_index);
-
-	Ok(RecordedScrollCaptureReplaySummary {
-		replay_mode,
-		trace_id: trace.manifest.trace_id.clone(),
-		manifest_path: trace.manifest_path.clone(),
-		final_export_height: final_session.export_image().height(),
-		final_preview_height: session
-			.scroll_capture_preview_dimensions()
-			.map_or(final_session.preview_image().height(), |dimensions| dimensions[1]),
-		final_viewport_top_y: final_session.current_viewport_top_y(),
-		recorded_final_export_height: trace
-			.manifest
-			.final_snapshot
-			.as_ref()
-			.and_then(|snapshot| snapshot.export_dimensions)
-			.map(|dimensions| dimensions[1]),
-		recorded_final_preview_height: trace
-			.manifest
-			.final_snapshot
-			.as_ref()
-			.and_then(|snapshot| snapshot.preview_dimensions)
-			.map(|dimensions| dimensions[1]),
-		final_preview_path: trace
-			.manifest
-			.final_preview_path
-			.as_deref()
-			.map(|path| trace.resolve_frame_path(path)),
-		final_export_path: trace
-			.manifest
-			.final_export_path
-			.as_deref()
-			.map(|path| trace.resolve_frame_path(path)),
-		first_outcome_divergence_frame,
-		first_export_height_drift_frame,
-		first_preview_height_drift_frame,
-		max_recorded_committed_growth_rows: replay_stats.max_recorded_committed_growth_rows,
-		max_replayed_committed_growth_rows: replay_stats.max_replayed_committed_growth_rows,
-		max_recorded_export_jump: replay_stats.max_recorded_export_jump,
-		max_recorded_preview_jump: replay_stats.max_recorded_preview_jump,
-		max_replayed_export_jump: replay_stats.max_replayed_export_jump,
-		max_replayed_preview_jump: replay_stats.max_replayed_preview_jump,
-		first_semantic_issue_frame,
-		first_missed_downward_motion_frame,
-		first_underconsumed_downward_motion_frame,
-		first_growth_overshoot_frame,
-		step_results: replay_stats.step_results,
-	})
-}
-
 fn estimate_recorded_downward_shift_rows(previous: &RgbaImage, current: &RgbaImage) -> Option<u32> {
 	semantic::estimate_recorded_downward_shift_rows(previous, current)
 }
@@ -626,50 +515,6 @@ fn replay_frame_source(
 	}
 }
 
-fn recorded_outcome_matches_replayed(
-	recorded: &RecordedScrollCaptureReplayRecordedOutcome,
-	replayed: ScrollCaptureReplayOutcome,
-) -> bool {
-	match (recorded, replayed) {
-		(
-			RecordedScrollCaptureReplayRecordedOutcome::NoChange,
-			ScrollCaptureReplayOutcome::NoChange,
-		) => true,
-		(
-			RecordedScrollCaptureReplayRecordedOutcome::PreviewUpdated,
-			ScrollCaptureReplayOutcome::PreviewUpdated,
-		) => true,
-		(
-			RecordedScrollCaptureReplayRecordedOutcome::Unsupported { direction },
-			ScrollCaptureReplayOutcome::UnsupportedUp,
-		) => *direction == "up",
-		(
-			RecordedScrollCaptureReplayRecordedOutcome::Committed { direction, growth_rows },
-			ScrollCaptureReplayOutcome::CommittedDown { growth_rows: replayed_growth_rows },
-		) => *direction == "down" && *growth_rows == replayed_growth_rows,
-		(RecordedScrollCaptureReplayRecordedOutcome::Error { .. }, _) => false,
-		_ => false,
-	}
-}
-
-fn recorded_step_outcome_matches_replayed(step: &RecordedScrollCaptureReplayStepResult) -> bool {
-	if recorded_outcome_matches_replayed(&step.recorded_outcome, step.replayed_outcome) {
-		return true;
-	}
-
-	matches!(
-		(&step.recorded_outcome, step.replayed_outcome),
-		(
-			RecordedScrollCaptureReplayRecordedOutcome::NoChange,
-			ScrollCaptureReplayOutcome::PreviewUpdated,
-		) | (
-			RecordedScrollCaptureReplayRecordedOutcome::PreviewUpdated,
-			ScrollCaptureReplayOutcome::NoChange,
-		)
-	) && step.recorded_export_height == Some(step.export_height)
-		&& step.recorded_preview_height == Some(step.preview_height)
-}
-
 fn replay_monitor_from_trace(trace: &LoadedScrollCaptureLiveTrace) -> MonitorRect {
 	MonitorRect {
 		id: trace.manifest.monitor.id,
@@ -702,6 +547,7 @@ mod tests {
 
 	use image::{Rgba, RgbaImage};
 
+	use crate::overlay::replay_support::summary;
 	use crate::overlay::replay_support::{self, RecordedScrollCaptureReplayMode};
 	use crate::overlay::{
 		GlobalPoint, MonitorRect, OverlaySession, RectPoints, ScrollCaptureFrameSource,
@@ -1121,7 +967,7 @@ mod tests {
 			semantic_issue: None,
 		};
 
-		assert!(super::recorded_step_outcome_matches_replayed(&step));
+		assert!(summary::recorded_step_outcome_matches_replayed(&step));
 	}
 
 	#[test]
@@ -1189,7 +1035,7 @@ mod tests {
 			semantic_issue: None,
 		};
 
-		assert!(!super::recorded_step_outcome_matches_replayed(&step));
+		assert!(!summary::recorded_step_outcome_matches_replayed(&step));
 	}
 
 	#[test]

--- a/packages/rsnap-overlay/src/overlay/replay_support/summary.rs
+++ b/packages/rsnap-overlay/src/overlay/replay_support/summary.rs
@@ -1,0 +1,169 @@
+use color_eyre::eyre::{self, Result};
+
+use crate::overlay::{
+	OverlaySession,
+	replay_support::{
+		RecordedScrollCaptureReplayMode, RecordedScrollCaptureReplayRecordedOutcome,
+		RecordedScrollCaptureReplayStepResult, RecordedScrollCaptureReplaySummary,
+		RecordedScrollCaptureSemanticIssue, ReplayStats, ScrollCaptureReplayOutcome,
+	},
+	trace_recording::LoadedScrollCaptureLiveTrace,
+};
+
+pub(super) fn finalize_replay_summary(
+	trace: LoadedScrollCaptureLiveTrace,
+	session: &OverlaySession,
+	replay_stats: ReplayStats,
+	replay_mode: RecordedScrollCaptureReplayMode,
+) -> Result<RecordedScrollCaptureReplaySummary> {
+	let final_session = session.scroll_capture.session.as_ref().ok_or_else(|| {
+		eyre::eyre!("scroll-capture session missing after replaying recorded live trace")
+	})?;
+	let first_outcome_divergence_frame = replay_stats
+		.step_results
+		.iter()
+		.find(|step| !recorded_step_outcome_matches_replayed(step))
+		.map(|step| step.frame_index);
+	let first_export_height_drift_frame = replay_stats
+		.step_results
+		.iter()
+		.find(|step| {
+			step.recorded_export_height.is_some_and(|recorded| recorded != step.export_height)
+		})
+		.map(|step| step.frame_index);
+	let first_preview_height_drift_frame = replay_stats
+		.step_results
+		.iter()
+		.find(|step| {
+			step.recorded_preview_height.is_some_and(|recorded| recorded != step.preview_height)
+		})
+		.map(|step| step.frame_index);
+	let first_semantic_issue_frame = replay_stats
+		.step_results
+		.iter()
+		.find(|step| step.semantic_issue.is_some())
+		.map(|step| step.frame_index);
+	let first_missed_downward_motion_frame = replay_stats
+		.step_results
+		.iter()
+		.find(|step| {
+			matches!(
+				step.semantic_issue,
+				Some(RecordedScrollCaptureSemanticIssue::MissedDownwardMotion)
+			)
+		})
+		.map(|step| step.frame_index);
+	let first_underconsumed_downward_motion_frame = replay_stats
+		.step_results
+		.iter()
+		.find(|step| {
+			matches!(
+				step.semantic_issue,
+				Some(RecordedScrollCaptureSemanticIssue::UnderconsumedDownwardMotion)
+			)
+		})
+		.map(|step| step.frame_index);
+	let first_growth_overshoot_frame = replay_stats
+		.step_results
+		.iter()
+		.find(|step| {
+			matches!(
+				step.semantic_issue,
+				Some(RecordedScrollCaptureSemanticIssue::GrowthExceedsRecordedShift)
+			)
+		})
+		.map(|step| step.frame_index);
+
+	Ok(RecordedScrollCaptureReplaySummary {
+		replay_mode,
+		trace_id: trace.manifest.trace_id.clone(),
+		manifest_path: trace.manifest_path.clone(),
+		final_export_height: final_session.export_image().height(),
+		final_preview_height: session
+			.scroll_capture_preview_dimensions()
+			.map_or(final_session.preview_image().height(), |dimensions| dimensions[1]),
+		final_viewport_top_y: final_session.current_viewport_top_y(),
+		recorded_final_export_height: trace
+			.manifest
+			.final_snapshot
+			.as_ref()
+			.and_then(|snapshot| snapshot.export_dimensions)
+			.map(|dimensions| dimensions[1]),
+		recorded_final_preview_height: trace
+			.manifest
+			.final_snapshot
+			.as_ref()
+			.and_then(|snapshot| snapshot.preview_dimensions)
+			.map(|dimensions| dimensions[1]),
+		final_preview_path: trace
+			.manifest
+			.final_preview_path
+			.as_deref()
+			.map(|path| trace.resolve_frame_path(path)),
+		final_export_path: trace
+			.manifest
+			.final_export_path
+			.as_deref()
+			.map(|path| trace.resolve_frame_path(path)),
+		first_outcome_divergence_frame,
+		first_export_height_drift_frame,
+		first_preview_height_drift_frame,
+		max_recorded_committed_growth_rows: replay_stats.max_recorded_committed_growth_rows,
+		max_replayed_committed_growth_rows: replay_stats.max_replayed_committed_growth_rows,
+		max_recorded_export_jump: replay_stats.max_recorded_export_jump,
+		max_recorded_preview_jump: replay_stats.max_recorded_preview_jump,
+		max_replayed_export_jump: replay_stats.max_replayed_export_jump,
+		max_replayed_preview_jump: replay_stats.max_replayed_preview_jump,
+		first_semantic_issue_frame,
+		first_missed_downward_motion_frame,
+		first_underconsumed_downward_motion_frame,
+		first_growth_overshoot_frame,
+		step_results: replay_stats.step_results,
+	})
+}
+
+pub(super) fn recorded_step_outcome_matches_replayed(
+	step: &RecordedScrollCaptureReplayStepResult,
+) -> bool {
+	if recorded_outcome_matches_replayed(&step.recorded_outcome, step.replayed_outcome) {
+		return true;
+	}
+
+	matches!(
+		(&step.recorded_outcome, step.replayed_outcome),
+		(
+			RecordedScrollCaptureReplayRecordedOutcome::NoChange,
+			ScrollCaptureReplayOutcome::PreviewUpdated,
+		) | (
+			RecordedScrollCaptureReplayRecordedOutcome::PreviewUpdated,
+			ScrollCaptureReplayOutcome::NoChange,
+		)
+	) && step.recorded_export_height == Some(step.export_height)
+		&& step.recorded_preview_height == Some(step.preview_height)
+}
+
+fn recorded_outcome_matches_replayed(
+	recorded: &RecordedScrollCaptureReplayRecordedOutcome,
+	replayed: ScrollCaptureReplayOutcome,
+) -> bool {
+	match (recorded, replayed) {
+		(
+			RecordedScrollCaptureReplayRecordedOutcome::NoChange,
+			ScrollCaptureReplayOutcome::NoChange,
+		) => true,
+		(
+			RecordedScrollCaptureReplayRecordedOutcome::PreviewUpdated,
+			ScrollCaptureReplayOutcome::PreviewUpdated,
+		) => true,
+		(
+			RecordedScrollCaptureReplayRecordedOutcome::Unsupported { direction },
+			ScrollCaptureReplayOutcome::UnsupportedUp,
+		) => *direction == "up",
+		(
+			RecordedScrollCaptureReplayRecordedOutcome::Committed { direction, growth_rows },
+			ScrollCaptureReplayOutcome::CommittedDown { growth_rows: replayed_growth_rows },
+		) => *direction == "down" && *growth_rows == replayed_growth_rows,
+		(RecordedScrollCaptureReplayRecordedOutcome::Error { .. }, _) => false,
+		_ => false,
+	}
+}


### PR DESCRIPTION
## Summary
- Extract replay summary assembly and recorded/replayed outcome equivalence into `overlay/replay_support/summary.rs`
- Keep `replay_support.rs` focused on replay loading, session setup, input/frame replay, and telemetry capture
- Use normal Rust `mod` boundaries; no `include!` or `#[path]` physical splitting

## Validation
- `cargo make fmt-rust`
- `cargo check -p rsnap-overlay --all-targets --all-features`
- `cargo make check-vstyle-rust`
- `cargo test -p rsnap-overlay --all-features overlay::replay_support::` (8 passed)
- `git diff --check`
- forbidden `include!` / `#[path]` scan
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check` (clippy, Swift strict build/vstyle, nextest 682 passed, native host probes passed)

## Skeptic
Fresh read-only skeptic found no blockers. It verified the staged scope, no omitted untracked summary module, normal Rust module extraction, no forbidden split patterns, preserved public surface, coherent ownership boundary, and clean staged diff check. Non-blocking note: finalization field coverage is mostly indirect through public replay tests; outcome equivalence moved behavior remains directly exercised.