### PR TITLE
Modularize window redraw requests

### DIFF
--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -15,6 +15,8 @@ use crate::backend;
 use crate::overlay::MacLiveFrameStream;
 #[cfg(target_os = "macos")]
 use crate::overlay::MacOSHudWindowConfigState;
+#[cfg(target_os = "macos")]
+use crate::overlay::OverlayMode;
 use crate::overlay::hud_geometry::LOUPE_TILE_CORNER_RADIUS_POINTS;
 use crate::overlay::toolbar_geometry::TOOLBAR_EXPANDED_HEIGHT_PX;
 use crate::overlay::toolbar_layout_model;
@@ -23,8 +25,8 @@ use crate::overlay::window_content_policy::CAPTURE_WINDOW_CONTENT_PROTECTION_ENA
 use crate::overlay::{self, macos_cursor_runtime};
 use crate::overlay::{
 	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LogicalPosition, LogicalSize,
-	MonitorRect, OverlayMode, OverlaySession, OverlayWindow, OverlayWorker, Result,
-	ScrollPreviewWindow, WindowLevel, WindowRenderer, hud_helpers,
+	MonitorRect, OverlaySession, OverlayWindow, OverlayWorker, Result, ScrollPreviewWindow,
+	WindowLevel, WindowRenderer, hud_helpers,
 };
 
 impl OverlaySession {

--- a/packages/rsnap-overlay/src/overlay/window_runtime.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime.rs
@@ -1,4 +1,5 @@
 mod monitor_enumeration;
+mod redraw_requests;
 
 use std::collections::HashMap;
 use std::mem;
@@ -21,9 +22,9 @@ use crate::overlay::window_content_policy::CAPTURE_WINDOW_CONTENT_PROTECTION_ENA
 #[cfg(target_os = "macos")]
 use crate::overlay::{self, macos_cursor_runtime};
 use crate::overlay::{
-	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LiveSampleApplyResult,
-	LogicalPosition, LogicalSize, MonitorRect, OverlayMode, OverlaySession, OverlayWindow,
-	OverlayWorker, Result, ScrollPreviewWindow, WindowLevel, WindowRenderer, hud_helpers,
+	ActiveEventLoop, GlobalPoint, GpuContext, HudOverlayWindow, LogicalPosition, LogicalSize,
+	MonitorRect, OverlayMode, OverlaySession, OverlayWindow, OverlayWorker, Result,
+	ScrollPreviewWindow, WindowLevel, WindowRenderer, hud_helpers,
 };
 
 impl OverlaySession {
@@ -823,158 +824,6 @@ impl OverlaySession {
 		self.scroll_preview_window = Some(window);
 
 		Ok(())
-	}
-
-	pub(super) fn request_redraw_all(&self) {
-		for w in self.windows.values() {
-			w.window.request_redraw();
-		}
-
-		if let Some(hud) = self.hud_window.as_ref() {
-			hud.window.request_redraw();
-		}
-		if let Some(loupe) = self.loupe_window.as_ref() {
-			loupe.window.request_redraw();
-		}
-		if let Some(toolbar) = self.toolbar_window.as_ref() {
-			toolbar.window.request_redraw();
-		}
-		if let Some(preview) = self.scroll_preview_window.as_ref() {
-			preview.window.request_redraw();
-		}
-	}
-
-	pub(super) fn request_redraw_for_monitor(&self, monitor: MonitorRect) {
-		for w in self.windows.values() {
-			if w.monitor == monitor {
-				w.window.request_redraw();
-			}
-		}
-
-		let hide_auxiliary_windows = self.frozen_selection_drag_hides_auxiliary_windows();
-		let hide_live_drag_auxiliary_windows = self.live_capture_hides_auxiliary_windows();
-		let request_hud_window = !hide_auxiliary_windows
-			&& !hide_live_drag_auxiliary_windows
-			&& self.hud_window.is_some();
-		let request_loupe_window = !hide_auxiliary_windows
-			&& !hide_live_drag_auxiliary_windows
-			&& self.loupe_window.is_some();
-		let request_toolbar_window = !hide_auxiliary_windows
-			&& cfg!(target_os = "macos")
-			&& self.frozen_display_ready_for_monitor(monitor)
-			&& self.toolbar_state.visible;
-		let request_scroll_preview_window =
-			!hide_auxiliary_windows && self.scroll_preview_window.is_some();
-
-		if tracing::enabled!(tracing::Level::TRACE)
-			&& matches!(self.state.mode, OverlayMode::Frozen)
-			&& self.frozen_selection_drag.active
-			&& self.state.monitor == Some(monitor)
-		{
-			let overlay_windows =
-				self.windows.values().filter(|window| window.monitor == monitor).count();
-
-			tracing::trace!(
-				op = "overlay.frozen_selection_drag.redraw_fanout",
-				monitor_id = monitor.id,
-				overlay_window_count = overlay_windows,
-				request_hud_window,
-				request_loupe_window,
-				request_toolbar_window,
-				request_scroll_preview_window,
-				hide_auxiliary_windows,
-				scroll_capture_active = self.scroll_capture.active,
-				alt_held = self.state.alt_held,
-				"Requested redraw fan-out for frozen selection drag."
-			);
-		}
-		if hide_auxiliary_windows {
-			return;
-		}
-		if request_hud_window && let Some(hud) = self.hud_window.as_ref() {
-			hud.window.request_redraw();
-		}
-		if request_loupe_window && let Some(loupe) = self.loupe_window.as_ref() {
-			loupe.window.request_redraw();
-		}
-		// macOS uses a native toolbar popup window with compositor blur; keep shader-viewport
-		// toolbar redraw on the fullscreen overlay path disabled for this platform.
-		// Future direction: if toolbar styling moves off native blur, add a dedicated capture
-		// pass feeding a toolbar-local shader-blur texture.
-		if request_toolbar_window {
-			self.request_redraw_toolbar_window();
-		}
-		if request_scroll_preview_window {
-			self.request_redraw_scroll_preview_window();
-		}
-	}
-
-	pub(super) fn request_redraw_hud_window(&self) {
-		if self.frozen_selection_drag_hides_auxiliary_windows()
-			|| self.live_capture_hides_auxiliary_windows()
-		{
-			return;
-		}
-
-		if let Some(hud) = self.hud_window.as_ref() {
-			hud.window.request_redraw();
-		}
-	}
-
-	pub(super) fn request_redraw_toolbar_window(&self) {
-		if self.frozen_selection_drag_hides_auxiliary_windows() {
-			return;
-		}
-
-		if let Some(toolbar) = self.toolbar_window.as_ref() {
-			toolbar.window.request_redraw();
-		}
-	}
-
-	pub(super) fn request_redraw_loupe_window(&self) {
-		if self.frozen_selection_drag_hides_auxiliary_windows()
-			|| self.live_capture_hides_auxiliary_windows()
-		{
-			return;
-		}
-
-		if let Some(loupe) = self.loupe_window.as_ref() {
-			loupe.window.request_redraw();
-		}
-	}
-
-	pub(super) fn request_redraw_scroll_preview_window(&self) {
-		if self.frozen_selection_drag_hides_auxiliary_windows() {
-			return;
-		}
-
-		if let Some(preview) = self.scroll_preview_window.as_ref() {
-			preview.window.request_redraw();
-		}
-	}
-
-	pub(super) fn request_redraw_live_sample_targets(
-		&self,
-		monitor: MonitorRect,
-		apply: LiveSampleApplyResult,
-	) {
-		if apply.overlay_changed {
-			for window in self.windows.values() {
-				if window.monitor == monitor {
-					window.window.request_redraw();
-				}
-			}
-		}
-		if apply.hud_changed {
-			self.request_redraw_hud_window();
-		}
-		if apply.loupe_changed {
-			if self.live_loupe_uses_hud_window() {
-				self.request_redraw_hud_window();
-			} else {
-				self.request_redraw_loupe_window();
-			}
-		}
 	}
 }
 

--- a/packages/rsnap-overlay/src/overlay/window_runtime/redraw_requests.rs
+++ b/packages/rsnap-overlay/src/overlay/window_runtime/redraw_requests.rs
@@ -1,0 +1,155 @@
+use crate::overlay::{LiveSampleApplyResult, MonitorRect, OverlayMode, OverlaySession};
+
+impl OverlaySession {
+	pub(in crate::overlay) fn request_redraw_all(&self) {
+		for w in self.windows.values() {
+			w.window.request_redraw();
+		}
+
+		if let Some(hud) = self.hud_window.as_ref() {
+			hud.window.request_redraw();
+		}
+		if let Some(loupe) = self.loupe_window.as_ref() {
+			loupe.window.request_redraw();
+		}
+		if let Some(toolbar) = self.toolbar_window.as_ref() {
+			toolbar.window.request_redraw();
+		}
+		if let Some(preview) = self.scroll_preview_window.as_ref() {
+			preview.window.request_redraw();
+		}
+	}
+
+	pub(in crate::overlay) fn request_redraw_for_monitor(&self, monitor: MonitorRect) {
+		for w in self.windows.values() {
+			if w.monitor == monitor {
+				w.window.request_redraw();
+			}
+		}
+
+		let hide_auxiliary_windows = self.frozen_selection_drag_hides_auxiliary_windows();
+		let hide_live_drag_auxiliary_windows = self.live_capture_hides_auxiliary_windows();
+		let request_hud_window = !hide_auxiliary_windows
+			&& !hide_live_drag_auxiliary_windows
+			&& self.hud_window.is_some();
+		let request_loupe_window = !hide_auxiliary_windows
+			&& !hide_live_drag_auxiliary_windows
+			&& self.loupe_window.is_some();
+		let request_toolbar_window = !hide_auxiliary_windows
+			&& cfg!(target_os = "macos")
+			&& self.frozen_display_ready_for_monitor(monitor)
+			&& self.toolbar_state.visible;
+		let request_scroll_preview_window =
+			!hide_auxiliary_windows && self.scroll_preview_window.is_some();
+
+		if tracing::enabled!(tracing::Level::TRACE)
+			&& matches!(self.state.mode, OverlayMode::Frozen)
+			&& self.frozen_selection_drag.active
+			&& self.state.monitor == Some(monitor)
+		{
+			let overlay_windows =
+				self.windows.values().filter(|window| window.monitor == monitor).count();
+
+			tracing::trace!(
+				op = "overlay.frozen_selection_drag.redraw_fanout",
+				monitor_id = monitor.id,
+				overlay_window_count = overlay_windows,
+				request_hud_window,
+				request_loupe_window,
+				request_toolbar_window,
+				request_scroll_preview_window,
+				hide_auxiliary_windows,
+				scroll_capture_active = self.scroll_capture.active,
+				alt_held = self.state.alt_held,
+				"Requested redraw fan-out for frozen selection drag."
+			);
+		}
+		if hide_auxiliary_windows {
+			return;
+		}
+		if request_hud_window && let Some(hud) = self.hud_window.as_ref() {
+			hud.window.request_redraw();
+		}
+		if request_loupe_window && let Some(loupe) = self.loupe_window.as_ref() {
+			loupe.window.request_redraw();
+		}
+		// macOS uses a native toolbar popup window with compositor blur; keep shader-viewport
+		// toolbar redraw on the fullscreen overlay path disabled for this platform.
+		// Future direction: if toolbar styling moves off native blur, add a dedicated capture
+		// pass feeding a toolbar-local shader-blur texture.
+		if request_toolbar_window {
+			self.request_redraw_toolbar_window();
+		}
+		if request_scroll_preview_window {
+			self.request_redraw_scroll_preview_window();
+		}
+	}
+
+	pub(in crate::overlay) fn request_redraw_hud_window(&self) {
+		if self.frozen_selection_drag_hides_auxiliary_windows()
+			|| self.live_capture_hides_auxiliary_windows()
+		{
+			return;
+		}
+
+		if let Some(hud) = self.hud_window.as_ref() {
+			hud.window.request_redraw();
+		}
+	}
+
+	pub(in crate::overlay) fn request_redraw_toolbar_window(&self) {
+		if self.frozen_selection_drag_hides_auxiliary_windows() {
+			return;
+		}
+
+		if let Some(toolbar) = self.toolbar_window.as_ref() {
+			toolbar.window.request_redraw();
+		}
+	}
+
+	pub(in crate::overlay) fn request_redraw_loupe_window(&self) {
+		if self.frozen_selection_drag_hides_auxiliary_windows()
+			|| self.live_capture_hides_auxiliary_windows()
+		{
+			return;
+		}
+
+		if let Some(loupe) = self.loupe_window.as_ref() {
+			loupe.window.request_redraw();
+		}
+	}
+
+	pub(in crate::overlay) fn request_redraw_scroll_preview_window(&self) {
+		if self.frozen_selection_drag_hides_auxiliary_windows() {
+			return;
+		}
+
+		if let Some(preview) = self.scroll_preview_window.as_ref() {
+			preview.window.request_redraw();
+		}
+	}
+
+	pub(in crate::overlay) fn request_redraw_live_sample_targets(
+		&self,
+		monitor: MonitorRect,
+		apply: LiveSampleApplyResult,
+	) {
+		if apply.overlay_changed {
+			for window in self.windows.values() {
+				if window.monitor == monitor {
+					window.window.request_redraw();
+				}
+			}
+		}
+		if apply.hud_changed {
+			self.request_redraw_hud_window();
+		}
+		if apply.loupe_changed {
+			if self.live_loupe_uses_hud_window() {
+				self.request_redraw_hud_window();
+			} else {
+				self.request_redraw_loupe_window();
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Move window redraw request helpers into overlay/window_runtime/redraw_requests.rs
- Keep normal Rust module boundaries with overlay-scoped visibility for existing sibling callers
- Reduce window_runtime.rs while preserving redraw behavior

## Validation
- cargo make fmt-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo clippy --all-features --all-targets --workspace -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D unused-crate-dependencies -D warnings
- cargo make check-vstyle-rust
- cargo test -p rsnap-overlay --all-features overlay::tests::toolbar_runtime::
- cargo test -p rsnap-overlay --all-features overlay::tests::live_runtime::
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check