### PR TITLE
Modularize capture-frame model types

### DIFF
--- a/packages/rsnap-capture-core/src/capture_frame.rs
+++ b/packages/rsnap-capture-core/src/capture_frame.rs
@@ -1,171 +1,18 @@
 //! Capture-frame layout and rendering owned by the Rust product core.
 
+mod model;
+
+pub use self::model::{
+	CaptureFrameBackgroundKind, CaptureFrameBackgroundPlan, CaptureFrameColorStop,
+	CaptureFramePlan, CaptureFrameRenderImageRef, CaptureFrameRenderKind, CaptureFrameShadow,
+	CaptureFrameSourceKind, CaptureFrameWallpaperRequest,
+};
+
 use color_eyre::eyre::{self, Result, WrapErr};
 use fast_image_resize::images::{Image, ImageRef};
 use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
 
 use crate::{DisplayPointRect, RgbaExportImage};
-
-/// Product source kind used to tune capture-frame styling.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CaptureFrameSourceKind {
-	/// User-dragged region capture.
-	DragRegion,
-	/// Single-window capture.
-	Window,
-	/// Full-screen capture.
-	FullScreen,
-	/// Scroll-capture export.
-	ScrollCapture,
-	/// Unknown or future capture source.
-	Unknown,
-}
-
-/// Capture-frame background preset chosen by the user.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CaptureFrameBackgroundKind {
-	/// Prefer the current system wallpaper with a subtle dark overlay, falling back to Aurora.
-	SystemWallpaper,
-	/// Blue-to-warm product gradient.
-	Aurora,
-	/// Neutral graphite gradient.
-	Graphite,
-	/// Light linen gradient.
-	Linen,
-}
-
-/// Capture-frame render mode.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CaptureFrameRenderKind {
-	/// Draw the capture as a framed object with shadows and rounded clipping.
-	FramedCapture,
-	/// Draw the capture as a floating window snapshot without additional clipping.
-	WindowSnapshot,
-}
-
-/// Borrowed RGBA image consumed by the capture-frame renderer.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CaptureFrameRenderImageRef<'a> {
-	width: u32,
-	height: u32,
-	rgba: &'a [u8],
-}
-impl<'a> CaptureFrameRenderImageRef<'a> {
-	/// Creates a borrowed RGBA image after validating dimensions and byte count.
-	pub fn new(width: u32, height: u32, rgba: &'a [u8]) -> Result<Self> {
-		let expected = expected_rgba_len(width, height)?;
-
-		if rgba.len() != expected {
-			return Err(eyre::eyre!(
-				"capture-frame RGBA byte length mismatch: expected {expected}, got {}",
-				rgba.len()
-			));
-		}
-
-		Ok(Self { width, height, rgba })
-	}
-
-	/// Borrows an owned product-core export image.
-	#[must_use]
-	pub fn from_export(image: &'a RgbaExportImage) -> Self {
-		Self { width: image.width(), height: image.height(), rgba: image.as_raw() }
-	}
-
-	/// Returns image width in pixels.
-	#[must_use]
-	pub const fn width(self) -> u32 {
-		self.width
-	}
-
-	/// Returns image height in pixels.
-	#[must_use]
-	pub const fn height(self) -> u32 {
-		self.height
-	}
-
-	/// Returns raw row-major RGBA bytes.
-	#[must_use]
-	pub const fn rgba(self) -> &'a [u8] {
-		self.rgba
-	}
-}
-
-/// One sRGB capture-frame background color stop.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct CaptureFrameColorStop {
-	/// Red component in sRGB space.
-	pub red: f64,
-	/// Green component in sRGB space.
-	pub green: f64,
-	/// Blue component in sRGB space.
-	pub blue: f64,
-	/// Alpha component.
-	pub alpha: f64,
-}
-impl CaptureFrameColorStop {
-	/// Creates an sRGB color stop.
-	#[must_use]
-	pub const fn new(red: f64, green: f64, blue: f64, alpha: f64) -> Self {
-		Self { red, green, blue, alpha }
-	}
-}
-
-/// Capture-frame background plan consumed by native hosts.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct CaptureFrameBackgroundPlan {
-	/// Ordered sRGB gradient color stops.
-	pub colors: [CaptureFrameColorStop; 3],
-	/// Gradient locations matching `colors`.
-	pub locations: [f64; 3],
-	/// Whether the host should first try drawing the system wallpaper.
-	pub prefers_wallpaper: bool,
-	/// Overlay alpha applied when wallpaper drawing succeeds.
-	pub wallpaper_overlay_alpha: f64,
-}
-
-/// Platform wallpaper thumbnail request planned by the Rust product core.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct CaptureFrameWallpaperRequest {
-	/// Maximum thumbnail dimension requested from the platform image pipeline.
-	pub target_pixel_size: u32,
-	/// Overlay alpha applied after drawing the wallpaper thumbnail.
-	pub overlay_alpha: f64,
-}
-
-/// One capture-frame shadow pass.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct CaptureFrameShadow {
-	/// Horizontal shadow offset in output pixels.
-	pub offset_x: f64,
-	/// Vertical shadow offset in output pixels.
-	pub offset_y: f64,
-	/// Shadow blur radius in output pixels.
-	pub blur: f64,
-	/// Shadow alpha.
-	pub alpha: f64,
-}
-impl CaptureFrameShadow {
-	/// Creates a shadow pass.
-	#[must_use]
-	pub const fn new(offset_x: f64, offset_y: f64, blur: f64, alpha: f64) -> Self {
-		Self { offset_x, offset_y, blur, alpha }
-	}
-}
-
-/// Capture-frame plan consumed by native hosts for final drawing.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct CaptureFramePlan {
-	/// Canvas width in output pixels.
-	pub canvas_width: f64,
-	/// Canvas height in output pixels.
-	pub canvas_height: f64,
-	/// Image placement inside the canvas.
-	pub image_rect: DisplayPointRect,
-	/// Rounded capture corner radius.
-	pub corner_radius: f64,
-	/// Ordered shadow passes behind the framed capture.
-	pub shadows: [CaptureFrameShadow; 3],
-}
 
 /// Resolves capture-frame layout, rounded-corner, and shadow parameters.
 #[must_use]
@@ -336,7 +183,7 @@ pub fn render_capture_frame_effect(
 	};
 	let canvas_width = finite_canvas_dimension(plan.canvas_width)?;
 	let canvas_height = finite_canvas_dimension(plan.canvas_height)?;
-	let canvas_len = expected_rgba_len(canvas_width, canvas_height)?;
+	let canvas_len = model::expected_rgba_len(canvas_width, canvas_height)?;
 	let mut canvas = vec![0_u8; canvas_len];
 
 	draw_capture_frame_background(
@@ -817,7 +664,7 @@ fn resize_rgba_exact(
 	destination_width: u32,
 	destination_height: u32,
 ) -> Result<Vec<u8>> {
-	let expected = expected_rgba_len(source_width, source_height)?;
+	let expected = model::expected_rgba_len(source_width, source_height)?;
 
 	if source_rgba.len() != expected {
 		return Err(eyre::eyre!(
@@ -896,19 +743,6 @@ fn lerp(start: f64, end: f64, t: f64) -> f64 {
 
 fn unit_to_u8(value: f64) -> u8 {
 	(value.clamp(0.0, 1.0) * 255.0).round() as u8
-}
-
-fn expected_rgba_len(width: u32, height: u32) -> Result<usize> {
-	if width == 0 || height == 0 {
-		return Err(eyre::eyre!(
-			"capture-frame RGBA dimensions must be non-zero: width={width}, height={height}"
-		));
-	}
-
-	(width as usize)
-		.checked_mul(height as usize)
-		.and_then(|pixels| pixels.checked_mul(4))
-		.ok_or_else(|| eyre::eyre!("capture-frame RGBA byte length overflow"))
 }
 
 #[cfg(test)]

--- a/packages/rsnap-capture-core/src/capture_frame/model.rs
+++ b/packages/rsnap-capture-core/src/capture_frame/model.rs
@@ -1,0 +1,177 @@
+use color_eyre::eyre::{self, Result};
+
+use crate::{DisplayPointRect, RgbaExportImage};
+
+/// Product source kind used to tune capture-frame styling.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CaptureFrameSourceKind {
+	/// User-dragged region capture.
+	DragRegion,
+	/// Single-window capture.
+	Window,
+	/// Full-screen capture.
+	FullScreen,
+	/// Scroll-capture export.
+	ScrollCapture,
+	/// Unknown or future capture source.
+	Unknown,
+}
+
+/// Capture-frame background preset chosen by the user.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CaptureFrameBackgroundKind {
+	/// Prefer the current system wallpaper with a subtle dark overlay, falling back to Aurora.
+	SystemWallpaper,
+	/// Blue-to-warm product gradient.
+	Aurora,
+	/// Neutral graphite gradient.
+	Graphite,
+	/// Light linen gradient.
+	Linen,
+}
+
+/// Capture-frame render mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CaptureFrameRenderKind {
+	/// Draw the capture as a framed object with shadows and rounded clipping.
+	FramedCapture,
+	/// Draw the capture as a floating window snapshot without additional clipping.
+	WindowSnapshot,
+}
+
+/// Borrowed RGBA image consumed by the capture-frame renderer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CaptureFrameRenderImageRef<'a> {
+	width: u32,
+	height: u32,
+	rgba: &'a [u8],
+}
+impl<'a> CaptureFrameRenderImageRef<'a> {
+	/// Creates a borrowed RGBA image after validating dimensions and byte count.
+	pub fn new(width: u32, height: u32, rgba: &'a [u8]) -> Result<Self> {
+		let expected = expected_rgba_len(width, height)?;
+
+		if rgba.len() != expected {
+			return Err(eyre::eyre!(
+				"capture-frame RGBA byte length mismatch: expected {expected}, got {}",
+				rgba.len()
+			));
+		}
+
+		Ok(Self { width, height, rgba })
+	}
+
+	/// Borrows an owned product-core export image.
+	#[must_use]
+	pub fn from_export(image: &'a RgbaExportImage) -> Self {
+		Self { width: image.width(), height: image.height(), rgba: image.as_raw() }
+	}
+
+	/// Returns image width in pixels.
+	#[must_use]
+	pub const fn width(self) -> u32 {
+		self.width
+	}
+
+	/// Returns image height in pixels.
+	#[must_use]
+	pub const fn height(self) -> u32 {
+		self.height
+	}
+
+	/// Returns raw row-major RGBA bytes.
+	#[must_use]
+	pub const fn rgba(self) -> &'a [u8] {
+		self.rgba
+	}
+}
+
+/// One sRGB capture-frame background color stop.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CaptureFrameColorStop {
+	/// Red component in sRGB space.
+	pub red: f64,
+	/// Green component in sRGB space.
+	pub green: f64,
+	/// Blue component in sRGB space.
+	pub blue: f64,
+	/// Alpha component.
+	pub alpha: f64,
+}
+impl CaptureFrameColorStop {
+	/// Creates an sRGB color stop.
+	#[must_use]
+	pub const fn new(red: f64, green: f64, blue: f64, alpha: f64) -> Self {
+		Self { red, green, blue, alpha }
+	}
+}
+
+/// Capture-frame background plan consumed by native hosts.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CaptureFrameBackgroundPlan {
+	/// Ordered sRGB gradient color stops.
+	pub colors: [CaptureFrameColorStop; 3],
+	/// Gradient locations matching `colors`.
+	pub locations: [f64; 3],
+	/// Whether the host should first try drawing the system wallpaper.
+	pub prefers_wallpaper: bool,
+	/// Overlay alpha applied when wallpaper drawing succeeds.
+	pub wallpaper_overlay_alpha: f64,
+}
+
+/// Platform wallpaper thumbnail request planned by the Rust product core.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CaptureFrameWallpaperRequest {
+	/// Maximum thumbnail dimension requested from the platform image pipeline.
+	pub target_pixel_size: u32,
+	/// Overlay alpha applied after drawing the wallpaper thumbnail.
+	pub overlay_alpha: f64,
+}
+
+/// One capture-frame shadow pass.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CaptureFrameShadow {
+	/// Horizontal shadow offset in output pixels.
+	pub offset_x: f64,
+	/// Vertical shadow offset in output pixels.
+	pub offset_y: f64,
+	/// Shadow blur radius in output pixels.
+	pub blur: f64,
+	/// Shadow alpha.
+	pub alpha: f64,
+}
+impl CaptureFrameShadow {
+	/// Creates a shadow pass.
+	#[must_use]
+	pub const fn new(offset_x: f64, offset_y: f64, blur: f64, alpha: f64) -> Self {
+		Self { offset_x, offset_y, blur, alpha }
+	}
+}
+
+/// Capture-frame plan consumed by native hosts for final drawing.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CaptureFramePlan {
+	/// Canvas width in output pixels.
+	pub canvas_width: f64,
+	/// Canvas height in output pixels.
+	pub canvas_height: f64,
+	/// Image placement inside the canvas.
+	pub image_rect: DisplayPointRect,
+	/// Rounded capture corner radius.
+	pub corner_radius: f64,
+	/// Ordered shadow passes behind the framed capture.
+	pub shadows: [CaptureFrameShadow; 3],
+}
+
+pub(super) fn expected_rgba_len(width: u32, height: u32) -> Result<usize> {
+	if width == 0 || height == 0 {
+		return Err(eyre::eyre!(
+			"capture-frame RGBA dimensions must be non-zero: width={width}, height={height}"
+		));
+	}
+
+	(width as usize)
+		.checked_mul(height as usize)
+		.and_then(|pixels| pixels.checked_mul(4))
+		.ok_or_else(|| eyre::eyre!("capture-frame RGBA byte length overflow"))
+}


### PR DESCRIPTION
## Summary
- extract capture-frame public model/value types into a dedicated Rust module
- keep the existing capture_frame public API through re-exports
- share RGBA byte-length validation through the model boundary without include/path tricks

## Validation
- cargo make fmt-rust
- cargo check -p rsnap-capture-core --all-targets --all-features
- cargo make check-rust
- cargo make check-vstyle-rust
- cargo test -p rsnap-capture-core --all-features capture_frame::tests::
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts (no matches)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check