### PR TITLE
Modularize frozen export stroke rasterization

### DIFF
--- a/packages/rsnap-overlay/src/frozen_export.rs
+++ b/packages/rsnap-overlay/src/frozen_export.rs
@@ -1,5 +1,7 @@
 //! Portable frozen-overlay export compositing used by native hosts.
 
+mod stroke_raster;
+
 use std::f32::consts::PI;
 
 use color_eyre::eyre::{self, Result};
@@ -402,7 +404,7 @@ fn render_spotlight_border(
 	let bottom = rect.y + rect.height - inset;
 	let color = with_scaled_alpha(style.border_rgba, STROKE_EXPORT_ALPHA);
 
-	draw_segments(
+	stroke_raster::draw_segments(
 		image,
 		&[
 			(Pos2::new(left, top), Pos2::new(right, top)),
@@ -431,7 +433,7 @@ fn render_pen_annotations(
 			.collect::<Vec<_>>();
 		let color = Rgba(with_scaled_alpha(annotation.style.rgba, STROKE_EXPORT_ALPHA));
 
-		draw_polyline(
+		stroke_raster::draw_polyline(
 			image,
 			&points,
 			annotation.style.stroke_width_points * transform.scalar_scale(),
@@ -473,7 +475,7 @@ fn render_arrow_annotation(
 	let stroke_width = annotation.style.stroke_width_points * 1.4 * transform.scalar_scale();
 	let color = Rgba(with_scaled_alpha(annotation.style.rgba, STROKE_EXPORT_ALPHA));
 
-	draw_segments(
+	stroke_raster::draw_segments(
 		image,
 		&[(start, geometry.shaft_end), (end, geometry.head_left), (end, geometry.head_right)],
 		stroke_width,
@@ -531,294 +533,6 @@ fn text_shadow_rgba(fill: [u8; 4]) -> [u8; 4] {
 	} else {
 		DARK_TEXT_SHADOW_RGBA
 	}
-}
-
-fn draw_polyline(image: &mut RgbaImage, points: &[Pos2], line_width: f32, color: Rgba<u8>) {
-	if points.is_empty() || line_width <= f32::EPSILON {
-		return;
-	}
-	if points.len() == 1 {
-		draw_segments(image, &[(points[0], points[0])], line_width, color);
-
-		return;
-	}
-
-	let segments = points.windows(2).map(|points| (points[0], points[1])).collect::<Vec<_>>();
-
-	draw_segments(image, &segments, line_width, color);
-}
-
-fn draw_segments(
-	image: &mut RgbaImage,
-	segments: &[(Pos2, Pos2)],
-	line_width: f32,
-	color: Rgba<u8>,
-) {
-	if segments.is_empty() || image.width() == 0 || image.height() == 0 {
-		return;
-	}
-
-	let radius = (line_width * 0.5).max(0.5);
-	let Some(mask_rect) = segments_pixel_bounds(segments, image.width(), image.height(), radius)
-	else {
-		return;
-	};
-	let mut coverage_mask = vec![0_u8; mask_rect.width as usize * mask_rect.height as usize];
-
-	for (start, end) in segments {
-		rasterize_segment(
-			&mut coverage_mask,
-			mask_rect,
-			image.width(),
-			image.height(),
-			*start,
-			*end,
-			radius,
-		);
-	}
-
-	blend_coverage_mask(image, mask_rect, &coverage_mask, color);
-}
-
-fn rasterize_segment(
-	coverage_mask: &mut [u8],
-	mask_rect: PixelRect,
-	width: u32,
-	height: u32,
-	start: Pos2,
-	end: Pos2,
-	radius: f32,
-) {
-	let delta = end - start;
-	let delta_len_sq = delta.length_sq();
-
-	if delta_len_sq <= f32::EPSILON {
-		rasterize_circle(coverage_mask, mask_rect, width, height, start, radius);
-
-		return;
-	}
-
-	let Some(bounds) = segment_pixel_bounds(start, end, width, height, radius)
-		.and_then(|bounds| intersect_pixel_rect(bounds, mask_rect))
-	else {
-		return;
-	};
-
-	for y in bounds.y..bounds.y + bounds.height {
-		for x in bounds.x..bounds.x + bounds.width {
-			let sample = Pos2::new(x as f32 + 0.5, y as f32 + 0.5);
-			let projection = ((sample - start).dot(delta) / delta_len_sq).clamp(0.0, 1.0);
-			let nearest = start + delta * projection;
-
-			update_coverage_mask(
-				coverage_mask,
-				mask_rect,
-				x,
-				y,
-				stroke_coverage(sample.distance(nearest), radius),
-			);
-		}
-	}
-}
-
-fn rasterize_circle(
-	coverage_mask: &mut [u8],
-	mask_rect: PixelRect,
-	width: u32,
-	height: u32,
-	center: Pos2,
-	radius: f32,
-) {
-	let Some(bounds) = circle_pixel_bounds(center, width, height, radius)
-		.and_then(|bounds| intersect_pixel_rect(bounds, mask_rect))
-	else {
-		return;
-	};
-
-	for y in bounds.y..bounds.y + bounds.height {
-		for x in bounds.x..bounds.x + bounds.width {
-			let sample = Pos2::new(x as f32 + 0.5, y as f32 + 0.5);
-
-			update_coverage_mask(
-				coverage_mask,
-				mask_rect,
-				x,
-				y,
-				stroke_coverage(sample.distance(center), radius),
-			);
-		}
-	}
-}
-
-fn segments_pixel_bounds(
-	segments: &[(Pos2, Pos2)],
-	width: u32,
-	height: u32,
-	radius: f32,
-) -> Option<PixelRect> {
-	let mut bounds = None;
-
-	for (start, end) in segments {
-		let Some(segment_bounds) = segment_pixel_bounds(*start, *end, width, height, radius) else {
-			continue;
-		};
-
-		bounds = Some(match bounds {
-			Some(bounds) => union_pixel_rect(bounds, segment_bounds),
-			None => segment_bounds,
-		});
-	}
-
-	bounds
-}
-
-fn segment_pixel_bounds(
-	start: Pos2,
-	end: Pos2,
-	width: u32,
-	height: u32,
-	radius: f32,
-) -> Option<PixelRect> {
-	pixel_bounds(
-		start.x.min(end.x) - radius - 0.5,
-		start.y.min(end.y) - radius - 0.5,
-		start.x.max(end.x) + radius + 0.5,
-		start.y.max(end.y) + radius + 0.5,
-		width,
-		height,
-	)
-}
-
-fn circle_pixel_bounds(center: Pos2, width: u32, height: u32, radius: f32) -> Option<PixelRect> {
-	pixel_bounds(
-		center.x - radius - 0.5,
-		center.y - radius - 0.5,
-		center.x + radius + 0.5,
-		center.y + radius + 0.5,
-		width,
-		height,
-	)
-}
-
-fn pixel_bounds(
-	min_x: f32,
-	min_y: f32,
-	max_x: f32,
-	max_y: f32,
-	width: u32,
-	height: u32,
-) -> Option<PixelRect> {
-	if !min_x.is_finite() || !min_y.is_finite() || !max_x.is_finite() || !max_y.is_finite() {
-		return None;
-	}
-
-	let left = min_x.floor().max(0.0) as u32;
-	let top = min_y.floor().max(0.0) as u32;
-	let right = (max_x.ceil() + 1.0).clamp(0.0, width as f32) as u32;
-	let bottom = (max_y.ceil() + 1.0).clamp(0.0, height as f32) as u32;
-
-	if left >= right || top >= bottom {
-		return None;
-	}
-
-	Some(PixelRect { x: left, y: top, width: right - left, height: bottom - top })
-}
-
-fn intersect_pixel_rect(first: PixelRect, second: PixelRect) -> Option<PixelRect> {
-	let left = first.x.max(second.x);
-	let top = first.y.max(second.y);
-	let right = (first.x + first.width).min(second.x + second.width);
-	let bottom = (first.y + first.height).min(second.y + second.height);
-
-	if left >= right || top >= bottom {
-		return None;
-	}
-
-	Some(PixelRect { x: left, y: top, width: right - left, height: bottom - top })
-}
-
-fn union_pixel_rect(first: PixelRect, second: PixelRect) -> PixelRect {
-	let left = first.x.min(second.x);
-	let top = first.y.min(second.y);
-	let right = (first.x + first.width).max(second.x + second.width);
-	let bottom = (first.y + first.height).max(second.y + second.height);
-
-	PixelRect { x: left, y: top, width: right - left, height: bottom - top }
-}
-
-fn stroke_coverage(distance: f32, radius: f32) -> u8 {
-	((radius + 0.5 - distance).clamp(0.0, 1.0) * 255.0).round() as u8
-}
-
-fn update_coverage_mask(
-	coverage_mask: &mut [u8],
-	mask_rect: PixelRect,
-	x: u32,
-	y: u32,
-	coverage: u8,
-) {
-	if coverage == 0 {
-		return;
-	}
-
-	let index = (y - mask_rect.y) as usize * mask_rect.width as usize + (x - mask_rect.x) as usize;
-
-	coverage_mask[index] = coverage_mask[index].max(coverage);
-}
-
-fn blend_coverage_mask(
-	image: &mut RgbaImage,
-	mask_rect: PixelRect,
-	coverage_mask: &[u8],
-	color: Rgba<u8>,
-) {
-	let source_alpha = f32::from(color[3]) / 255.0;
-	let image_width = image.width() as usize;
-	let image_bytes = image.as_mut();
-	let mask_width = mask_rect.width as usize;
-	let left = mask_rect.x as usize;
-	let top = mask_rect.y as usize;
-
-	for local_y in 0..mask_rect.height as usize {
-		let mask_row_start = local_y * mask_width;
-		let image_row_start = ((top + local_y) * image_width + left) * 4;
-
-		for local_x in 0..mask_width {
-			let mask_alpha = coverage_mask[mask_row_start + local_x];
-
-			if mask_alpha == 0 {
-				continue;
-			}
-
-			let pixel_start = image_row_start + local_x * 4;
-			let pixel_end = pixel_start + 4;
-
-			blend_pixel_channels(
-				&mut image_bytes[pixel_start..pixel_end],
-				color,
-				f32::from(mask_alpha) / 255.0 * source_alpha,
-			);
-		}
-	}
-}
-
-fn blend_pixel_channels(pixel: &mut [u8], color: Rgba<u8>, src_a: f32) {
-	let dst_a = f32::from(pixel[3]) / 255.0;
-	let out_a = src_a + dst_a * (1.0 - src_a);
-
-	if out_a <= f32::EPSILON {
-		return;
-	}
-
-	for channel in 0..3 {
-		let src = f32::from(color[channel]) / 255.0;
-		let dst = f32::from(pixel[channel]) / 255.0;
-		let out = (src * src_a + dst * dst_a * (1.0 - src_a)) / out_a;
-
-		pixel[channel] = (out * 255.0).round().clamp(0.0, 255.0) as u8;
-	}
-
-	pixel[3] = (out_a * 255.0).round().clamp(0.0, 255.0) as u8;
 }
 
 fn with_scaled_alpha(mut rgba: [u8; 4], scale: f32) -> [u8; 4] {

--- a/packages/rsnap-overlay/src/frozen_export/stroke_raster.rs
+++ b/packages/rsnap-overlay/src/frozen_export/stroke_raster.rs
@@ -1,0 +1,339 @@
+use egui::Pos2;
+use image::{Rgba, RgbaImage};
+
+#[derive(Clone, Copy, Debug)]
+struct PixelRect {
+	x: u32,
+	y: u32,
+	width: u32,
+	height: u32,
+}
+
+pub(super) fn draw_polyline(
+	image: &mut RgbaImage,
+	points: &[Pos2],
+	line_width: f32,
+	color: Rgba<u8>,
+) {
+	if points.is_empty() || line_width <= f32::EPSILON {
+		return;
+	}
+	if points.len() == 1 {
+		draw_segments(image, &[(points[0], points[0])], line_width, color);
+
+		return;
+	}
+
+	let segments = points.windows(2).map(|points| (points[0], points[1])).collect::<Vec<_>>();
+
+	draw_segments(image, &segments, line_width, color);
+}
+
+pub(super) fn draw_segments(
+	image: &mut RgbaImage,
+	segments: &[(Pos2, Pos2)],
+	line_width: f32,
+	color: Rgba<u8>,
+) {
+	if segments.is_empty() || image.width() == 0 || image.height() == 0 {
+		return;
+	}
+
+	let radius = (line_width * 0.5).max(0.5);
+	let Some(mask_rect) = segments_pixel_bounds(segments, image.width(), image.height(), radius)
+	else {
+		return;
+	};
+	let mut coverage_mask = vec![0_u8; mask_rect.width as usize * mask_rect.height as usize];
+
+	for (start, end) in segments {
+		rasterize_segment(
+			&mut coverage_mask,
+			mask_rect,
+			image.width(),
+			image.height(),
+			*start,
+			*end,
+			radius,
+		);
+	}
+
+	blend_coverage_mask(image, mask_rect, &coverage_mask, color);
+}
+
+fn rasterize_segment(
+	coverage_mask: &mut [u8],
+	mask_rect: PixelRect,
+	width: u32,
+	height: u32,
+	start: Pos2,
+	end: Pos2,
+	radius: f32,
+) {
+	let delta = end - start;
+	let delta_len_sq = delta.length_sq();
+
+	if delta_len_sq <= f32::EPSILON {
+		rasterize_circle(coverage_mask, mask_rect, width, height, start, radius);
+
+		return;
+	}
+
+	let Some(bounds) = segment_pixel_bounds(start, end, width, height, radius)
+		.and_then(|bounds| intersect_pixel_rect(bounds, mask_rect))
+	else {
+		return;
+	};
+
+	for y in bounds.y..bounds.y + bounds.height {
+		for x in bounds.x..bounds.x + bounds.width {
+			let sample = Pos2::new(x as f32 + 0.5, y as f32 + 0.5);
+			let projection = ((sample - start).dot(delta) / delta_len_sq).clamp(0.0, 1.0);
+			let nearest = start + delta * projection;
+
+			update_coverage_mask(
+				coverage_mask,
+				mask_rect,
+				x,
+				y,
+				stroke_coverage(sample.distance(nearest), radius),
+			);
+		}
+	}
+}
+
+fn rasterize_circle(
+	coverage_mask: &mut [u8],
+	mask_rect: PixelRect,
+	width: u32,
+	height: u32,
+	center: Pos2,
+	radius: f32,
+) {
+	let Some(bounds) = circle_pixel_bounds(center, width, height, radius)
+		.and_then(|bounds| intersect_pixel_rect(bounds, mask_rect))
+	else {
+		return;
+	};
+
+	for y in bounds.y..bounds.y + bounds.height {
+		for x in bounds.x..bounds.x + bounds.width {
+			let sample = Pos2::new(x as f32 + 0.5, y as f32 + 0.5);
+
+			update_coverage_mask(
+				coverage_mask,
+				mask_rect,
+				x,
+				y,
+				stroke_coverage(sample.distance(center), radius),
+			);
+		}
+	}
+}
+
+fn segments_pixel_bounds(
+	segments: &[(Pos2, Pos2)],
+	width: u32,
+	height: u32,
+	radius: f32,
+) -> Option<PixelRect> {
+	let mut bounds = None;
+
+	for (start, end) in segments {
+		let Some(segment_bounds) = segment_pixel_bounds(*start, *end, width, height, radius) else {
+			continue;
+		};
+
+		bounds = Some(match bounds {
+			Some(bounds) => union_pixel_rect(bounds, segment_bounds),
+			None => segment_bounds,
+		});
+	}
+
+	bounds
+}
+
+fn segment_pixel_bounds(
+	start: Pos2,
+	end: Pos2,
+	width: u32,
+	height: u32,
+	radius: f32,
+) -> Option<PixelRect> {
+	pixel_bounds(
+		start.x.min(end.x) - radius - 0.5,
+		start.y.min(end.y) - radius - 0.5,
+		start.x.max(end.x) + radius + 0.5,
+		start.y.max(end.y) + radius + 0.5,
+		width,
+		height,
+	)
+}
+
+fn circle_pixel_bounds(center: Pos2, width: u32, height: u32, radius: f32) -> Option<PixelRect> {
+	pixel_bounds(
+		center.x - radius - 0.5,
+		center.y - radius - 0.5,
+		center.x + radius + 0.5,
+		center.y + radius + 0.5,
+		width,
+		height,
+	)
+}
+
+fn pixel_bounds(
+	min_x: f32,
+	min_y: f32,
+	max_x: f32,
+	max_y: f32,
+	width: u32,
+	height: u32,
+) -> Option<PixelRect> {
+	if !min_x.is_finite() || !min_y.is_finite() || !max_x.is_finite() || !max_y.is_finite() {
+		return None;
+	}
+
+	let left = min_x.floor().max(0.0) as u32;
+	let top = min_y.floor().max(0.0) as u32;
+	let right = (max_x.ceil() + 1.0).clamp(0.0, width as f32) as u32;
+	let bottom = (max_y.ceil() + 1.0).clamp(0.0, height as f32) as u32;
+
+	if left >= right || top >= bottom {
+		return None;
+	}
+
+	Some(PixelRect { x: left, y: top, width: right - left, height: bottom - top })
+}
+
+fn intersect_pixel_rect(first: PixelRect, second: PixelRect) -> Option<PixelRect> {
+	let left = first.x.max(second.x);
+	let top = first.y.max(second.y);
+	let right = (first.x + first.width).min(second.x + second.width);
+	let bottom = (first.y + first.height).min(second.y + second.height);
+
+	if left >= right || top >= bottom {
+		return None;
+	}
+
+	Some(PixelRect { x: left, y: top, width: right - left, height: bottom - top })
+}
+
+fn union_pixel_rect(first: PixelRect, second: PixelRect) -> PixelRect {
+	let left = first.x.min(second.x);
+	let top = first.y.min(second.y);
+	let right = (first.x + first.width).max(second.x + second.width);
+	let bottom = (first.y + first.height).max(second.y + second.height);
+
+	PixelRect { x: left, y: top, width: right - left, height: bottom - top }
+}
+
+fn stroke_coverage(distance: f32, radius: f32) -> u8 {
+	((radius + 0.5 - distance).clamp(0.0, 1.0) * 255.0).round() as u8
+}
+
+fn update_coverage_mask(
+	coverage_mask: &mut [u8],
+	mask_rect: PixelRect,
+	x: u32,
+	y: u32,
+	coverage: u8,
+) {
+	if coverage == 0 {
+		return;
+	}
+
+	let index = (y - mask_rect.y) as usize * mask_rect.width as usize + (x - mask_rect.x) as usize;
+
+	coverage_mask[index] = coverage_mask[index].max(coverage);
+}
+
+fn blend_coverage_mask(
+	image: &mut RgbaImage,
+	mask_rect: PixelRect,
+	coverage_mask: &[u8],
+	color: Rgba<u8>,
+) {
+	let source_alpha = f32::from(color[3]) / 255.0;
+	let image_width = image.width() as usize;
+	let image_bytes = image.as_mut();
+	let mask_width = mask_rect.width as usize;
+	let left = mask_rect.x as usize;
+	let top = mask_rect.y as usize;
+
+	for local_y in 0..mask_rect.height as usize {
+		let mask_row_start = local_y * mask_width;
+		let image_row_start = ((top + local_y) * image_width + left) * 4;
+
+		for local_x in 0..mask_width {
+			let mask_alpha = coverage_mask[mask_row_start + local_x];
+
+			if mask_alpha == 0 {
+				continue;
+			}
+
+			let pixel_start = image_row_start + local_x * 4;
+			let pixel_end = pixel_start + 4;
+
+			blend_pixel_channels(
+				&mut image_bytes[pixel_start..pixel_end],
+				color,
+				f32::from(mask_alpha) / 255.0 * source_alpha,
+			);
+		}
+	}
+}
+
+fn blend_pixel_channels(pixel: &mut [u8], color: Rgba<u8>, src_a: f32) {
+	let dst_a = f32::from(pixel[3]) / 255.0;
+	let out_a = src_a + dst_a * (1.0 - src_a);
+
+	if out_a <= f32::EPSILON {
+		return;
+	}
+
+	for channel in 0..3 {
+		let src = f32::from(color[channel]) / 255.0;
+		let dst = f32::from(pixel[channel]) / 255.0;
+		let out = (src * src_a + dst * dst_a * (1.0 - src_a)) / out_a;
+
+		pixel[channel] = (out * 255.0).round().clamp(0.0, 255.0) as u8;
+	}
+
+	pixel[3] = (out_a * 255.0).round().clamp(0.0, 255.0) as u8;
+}
+
+#[cfg(test)]
+mod tests {
+	use egui::Pos2;
+	use image::{Rgba, RgbaImage};
+
+	use crate::frozen_export::stroke_raster;
+
+	#[test]
+	fn draw_polyline_renders_single_point_strokes() {
+		let mut image = RgbaImage::from_pixel(8, 8, Rgba([0, 0, 0, 255]));
+
+		stroke_raster::draw_polyline(
+			&mut image,
+			&[Pos2::new(4.0, 4.0)],
+			2.0,
+			Rgba([255, 0, 0, 255]),
+		);
+
+		assert!(image.pixels().any(|pixel| pixel[0] > 0));
+	}
+
+	#[test]
+	fn draw_segments_skips_non_finite_bounds() {
+		let mut image = RgbaImage::from_pixel(8, 8, Rgba([0, 0, 0, 255]));
+
+		stroke_raster::draw_segments(
+			&mut image,
+			&[(Pos2::new(f32::NAN, 4.0), Pos2::new(4.0, 4.0))],
+			2.0,
+			Rgba([255, 0, 0, 255]),
+		);
+
+		assert!(image.pixels().all(|pixel| *pixel == Rgba([0, 0, 0, 255])));
+	}
+}


### PR DESCRIPTION
## Summary
- Extract frozen-overlay export stroke rasterization into a normal Rust child module
- Keep the compositor surface focused on export ordering, transforms, mosaics, spotlights, arrows, and text
- Add stroke-raster boundary tests for single-point strokes and non-finite segment bounds

## Validation
- cargo make fmt-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features frozen_export
- cargo make check-vstyle-rust
- cargo make check-rust
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts; test $? -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Skeptic
- Read-only skeptic: no blockers