### PR TITLE
Modularize backend macOS region capture

### DIFF
--- a/packages/rsnap-overlay/src/backend.rs
+++ b/packages/rsnap-overlay/src/backend.rs
@@ -4,13 +4,11 @@
 )]
 
 mod image_capture;
+#[cfg(target_os = "macos")]
+mod macos_region_capture;
 mod window_list;
 
-#[cfg(target_os = "macos")]
-use std::collections::HashMap;
 use std::sync::Arc;
-#[cfg(target_os = "macos")]
-use std::thread;
 use std::time::{Duration, Instant};
 
 #[cfg(target_os = "macos")]
@@ -27,8 +25,6 @@ use objc2_core_foundation::CGRect;
 use objc2_core_graphics::{CGDisplayCreateImage, CGWindowListCreateImage};
 #[cfg(target_os = "macos")]
 use objc2_core_graphics::{CGRectNull, CGWindowID, CGWindowImageOption, CGWindowListOption};
-#[cfg(target_os = "macos")]
-use objc2_foundation::NSProcessInfo;
 use thiserror::Error;
 #[cfg(not(target_os = "macos"))]
 use xcap::Window;
@@ -39,11 +35,6 @@ use crate::state::{
 	GlobalPoint, LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints, Rgb, WindowHit,
 	WindowListSnapshot,
 };
-
-#[cfg(target_os = "macos")]
-const MACOS_REGION_FRAME_WAIT_TIMEOUT: Duration = Duration::from_millis(120);
-#[cfg(target_os = "macos")]
-const MACOS_REGION_FRAME_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(8);
 
 /// Capture backend contract used by the overlay worker.
 pub trait CaptureBackend: Send {
@@ -242,7 +233,7 @@ pub struct XcapCaptureBackend {
 	#[cfg(target_os = "macos")]
 	live_frame_stream: MacLiveFrameStream,
 	#[cfg(target_os = "macos")]
-	last_region_capture: HashMap<u32, MacosRegionCaptureState>,
+	region_capture_tracker: macos_region_capture::RegionCaptureTracker,
 }
 impl XcapCaptureBackend {
 	#[must_use]
@@ -271,7 +262,7 @@ impl XcapCaptureBackend {
 				self_capture_exception_window_ids,
 			),
 			#[cfg(target_os = "macos")]
-			last_region_capture: HashMap::new(),
+			region_capture_tracker: macos_region_capture::RegionCaptureTracker::default(),
 		}
 	}
 
@@ -422,52 +413,11 @@ impl XcapCaptureBackend {
 		monitor: MonitorRect,
 		rect_px: RectPoints,
 	) -> Result<RgbaImage> {
-		let after_frame_seq = self.region_capture_after_seq(monitor, rect_px);
-
-		if let Some((frame_seq, image)) =
-			self.wait_for_live_stream_region(monitor, rect_px, after_frame_seq)
-		{
-			self.record_region_capture(monitor, rect_px, frame_seq);
-
-			tracing::trace!(
-				op = "capture_backend.region_stream_hit",
-				monitor_id = monitor.id,
-				rect_px = ?rect_px,
-				frame_seq,
-				frame_px = ?image.dimensions(),
-				"Captured monitor region from ScreenCaptureKit stream."
-			);
-
-			return Ok(image);
-		}
-		if let Some(image) = self.live_frame_stream.latest_rgba_region(monitor, rect_px) {
-			tracing::trace!(
-				op = "capture_backend.region_stream_stale_reuse",
-				monitor_id = monitor.id,
-				rect_px = ?rect_px,
-				after_frame_seq,
-				frame_px = ?image.dimensions(),
-				"Reused the latest ScreenCaptureKit region frame after waiting for a fresher frame."
-			);
-
-			return Ok(image);
-		}
-		if let Some(snapshot) = self.live_frame_stream.latest_rgba_snapshot(monitor) {
-			let image = image_capture::crop_monitor_image_region(&snapshot.image, rect_px)
-				.wrap_err("failed to crop ScreenCaptureKit snapshot for region capture")?;
-
-			tracing::trace!(
-				op = "capture_backend.region_snapshot_crop_fallback",
-				monitor_id = monitor.id,
-				rect_px = ?rect_px,
-				frame_px = ?image.dimensions(),
-				"Fell back to cropping the latest ScreenCaptureKit monitor snapshot."
-			);
-
-			return Ok(image);
-		}
-
-		Err(CaptureBackendError::NotSupported { backend: "ScreenCaptureKit region stream" }.into())
+		self.region_capture_tracker.capture_monitor_region(
+			&mut self.live_frame_stream,
+			monitor,
+			rect_px,
+		)
 	}
 
 	#[cfg(target_os = "macos")]
@@ -476,90 +426,7 @@ impl XcapCaptureBackend {
 		monitor: MonitorRect,
 		rect_px: RectPoints,
 	) -> Result<Option<RgbaImage>> {
-		if !Self::macos_supports_scroll_capture_screenshot_api() {
-			let image = image_capture::capture_monitor_region_with_core_graphics(monitor, rect_px)
-				.wrap_err_with(|| {
-					format!(
-						"failed to capture monitor region via CoreGraphics fallback: {monitor:?}"
-					)
-				})?;
-
-			tracing::trace!(
-				op = "capture_backend.region_core_graphics_fallback",
-				monitor_id = monitor.id,
-				rect_px = ?rect_px,
-				frame_px = ?image.dimensions(),
-				"Captured monitor region from the CoreGraphics fallback because the screenshot API is unavailable."
-			);
-
-			return Ok(Some(image));
-		}
-
-		let image =
-			image_capture::capture_monitor_region_image_with_screenshot_manager(monitor, rect_px)
-				.wrap_err_with(|| {
-				format!("failed to capture monitor region via SCScreenshotManager: {monitor:?}")
-			})?;
-
-		tracing::trace!(
-			op = "capture_backend.region_screenshot_hit",
-			monitor_id = monitor.id,
-			rect_px = ?rect_px,
-			frame_px = ?image.dimensions(),
-			"Captured monitor region from ScreenCaptureKit screenshot API."
-		);
-
-		Ok(Some(image))
-	}
-
-	#[cfg(target_os = "macos")]
-	fn macos_supports_scroll_capture_screenshot_api() -> bool {
-		let process_info = NSProcessInfo::processInfo();
-
-		image_capture::macos_supports_scroll_capture_screenshot_api_with_version(
-			process_info.operatingSystemVersion(),
-		)
-	}
-
-	#[cfg(target_os = "macos")]
-	fn region_capture_after_seq(&self, monitor: MonitorRect, rect_px: RectPoints) -> u64 {
-		self.last_region_capture
-			.get(&monitor.id)
-			.filter(|state| state.rect_px == rect_px)
-			.map_or(0, |state| state.frame_seq)
-	}
-
-	#[cfg(target_os = "macos")]
-	fn record_region_capture(&mut self, monitor: MonitorRect, rect_px: RectPoints, frame_seq: u64) {
-		let _ = self
-			.last_region_capture
-			.insert(monitor.id, MacosRegionCaptureState { rect_px, frame_seq });
-	}
-
-	#[cfg(target_os = "macos")]
-	fn wait_for_live_stream_region(
-		&mut self,
-		monitor: MonitorRect,
-		rect_px: RectPoints,
-		after_frame_seq: u64,
-	) -> Option<(u64, RgbaImage)> {
-		let deadline = Instant::now() + MACOS_REGION_FRAME_WAIT_TIMEOUT;
-
-		loop {
-			if let Some(frame) =
-				self.live_frame_stream.latest_rgba_region_if_new(monitor, rect_px, after_frame_seq)
-			{
-				return Some(frame);
-			}
-
-			let remaining = deadline.saturating_duration_since(Instant::now());
-
-			if remaining.is_zero() {
-				return None;
-			}
-
-			thread::sleep(remaining.min(MACOS_REGION_FRAME_WAIT_POLL_INTERVAL));
-		}
+		macos_region_capture::capture_monitor_region_for_scroll_capture(monitor, rect_px)
 	}
 
 	fn window_cache_valid_for(&self) -> bool {
@@ -918,13 +785,6 @@ impl CaptureBackend for XcapCaptureBackend {
 	}
 }
 
-#[cfg(target_os = "macos")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct MacosRegionCaptureState {
-	rect_px: RectPoints,
-	frame_seq: u64,
-}
-
 #[must_use]
 /// Builds the default capture backend used by overlay worker threads.
 pub fn default_capture_backend() -> Box<dyn CaptureBackend> {
@@ -944,8 +804,6 @@ pub fn default_capture_backend_with_self_capture_exception_window_ids(
 #[cfg(test)]
 mod tests {
 	use crate::backend::{CaptureBackend, StubCaptureBackend};
-	#[cfg(target_os = "macos")]
-	use crate::state::{GlobalPoint, MonitorRect, RectPoints};
 
 	#[test]
 	fn stub_backend_returns_cursor_position() {
@@ -953,29 +811,5 @@ mod tests {
 		let pos = backend.global_cursor_position().unwrap();
 
 		assert!(pos.is_none());
-	}
-
-	#[cfg(target_os = "macos")]
-	#[test]
-	fn region_capture_after_seq_only_reuses_matching_monitor_and_rect() {
-		let monitor = MonitorRect {
-			id: 11,
-			origin: GlobalPoint::new(0, 0),
-			width: 800,
-			height: 600,
-			scale_factor_x1000: 2_000,
-		};
-		let other_monitor = MonitorRect { id: 22, ..monitor };
-		let rect = RectPoints::new(10, 20, 300, 200);
-		let other_rect = RectPoints::new(10, 20, 320, 200);
-		let mut backend = crate::backend::XcapCaptureBackend::new();
-
-		assert_eq!(backend.region_capture_after_seq(monitor, rect), 0);
-
-		backend.record_region_capture(monitor, rect, 41);
-
-		assert_eq!(backend.region_capture_after_seq(monitor, rect), 41);
-		assert_eq!(backend.region_capture_after_seq(monitor, other_rect), 0);
-		assert_eq!(backend.region_capture_after_seq(other_monitor, rect), 0);
 	}
 }

--- a/packages/rsnap-overlay/src/backend/macos_region_capture.rs
+++ b/packages/rsnap-overlay/src/backend/macos_region_capture.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use color_eyre::eyre::{Result, WrapErr};
+use image::RgbaImage;
+use objc2_foundation::NSProcessInfo;
+
+use crate::backend::{CaptureBackendError, image_capture};
+use crate::live_frame_stream_macos::MacLiveFrameStream;
+use crate::state::{MonitorRect, RectPoints};
+
+const REGION_FRAME_WAIT_TIMEOUT: Duration = Duration::from_millis(120);
+const REGION_FRAME_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(8);
+
+#[derive(Debug, Default)]
+pub(super) struct RegionCaptureTracker {
+	last_capture: HashMap<u32, RegionCaptureState>,
+}
+impl RegionCaptureTracker {
+	pub(super) fn capture_monitor_region(
+		&mut self,
+		live_frame_stream: &mut MacLiveFrameStream,
+		monitor: MonitorRect,
+		rect_px: RectPoints,
+	) -> Result<RgbaImage> {
+		let after_frame_seq = self.after_seq(monitor, rect_px);
+
+		if let Some((frame_seq, image)) =
+			wait_for_live_stream_region(live_frame_stream, monitor, rect_px, after_frame_seq)
+		{
+			self.record(monitor, rect_px, frame_seq);
+
+			tracing::trace!(
+				op = "capture_backend.region_stream_hit",
+				monitor_id = monitor.id,
+				rect_px = ?rect_px,
+				frame_seq,
+				frame_px = ?image.dimensions(),
+				"Captured monitor region from ScreenCaptureKit stream."
+			);
+
+			return Ok(image);
+		}
+		if let Some(image) = live_frame_stream.latest_rgba_region(monitor, rect_px) {
+			tracing::trace!(
+				op = "capture_backend.region_stream_stale_reuse",
+				monitor_id = monitor.id,
+				rect_px = ?rect_px,
+				after_frame_seq,
+				frame_px = ?image.dimensions(),
+				"Reused the latest ScreenCaptureKit region frame after waiting for a fresher frame."
+			);
+
+			return Ok(image);
+		}
+		if let Some(snapshot) = live_frame_stream.latest_rgba_snapshot(monitor) {
+			let image = image_capture::crop_monitor_image_region(&snapshot.image, rect_px)
+				.wrap_err("failed to crop ScreenCaptureKit snapshot for region capture")?;
+
+			tracing::trace!(
+				op = "capture_backend.region_snapshot_crop_fallback",
+				monitor_id = monitor.id,
+				rect_px = ?rect_px,
+				frame_px = ?image.dimensions(),
+				"Fell back to cropping the latest ScreenCaptureKit monitor snapshot."
+			);
+
+			return Ok(image);
+		}
+
+		Err(CaptureBackendError::NotSupported { backend: "ScreenCaptureKit region stream" }.into())
+	}
+
+	fn after_seq(&self, monitor: MonitorRect, rect_px: RectPoints) -> u64 {
+		self.last_capture
+			.get(&monitor.id)
+			.filter(|state| state.rect_px == rect_px)
+			.map_or(0, |state| state.frame_seq)
+	}
+
+	fn record(&mut self, monitor: MonitorRect, rect_px: RectPoints, frame_seq: u64) {
+		let _ = self.last_capture.insert(monitor.id, RegionCaptureState { rect_px, frame_seq });
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RegionCaptureState {
+	rect_px: RectPoints,
+	frame_seq: u64,
+}
+
+pub(super) fn capture_monitor_region_for_scroll_capture(
+	monitor: MonitorRect,
+	rect_px: RectPoints,
+) -> Result<Option<RgbaImage>> {
+	if !supports_scroll_capture_screenshot_api() {
+		let image = image_capture::capture_monitor_region_with_core_graphics(monitor, rect_px)
+			.wrap_err_with(|| {
+				format!("failed to capture monitor region via CoreGraphics fallback: {monitor:?}")
+			})?;
+
+		tracing::trace!(
+			op = "capture_backend.region_core_graphics_fallback",
+			monitor_id = monitor.id,
+			rect_px = ?rect_px,
+			frame_px = ?image.dimensions(),
+			"Captured monitor region from the CoreGraphics fallback because the screenshot API is unavailable."
+		);
+
+		return Ok(Some(image));
+	}
+
+	let image =
+		image_capture::capture_monitor_region_image_with_screenshot_manager(monitor, rect_px)
+			.wrap_err_with(|| {
+				format!("failed to capture monitor region via SCScreenshotManager: {monitor:?}")
+			})?;
+
+	tracing::trace!(
+		op = "capture_backend.region_screenshot_hit",
+		monitor_id = monitor.id,
+		rect_px = ?rect_px,
+		frame_px = ?image.dimensions(),
+		"Captured monitor region from ScreenCaptureKit screenshot API."
+	);
+
+	Ok(Some(image))
+}
+
+fn supports_scroll_capture_screenshot_api() -> bool {
+	let process_info = NSProcessInfo::processInfo();
+
+	image_capture::macos_supports_scroll_capture_screenshot_api_with_version(
+		process_info.operatingSystemVersion(),
+	)
+}
+
+fn wait_for_live_stream_region(
+	live_frame_stream: &mut MacLiveFrameStream,
+	monitor: MonitorRect,
+	rect_px: RectPoints,
+	after_frame_seq: u64,
+) -> Option<(u64, RgbaImage)> {
+	let deadline = Instant::now() + REGION_FRAME_WAIT_TIMEOUT;
+
+	loop {
+		if let Some(frame) =
+			live_frame_stream.latest_rgba_region_if_new(monitor, rect_px, after_frame_seq)
+		{
+			return Some(frame);
+		}
+
+		let remaining = deadline.saturating_duration_since(Instant::now());
+
+		if remaining.is_zero() {
+			return None;
+		}
+
+		thread::sleep(remaining.min(REGION_FRAME_WAIT_POLL_INTERVAL));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::backend::macos_region_capture::RegionCaptureTracker;
+	use crate::state::{GlobalPoint, MonitorRect, RectPoints};
+
+	#[test]
+	fn region_capture_after_seq_only_reuses_matching_monitor_and_rect() {
+		let monitor = MonitorRect {
+			id: 11,
+			origin: GlobalPoint::new(0, 0),
+			width: 800,
+			height: 600,
+			scale_factor_x1000: 2_000,
+		};
+		let other_monitor = MonitorRect { id: 22, ..monitor };
+		let rect = RectPoints::new(10, 20, 300, 200);
+		let other_rect = RectPoints::new(10, 20, 320, 200);
+		let mut tracker = RegionCaptureTracker::default();
+
+		assert_eq!(tracker.after_seq(monitor, rect), 0);
+
+		tracker.record(monitor, rect, 41);
+
+		assert_eq!(tracker.after_seq(monitor, rect), 41);
+		assert_eq!(tracker.after_seq(monitor, other_rect), 0);
+		assert_eq!(tracker.after_seq(other_monitor, rect), 0);
+	}
+}


### PR DESCRIPTION
## Summary
- Extract macOS region capture tracking and live-stream wait logic from `backend.rs` into `backend/macos_region_capture.rs`.
- Keep backend ownership narrow: `XcapCaptureBackend` delegates region capture while the new module owns per-monitor/rect sequence state and scroll-capture API fallback.
- Add a focused boundary test for reuse of matching region-capture state.

## Validation
- `cargo make fmt-rust`
- `cargo check -p rsnap-overlay --all-targets --all-features`
- `cargo test -p rsnap-overlay --all-features backend::macos_region_capture::tests::`
- `cargo test -p rsnap-overlay --all-features backend::tests::`
- `cargo make check-vstyle-rust`
- `cargo make check-rust`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts; test $? -eq 1`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

Skeptic pass: no blockers found.