### PR TITLE
Modularize live stream setup

### DIFF
--- a/packages/rsnap-overlay/src/live_frame_stream_macos.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos.rs
@@ -10,6 +10,7 @@ mod stream_facade;
 mod stream_filter;
 mod stream_lifecycle;
 mod stream_output;
+mod stream_setup;
 mod stream_worker;
 
 pub(crate) use self::stream_facade::{CursorSampleRequest, MacLiveFrameStream};
@@ -47,7 +48,7 @@ const STREAM_ERROR_NULL_CONTENT_CODE: isize = 2;
 const STREAM_ERROR_RETAIN_FAILED_CODE: isize = 3;
 
 fn stream_error(code: isize) -> Retained<NSError> {
-	stream_lifecycle::stream_error(code)
+	stream_setup::stream_error(code)
 }
 
 #[cfg(test)]

--- a/packages/rsnap-overlay/src/live_frame_stream_macos/stream_lifecycle.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos/stream_lifecycle.rs
@@ -1,44 +1,24 @@
-use std::sync::{
-	Arc, Mutex,
-	atomic::{AtomicU64, Ordering},
-	mpsc,
-};
+use std::sync::{Arc, atomic::AtomicU64};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use block2::RcBlock;
-use dispatch2::{DispatchQueue, DispatchRetained};
 use image::RgbaImage;
-use objc2::AnyThread;
-use objc2::rc::Retained;
-use objc2::runtime::ProtocolObject;
-use objc2_foundation::NSError;
-use objc2_screen_capture_kit::{SCContentFilter, SCStream, SCStreamOutputType};
 
 use crate::live_frame_stream_macos::frame_store::SharedLatestFrame;
 use crate::live_frame_stream_macos::live_frame_buffer::{
 	self, OrderedRegionFrame, QueuedPixelBufferFrame,
 };
-use crate::live_frame_stream_macos::stream_config::{self, StreamCaptureTarget};
-use crate::live_frame_stream_macos::stream_filter::{self, StreamFilterConfig, StreamFilterMode};
+use crate::live_frame_stream_macos::stream_config::StreamCaptureTarget;
+use crate::live_frame_stream_macos::stream_filter::StreamFilterConfig;
 use crate::live_frame_stream_macos::stream_output::StreamOutput;
+use crate::live_frame_stream_macos::stream_setup::{self, StreamState};
 use crate::live_frame_stream_macos::stream_worker;
 use crate::live_frame_stream_macos::{
-	STREAM_ERROR_RETAIN_FAILED_CODE, STREAM_ERROR_TIMEOUT_CODE,
 	STREAM_INCOMPLETE_EXCEPTION_UPGRADE_BACKOFF, STREAM_REGION_FRAME_AHEAD_WAIT_TIMEOUT,
 	STREAM_REGION_FRAME_MAX_AGE, STREAM_REGION_FRAME_REFRESH_POLL_INTERVAL,
 	STREAM_REGION_FRAME_REFRESH_TIMEOUT, STREAM_SETUP_BACKOFF,
 };
 use crate::state::{MonitorRect, RectPoints};
-
-pub(super) struct StreamState {
-	pub(super) monitor_id: u32,
-	pub(super) stream_generation: u64,
-	self_capture_filter_complete: bool,
-	stream: Retained<SCStream>,
-	pub(super) output: Retained<StreamOutput>,
-	sample_handler_queue: DispatchRetained<DispatchQueue>,
-}
 
 pub(super) struct RefreshStreamArgs<'a> {
 	pub(super) state: &'a mut Option<StreamState>,
@@ -49,19 +29,6 @@ pub(super) struct RefreshStreamArgs<'a> {
 	pub(super) frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
 	pub(super) frame_seq_counter: Arc<AtomicU64>,
 	pub(super) shared_latest_frame: Arc<SharedLatestFrame>,
-}
-
-struct StartedStreamArtifacts {
-	stream_generation: u64,
-	stream: Retained<SCStream>,
-	output: Retained<StreamOutput>,
-	sample_handler_queue: DispatchRetained<DispatchQueue>,
-	config_build_ms: u128,
-	queue_build_ms: u128,
-	output_build_ms: u128,
-	stream_init_ms: u128,
-	add_output_ms: u128,
-	start_capture_ms: u128,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -162,7 +129,7 @@ pub(super) fn ensure_stream(
 ) -> StreamRequestProgress {
 	let reuse_decision = stream_reuse_decision(
 		state.as_ref().map(|current| current.monitor_id),
-		state.as_ref().is_some_and(|current| current.self_capture_filter_complete),
+		state.as_ref().is_some_and(StreamState::self_capture_filter_complete),
 		monitor.id,
 	);
 	let setup_backoff = stream_setup_backoff(reuse_decision, setup_backoff, force_retry_upgrade);
@@ -190,7 +157,7 @@ pub(super) fn ensure_stream(
 
 	*last_setup_attempt_at = Some(now);
 
-	let Some(next_state) = setup_stream_for_monitor(
+	let Some(next_state) = stream_setup::setup_stream_for_monitor(
 		monitor,
 		filter,
 		capture_target,
@@ -210,7 +177,7 @@ pub(super) fn ensure_stream(
 	};
 
 	if reuse_decision == StreamReuseDecision::RetryUpgradeUsingCurrent {
-		if !next_state.self_capture_filter_complete {
+		if !next_state.self_capture_filter_complete() {
 			tracing::info!(
 				op = "live_frame_stream.ensure_stream_upgrade_deferred",
 				monitor_id = monitor.id,
@@ -219,7 +186,7 @@ pub(super) fn ensure_stream(
 
 			let mut next_state = Some(next_state);
 
-			teardown_stream(&mut next_state);
+			stream_setup::teardown_stream(&mut next_state);
 
 			return StreamRequestProgress::Settled;
 		}
@@ -236,7 +203,7 @@ pub(super) fn ensure_stream(
 			true,
 		);
 
-		teardown_stream(&mut previous_state);
+		stream_setup::teardown_stream(&mut previous_state);
 
 		shared_latest_frame.mark_waiting_for_frame(monitor.id);
 
@@ -252,9 +219,9 @@ pub(super) fn ensure_stream(
 		return StreamRequestProgress::AwaitingFirstFrame;
 	}
 
-	teardown_stream(state);
+	stream_setup::teardown_stream(state);
 
-	let self_capture_filter_complete = next_state.self_capture_filter_complete;
+	let self_capture_filter_complete = next_state.self_capture_filter_complete();
 	let stream_generation = next_state.stream_generation;
 
 	shared_latest_frame.activate_stream_generation(monitor.id, stream_generation);
@@ -492,7 +459,7 @@ pub(super) fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgre
 
 	*last_setup_attempt_at = Some(Instant::now());
 
-	let Some(next_state) = setup_stream_for_monitor(
+	let Some(next_state) = stream_setup::setup_stream_for_monitor(
 		monitor,
 		filter,
 		capture_target,
@@ -502,7 +469,7 @@ pub(super) fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgre
 	) else {
 		return StreamRequestProgress::Settled;
 	};
-	let self_capture_filter_complete = next_state.self_capture_filter_complete;
+	let self_capture_filter_complete = next_state.self_capture_filter_complete();
 	let stream_generation = next_state.stream_generation;
 	let replaced_existing_state = state.is_some();
 
@@ -516,7 +483,7 @@ pub(super) fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgre
 		self_capture_filter_complete,
 	);
 
-	teardown_stream(&mut previous_state);
+	stream_setup::teardown_stream(&mut previous_state);
 
 	shared_latest_frame.mark_waiting_for_frame(monitor.id);
 
@@ -529,22 +496,6 @@ pub(super) fn refresh_stream(args: RefreshStreamArgs<'_>) -> StreamRequestProgre
 	);
 
 	StreamRequestProgress::AwaitingFirstFrame
-}
-
-pub(super) fn teardown_stream(state: &mut Option<StreamState>) {
-	let Some(state) = state.take() else {
-		return;
-	};
-
-	tracing::info!(
-		op = "live_frame_stream.teardown_stream",
-		monitor_id = state.monitor_id,
-		"Stopping the current ScreenCaptureKit live stream."
-	);
-
-	let stop_block = RcBlock::new(|_err: *mut NSError| {});
-
-	unsafe { state.stream.stopCaptureWithCompletionHandler(Some(&stop_block)) };
 }
 
 pub(super) fn stream_reuse_decision(
@@ -579,196 +530,6 @@ pub(super) fn stream_setup_backoff(
 			default_setup_backoff
 		},
 	}
-}
-
-pub(super) fn stream_error(code: isize) -> Retained<NSError> {
-	NSError::new(code, objc2_foundation::ns_string!("io.hackink.rsnap.live_frame_stream"))
-}
-
-fn setup_stream_for_monitor(
-	monitor: MonitorRect,
-	filter: &StreamFilterConfig,
-	capture_target: StreamCaptureTarget,
-	frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
-	frame_seq_counter: Arc<AtomicU64>,
-	shared_latest_frame: Arc<SharedLatestFrame>,
-) -> Option<StreamState> {
-	let setup_started_at = Instant::now();
-	let prepared_filter = stream_filter::prepare_stream_filter_for_monitor(
-		monitor,
-		&filter.self_capture_exception_window_ids,
-	)?;
-	let started_stream = build_and_start_stream_artifacts(
-		monitor,
-		capture_target,
-		frame_waker,
-		frame_seq_counter,
-		shared_latest_frame,
-		prepared_filter.filter_mode,
-		prepared_filter.filter,
-	)?;
-
-	tracing::debug!(
-			op = "live_frame_stream.setup_stream_ready",
-			monitor_id = monitor.id,
-			shareable_content_mode = "on_screen_windows_only",
-			filter_mode = ?prepared_filter.filter_mode,
-			self_capture_filter_complete = prepared_filter.self_capture_filter_complete,
-			self_capture_exception_window_ids_complete =
-				prepared_filter.self_capture_exception_window_ids_complete,
-			excepting_window_count = prepared_filter.excepting_window_count,
-			fallback_excluded_window_count = prepared_filter.fallback_excluded_window_count,
-		missing_window_ids = ?prepared_filter.missing_window_ids,
-		shareable_content_ms = prepared_filter.shareable_content_ms,
-		find_display_ms = prepared_filter.find_display_ms,
-		exception_windows_ms = prepared_filter.exception_windows_ms,
-		filter_build_ms = prepared_filter.filter_build_ms,
-		config_build_ms = started_stream.config_build_ms,
-		queue_build_ms = started_stream.queue_build_ms,
-		output_build_ms = started_stream.output_build_ms,
-		stream_init_ms = started_stream.stream_init_ms,
-		add_output_ms = started_stream.add_output_ms,
-		start_capture_ms = started_stream.start_capture_ms,
-		total_setup_ms = setup_started_at.elapsed().as_millis(),
-		"ScreenCaptureKit setup created a live stream for the requested monitor."
-	);
-
-	Some(StreamState {
-		monitor_id: monitor.id,
-		stream_generation: started_stream.stream_generation,
-		self_capture_filter_complete: prepared_filter.self_capture_filter_complete,
-		stream: started_stream.stream,
-		output: started_stream.output,
-		sample_handler_queue: started_stream.sample_handler_queue,
-	})
-}
-
-fn build_and_start_stream_artifacts(
-	monitor: MonitorRect,
-	capture_target: StreamCaptureTarget,
-	frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
-	frame_seq_counter: Arc<AtomicU64>,
-	shared_latest_frame: Arc<SharedLatestFrame>,
-	filter_mode: StreamFilterMode,
-	filter: Retained<SCContentFilter>,
-) -> Option<StartedStreamArtifacts> {
-	let config_build_started_at = Instant::now();
-	let config = stream_config::build_stream_config_for_monitor(monitor, capture_target);
-	let config_build_ms = config_build_started_at.elapsed().as_millis();
-	let queue_build_started_at = Instant::now();
-	let sample_handler_queue = stream_config::build_sample_handler_queue_for_monitor(monitor.id);
-	let queue_build_ms = queue_build_started_at.elapsed().as_millis();
-	let output_build_started_at = Instant::now();
-	let stream_generation = frame_seq_counter.fetch_add(1, Ordering::AcqRel).wrapping_add(1);
-	let output = StreamOutput::new(
-		monitor.id,
-		stream_generation,
-		frame_waker,
-		frame_seq_counter,
-		shared_latest_frame,
-	);
-	let output_build_ms = output_build_started_at.elapsed().as_millis();
-	let stream_init_started_at = Instant::now();
-	let delegate_proto = ProtocolObject::from_ref(&*output);
-	let stream = unsafe {
-		SCStream::initWithFilter_configuration_delegate(
-			SCStream::alloc(),
-			&filter,
-			&config,
-			Some(delegate_proto),
-		)
-	};
-	let stream_init_ms = stream_init_started_at.elapsed().as_millis();
-	let add_output_started_at = Instant::now();
-	let output_proto = ProtocolObject::from_ref(&*output);
-
-	if unsafe {
-		stream.addStreamOutput_type_sampleHandlerQueue_error(
-			output_proto,
-			SCStreamOutputType::Screen,
-			Some(&sample_handler_queue),
-		)
-	}
-	.is_err()
-	{
-		log_add_stream_output_failed(monitor.id, filter_mode);
-
-		return None;
-	}
-
-	let add_output_ms = add_output_started_at.elapsed().as_millis();
-	let start_capture_started_at = Instant::now();
-
-	if let Err(error) = start_capture_blocking(&stream) {
-		log_start_capture_failed(monitor.id, filter_mode, &error);
-
-		return None;
-	}
-
-	Some(StartedStreamArtifacts {
-		stream_generation,
-		stream,
-		output,
-		sample_handler_queue,
-		config_build_ms,
-		queue_build_ms,
-		output_build_ms,
-		stream_init_ms,
-		add_output_ms,
-		start_capture_ms: start_capture_started_at.elapsed().as_millis(),
-	})
-}
-
-fn log_add_stream_output_failed(monitor_id: u32, filter_mode: StreamFilterMode) {
-	tracing::warn!(
-		op = "live_frame_stream.add_stream_output_failed",
-		monitor_id,
-		filter_mode = ?filter_mode,
-		"Failed to register the ScreenCaptureKit stream output."
-	);
-}
-
-fn log_start_capture_failed(monitor_id: u32, filter_mode: StreamFilterMode, error: &NSError) {
-	tracing::warn!(
-		op = "live_frame_stream.start_capture_failed",
-		monitor_id,
-		filter_mode = ?filter_mode,
-		error_code = error.code(),
-		error_domain = %error.domain(),
-		error_description = %error.localizedDescription(),
-		"ScreenCaptureKit failed to start the live stream."
-	);
-}
-
-fn start_capture_blocking(stream: &SCStream) -> Result<(), Retained<NSError>> {
-	let (tx, rx) = mpsc::sync_channel::<Result<(), Retained<NSError>>>(1);
-	let tx = Mutex::new(Some(tx));
-	let block = RcBlock::new(move |err: *mut NSError| {
-		let mut maybe_tx = match tx.lock() {
-			Ok(guard) => guard,
-			Err(poisoned) => poisoned.into_inner(),
-		};
-		let Some(tx) = maybe_tx.take() else {
-			return;
-		};
-
-		if err.is_null() {
-			let _ = tx.send(Ok(()));
-
-			return;
-		}
-
-		let Some(err) = (unsafe { Retained::retain(err) }) else {
-			let _ = tx.send(Err(stream_error(STREAM_ERROR_RETAIN_FAILED_CODE)));
-
-			return;
-		};
-		let _ = tx.send(Err(err));
-	});
-
-	unsafe { stream.startCaptureWithCompletionHandler(Some(&block)) };
-
-	rx.recv_timeout(Duration::from_secs(2)).map_err(|_| stream_error(STREAM_ERROR_TIMEOUT_CODE))?
 }
 
 fn fresh_queued_frames_after_seq(

--- a/packages/rsnap-overlay/src/live_frame_stream_macos/stream_setup.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos/stream_setup.rs
@@ -1,0 +1,254 @@
+use std::sync::{
+	Arc, Mutex,
+	atomic::{AtomicU64, Ordering},
+	mpsc,
+};
+use std::time::{Duration, Instant};
+
+use block2::RcBlock;
+use dispatch2::{DispatchQueue, DispatchRetained};
+use objc2::AnyThread;
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2_foundation::NSError;
+use objc2_screen_capture_kit::{SCContentFilter, SCStream, SCStreamOutputType};
+
+use crate::live_frame_stream_macos::frame_store::SharedLatestFrame;
+use crate::live_frame_stream_macos::stream_config::{self, StreamCaptureTarget};
+use crate::live_frame_stream_macos::stream_filter::{self, StreamFilterConfig, StreamFilterMode};
+use crate::live_frame_stream_macos::stream_output::StreamOutput;
+use crate::live_frame_stream_macos::{STREAM_ERROR_RETAIN_FAILED_CODE, STREAM_ERROR_TIMEOUT_CODE};
+use crate::state::MonitorRect;
+
+pub(super) struct StreamState {
+	pub(super) monitor_id: u32,
+	pub(super) stream_generation: u64,
+	self_capture_filter_complete: bool,
+	stream: Retained<SCStream>,
+	pub(super) output: Retained<StreamOutput>,
+	sample_handler_queue: DispatchRetained<DispatchQueue>,
+}
+impl StreamState {
+	pub(super) fn self_capture_filter_complete(&self) -> bool {
+		self.self_capture_filter_complete
+	}
+}
+
+struct StartedStreamArtifacts {
+	stream_generation: u64,
+	stream: Retained<SCStream>,
+	output: Retained<StreamOutput>,
+	sample_handler_queue: DispatchRetained<DispatchQueue>,
+	config_build_ms: u128,
+	queue_build_ms: u128,
+	output_build_ms: u128,
+	stream_init_ms: u128,
+	add_output_ms: u128,
+	start_capture_ms: u128,
+}
+
+pub(super) fn setup_stream_for_monitor(
+	monitor: MonitorRect,
+	filter: &StreamFilterConfig,
+	capture_target: StreamCaptureTarget,
+	frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
+	frame_seq_counter: Arc<AtomicU64>,
+	shared_latest_frame: Arc<SharedLatestFrame>,
+) -> Option<StreamState> {
+	let setup_started_at = Instant::now();
+	let prepared_filter = stream_filter::prepare_stream_filter_for_monitor(
+		monitor,
+		&filter.self_capture_exception_window_ids,
+	)?;
+	let started_stream = build_and_start_stream_artifacts(
+		monitor,
+		capture_target,
+		frame_waker,
+		frame_seq_counter,
+		shared_latest_frame,
+		prepared_filter.filter_mode,
+		prepared_filter.filter,
+	)?;
+
+	tracing::debug!(
+		op = "live_frame_stream.setup_stream_ready",
+		monitor_id = monitor.id,
+		shareable_content_mode = "on_screen_windows_only",
+		filter_mode = ?prepared_filter.filter_mode,
+		self_capture_filter_complete = prepared_filter.self_capture_filter_complete,
+		self_capture_exception_window_ids_complete =
+			prepared_filter.self_capture_exception_window_ids_complete,
+		excepting_window_count = prepared_filter.excepting_window_count,
+		fallback_excluded_window_count = prepared_filter.fallback_excluded_window_count,
+		missing_window_ids = ?prepared_filter.missing_window_ids,
+		shareable_content_ms = prepared_filter.shareable_content_ms,
+		find_display_ms = prepared_filter.find_display_ms,
+		exception_windows_ms = prepared_filter.exception_windows_ms,
+		filter_build_ms = prepared_filter.filter_build_ms,
+		config_build_ms = started_stream.config_build_ms,
+		queue_build_ms = started_stream.queue_build_ms,
+		output_build_ms = started_stream.output_build_ms,
+		stream_init_ms = started_stream.stream_init_ms,
+		add_output_ms = started_stream.add_output_ms,
+		start_capture_ms = started_stream.start_capture_ms,
+		total_setup_ms = setup_started_at.elapsed().as_millis(),
+		"ScreenCaptureKit setup created a live stream for the requested monitor."
+	);
+
+	Some(StreamState {
+		monitor_id: monitor.id,
+		stream_generation: started_stream.stream_generation,
+		self_capture_filter_complete: prepared_filter.self_capture_filter_complete,
+		stream: started_stream.stream,
+		output: started_stream.output,
+		sample_handler_queue: started_stream.sample_handler_queue,
+	})
+}
+
+pub(super) fn teardown_stream(state: &mut Option<StreamState>) {
+	let Some(state) = state.take() else {
+		return;
+	};
+
+	tracing::info!(
+		op = "live_frame_stream.teardown_stream",
+		monitor_id = state.monitor_id,
+		"Stopping the current ScreenCaptureKit live stream."
+	);
+
+	let stop_block = RcBlock::new(|_err: *mut NSError| {});
+
+	unsafe { state.stream.stopCaptureWithCompletionHandler(Some(&stop_block)) };
+}
+
+pub(super) fn stream_error(code: isize) -> Retained<NSError> {
+	NSError::new(code, objc2_foundation::ns_string!("io.hackink.rsnap.live_frame_stream"))
+}
+
+fn build_and_start_stream_artifacts(
+	monitor: MonitorRect,
+	capture_target: StreamCaptureTarget,
+	frame_waker: Option<Arc<dyn Fn() + Send + Sync>>,
+	frame_seq_counter: Arc<AtomicU64>,
+	shared_latest_frame: Arc<SharedLatestFrame>,
+	filter_mode: StreamFilterMode,
+	filter: Retained<SCContentFilter>,
+) -> Option<StartedStreamArtifacts> {
+	let config_build_started_at = Instant::now();
+	let config = stream_config::build_stream_config_for_monitor(monitor, capture_target);
+	let config_build_ms = config_build_started_at.elapsed().as_millis();
+	let queue_build_started_at = Instant::now();
+	let sample_handler_queue = stream_config::build_sample_handler_queue_for_monitor(monitor.id);
+	let queue_build_ms = queue_build_started_at.elapsed().as_millis();
+	let output_build_started_at = Instant::now();
+	let stream_generation = frame_seq_counter.fetch_add(1, Ordering::AcqRel).wrapping_add(1);
+	let output = StreamOutput::new(
+		monitor.id,
+		stream_generation,
+		frame_waker,
+		frame_seq_counter,
+		shared_latest_frame,
+	);
+	let output_build_ms = output_build_started_at.elapsed().as_millis();
+	let stream_init_started_at = Instant::now();
+	let delegate_proto = ProtocolObject::from_ref(&*output);
+	let stream = unsafe {
+		SCStream::initWithFilter_configuration_delegate(
+			SCStream::alloc(),
+			&filter,
+			&config,
+			Some(delegate_proto),
+		)
+	};
+	let stream_init_ms = stream_init_started_at.elapsed().as_millis();
+	let add_output_started_at = Instant::now();
+	let output_proto = ProtocolObject::from_ref(&*output);
+
+	if unsafe {
+		stream.addStreamOutput_type_sampleHandlerQueue_error(
+			output_proto,
+			SCStreamOutputType::Screen,
+			Some(&sample_handler_queue),
+		)
+	}
+	.is_err()
+	{
+		log_add_stream_output_failed(monitor.id, filter_mode);
+
+		return None;
+	}
+
+	let add_output_ms = add_output_started_at.elapsed().as_millis();
+	let start_capture_started_at = Instant::now();
+
+	if let Err(error) = start_capture_blocking(&stream) {
+		log_start_capture_failed(monitor.id, filter_mode, &error);
+
+		return None;
+	}
+
+	Some(StartedStreamArtifacts {
+		stream_generation,
+		stream,
+		output,
+		sample_handler_queue,
+		config_build_ms,
+		queue_build_ms,
+		output_build_ms,
+		stream_init_ms,
+		add_output_ms,
+		start_capture_ms: start_capture_started_at.elapsed().as_millis(),
+	})
+}
+
+fn log_add_stream_output_failed(monitor_id: u32, filter_mode: StreamFilterMode) {
+	tracing::warn!(
+		op = "live_frame_stream.add_stream_output_failed",
+		monitor_id,
+		filter_mode = ?filter_mode,
+		"Failed to register the ScreenCaptureKit stream output."
+	);
+}
+
+fn log_start_capture_failed(monitor_id: u32, filter_mode: StreamFilterMode, error: &NSError) {
+	tracing::warn!(
+		op = "live_frame_stream.start_capture_failed",
+		monitor_id,
+		filter_mode = ?filter_mode,
+		error_code = error.code(),
+		error_domain = %error.domain(),
+		error_description = %error.localizedDescription(),
+		"ScreenCaptureKit failed to start the live stream."
+	);
+}
+
+fn start_capture_blocking(stream: &SCStream) -> Result<(), Retained<NSError>> {
+	let (tx, rx) = mpsc::sync_channel::<Result<(), Retained<NSError>>>(1);
+	let tx = Mutex::new(Some(tx));
+	let block = RcBlock::new(move |err: *mut NSError| {
+		let mut maybe_tx = match tx.lock() {
+			Ok(guard) => guard,
+			Err(poisoned) => poisoned.into_inner(),
+		};
+		let Some(tx) = maybe_tx.take() else {
+			return;
+		};
+
+		if err.is_null() {
+			let _ = tx.send(Ok(()));
+
+			return;
+		}
+
+		let Some(err) = (unsafe { Retained::retain(err) }) else {
+			let _ = tx.send(Err(stream_error(STREAM_ERROR_RETAIN_FAILED_CODE)));
+
+			return;
+		};
+		let _ = tx.send(Err(err));
+	});
+
+	unsafe { stream.startCaptureWithCompletionHandler(Some(&block)) };
+
+	rx.recv_timeout(Duration::from_secs(2)).map_err(|_| stream_error(STREAM_ERROR_TIMEOUT_CODE))?
+}

--- a/packages/rsnap-overlay/src/live_frame_stream_macos/stream_worker.rs
+++ b/packages/rsnap-overlay/src/live_frame_stream_macos/stream_worker.rs
@@ -11,7 +11,8 @@ use crate::live_frame_stream_macos::frame_store::{SharedLatestFrame, StreamGener
 use crate::live_frame_stream_macos::live_frame_buffer::{self, OrderedRegionFrame};
 use crate::live_frame_stream_macos::stream_config::StreamCaptureTarget;
 use crate::live_frame_stream_macos::stream_filter::StreamFilterConfig;
-use crate::live_frame_stream_macos::stream_lifecycle::{self, StreamRequestProgress, StreamState};
+use crate::live_frame_stream_macos::stream_lifecycle::{self, StreamRequestProgress};
+use crate::live_frame_stream_macos::stream_setup::{self, StreamState};
 use crate::live_frame_stream_macos::{STREAM_REGION_FRAME_MAX_AGE, STREAM_SETUP_BACKOFF};
 use crate::state::{LiveCursorSample, MonitorImageSnapshot, MonitorRect, RectPoints};
 
@@ -123,7 +124,7 @@ pub(super) fn stream_worker_loop(
 		}
 	}
 
-	stream_lifecycle::teardown_stream(&mut state);
+	stream_setup::teardown_stream(&mut state);
 }
 
 fn handle_reset_request(
@@ -136,7 +137,7 @@ fn handle_reset_request(
 		stream_generation: state.stream_generation,
 	});
 
-	stream_lifecycle::teardown_stream(state);
+	stream_setup::teardown_stream(state);
 
 	*last_setup_attempt_at = None;
 


### PR DESCRIPTION
## Summary
- Extract ScreenCaptureKit live-stream setup/state/teardown ownership into live_frame_stream_macos::stream_setup.
- Keep lifecycle focused on refresh/reuse policy while worker imports stream state from the new owner module.
- Preserve normal Rust module boundaries; no include! or #[path] physical split.

## Validation
- cargo make fmt-rust
- cargo check -p rsnap-overlay --all-targets --all-features
- cargo test -p rsnap-overlay --all-features live_frame_stream_macos::tests::
- cargo test -p rsnap-overlay --all-features live_frame_stream_macos::stream_worker::tests::
- cargo make check-vstyle-rust
- cargo make check-rust
- git diff --check and forbidden include/path scan
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh skeptic review found no code blockers after staging stream_setup.rs; ownership and visibility boundaries look reasonable.