### PR TITLE
Modularize settings dashboard

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsNavigation.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsNavigation.swift
@@ -1,0 +1,263 @@
+import AppKit
+import SwiftUI
+
+enum NativeHostSettingsSection: String, CaseIterable, Identifiable {
+	case appearance
+	case capture
+	case output
+	case permissions
+	case about
+
+	var id: Self { self }
+
+	var title: String {
+		switch self {
+		case .appearance:
+			return "Appearance"
+		case .capture:
+			return "Capture"
+		case .output:
+			return "Output"
+		case .permissions:
+			return "Permissions"
+		case .about:
+			return "About"
+		}
+	}
+
+	var subtitle: String {
+		switch self {
+		case .appearance:
+			return "HUD style"
+		case .capture:
+			return "Shortcut"
+		case .output:
+			return "Files"
+		case .permissions:
+			return "Access"
+		case .about:
+			return "Project"
+		}
+	}
+
+	var symbolName: String {
+		switch self {
+		case .appearance:
+			return "sparkles"
+		case .capture:
+			return "viewfinder"
+		case .output:
+			return "folder"
+		case .permissions:
+			return "lock.shield"
+		case .about:
+			return "info.circle"
+		}
+	}
+
+	var allowsRestoreDefaults: Bool {
+		switch self {
+		case .appearance, .capture, .output:
+			return true
+		case .permissions, .about:
+			return false
+		}
+	}
+}
+
+struct SettingsRail: View {
+	@Binding var selectedSection: NativeHostSettingsSection
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 14) {
+			HStack(spacing: 8) {
+				SettingsBrandIcon()
+				Text(NativeHostBrand.displayName)
+					.font(.system(size: 17, weight: .semibold, design: .rounded))
+					.lineLimit(1)
+			}
+			.padding(.horizontal, 2)
+
+			VStack(spacing: 5) {
+				ForEach(NativeHostSettingsSection.allCases) { section in
+					SettingsRailButton(
+						section: section,
+						isSelected: selectedSection == section
+					) {
+						selectedSection = section
+					}
+				}
+			}
+		}
+		.padding(.top, 2)
+	}
+}
+
+struct SettingsBrandIcon: View {
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		Image(nsImage: NSApp.applicationIconImage)
+			.resizable()
+			.interpolation(.high)
+			.scaledToFit()
+			.padding(1)
+			.frame(width: 28, height: 28)
+			.clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+			.overlay {
+				RoundedRectangle(cornerRadius: 7, style: .continuous)
+					.stroke(
+						colorScheme == .light
+							? Color.black.opacity(0.08)
+							: Color.white.opacity(0.16),
+						lineWidth: 1
+					)
+			}
+	}
+}
+
+private struct SettingsRailButton: View {
+	let section: NativeHostSettingsSection
+	let isSelected: Bool
+	let action: () -> Void
+	@Environment(\.colorScheme) private var colorScheme
+	@State private var isHovered = false
+
+	var body: some View {
+		Button(action: action) {
+			HStack(spacing: 8) {
+				Image(systemName: section.symbolName)
+					.symbolRenderingMode(.hierarchical)
+					.font(.system(size: 12.5, weight: .semibold))
+					.foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+					.frame(width: 23, height: 23)
+
+				VStack(alignment: .leading, spacing: 2) {
+					Text(section.title)
+						.font(.system(size: 12.5, weight: .semibold))
+						.foregroundStyle(isSelected ? Color.primary : Color.primary.opacity(0.88))
+						.lineLimit(1)
+						.minimumScaleFactor(0.88)
+					Text(section.subtitle)
+						.font(.system(size: 10, weight: .medium))
+						.foregroundStyle(.secondary)
+						.lineLimit(1)
+				}
+				Spacer(minLength: 0)
+			}
+			.padding(.horizontal, 8)
+			.padding(.vertical, 5)
+			.frame(maxWidth: .infinity)
+			.contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+			.background {
+				if isSelected {
+					RoundedRectangle(cornerRadius: 9, style: .continuous)
+						.fill(
+							colorScheme == .light
+								? Color.black.opacity(0.040)
+								: Color.white.opacity(0.058)
+						)
+					HStack {
+						Capsule()
+							.fill(Color.accentColor)
+							.frame(width: 2, height: 16)
+						Spacer()
+					}
+					.padding(.leading, 1)
+				} else if isHovered {
+					RoundedRectangle(cornerRadius: 9, style: .continuous)
+						.fill(
+							colorScheme == .light
+								? Color.black.opacity(0.022)
+								: Color.white.opacity(0.034)
+						)
+				}
+			}
+		}
+		.buttonStyle(.plain)
+		.animation(.easeOut(duration: 0.14), value: isSelected)
+		.onHover { hovering in
+			withAnimation(.easeOut(duration: 0.14)) {
+				isHovered = hovering
+			}
+		}
+	}
+}
+
+struct SettingsDashboard: View {
+	@ObservedObject var model: NativeHostSettingsViewModel
+	let section: NativeHostSettingsSection
+	let restoreDefaults: () -> Void
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 6) {
+			SettingsContentHeader(
+				section: section,
+				restoreDefaults: restoreDefaults
+			)
+
+			ScrollView {
+				activePanel
+					.id(section)
+					.transition(
+						.asymmetric(
+							insertion: .opacity.combined(with: .move(edge: .bottom)),
+							removal: .opacity.combined(with: .move(edge: .top))
+						)
+					)
+					.padding(.trailing, 8)
+					.padding(.bottom, 2)
+			}
+			.scrollIndicators(.hidden)
+			.frame(maxWidth: .infinity, alignment: .topLeading)
+			.animation(.spring(response: 0.34, dampingFraction: 0.86), value: section)
+		}
+		.padding(.horizontal, 13)
+		.padding(.vertical, 9)
+		.settingsGlassSurface(cornerRadius: 18, role: .panel)
+	}
+
+	@ViewBuilder
+	private var activePanel: some View {
+		switch section {
+		case .appearance:
+			AppearanceSettingsPanel(model: model)
+		case .capture:
+			CaptureSettingsPanel(model: model)
+		case .output:
+			OutputSettingsPanel(model: model)
+		case .permissions:
+			PermissionsSettingsPanel(model: model)
+		case .about:
+			AboutSettingsPanel(model: model)
+		}
+	}
+}
+
+private struct SettingsContentHeader: View {
+	let section: NativeHostSettingsSection
+	let restoreDefaults: () -> Void
+
+	var body: some View {
+		HStack(alignment: .firstTextBaseline, spacing: 10) {
+			VStack(alignment: .leading, spacing: 2) {
+				Text(section.title)
+					.font(.system(size: 18, weight: .semibold))
+				Text(section.subtitle)
+					.font(.system(size: 11, weight: .medium))
+					.foregroundStyle(.secondary)
+			}
+			.frame(maxWidth: .infinity, alignment: .leading)
+
+			if section.allowsRestoreDefaults {
+				Button(action: restoreDefaults) {
+					Label("Restore Defaults", systemImage: "arrow.counterclockwise")
+						.labelStyle(.titleAndIcon)
+				}
+				.rsnapGlassButton(prominent: false)
+				.controlSize(.small)
+			}
+		}
+		.padding(.bottom, 2)
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -111,270 +111,9 @@ struct NativeHostSettingsView: View {
 	}
 }
 
-private enum NativeHostSettingsSection: String, CaseIterable, Identifiable {
-	case appearance
-	case capture
-	case output
-	case permissions
-	case about
-
-	var id: Self { self }
-
-	var title: String {
-		switch self {
-		case .appearance:
-			return "Appearance"
-		case .capture:
-			return "Capture"
-		case .output:
-			return "Output"
-		case .permissions:
-			return "Permissions"
-		case .about:
-			return "About"
-		}
-	}
-
-	var subtitle: String {
-		switch self {
-		case .appearance:
-			return "HUD style"
-		case .capture:
-			return "Shortcut"
-		case .output:
-			return "Files"
-		case .permissions:
-			return "Access"
-		case .about:
-			return "Project"
-		}
-	}
-
-	var symbolName: String {
-		switch self {
-		case .appearance:
-			return "sparkles"
-		case .capture:
-			return "viewfinder"
-		case .output:
-			return "folder"
-		case .permissions:
-			return "lock.shield"
-		case .about:
-			return "info.circle"
-		}
-	}
-
-	var allowsRestoreDefaults: Bool {
-		switch self {
-		case .appearance, .capture, .output:
-			return true
-		case .permissions, .about:
-			return false
-		}
-	}
-}
-
 private enum NativeHostAboutLinks {
 	static let source = "https://github.com/hack-ink/rsnap"
 	static let creator = "https://x.com/hackink"
-}
-
-private struct SettingsRail: View {
-	@Binding var selectedSection: NativeHostSettingsSection
-
-	var body: some View {
-		VStack(alignment: .leading, spacing: 14) {
-			HStack(spacing: 8) {
-				SettingsBrandIcon()
-				Text(NativeHostBrand.displayName)
-					.font(.system(size: 17, weight: .semibold, design: .rounded))
-					.lineLimit(1)
-			}
-			.padding(.horizontal, 2)
-
-			VStack(spacing: 5) {
-				ForEach(NativeHostSettingsSection.allCases) { section in
-					SettingsRailButton(
-						section: section,
-						isSelected: selectedSection == section
-					) {
-						selectedSection = section
-					}
-				}
-			}
-		}
-		.padding(.top, 2)
-	}
-}
-
-private struct SettingsBrandIcon: View {
-	@Environment(\.colorScheme) private var colorScheme
-
-	var body: some View {
-		Image(nsImage: NSApp.applicationIconImage)
-			.resizable()
-			.interpolation(.high)
-			.scaledToFit()
-			.padding(1)
-			.frame(width: 28, height: 28)
-			.clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-			.overlay {
-				RoundedRectangle(cornerRadius: 7, style: .continuous)
-					.stroke(
-						colorScheme == .light
-							? Color.black.opacity(0.08)
-							: Color.white.opacity(0.16),
-						lineWidth: 1
-					)
-			}
-	}
-}
-
-private struct SettingsRailButton: View {
-	let section: NativeHostSettingsSection
-	let isSelected: Bool
-	let action: () -> Void
-	@Environment(\.colorScheme) private var colorScheme
-	@State private var isHovered = false
-
-	var body: some View {
-		Button(action: action) {
-			HStack(spacing: 8) {
-				Image(systemName: section.symbolName)
-					.symbolRenderingMode(.hierarchical)
-					.font(.system(size: 12.5, weight: .semibold))
-					.foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
-					.frame(width: 23, height: 23)
-
-				VStack(alignment: .leading, spacing: 2) {
-					Text(section.title)
-						.font(.system(size: 12.5, weight: .semibold))
-						.foregroundStyle(isSelected ? Color.primary : Color.primary.opacity(0.88))
-						.lineLimit(1)
-						.minimumScaleFactor(0.88)
-					Text(section.subtitle)
-						.font(.system(size: 10, weight: .medium))
-						.foregroundStyle(.secondary)
-						.lineLimit(1)
-				}
-				Spacer(minLength: 0)
-			}
-			.padding(.horizontal, 8)
-			.padding(.vertical, 5)
-			.frame(maxWidth: .infinity)
-			.contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
-			.background {
-				if isSelected {
-					RoundedRectangle(cornerRadius: 9, style: .continuous)
-						.fill(
-							colorScheme == .light
-								? Color.black.opacity(0.040)
-								: Color.white.opacity(0.058)
-						)
-					HStack {
-						Capsule()
-							.fill(Color.accentColor)
-							.frame(width: 2, height: 16)
-						Spacer()
-					}
-					.padding(.leading, 1)
-				} else if isHovered {
-					RoundedRectangle(cornerRadius: 9, style: .continuous)
-						.fill(
-							colorScheme == .light
-								? Color.black.opacity(0.022)
-								: Color.white.opacity(0.034)
-						)
-				}
-			}
-		}
-		.buttonStyle(.plain)
-		.animation(.easeOut(duration: 0.14), value: isSelected)
-		.onHover { hovering in
-			withAnimation(.easeOut(duration: 0.14)) {
-				isHovered = hovering
-			}
-		}
-	}
-}
-
-private struct SettingsDashboard: View {
-	@ObservedObject var model: NativeHostSettingsViewModel
-	let section: NativeHostSettingsSection
-	let restoreDefaults: () -> Void
-
-	var body: some View {
-		VStack(alignment: .leading, spacing: 6) {
-			SettingsContentHeader(
-				section: section,
-				restoreDefaults: restoreDefaults
-			)
-
-			ScrollView {
-				activePanel
-					.id(section)
-					.transition(
-						.asymmetric(
-							insertion: .opacity.combined(with: .move(edge: .bottom)),
-							removal: .opacity.combined(with: .move(edge: .top))
-						)
-					)
-					.padding(.trailing, 8)
-					.padding(.bottom, 2)
-			}
-			.scrollIndicators(.hidden)
-			.frame(maxWidth: .infinity, alignment: .topLeading)
-			.animation(.spring(response: 0.34, dampingFraction: 0.86), value: section)
-		}
-		.padding(.horizontal, 13)
-		.padding(.vertical, 9)
-		.settingsGlassSurface(cornerRadius: 18, role: .panel)
-	}
-
-	@ViewBuilder
-	private var activePanel: some View {
-		switch section {
-		case .appearance:
-			AppearanceSettingsPanel(model: model)
-		case .capture:
-			CaptureSettingsPanel(model: model)
-		case .output:
-			OutputSettingsPanel(model: model)
-		case .permissions:
-			PermissionsSettingsPanel(model: model)
-		case .about:
-			AboutSettingsPanel(model: model)
-		}
-	}
-}
-
-private struct SettingsContentHeader: View {
-	let section: NativeHostSettingsSection
-	let restoreDefaults: () -> Void
-
-	var body: some View {
-		HStack(alignment: .firstTextBaseline, spacing: 10) {
-			VStack(alignment: .leading, spacing: 2) {
-				Text(section.title)
-					.font(.system(size: 18, weight: .semibold))
-				Text(section.subtitle)
-					.font(.system(size: 11, weight: .medium))
-					.foregroundStyle(.secondary)
-			}
-			.frame(maxWidth: .infinity, alignment: .leading)
-
-			if section.allowsRestoreDefaults {
-				Button(action: restoreDefaults) {
-					Label("Restore Defaults", systemImage: "arrow.counterclockwise")
-						.labelStyle(.titleAndIcon)
-				}
-				.rsnapGlassButton(prominent: false)
-				.controlSize(.small)
-			}
-		}
-		.padding(.bottom, 2)
-	}
 }
 
 private struct SettingsSectionInspector: View {
@@ -1580,7 +1319,7 @@ private struct LaunchAtLoginToggle: View {
 	}
 }
 
-private struct AppearanceSettingsPanel: View {
+struct AppearanceSettingsPanel: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
 
 	var body: some View {
@@ -1983,7 +1722,7 @@ private struct SettingsColorWell: NSViewRepresentable {
 	}
 }
 
-private struct CaptureSettingsPanel: View {
+struct CaptureSettingsPanel: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
 
 	var body: some View {
@@ -2169,7 +1908,7 @@ private struct QuickScreenshotHotKeyField: View {
 	}
 }
 
-private struct PermissionsSettingsPanel: View {
+struct PermissionsSettingsPanel: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
 	@State private var refreshID = 0
 
@@ -2391,7 +2130,7 @@ private struct PermissionStateBadge: View {
 	}
 }
 
-private struct AboutSettingsPanel: View {
+struct AboutSettingsPanel: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
 
 	var body: some View {
@@ -2558,7 +2297,7 @@ private struct AboutLinkTile: View {
 	}
 }
 
-private struct OutputSettingsPanel: View {
+struct OutputSettingsPanel: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
 
 	var body: some View {


### PR DESCRIPTION
Summary
- Extract the NativeHost settings section enum, rail, brand icon, and dashboard shell into NativeHostSettingsNavigation.swift.
- Keep About links private to the About/settings content owner instead of the navigation file.
- Preserve normal Swift source boundaries with no include!/#[path] physical splitting.

Validation
- cargo make fmt-swift
- cargo make fmt-swift-check
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make check-vstyle-swift
- git diff --check plus forbidden include/path scan
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

Review
- Fresh read-only skeptic review found an untracked-file staging blocker and an About-links ownership caveat. The About links were moved back to the settings content file, and the new navigation file was staged deliberately before commit.