### PR TITLE
Modularize capture host support

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -86,6 +86,10 @@ The current native-host Swift split is:
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, cursor presentation, Liquid Glass
   surfaces, live/frozen HUD and toolbar rendering, and native pointer/key event routing into the
   session controller.
+- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, capture-host cursor adaptation, Rust-backed frozen image
+  effects, live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -190,6 +190,10 @@ The main host-kit files are split by responsibility:
   capture source management
 - `CaptureHostView.swift`: AppKit view rendering, hit testing, cursor presentation, and native
   pointer/key routing
+- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, capture-host cursors, Rust-backed frozen image effects,
+  live-chrome telemetry identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureGeometry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureGeometry.swift
@@ -16,6 +16,24 @@ extension CGRect {
 			y: point.y.clamped(to: minY...maxY)
 		)
 	}
+
+	private func clampedPoint(_ point: CGPoint) -> CGPoint {
+		CGPoint(
+			x: point.x.clamped(to: minX...maxX),
+			y: point.y.clamped(to: minY...maxY)
+		)
+	}
+
+	package func normalizedRect(anchor: CGPoint, current: CGPoint) -> CGRect {
+		let clampedAnchor = clampedPoint(anchor)
+		let clampedCurrent = clampedPoint(current)
+		return CGRect(
+			x: min(clampedAnchor.x, clampedCurrent.x),
+			y: min(clampedAnchor.y, clampedCurrent.y),
+			width: abs(clampedCurrent.x - clampedAnchor.x),
+			height: abs(clampedCurrent.y - clampedAnchor.y)
+		)
+	}
 }
 
 package func captureOverlayLocalPoint(

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorSupport.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorSupport.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+extension NSCursor {
+	private static func frozenDiagonalCursor(
+		from baseCursor: NSCursor
+	) -> NSCursor {
+		NSCursor(image: baseCursor.image, hotSpot: baseCursor.hotSpot)
+	}
+
+	private static var _diagonalTopLeftBottomRight: NSCursor {
+		if #available(macOS 15.0, *) {
+			return frozenDiagonalCursor(
+				from: .frameResize(position: .topLeft, directions: [.inward, .outward])
+			)
+		}
+		return .crosshair
+	}
+
+	private static var _diagonalTopRightBottomLeft: NSCursor {
+		if #available(macOS 15.0, *) {
+			return frozenDiagonalCursor(
+				from: .frameResize(position: .topRight, directions: [.inward, .outward])
+			)
+		}
+		return .crosshair
+	}
+
+	static var _windowResizeTopRight: NSCursor {
+		_diagonalTopRightBottomLeft
+	}
+
+	static var _windowResizeTopLeft: NSCursor {
+		_diagonalTopLeftBottomRight
+	}
+
+	static var _windowResizeBottomLeft: NSCursor {
+		_diagonalTopRightBottomLeft
+	}
+
+	static var _windowResizeBottomRight: NSCursor {
+		_diagonalTopLeftBottomRight
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostFrozenImageEffects.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostFrozenImageEffects.swift
@@ -1,0 +1,23 @@
+import CoreGraphics
+import RsnapHostBridge
+
+func makeFrozenMosaicPatch(from image: CGImage, sourceRect: CGRect) -> CGImage? {
+	guard
+		let patch = try? RsnapExportEncoder.frozenMosaicLightPrivacyPatch(
+			imageWidth: image.width,
+			imageHeight: image.height,
+			sourceRect: sourceRect
+		)
+	else {
+		return nil
+	}
+
+	let bitmapInfo =
+		CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
+	return NativeHostImageBridge.cgImage(
+		width: patch.width,
+		height: patch.height,
+		rgba: patch.rgba,
+		bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo)
+	)
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -8,35 +8,6 @@ import RsnapHostBridge
 
 @MainActor private let frozenEffectCIContext = CIContext(options: nil)
 
-struct LiveChromeRefreshTelemetryKey: Equatable {
-	let targetHz: Int
-	let hudGlassEnabled: Bool
-	let hudGlassMode: String
-	let liquidGlassStyle: String
-	let liquidGlassAvailable: Bool
-}
-
-func makeFrozenMosaicPatch(from image: CGImage, sourceRect: CGRect) -> CGImage? {
-	guard
-		let patch = try? RsnapExportEncoder.frozenMosaicLightPrivacyPatch(
-			imageWidth: image.width,
-			imageHeight: image.height,
-			sourceRect: sourceRect
-		)
-	else {
-		return nil
-	}
-
-	let bitmapInfo =
-		CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
-	return NativeHostImageBridge.cgImage(
-		width: patch.width,
-		height: patch.height,
-		rgba: patch.rgba,
-		bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo)
-	)
-}
-
 @MainActor
 final class CaptureHostView: NSView {
 	private static let liveDragIntentThreshold: CGFloat = 3
@@ -4139,72 +4110,4 @@ final class CaptureHostView: NSView {
 		}
 	}
 
-}
-
-extension NSCursor {
-	private static func frozenDiagonalCursor(
-		from baseCursor: NSCursor
-	) -> NSCursor {
-		NSCursor(image: baseCursor.image, hotSpot: baseCursor.hotSpot)
-	}
-
-	private static var _diagonalTopLeftBottomRight: NSCursor {
-		if #available(macOS 15.0, *) {
-			return frozenDiagonalCursor(
-				from: .frameResize(position: .topLeft, directions: [.inward, .outward])
-			)
-		}
-		return .crosshair
-	}
-
-	private static var _diagonalTopRightBottomLeft: NSCursor {
-		if #available(macOS 15.0, *) {
-			return frozenDiagonalCursor(
-				from: .frameResize(position: .topRight, directions: [.inward, .outward])
-			)
-		}
-		return .crosshair
-	}
-
-	fileprivate static var _windowResizeTopRight: NSCursor {
-		_diagonalTopRightBottomLeft
-	}
-
-	fileprivate static var _windowResizeTopLeft: NSCursor {
-		_diagonalTopLeftBottomRight
-	}
-
-	fileprivate static var _windowResizeBottomLeft: NSCursor {
-		_diagonalTopRightBottomLeft
-	}
-
-	fileprivate static var _windowResizeBottomRight: NSCursor {
-		_diagonalTopLeftBottomRight
-	}
-}
-
-extension CGRect {
-	fileprivate func clamp(_ point: CGPoint) -> CGPoint {
-		CGPoint(
-			x: point.x.clamped(to: minX...maxX),
-			y: point.y.clamped(to: minY...maxY)
-		)
-	}
-
-	fileprivate func normalizedRect(anchor: CGPoint, current: CGPoint) -> CGRect {
-		let clampedAnchor = clamp(anchor)
-		let clampedCurrent = clamp(current)
-		return CGRect(
-			x: min(clampedAnchor.x, clampedCurrent.x),
-			y: min(clampedAnchor.y, clampedCurrent.y),
-			width: abs(clampedCurrent.x - clampedAnchor.x),
-			height: abs(clampedCurrent.y - clampedAnchor.y)
-		)
-	}
-}
-
-extension String {
-	func size(using font: NSFont) -> CGSize {
-		(self as NSString).size(withAttributes: [.font: font])
-	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeRefreshTelemetryKey.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveChromeRefreshTelemetryKey.swift
@@ -1,0 +1,7 @@
+struct LiveChromeRefreshTelemetryKey: Equatable {
+	let targetHz: Int
+	let hudGlassEnabled: Bool
+	let hudGlassMode: String
+	let liquidGlassStyle: String
+	let liquidGlassAvailable: Bool
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTextMetrics.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostTextMetrics.swift
@@ -1,0 +1,7 @@
+import AppKit
+
+extension String {
+	func size(using font: NSFont) -> CGSize {
+		(self as NSString).size(withAttributes: [.font: font])
+	}
+}


### PR DESCRIPTION
Summary
- Extract CaptureHostView support into focused Swift source boundaries for cursor adaptation, Rust-backed frozen image effects, live-chrome telemetry identity, and shared text metrics.
- Move capture-host normalized selection geometry into the existing CaptureGeometry.swift owner instead of adding a competing geometry file.
- Update host layout docs to document the new support boundaries.
- Preserve normal Swift source/module boundaries with no include!/#[path] physical splitting.

Validation
- cargo make fmt-swift
- cargo make fmt-swift-check
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make check-vstyle-swift
- git diff --check plus forbidden include/path scan
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

Review
- First fresh skeptic review found a generic support-file boundary and untracked-file risk. The patch was tightened into focused support files, geometry moved to CaptureGeometry.swift, and docs were updated.
- Second fresh skeptic review found no staging/commit blocker; new files were staged explicitly.