### PR TITLE
Modularize frozen toolbar layout

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -93,6 +93,8 @@ The current native-host Swift split is:
 - `LiveOverlayWindowSnapshotFeed.swift`, `LiveOverlayChromeSampleFeed.swift`, and
   `LiveFrameClockDriver.swift`: native live overlay support boundaries for target-window snapshots,
   chrome color/patch sampling, and display-rate frame ticks.
+- `FrozenToolbarLayoutPlanner.swift`: deterministic frozen-toolbar item availability, layout, and
+  hit-test geometry used by AppKit drawing, Liquid Glass toolbar content, and native probes.
 - `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, capture-host cursor adaptation, Rust-backed frozen image

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -197,6 +197,8 @@ The main host-kit files are split by responsibility:
 - `LiveOverlayWindowSnapshotFeed.swift`, `LiveOverlayChromeSampleFeed.swift`, and
   `LiveFrameClockDriver.swift`: live overlay support boundaries for target-window snapshots,
   chrome color/patch sampling, and display-rate frame ticks
+- `FrozenToolbarLayoutPlanner.swift`: deterministic frozen-toolbar item availability, layout, and
+  hit-test geometry shared by classic drawing, Liquid Glass content, and native probes
 - `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, capture-host cursors, Rust-backed frozen image effects,

--- a/native/macos-host/Package.swift
+++ b/native/macos-host/Package.swift
@@ -75,7 +75,7 @@ let package = Package(
 		),
 		.executableTarget(
 			name: "RsnapNativeHostKitProbe",
-			dependencies: ["RsnapNativeHostKit"]
+			dependencies: ["RsnapHostBridge", "RsnapNativeHostKit"]
 		),
 		.executableTarget(
 			name: "RsnapNativeHost",

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -1927,173 +1927,12 @@ final class CaptureHostView: NSView {
 	}
 
 	private func toolbarLayout(for selection: CGRect) -> FrozenToolbarLayout? {
-		let items = visibleToolbarItems()
-		guard items.isEmpty == false else {
-			return nil
-		}
-
-		var styleKind: FrozenAnnotationStyleToolbarKind?
-		for item in items where item.enabled && item.selected {
-			if let kind = FrozenAnnotationStyleToolbarKind(selectedTool: item.kind) {
-				styleKind = kind
-				break
-			}
-		}
-		let metrics = CaptureChrome.toolbarMetrics()
-		let itemCount = CGFloat(items.count)
-		let primaryContentWidth =
-			itemCount * metrics.buttonSize
-			+ max(0, itemCount - 1) * metrics.itemSpacing
-		let styleContentWidth =
-			styleKind.map { annotationStyleContentWidth(for: $0, metrics: metrics) } ?? 0
-		let contentWidth = max(primaryContentWidth, styleContentWidth)
-		let width = contentWidth + metrics.horizontalPadding * 2
-		let primaryRowHeight = metrics.verticalPadding * 2 + metrics.buttonSize
-		let height = styleKind == nil ? primaryRowHeight : primaryRowHeight * 2
-		let desiredY = selection.maxY + metrics.gap
-		let wantsTop = settings.toolbarPlacement == .top
-		let placedAbove =
-			wantsTop || desiredY + height > bounds.maxY - CaptureChrome.toolbarScreenMargin
-		let y =
-			placedAbove
-			? max(
-				bounds.minY + CaptureChrome.toolbarScreenMargin,
-				selection.minY - metrics.gap - height)
-			: min(bounds.maxY - CaptureChrome.toolbarScreenMargin - height, desiredY)
-		let minX = bounds.minX + CaptureChrome.toolbarScreenMargin
-		let maxX = max(minX, bounds.maxX - CaptureChrome.toolbarScreenMargin - width)
-		let x = (selection.midX - width / 2).clamped(to: minX...maxX)
-		let frame = CGRect(x: x, y: y, width: width, height: height)
-		let toolbarAboveSelection = frame.midY >= selection.midY
-		let primaryY =
-			if styleKind == nil {
-				frame.midY - metrics.buttonSize / 2
-			} else if toolbarAboveSelection {
-				frame.minY + metrics.verticalPadding
-			} else {
-				frame.maxY - metrics.verticalPadding - metrics.buttonSize
-			}
-		var itemFrames: [FrozenToolbarItemLayout] = []
-		var cursorX = frame.midX - primaryContentWidth / 2
-		for item in items {
-			let itemFrame = CGRect(
-				x: cursorX,
-				y: primaryY,
-				width: metrics.buttonSize,
-				height: metrics.buttonSize
-			)
-			itemFrames.append(
-				FrozenToolbarItemLayout(
-					kind: item.kind,
-					frame: itemFrame,
-					enabled: item.enabled,
-					selected: item.selected
-				)
-			)
-			cursorX += metrics.buttonSize + metrics.itemSpacing
-		}
-
-		let styleLayout: FrozenAnnotationStyleLayout?
-		if let styleKind {
-			styleLayout = annotationStyleLayout(
-				for: styleKind,
-				in: frame,
-				contentWidth: styleContentWidth,
-				metrics: metrics,
-				toolbarAboveSelection: toolbarAboveSelection
-			)
-		} else {
-			styleLayout = nil
-		}
-
-		return FrozenToolbarLayout(
-			scale: metrics.scale,
-			frame: frame,
-			items: itemFrames,
-			annotationStyle: styleLayout
-		)
-	}
-
-	private func annotationStyleContentWidth(
-		for kind: FrozenAnnotationStyleToolbarKind,
-		metrics: CaptureChrome.ToolbarMetrics
-	) -> CGFloat {
-		let swatchCount = CGFloat(FrozenAnnotationColor.allCases.count)
-		let swatchesWidth =
-			swatchCount * metrics.annotationSwatchSize
-			+ max(0, swatchCount - 1) * metrics.annotationSwatchGap
-		return kind.sizeControlWidth(scale: metrics.scale)
-			+ metrics.annotationStyleControlGap
-			+ swatchesWidth
-	}
-
-	private func annotationStyleLayout(
-		for kind: FrozenAnnotationStyleToolbarKind,
-		in frame: CGRect,
-		contentWidth: CGFloat,
-		metrics: CaptureChrome.ToolbarMetrics,
-		toolbarAboveSelection: Bool
-	) -> FrozenAnnotationStyleLayout {
-		let rowY =
-			toolbarAboveSelection
-			? frame.maxY - metrics.verticalPadding - metrics.annotationStyleRowHeight
-			: frame.minY + metrics.verticalPadding
-		let rowFrame = CGRect(
-			x: frame.midX - contentWidth / 2,
-			y: rowY,
-			width: contentWidth,
-			height: metrics.annotationStyleRowHeight
-		)
-		let sizeControlFrame = CGRect(
-			x: rowFrame.minX,
-			y: rowFrame.minY,
-			width: kind.sizeControlWidth(scale: metrics.scale),
-			height: rowFrame.height
-		)
-		let decreaseFrame = CGRect(
-			x: sizeControlFrame.minX,
-			y: sizeControlFrame.minY,
-			width: metrics.annotationSizeButtonWidth,
-			height: sizeControlFrame.height
-		)
-		let increaseFrame = CGRect(
-			x: sizeControlFrame.maxX - metrics.annotationSizeButtonWidth,
-			y: sizeControlFrame.minY,
-			width: metrics.annotationSizeButtonWidth,
-			height: sizeControlFrame.height
-		)
-		let displayFrame = CGRect(
-			x: decreaseFrame.maxX,
-			y: sizeControlFrame.minY,
-			width: max(0, increaseFrame.minX - decreaseFrame.maxX),
-			height: sizeControlFrame.height
-		)
-		var swatches: [FrozenAnnotationColorSwatchLayout] = []
-		var swatchX = sizeControlFrame.maxX + metrics.annotationStyleControlGap
-		for color in FrozenAnnotationColor.allCases {
-			let swatchFrame = CGRect(
-				x: swatchX,
-				y: rowFrame.midY - metrics.annotationSwatchSize / 2,
-				width: metrics.annotationSwatchSize,
-				height: metrics.annotationSwatchSize
-			)
-			swatches.append(
-				FrozenAnnotationColorSwatchLayout(
-					color: color,
-					frame: swatchFrame,
-					selected: kind.selectedColor(in: chrome.annotationStyle) == color
-				))
-			swatchX += metrics.annotationSwatchSize + metrics.annotationSwatchGap
-		}
-		return FrozenAnnotationStyleLayout(
-			kind: kind,
-			scale: metrics.scale,
-			frame: rowFrame,
-			sizeControlFrame: sizeControlFrame,
-			decreaseFrame: decreaseFrame,
-			increaseFrame: increaseFrame,
-			displayFrame: displayFrame,
-			swatches: swatches
+		FrozenToolbarLayoutPlanner.layout(
+			selection: selection,
+			bounds: bounds,
+			prefersTopPlacement: settings.toolbarPlacement == .top,
+			items: visibleToolbarItems(),
+			annotationStyle: chrome.annotationStyle
 		)
 	}
 
@@ -2135,33 +1974,18 @@ final class CaptureHostView: NSView {
 	}
 
 	private func visibleToolbarItems() -> [ToolbarItem] {
-		var items: [ToolbarItem] = []
-		let scrollCaptureActive = chrome.scrollMinimapPreview != nil
-		for originalItem in scene.toolbarItems {
-			var item = originalItem
-			switch item.kind {
-			case .pointer, .pen, .arrow, .mosaic, .spotlight, .text:
-				item.enabled = originalItem.enabled && !scrollCaptureActive
-			case .undo:
-				item.enabled = chrome.frozenOverlay.canUndo && !scrollCaptureActive
-			case .redo:
-				item.enabled = chrome.frozenOverlay.canRedo && !scrollCaptureActive
-			case .autoCenter:
-				item.enabled =
-					scene.frozenSelection != nil
-					&& !chrome.frozenOverlay.keepsFrozenSelectionFixed
-					&& !scrollCaptureActive
-			case .scroll:
-				item.enabled = controller?.scrollCaptureToolbarEnabled ?? false
-			case .ocr:
-				item.enabled =
-					originalItem.enabled && !chrome.frozenOverlay.hasRecognizeTextBlockingEdits
-			case .copy, .save:
-				item.enabled = originalItem.enabled
-			}
-			items.append(item)
-		}
-		return items
+		FrozenToolbarLayoutPlanner.visibleItems(
+			from: scene.toolbarItems,
+			availability: FrozenToolbarAvailability(
+				scrollCaptureActive: chrome.scrollMinimapPreview != nil,
+				canUndo: chrome.frozenOverlay.canUndo,
+				canRedo: chrome.frozenOverlay.canRedo,
+				frozenSelectionAvailable: scene.frozenSelection != nil,
+				keepsFrozenSelectionFixed: chrome.frozenOverlay.keepsFrozenSelectionFixed,
+				scrollToolbarEnabled: controller?.scrollCaptureToolbarEnabled ?? false,
+				hasRecognizeTextBlockingEdits: chrome.frozenOverlay.hasRecognizeTextBlockingEdits
+			)
+		)
 	}
 
 	private func toolbarItem(_ kind: ToolbarItemKind) -> ToolbarItem? {
@@ -2206,40 +2030,15 @@ final class CaptureHostView: NSView {
 		controller?.performFrozenAnnotationStyleAction(action)
 	}
 
-	private func frozenToolbarHitState(at point: CGPoint) -> (
-		pointerOverToolbar: Bool,
-		toolbarAction: ToolbarItemKind?,
-		annotationStyleAction: FrozenAnnotationStyleAction?
-	) {
-		guard scene.mode == .frozen, let selection = localFrozenSelectionRect(),
-			let layout = toolbarLayout(for: selection)
-		else {
-			return (false, nil, nil)
+	private func frozenToolbarHitState(at point: CGPoint) -> FrozenToolbarHitState {
+		guard scene.mode == .frozen, let selection = localFrozenSelectionRect() else {
+			return FrozenToolbarHitState(
+				pointerOverToolbar: false,
+				toolbarAction: nil,
+				annotationStyleAction: nil
+			)
 		}
-
-		var hoveredAction: ToolbarItemKind?
-		for item in layout.items where item.enabled {
-			if item.frame.contains(point) {
-				hoveredAction = item.kind
-				break
-			}
-		}
-
-		var hoveredStyleAction: FrozenAnnotationStyleAction?
-		if let styleLayout = layout.annotationStyle {
-			if styleLayout.decreaseFrame.contains(point) {
-				hoveredStyleAction = .decreaseSize
-			} else if styleLayout.increaseFrame.contains(point) {
-				hoveredStyleAction = .increaseSize
-			} else {
-				for swatch in styleLayout.swatches where swatch.frame.contains(point) {
-					hoveredStyleAction = .color(swatch.color)
-					break
-				}
-			}
-		}
-
-		return (layout.frame.contains(point), hoveredAction, hoveredStyleAction)
+		return FrozenToolbarLayoutPlanner.hitState(at: point, in: toolbarLayout(for: selection))
 	}
 
 	private func clearHoveredToolbarAction() {
@@ -2256,16 +2055,15 @@ final class CaptureHostView: NSView {
 
 	private func refreshHoveredToolbarAction(for localPoint: CGPoint? = nil) {
 		let probePoint = scene.mode == .frozen ? (localPoint ?? currentLocalMousePoint()) : nil
-		let hitState:
-			(
-				pointerOverToolbar: Bool,
-				toolbarAction: ToolbarItemKind?,
-				annotationStyleAction: FrozenAnnotationStyleAction?
-			)
+		let hitState: FrozenToolbarHitState
 		if let probePoint {
 			hitState = frozenToolbarHitState(at: probePoint)
 		} else {
-			hitState = (false, nil, nil)
+			hitState = FrozenToolbarHitState(
+				pointerOverToolbar: false,
+				toolbarAction: nil,
+				annotationStyleAction: nil
+			)
 		}
 		let pointerOverToolbar = hitState.pointerOverToolbar
 		let hoveredAction = hitState.toolbarAction
@@ -3695,43 +3493,6 @@ final class CaptureHostView: NSView {
 		return true
 	}
 
-	private func localAnnotationStyleLayout(
-		_ layout: FrozenAnnotationStyleLayout,
-		relativeTo toolbarFrame: CGRect
-	) -> FrozenAnnotationStyleLayout {
-		FrozenAnnotationStyleLayout(
-			kind: layout.kind,
-			scale: layout.scale,
-			frame: layout.frame.offsetBy(dx: -toolbarFrame.minX, dy: -toolbarFrame.minY),
-			sizeControlFrame: layout.sizeControlFrame.offsetBy(
-				dx: -toolbarFrame.minX,
-				dy: -toolbarFrame.minY
-			),
-			decreaseFrame: layout.decreaseFrame.offsetBy(
-				dx: -toolbarFrame.minX,
-				dy: -toolbarFrame.minY
-			),
-			increaseFrame: layout.increaseFrame.offsetBy(
-				dx: -toolbarFrame.minX,
-				dy: -toolbarFrame.minY
-			),
-			displayFrame: layout.displayFrame.offsetBy(
-				dx: -toolbarFrame.minX,
-				dy: -toolbarFrame.minY
-			),
-			swatches: layout.swatches.map { swatch in
-				FrozenAnnotationColorSwatchLayout(
-					color: swatch.color,
-					frame: swatch.frame.offsetBy(
-						dx: -toolbarFrame.minX,
-						dy: -toolbarFrame.minY
-					),
-					selected: swatch.selected
-				)
-			}
-		)
-	}
-
 	private func hideLiveLiquidGlassViews(removing: Bool = true) {
 		if removing {
 			hudLiquidGlassView?.removeFromSuperview()
@@ -3794,7 +3555,10 @@ final class CaptureHostView: NSView {
 			toolbarScale: layout.scale,
 			annotationStyleState: chrome.annotationStyle,
 			annotationStyleLayout: layout.annotationStyle.map {
-				localAnnotationStyleLayout($0, relativeTo: layout.frame)
+				FrozenToolbarLayoutPlanner.localAnnotationStyleLayout(
+					$0,
+					relativeTo: layout.frame
+				)
 			},
 			items: layout.items.map { item in
 				FrozenToolbarRenderView.Item(

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenCaptureModels.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenCaptureModels.swift
@@ -3,7 +3,7 @@ import CoreGraphics
 import Foundation
 import RsnapHostBridge
 
-enum FrozenAnnotationColor: CaseIterable, Equatable {
+package enum FrozenAnnotationColor: CaseIterable, Equatable {
 	case white
 	case yellow
 	case green
@@ -244,13 +244,13 @@ extension FrozenAnnotationStyleState {
 	}
 }
 
-enum FrozenAnnotationStyleAction: Equatable {
+package enum FrozenAnnotationStyleAction: Equatable {
 	case decreaseSize
 	case increaseSize
 	case color(FrozenAnnotationColor)
 }
 
-enum FrozenAnnotationStyleToolbarKind: Equatable {
+package enum FrozenAnnotationStyleToolbarKind: Equatable {
 	case brush
 	case spotlight
 	case text
@@ -327,10 +327,12 @@ enum FrozenAnnotationStyleToolbarKind: Equatable {
 	}
 }
 
-struct FrozenAnnotationStyleState: Equatable {
+package struct FrozenAnnotationStyleState: Equatable {
 	var brushStyle = FrozenBrushStyle()
 	var spotlightStyle = FrozenSpotlightStyle()
 	var textStyle = FrozenTextStyle()
+
+	package init() {}
 
 	mutating func apply(
 		_ action: FrozenAnnotationStyleAction,
@@ -803,33 +805,33 @@ final class FrozenOverlayState {
 	}
 }
 
-struct FrozenToolbarItemLayout: Equatable {
-	let kind: ToolbarItemKind
-	let frame: CGRect
-	let enabled: Bool
-	let selected: Bool
+package struct FrozenToolbarItemLayout: Equatable {
+	package let kind: ToolbarItemKind
+	package let frame: CGRect
+	package let enabled: Bool
+	package let selected: Bool
 }
 
-struct FrozenAnnotationColorSwatchLayout: Equatable {
-	let color: FrozenAnnotationColor
-	let frame: CGRect
-	let selected: Bool
+package struct FrozenAnnotationColorSwatchLayout: Equatable {
+	package let color: FrozenAnnotationColor
+	package let frame: CGRect
+	package let selected: Bool
 }
 
-struct FrozenAnnotationStyleLayout: Equatable {
-	let kind: FrozenAnnotationStyleToolbarKind
-	let scale: CGFloat
-	let frame: CGRect
-	let sizeControlFrame: CGRect
-	let decreaseFrame: CGRect
-	let increaseFrame: CGRect
-	let displayFrame: CGRect
-	let swatches: [FrozenAnnotationColorSwatchLayout]
+package struct FrozenAnnotationStyleLayout: Equatable {
+	package let kind: FrozenAnnotationStyleToolbarKind
+	package let scale: CGFloat
+	package let frame: CGRect
+	package let sizeControlFrame: CGRect
+	package let decreaseFrame: CGRect
+	package let increaseFrame: CGRect
+	package let displayFrame: CGRect
+	package let swatches: [FrozenAnnotationColorSwatchLayout]
 }
 
-struct FrozenToolbarLayout {
-	let scale: CGFloat
-	let frame: CGRect
-	let items: [FrozenToolbarItemLayout]
-	let annotationStyle: FrozenAnnotationStyleLayout?
+package struct FrozenToolbarLayout {
+	package let scale: CGFloat
+	package let frame: CGRect
+	package let items: [FrozenToolbarItemLayout]
+	package let annotationStyle: FrozenAnnotationStyleLayout?
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenToolbarLayoutPlanner.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenToolbarLayoutPlanner.swift
@@ -1,0 +1,373 @@
+import CoreGraphics
+import RsnapHostBridge
+
+package struct FrozenToolbarAvailability {
+	package let scrollCaptureActive: Bool
+	package let canUndo: Bool
+	package let canRedo: Bool
+	package let frozenSelectionAvailable: Bool
+	package let keepsFrozenSelectionFixed: Bool
+	package let scrollToolbarEnabled: Bool
+	package let hasRecognizeTextBlockingEdits: Bool
+
+	package init(
+		scrollCaptureActive: Bool,
+		canUndo: Bool,
+		canRedo: Bool,
+		frozenSelectionAvailable: Bool,
+		keepsFrozenSelectionFixed: Bool,
+		scrollToolbarEnabled: Bool,
+		hasRecognizeTextBlockingEdits: Bool
+	) {
+		self.scrollCaptureActive = scrollCaptureActive
+		self.canUndo = canUndo
+		self.canRedo = canRedo
+		self.frozenSelectionAvailable = frozenSelectionAvailable
+		self.keepsFrozenSelectionFixed = keepsFrozenSelectionFixed
+		self.scrollToolbarEnabled = scrollToolbarEnabled
+		self.hasRecognizeTextBlockingEdits = hasRecognizeTextBlockingEdits
+	}
+}
+
+package struct FrozenToolbarHitState: Equatable {
+	package let pointerOverToolbar: Bool
+	package let toolbarAction: ToolbarItemKind?
+	package let annotationStyleAction: FrozenAnnotationStyleAction?
+
+	package init(
+		pointerOverToolbar: Bool,
+		toolbarAction: ToolbarItemKind?,
+		annotationStyleAction: FrozenAnnotationStyleAction?
+	) {
+		self.pointerOverToolbar = pointerOverToolbar
+		self.toolbarAction = toolbarAction
+		self.annotationStyleAction = annotationStyleAction
+	}
+}
+
+package enum FrozenToolbarLayoutPlanner {
+	package static func visibleItems(
+		from sourceItems: [ToolbarItem],
+		availability: FrozenToolbarAvailability
+	) -> [ToolbarItem] {
+		sourceItems.map { originalItem in
+			var item = originalItem
+			switch item.kind {
+			case .pointer, .pen, .arrow, .mosaic, .spotlight, .text:
+				item.enabled = originalItem.enabled && !availability.scrollCaptureActive
+			case .undo:
+				item.enabled = availability.canUndo && !availability.scrollCaptureActive
+			case .redo:
+				item.enabled = availability.canRedo && !availability.scrollCaptureActive
+			case .autoCenter:
+				item.enabled =
+					availability.frozenSelectionAvailable
+					&& !availability.keepsFrozenSelectionFixed
+					&& !availability.scrollCaptureActive
+			case .scroll:
+				item.enabled = availability.scrollToolbarEnabled
+			case .ocr:
+				item.enabled =
+					originalItem.enabled && !availability.hasRecognizeTextBlockingEdits
+			case .copy, .save:
+				item.enabled = originalItem.enabled
+			}
+			return item
+		}
+	}
+
+	package static func layout(
+		selection: CGRect,
+		bounds: CGRect,
+		prefersTopPlacement: Bool,
+		items: [ToolbarItem],
+		annotationStyle: FrozenAnnotationStyleState
+	) -> FrozenToolbarLayout? {
+		guard items.isEmpty == false else {
+			return nil
+		}
+
+		let styleKind = selectedAnnotationStyleKind(in: items)
+		let metrics = CaptureChrome.toolbarMetrics()
+		let itemCount = CGFloat(items.count)
+		let primaryContentWidth =
+			itemCount * metrics.buttonSize
+			+ max(0, itemCount - 1) * metrics.itemSpacing
+		let styleContentWidth =
+			styleKind.map { annotationStyleContentWidth(for: $0, metrics: metrics) } ?? 0
+		let contentWidth = max(primaryContentWidth, styleContentWidth)
+		let width = contentWidth + metrics.horizontalPadding * 2
+		let primaryRowHeight = metrics.verticalPadding * 2 + metrics.buttonSize
+		let height = styleKind == nil ? primaryRowHeight : primaryRowHeight * 2
+		let frame = toolbarFrame(
+			selection: selection,
+			bounds: bounds,
+			width: width,
+			height: height,
+			gap: metrics.gap,
+			prefersTopPlacement: prefersTopPlacement
+		)
+		let toolbarAboveSelection = frame.midY >= selection.midY
+		let primaryY =
+			if styleKind == nil {
+				frame.midY - metrics.buttonSize / 2
+			} else if toolbarAboveSelection {
+				frame.minY + metrics.verticalPadding
+			} else {
+				frame.maxY - metrics.verticalPadding - metrics.buttonSize
+			}
+		let itemFrames = primaryItemLayouts(
+			for: items,
+			frame: frame,
+			primaryContentWidth: primaryContentWidth,
+			primaryY: primaryY,
+			metrics: metrics
+		)
+		let styleLayout: FrozenAnnotationStyleLayout?
+		if let styleKind {
+			styleLayout = annotationStyleLayout(
+				for: styleKind,
+				in: frame,
+				contentWidth: styleContentWidth,
+				metrics: metrics,
+				toolbarAboveSelection: toolbarAboveSelection,
+				annotationStyle: annotationStyle
+			)
+		} else {
+			styleLayout = nil
+		}
+
+		return FrozenToolbarLayout(
+			scale: metrics.scale,
+			frame: frame,
+			items: itemFrames,
+			annotationStyle: styleLayout
+		)
+	}
+
+	package static func hitState(at point: CGPoint, in layout: FrozenToolbarLayout?)
+		-> FrozenToolbarHitState
+	{
+		guard let layout else {
+			return FrozenToolbarHitState(
+				pointerOverToolbar: false,
+				toolbarAction: nil,
+				annotationStyleAction: nil
+			)
+		}
+
+		let hoveredAction = layout.items.first { item in
+			item.enabled && item.frame.contains(point)
+		}?.kind
+		let hoveredStyleAction = annotationStyleAction(at: point, in: layout.annotationStyle)
+		return FrozenToolbarHitState(
+			pointerOverToolbar: layout.frame.contains(point),
+			toolbarAction: hoveredAction,
+			annotationStyleAction: hoveredStyleAction
+		)
+	}
+
+	package static func localAnnotationStyleLayout(
+		_ layout: FrozenAnnotationStyleLayout,
+		relativeTo toolbarFrame: CGRect
+	) -> FrozenAnnotationStyleLayout {
+		FrozenAnnotationStyleLayout(
+			kind: layout.kind,
+			scale: layout.scale,
+			frame: layout.frame.offsetBy(dx: -toolbarFrame.minX, dy: -toolbarFrame.minY),
+			sizeControlFrame: layout.sizeControlFrame.offsetBy(
+				dx: -toolbarFrame.minX,
+				dy: -toolbarFrame.minY
+			),
+			decreaseFrame: layout.decreaseFrame.offsetBy(
+				dx: -toolbarFrame.minX,
+				dy: -toolbarFrame.minY
+			),
+			increaseFrame: layout.increaseFrame.offsetBy(
+				dx: -toolbarFrame.minX,
+				dy: -toolbarFrame.minY
+			),
+			displayFrame: layout.displayFrame.offsetBy(
+				dx: -toolbarFrame.minX,
+				dy: -toolbarFrame.minY
+			),
+			swatches: layout.swatches.map { swatch in
+				FrozenAnnotationColorSwatchLayout(
+					color: swatch.color,
+					frame: swatch.frame.offsetBy(
+						dx: -toolbarFrame.minX,
+						dy: -toolbarFrame.minY
+					),
+					selected: swatch.selected
+				)
+			}
+		)
+	}
+
+	private static func selectedAnnotationStyleKind(in items: [ToolbarItem])
+		-> FrozenAnnotationStyleToolbarKind?
+	{
+		for item in items where item.enabled && item.selected {
+			if let kind = FrozenAnnotationStyleToolbarKind(selectedTool: item.kind) {
+				return kind
+			}
+		}
+		return nil
+	}
+
+	private static func toolbarFrame(
+		selection: CGRect,
+		bounds: CGRect,
+		width: CGFloat,
+		height: CGFloat,
+		gap: CGFloat,
+		prefersTopPlacement: Bool
+	) -> CGRect {
+		let desiredY = selection.maxY + gap
+		let placedAbove =
+			prefersTopPlacement
+			|| desiredY + height > bounds.maxY - CaptureChrome.toolbarScreenMargin
+		let y =
+			placedAbove
+			? max(
+				bounds.minY + CaptureChrome.toolbarScreenMargin,
+				selection.minY - gap - height)
+			: min(bounds.maxY - CaptureChrome.toolbarScreenMargin - height, desiredY)
+		let minX = bounds.minX + CaptureChrome.toolbarScreenMargin
+		let maxX = max(minX, bounds.maxX - CaptureChrome.toolbarScreenMargin - width)
+		let x = (selection.midX - width / 2).clamped(to: minX...maxX)
+		return CGRect(x: x, y: y, width: width, height: height)
+	}
+
+	private static func primaryItemLayouts(
+		for items: [ToolbarItem],
+		frame: CGRect,
+		primaryContentWidth: CGFloat,
+		primaryY: CGFloat,
+		metrics: CaptureChrome.ToolbarMetrics
+	) -> [FrozenToolbarItemLayout] {
+		var itemFrames: [FrozenToolbarItemLayout] = []
+		var cursorX = frame.midX - primaryContentWidth / 2
+		for item in items {
+			let itemFrame = CGRect(
+				x: cursorX,
+				y: primaryY,
+				width: metrics.buttonSize,
+				height: metrics.buttonSize
+			)
+			itemFrames.append(
+				FrozenToolbarItemLayout(
+					kind: item.kind,
+					frame: itemFrame,
+					enabled: item.enabled,
+					selected: item.selected
+				)
+			)
+			cursorX += metrics.buttonSize + metrics.itemSpacing
+		}
+		return itemFrames
+	}
+
+	private static func annotationStyleContentWidth(
+		for kind: FrozenAnnotationStyleToolbarKind,
+		metrics: CaptureChrome.ToolbarMetrics
+	) -> CGFloat {
+		let swatchCount = CGFloat(FrozenAnnotationColor.allCases.count)
+		let swatchesWidth =
+			swatchCount * metrics.annotationSwatchSize
+			+ max(0, swatchCount - 1) * metrics.annotationSwatchGap
+		return kind.sizeControlWidth(scale: metrics.scale)
+			+ metrics.annotationStyleControlGap
+			+ swatchesWidth
+	}
+
+	private static func annotationStyleLayout(
+		for kind: FrozenAnnotationStyleToolbarKind,
+		in frame: CGRect,
+		contentWidth: CGFloat,
+		metrics: CaptureChrome.ToolbarMetrics,
+		toolbarAboveSelection: Bool,
+		annotationStyle: FrozenAnnotationStyleState
+	) -> FrozenAnnotationStyleLayout {
+		let rowY =
+			toolbarAboveSelection
+			? frame.maxY - metrics.verticalPadding - metrics.annotationStyleRowHeight
+			: frame.minY + metrics.verticalPadding
+		let rowFrame = CGRect(
+			x: frame.midX - contentWidth / 2,
+			y: rowY,
+			width: contentWidth,
+			height: metrics.annotationStyleRowHeight
+		)
+		let sizeControlFrame = CGRect(
+			x: rowFrame.minX,
+			y: rowFrame.minY,
+			width: kind.sizeControlWidth(scale: metrics.scale),
+			height: rowFrame.height
+		)
+		let decreaseFrame = CGRect(
+			x: sizeControlFrame.minX,
+			y: sizeControlFrame.minY,
+			width: metrics.annotationSizeButtonWidth,
+			height: sizeControlFrame.height
+		)
+		let increaseFrame = CGRect(
+			x: sizeControlFrame.maxX - metrics.annotationSizeButtonWidth,
+			y: sizeControlFrame.minY,
+			width: metrics.annotationSizeButtonWidth,
+			height: sizeControlFrame.height
+		)
+		let displayFrame = CGRect(
+			x: decreaseFrame.maxX,
+			y: sizeControlFrame.minY,
+			width: max(0, increaseFrame.minX - decreaseFrame.maxX),
+			height: sizeControlFrame.height
+		)
+		var swatches: [FrozenAnnotationColorSwatchLayout] = []
+		var swatchX = sizeControlFrame.maxX + metrics.annotationStyleControlGap
+		for color in FrozenAnnotationColor.allCases {
+			let swatchFrame = CGRect(
+				x: swatchX,
+				y: rowFrame.midY - metrics.annotationSwatchSize / 2,
+				width: metrics.annotationSwatchSize,
+				height: metrics.annotationSwatchSize
+			)
+			swatches.append(
+				FrozenAnnotationColorSwatchLayout(
+					color: color,
+					frame: swatchFrame,
+					selected: kind.selectedColor(in: annotationStyle) == color
+				))
+			swatchX += metrics.annotationSwatchSize + metrics.annotationSwatchGap
+		}
+		return FrozenAnnotationStyleLayout(
+			kind: kind,
+			scale: metrics.scale,
+			frame: rowFrame,
+			sizeControlFrame: sizeControlFrame,
+			decreaseFrame: decreaseFrame,
+			increaseFrame: increaseFrame,
+			displayFrame: displayFrame,
+			swatches: swatches
+		)
+	}
+
+	private static func annotationStyleAction(
+		at point: CGPoint,
+		in layout: FrozenAnnotationStyleLayout?
+	) -> FrozenAnnotationStyleAction? {
+		guard let layout else {
+			return nil
+		}
+		if layout.decreaseFrame.contains(point) {
+			return .decreaseSize
+		}
+		if layout.increaseFrame.contains(point) {
+			return .increaseSize
+		}
+		for swatch in layout.swatches where swatch.frame.contains(point) {
+			return .color(swatch.color)
+		}
+		return nil
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import RsnapHostBridge
 import RsnapNativeHostKit
 
 @main
@@ -12,6 +13,8 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureOverlayLocalPointKeepsScreenEdgesVisible()
 		assertScrollCaptureViewportPointAcceptsFlippedGlobalMouseCoordinates()
 		assertScrollCaptureObservedInputAcceptsSourceWindowGutter()
+		assertFrozenToolbarPlannerDisablesEditingDuringScroll()
+		assertFrozenToolbarPlannerPlacesStyleRowAndHitsControls()
 		assertSoftwareUpdateModeResolution()
 		assertManualUpdateCheckRemainsAvailable()
 		assertImmediateInstallGateWaitsForCaptureIdle()
@@ -123,6 +126,100 @@ enum RsnapNativeHostKitProbe {
 				userFacingWindowVisible: true) == false
 		else {
 			fatalError("immediate update install should wait until Rsnap is idle")
+		}
+	}
+
+	private static func assertFrozenToolbarPlannerDisablesEditingDuringScroll() {
+		let items = FrozenToolbarLayoutPlanner.visibleItems(
+			from: [
+				ToolbarItem(kind: .pen, enabled: true, selected: true),
+				ToolbarItem(kind: .undo, enabled: true, selected: false),
+				ToolbarItem(kind: .redo, enabled: true, selected: false),
+				ToolbarItem(kind: .autoCenter, enabled: true, selected: false),
+				ToolbarItem(kind: .scroll, enabled: false, selected: false),
+				ToolbarItem(kind: .copy, enabled: true, selected: false),
+			],
+			availability: FrozenToolbarAvailability(
+				scrollCaptureActive: true,
+				canUndo: true,
+				canRedo: true,
+				frozenSelectionAvailable: true,
+				keepsFrozenSelectionFixed: false,
+				scrollToolbarEnabled: true,
+				hasRecognizeTextBlockingEdits: false
+			)
+		)
+		guard
+			items.first(where: { $0.kind == .pen })?.enabled == false,
+			items.first(where: { $0.kind == .undo })?.enabled == false,
+			items.first(where: { $0.kind == .redo })?.enabled == false,
+			items.first(where: { $0.kind == .autoCenter })?.enabled == false,
+			items.first(where: { $0.kind == .scroll })?.enabled == true,
+			items.first(where: { $0.kind == .copy })?.enabled == true
+		else {
+			fatalError("frozen toolbar planner should isolate scroll capture edit availability")
+		}
+	}
+
+	private static func assertFrozenToolbarPlannerPlacesStyleRowAndHitsControls() {
+		let items = FrozenToolbarLayoutPlanner.visibleItems(
+			from: [
+				ToolbarItem(kind: .pen, enabled: true, selected: true),
+				ToolbarItem(kind: .copy, enabled: true, selected: false),
+				ToolbarItem(kind: .save, enabled: true, selected: false),
+			],
+			availability: FrozenToolbarAvailability(
+				scrollCaptureActive: false,
+				canUndo: false,
+				canRedo: false,
+				frozenSelectionAvailable: true,
+				keepsFrozenSelectionFixed: false,
+				scrollToolbarEnabled: false,
+				hasRecognizeTextBlockingEdits: false
+			)
+		)
+		let selection = CGRect(x: 100, y: 100, width: 80, height: 50)
+		guard
+			let layout = FrozenToolbarLayoutPlanner.layout(
+				selection: selection,
+				bounds: CGRect(x: 0, y: 0, width: 320, height: 320),
+				prefersTopPlacement: false,
+				items: items,
+				annotationStyle: FrozenAnnotationStyleState()
+			),
+			let annotationStyle = layout.annotationStyle
+		else {
+			fatalError("frozen toolbar planner should include brush style controls")
+		}
+
+		guard layout.frame.minY > selection.maxY else {
+			fatalError("frozen toolbar planner should place room-available bottom toolbar")
+		}
+		let firstItem = layout.items[0]
+		let itemHit = FrozenToolbarLayoutPlanner.hitState(
+			at: CGPoint(x: firstItem.frame.midX, y: firstItem.frame.midY),
+			in: layout
+		)
+		guard itemHit.pointerOverToolbar, itemHit.toolbarAction == .pen else {
+			fatalError("frozen toolbar planner should hit enabled primary toolbar items")
+		}
+
+		let decreaseHit = FrozenToolbarLayoutPlanner.hitState(
+			at: CGPoint(
+				x: annotationStyle.decreaseFrame.midX, y: annotationStyle.decreaseFrame.midY),
+			in: layout
+		)
+		guard decreaseHit.annotationStyleAction == .decreaseSize else {
+			fatalError("frozen toolbar planner should hit annotation size controls")
+		}
+
+		let localStyle = FrozenToolbarLayoutPlanner.localAnnotationStyleLayout(
+			annotationStyle,
+			relativeTo: layout.frame
+		)
+		guard localStyle.frame.minX >= 0, localStyle.frame.maxX <= layout.frame.width else {
+			fatalError(
+				"frozen toolbar planner should translate style controls into toolbar-local space")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Extract frozen-toolbar item availability, layout, hit-test, and toolbar-local annotation style geometry into FrozenToolbarLayoutPlanner.
- Keep CaptureHostView focused on host state collection, drawing, and action dispatch.
- Add native host probe coverage for scroll-capture availability gating and annotation toolbar hit geometry.
- Update native host reference docs for the new boundary.

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check && rg -n "include!|#\[path" packages apps native scripts; test 0 -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check