### PR TITLE
Modularize frozen toolbar rendering

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -95,6 +95,8 @@ The current native-host Swift split is:
   chrome color/patch sampling, and display-rate frame ticks.
 - `FrozenToolbarLayoutPlanner.swift`: deterministic frozen-toolbar item availability, layout, and
   hit-test geometry used by AppKit drawing, Liquid Glass toolbar content, and native probes.
+- `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
+  toolbar rendering and Liquid Glass toolbar content.
 - `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, capture-host cursor adaptation, Rust-backed frozen image

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -199,6 +199,8 @@ The main host-kit files are split by responsibility:
   chrome color/patch sampling, and display-rate frame ticks
 - `FrozenToolbarLayoutPlanner.swift`: deterministic frozen-toolbar item availability, layout, and
   hit-test geometry shared by classic drawing, Liquid Glass content, and native probes
+- `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
+  toolbar rendering and Liquid Glass toolbar content
 - `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, capture-host cursors, Rust-backed frozen image effects,

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -1,7 +1,6 @@
 import AppKit
 import CoreGraphics
 import CoreImage
-import CoreText
 import Foundation
 import QuartzCore
 import RsnapHostBridge
@@ -2101,77 +2100,16 @@ final class CaptureHostView: NSView {
 			surfaceKind: .toolbar,
 			allowsClassicGlass: !defersFrozenToolbarClassicGlassUntilAfterFirstDisplay
 		)
-
-		for item in layout.items {
-			if hoveredToolbarAction == item.kind, item.enabled, !item.selected {
-				context.setFillColor(palette.toolbarHoverBackground.cgColor)
-				let radius = CaptureChrome.toolbarControlCornerRadius * layout.scale
-				let hoverPath = NSBezierPath(
-					roundedRect: item.frame,
-					xRadius: radius,
-					yRadius: radius
-				)
-				hoverPath.fill()
-			}
-			if item.selected {
-				context.setFillColor(palette.toolbarSelectedBackground.cgColor)
-				let radius = CaptureChrome.toolbarControlCornerRadius * layout.scale
-				let selectedPath = NSBezierPath(
-					roundedRect: item.frame,
-					xRadius: radius,
-					yRadius: radius
-				)
-				selectedPath.fill()
-			}
-
-			let symbolColor =
-				item.enabled
-				? (item.selected ? palette.toolbarSelectedIcon : palette.toolbarIcon)
-				: palette.toolbarDisabledIcon
-			drawToolbarGlyph(
-				item.kind,
-				selected: item.selected,
-				in: item.frame,
-				scale: layout.scale,
-				color: symbolColor,
-				context: context
-			)
-		}
-
-		if let styleLayout = layout.annotationStyle {
-			FrozenToolbarDrawing.drawAnnotationStyleControls(
-				styleLayout,
-				state: chrome.annotationStyle,
-				hoveredAction: hoveredAnnotationStyleAction,
-				palette: palette,
-				in: context
-			)
-		}
-	}
-
-	private func drawToolbarGlyph(
-		_ kind: ToolbarItemKind,
-		selected: Bool,
-		in rect: CGRect,
-		scale: CGFloat,
-		color: NSColor,
-		context: CGContext
-	) {
-		let glyph = PhosphorToolbarIcons.cachedGlyph(
-			for: kind,
-			selected: selected,
-			size: CaptureChrome.toolbarGlyphSize * scale
+		FrozenToolbarDrawing.drawToolbarContent(
+			items: layout.items,
+			hoveredToolbarAction: hoveredToolbarAction,
+			toolbarScale: layout.scale,
+			annotationStyleState: chrome.annotationStyle,
+			annotationStyleLayout: layout.annotationStyle,
+			hoveredAnnotationStyleAction: hoveredAnnotationStyleAction,
+			palette: palette,
+			in: context
 		)
-		let origin = CGPoint(
-			x: rect.midX - glyph.bounds.width * 0.5 - glyph.bounds.origin.x,
-			y: rect.midY - glyph.bounds.height * 0.5 - glyph.bounds.origin.y
-		)
-		context.saveGState()
-		context.setFillColor(color.cgColor)
-		context.textMatrix = .identity
-		context.textPosition = origin
-		CTLineDraw(glyph.line, context)
-		context.restoreGState()
 	}
 
 	private func syncVisibleCursor() {
@@ -3561,7 +3499,7 @@ final class CaptureHostView: NSView {
 				)
 			},
 			items: layout.items.map { item in
-				FrozenToolbarRenderView.Item(
+				FrozenToolbarItemLayout(
 					kind: item.kind,
 					frame: item.frame.offsetBy(dx: -layout.frame.minX, dy: -layout.frame.minY),
 					enabled: item.enabled,

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenToolbarRenderView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenToolbarRenderView.swift
@@ -5,13 +5,6 @@ import RsnapHostBridge
 
 @MainActor
 final class FrozenToolbarRenderView: NSView {
-	struct Item: Equatable {
-		let kind: ToolbarItemKind
-		let frame: CGRect
-		let enabled: Bool
-		let selected: Bool
-	}
-
 	private var theme: CaptureChromeTheme = .dark
 	private var settings = NativeHostSettings.defaults
 	private var hoveredToolbarAction: ToolbarItemKind?
@@ -19,7 +12,7 @@ final class FrozenToolbarRenderView: NSView {
 	private var toolbarScale: CGFloat = 1
 	private var annotationStyleState = FrozenAnnotationStyleState()
 	private var annotationStyleLayout: FrozenAnnotationStyleLayout?
-	private var items: [Item] = []
+	private var items: [FrozenToolbarItemLayout] = []
 
 	override var isOpaque: Bool { false }
 
@@ -36,7 +29,7 @@ final class FrozenToolbarRenderView: NSView {
 		toolbarScale: CGFloat,
 		annotationStyleState: FrozenAnnotationStyleState,
 		annotationStyleLayout: FrozenAnnotationStyleLayout?,
-		items: [Item]
+		items: [FrozenToolbarItemLayout]
 	) -> Bool {
 		let changed =
 			self.theme != theme || self.settings != settings
@@ -79,6 +72,75 @@ final class FrozenToolbarRenderView: NSView {
 		context.setLineWidth(1)
 		pillPath.stroke()
 
+		FrozenToolbarDrawing.drawToolbarContent(
+			items: items,
+			hoveredToolbarAction: hoveredToolbarAction,
+			toolbarScale: toolbarScale,
+			annotationStyleState: annotationStyleState,
+			annotationStyleLayout: annotationStyleLayout,
+			hoveredAnnotationStyleAction: hoveredAnnotationStyleAction,
+			palette: palette,
+			in: context
+		)
+	}
+}
+
+@MainActor
+enum FrozenToolbarDrawing {
+	static func drawToolbarContent(
+		items: [FrozenToolbarItemLayout],
+		hoveredToolbarAction: ToolbarItemKind?,
+		toolbarScale: CGFloat,
+		annotationStyleState: FrozenAnnotationStyleState,
+		annotationStyleLayout: FrozenAnnotationStyleLayout?,
+		hoveredAnnotationStyleAction: FrozenAnnotationStyleAction?,
+		palette: CaptureChromePalette,
+		in context: CGContext
+	) {
+		drawToolbarItems(
+			items,
+			hoveredToolbarAction: hoveredToolbarAction,
+			toolbarScale: toolbarScale,
+			palette: palette,
+			in: context
+		)
+		if let annotationStyleLayout {
+			drawAnnotationStyleControls(
+				annotationStyleLayout,
+				state: annotationStyleState,
+				hoveredAction: hoveredAnnotationStyleAction,
+				palette: palette,
+				in: context
+			)
+		}
+	}
+
+	static func drawAnnotationStyleControls(
+		_ layout: FrozenAnnotationStyleLayout,
+		state: FrozenAnnotationStyleState,
+		hoveredAction: FrozenAnnotationStyleAction?,
+		palette: CaptureChromePalette,
+		in context: CGContext
+	) {
+		drawSizeControl(
+			layout,
+			state: state,
+			hoveredAction: hoveredAction,
+			palette: palette,
+			in: context
+		)
+		for swatch in layout.swatches {
+			drawColorSwatch(swatch, palette: palette, in: context)
+		}
+	}
+
+	private static func drawToolbarItems(
+		_ items: [FrozenToolbarItemLayout],
+		hoveredToolbarAction: ToolbarItemKind?,
+		toolbarScale: CGFloat,
+		palette: CaptureChromePalette,
+		in context: CGContext
+	) {
 		for item in items {
 			if hoveredToolbarAction == item.kind, item.enabled, !item.selected {
 				context.setFillColor(palette.toolbarHoverBackground.cgColor)
@@ -114,19 +176,9 @@ final class FrozenToolbarRenderView: NSView {
 				context: context
 			)
 		}
-
-		if let annotationStyleLayout {
-			FrozenToolbarDrawing.drawAnnotationStyleControls(
-				annotationStyleLayout,
-				state: annotationStyleState,
-				hoveredAction: hoveredAnnotationStyleAction,
-				palette: palette,
-				in: context
-			)
-		}
 	}
 
-	private func drawToolbarGlyph(
+	private static func drawToolbarGlyph(
 		_ kind: ToolbarItemKind,
 		selected: Bool,
 		in rect: CGRect,
@@ -149,28 +201,6 @@ final class FrozenToolbarRenderView: NSView {
 		context.textPosition = origin
 		CTLineDraw(glyph.line, context)
 		context.restoreGState()
-	}
-}
-
-@MainActor
-enum FrozenToolbarDrawing {
-	static func drawAnnotationStyleControls(
-		_ layout: FrozenAnnotationStyleLayout,
-		state: FrozenAnnotationStyleState,
-		hoveredAction: FrozenAnnotationStyleAction?,
-		palette: CaptureChromePalette,
-		in context: CGContext
-	) {
-		drawSizeControl(
-			layout,
-			state: state,
-			hoveredAction: hoveredAction,
-			palette: palette,
-			in: context
-		)
-		for swatch in layout.swatches {
-			drawColorSwatch(swatch, palette: palette, in: context)
-		}
 	}
 
 	private static func drawSizeControl(


### PR DESCRIPTION
## Summary
- Route classic frozen toolbar drawing and Liquid Glass toolbar content through the shared FrozenToolbarDrawing.drawToolbarContent path.
- Remove the duplicate toolbar glyph/content loop from CaptureHostView.
- Reuse FrozenToolbarItemLayout in the Liquid Glass render view instead of a second render-only item type.
- Update native host reference docs for the frozen toolbar rendering boundary.

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check && rg -n "include!|#\[path" packages apps native scripts; test 0 -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check