### PR TITLE
Modularize capture host cursor support

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -83,9 +83,8 @@ The current native-host Swift split is:
 - `CaptureOverlayController.swift`: AppKit overlay-window set management, focus/first-responder
   routing, capture-stream preparation, mouse passthrough, and CoreGraphics capture sources needed
   to sample below native overlay windows.
-- `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, cursor presentation, Liquid Glass
-  surfaces, live/frozen HUD and toolbar rendering, and native pointer/key event routing into the
-  session controller.
+- `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
+  HUD and toolbar rendering, and native pointer/key event routing into the session controller.
 - `LiveOverlayRenderer.swift`: live overlay layer composition for HUD, loupe, scrims, and selection
   affordances.
 - `LiveChromePlacement.swift`: live HUD/loupe text metrics, pending color text, and deterministic
@@ -99,8 +98,8 @@ The current native-host Swift split is:
   toolbar rendering and Liquid Glass toolbar content.
 - `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, capture-host cursor adaptation, Rust-backed frozen image
-  effects, live-chrome telemetry identity, and native text measurement.
+  boundaries for shared capture geometry, capture-host cursor presentation and NSCursor adaptation,
+  Rust-backed frozen image effects, live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -188,8 +188,7 @@ The main host-kit files are split by responsibility:
 - `CaptureOverlayWindow.swift`: AppKit `NSPanel` wrapper for capture overlay windows
 - `CaptureOverlayController.swift`: overlay window set, focus, stream preparation, and below-overlay
   capture source management
-- `CaptureHostView.swift`: AppKit view rendering, hit testing, cursor presentation, and native
-  pointer/key routing
+- `CaptureHostView.swift`: AppKit view rendering, hit testing, and native pointer/key routing
 - `LiveOverlayRenderer.swift`: live overlay layer composition for HUD, loupe, scrims, and selection
   affordances
 - `LiveChromePlacement.swift`: live HUD/loupe text metrics, pending color text, and deterministic
@@ -203,8 +202,9 @@ The main host-kit files are split by responsibility:
   toolbar rendering and Liquid Glass toolbar content
 - `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, capture-host cursors, Rust-backed frozen image effects,
-  live-chrome telemetry identity, and shared native text measurement
+  boundaries for shared capture geometry, capture-host cursor presentation and NSCursor adaptation,
+  Rust-backed frozen image effects, live-chrome telemetry identity, and shared native text
+  measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorSupport.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorSupport.swift
@@ -1,4 +1,119 @@
 import AppKit
+import CoreGraphics
+import RsnapHostBridge
+
+package enum CaptureHostCursorPresentation: Equatable {
+	case arrow
+	case crosshair
+	case openHand
+	case closedHand
+	case resizeUpDown
+	case resizeLeftRight
+	case resizeTopLeft
+	case resizeTopRight
+	case resizeBottomLeft
+	case resizeBottomRight
+	case iBeam
+}
+
+package enum CaptureHostCursorSupport {
+	package static func presentation(for intent: CursorIntent) -> CaptureHostCursorPresentation {
+		switch intent {
+		case .default:
+			return .arrow
+		case .crosshair:
+			return .crosshair
+		case .grab:
+			return .openHand
+		case .grabbing:
+			return .closedHand
+		case .resizeNorth, .resizeSouth:
+			return .resizeUpDown
+		case .resizeEast, .resizeWest:
+			return .resizeLeftRight
+		case .resizeNorthEast:
+			return .resizeTopRight
+		case .resizeNorthWest:
+			return .resizeTopLeft
+		case .resizeSouthEast:
+			return .resizeBottomRight
+		case .resizeSouthWest:
+			return .resizeBottomLeft
+		case .text:
+			return .iBeam
+		}
+	}
+
+	package static func cursorIntent(
+		for interactionKind: FrozenSelectionTransformKind,
+		active: Bool
+	) -> CursorIntent {
+		switch interactionKind {
+		case .move:
+			return active ? .grabbing : .grab
+		case .resizeLeft:
+			return .resizeWest
+		case .resizeRight:
+			return .resizeEast
+		case .resizeTop:
+			return .resizeNorth
+		case .resizeBottom:
+			return .resizeSouth
+		case .resizeTopLeft:
+			return .resizeNorthWest
+		case .resizeTopRight:
+			return .resizeNorthEast
+		case .resizeBottomLeft:
+			return .resizeSouthWest
+		case .resizeBottomRight:
+			return .resizeSouthEast
+		}
+	}
+
+	package static func editableFrozenCursorIntent(
+		at point: CGPoint,
+		selection: CGRect
+	) -> CursorIntent? {
+		guard
+			let kind = try? RsnapFrozenSelectionTransformPlanner.hitTest(
+				point: point,
+				selection: selection,
+				handleRadius: 12,
+				edgeTolerance: 4
+			)
+		else {
+			return nil
+		}
+		return cursorIntent(for: kind, active: false)
+	}
+
+	static func cursor(for presentation: CaptureHostCursorPresentation) -> NSCursor {
+		switch presentation {
+		case .arrow:
+			return .arrow
+		case .crosshair:
+			return .crosshair
+		case .openHand:
+			return .openHand
+		case .closedHand:
+			return .closedHand
+		case .resizeUpDown:
+			return .resizeUpDown
+		case .resizeLeftRight:
+			return .resizeLeftRight
+		case .resizeTopLeft:
+			return ._windowResizeTopLeft
+		case .resizeTopRight:
+			return ._windowResizeTopRight
+		case .resizeBottomLeft:
+			return ._windowResizeBottomLeft
+		case .resizeBottomRight:
+			return ._windowResizeBottomRight
+		case .iBeam:
+			return .iBeam
+		}
+	}
+}
 
 extension NSCursor {
 	private static func frozenDiagonalCursor(

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -30,20 +30,6 @@ final class CaptureHostView: NSView {
 		let image: CGImage
 	}
 
-	private enum CursorPresentation: Equatable {
-		case arrow
-		case crosshair
-		case openHand
-		case closedHand
-		case resizeUpDown
-		case resizeLeftRight
-		case resizeTopLeft
-		case resizeTopRight
-		case resizeBottomLeft
-		case resizeBottomRight
-		case iBeam
-	}
-
 	private static let liveChromeLiquidGlassZ: CGFloat = 200
 	private static let frozenToolbarLiquidGlassBackdropZ: CGFloat = 295
 	private static let frozenToolbarLiquidGlassZ: CGFloat = 300
@@ -111,8 +97,8 @@ final class CaptureHostView: NSView {
 	private var hoveredToolbarAction: ToolbarItemKind?
 	private var hoveredAnnotationStyleAction: FrozenAnnotationStyleAction?
 	private var annotationStyleWheelLastStepTimestamp: TimeInterval?
-	private var lastCursorPresentation: CursorPresentation?
-	private var lastAppliedCursorPresentation: CursorPresentation?
+	private var lastCursorPresentation: CaptureHostCursorPresentation?
+	private var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
 	private var queuedPointerEvent: QueuedPointerEvent?
 	private var queuedPointerWorkItem: DispatchWorkItem?
 	private var lastHoverPointerDispatchUptime: TimeInterval = 0
@@ -547,7 +533,10 @@ final class CaptureHostView: NSView {
 
 	override func resetCursorRects() {
 		super.resetCursorRects()
-		addCursorRect(bounds, cursor: cursor(for: currentCursorPresentation()))
+		addCursorRect(
+			bounds,
+			cursor: CaptureHostCursorSupport.cursor(for: currentCursorPresentation())
+		)
 	}
 
 	override func cursorUpdate(with event: NSEvent) {
@@ -1402,13 +1391,14 @@ final class CaptureHostView: NSView {
 		return bounds.clampedInclusivePoint(localPoint)
 	}
 
-	private func currentCursorPresentation() -> CursorPresentation {
+	private func currentCursorPresentation() -> CaptureHostCursorPresentation {
 		if pointerOverFrozenToolbar || hoveredToolbarAction != nil {
 			return .arrow
 		}
 		if scene.mode == .frozen {
 			if let interaction = chrome.frozenSelectionInteraction {
-				return cursorPresentation(for: cursorIntent(for: interaction.kind, active: true))
+				return CaptureHostCursorSupport.presentation(
+					for: CaptureHostCursorSupport.cursorIntent(for: interaction.kind, active: true))
 			}
 			if let selection = chrome.frozenSelectionSnapshot ?? scene.frozenSelection,
 				let selectedModeTool = visibleToolbarItems().first(where: { $0.selected })?.kind
@@ -1429,109 +1419,18 @@ final class CaptureHostView: NSView {
 						return .arrow
 					}
 					if let pointer = currentGlobalMousePoint(),
-						let intent = editableFrozenCursorIntent(at: pointer, selection: selection)
+						let intent = CaptureHostCursorSupport.editableFrozenCursorIntent(
+							at: pointer,
+							selection: selection
+						)
 					{
-						return cursorPresentation(for: intent)
+						return CaptureHostCursorSupport.presentation(for: intent)
 					}
 				}
 			}
 		}
 
-		return cursorPresentation(for: scene.cursorIntent)
-	}
-
-	private func cursorPresentation(for intent: CursorIntent) -> CursorPresentation {
-		switch intent {
-		case .default:
-			return .arrow
-		case .crosshair:
-			return .crosshair
-		case .grab:
-			return .openHand
-		case .grabbing:
-			return .closedHand
-		case .resizeNorth, .resizeSouth:
-			return .resizeUpDown
-		case .resizeEast, .resizeWest:
-			return .resizeLeftRight
-		case .resizeNorthEast:
-			return .resizeTopRight
-		case .resizeNorthWest:
-			return .resizeTopLeft
-		case .resizeSouthEast:
-			return .resizeBottomRight
-		case .resizeSouthWest:
-			return .resizeBottomLeft
-		case .text:
-			return .iBeam
-		}
-	}
-
-	private func cursorIntent(
-		for interactionKind: FrozenSelectionTransformKind,
-		active: Bool
-	) -> CursorIntent {
-		switch interactionKind {
-		case .move:
-			return active ? .grabbing : .grab
-		case .resizeLeft:
-			return .resizeWest
-		case .resizeRight:
-			return .resizeEast
-		case .resizeTop:
-			return .resizeNorth
-		case .resizeBottom:
-			return .resizeSouth
-		case .resizeTopLeft:
-			return .resizeNorthWest
-		case .resizeTopRight:
-			return .resizeNorthEast
-		case .resizeBottomLeft:
-			return .resizeSouthWest
-		case .resizeBottomRight:
-			return .resizeSouthEast
-		}
-	}
-
-	private func editableFrozenCursorIntent(at point: CGPoint, selection: CGRect) -> CursorIntent? {
-		guard
-			let kind = try? RsnapFrozenSelectionTransformPlanner.hitTest(
-				point: point,
-				selection: selection,
-				handleRadius: 12,
-				edgeTolerance: 4
-			)
-		else {
-			return nil
-		}
-		return cursorIntent(for: kind, active: false)
-	}
-
-	private func cursor(for presentation: CursorPresentation) -> NSCursor {
-		switch presentation {
-		case .arrow:
-			return .arrow
-		case .crosshair:
-			return .crosshair
-		case .openHand:
-			return .openHand
-		case .closedHand:
-			return .closedHand
-		case .resizeUpDown:
-			return .resizeUpDown
-		case .resizeLeftRight:
-			return .resizeLeftRight
-		case .resizeTopLeft:
-			return ._windowResizeTopLeft
-		case .resizeTopRight:
-			return ._windowResizeTopRight
-		case .resizeBottomLeft:
-			return ._windowResizeBottomLeft
-		case .resizeBottomRight:
-			return ._windowResizeBottomRight
-		case .iBeam:
-			return .iBeam
-		}
+		return CaptureHostCursorSupport.presentation(for: scene.cursorIntent)
 	}
 
 	private func globalPoint(from event: NSEvent) -> CGPoint {
@@ -2124,12 +2023,12 @@ final class CaptureHostView: NSView {
 		}
 	}
 
-	private func applyVisibleCursorIfNeeded(_ cursorPresentation: CursorPresentation) {
+	private func applyVisibleCursorIfNeeded(_ cursorPresentation: CaptureHostCursorPresentation) {
 		guard cursorPresentation != lastAppliedCursorPresentation else {
 			return
 		}
 		lastAppliedCursorPresentation = cursorPresentation
-		cursor(for: cursorPresentation).set()
+		CaptureHostCursorSupport.cursor(for: cursorPresentation).set()
 	}
 
 	private func currentHudPlacement() -> LiveChromeFloatingPlacement? {

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -18,6 +18,7 @@ enum RsnapNativeHostKitProbe {
 		assertSoftwareUpdateModeResolution()
 		assertManualUpdateCheckRemainsAvailable()
 		assertImmediateInstallGateWaitsForCaptureIdle()
+		assertCaptureHostCursorMapping()
 		let minimapExportSize = CGSize(width: 100, height: 200)
 		guard
 			let rightMinimap = scrollCaptureMinimapPlan(
@@ -126,6 +127,44 @@ enum RsnapNativeHostKitProbe {
 				userFacingWindowVisible: true) == false
 		else {
 			fatalError("immediate update install should wait until Rsnap is idle")
+		}
+	}
+
+	private static func assertCaptureHostCursorMapping() {
+		guard
+			CaptureHostCursorSupport.presentation(for: .default) == .arrow,
+			CaptureHostCursorSupport.presentation(for: .crosshair) == .crosshair,
+			CaptureHostCursorSupport.presentation(for: .grab) == .openHand,
+			CaptureHostCursorSupport.presentation(for: .grabbing) == .closedHand,
+			CaptureHostCursorSupport.presentation(for: .resizeNorth) == .resizeUpDown,
+			CaptureHostCursorSupport.presentation(for: .resizeSouth) == .resizeUpDown,
+			CaptureHostCursorSupport.presentation(for: .resizeEast) == .resizeLeftRight,
+			CaptureHostCursorSupport.presentation(for: .resizeWest) == .resizeLeftRight,
+			CaptureHostCursorSupport.presentation(for: .resizeNorthEast) == .resizeTopRight,
+			CaptureHostCursorSupport.presentation(for: .resizeNorthWest) == .resizeTopLeft,
+			CaptureHostCursorSupport.presentation(for: .resizeSouthEast) == .resizeBottomRight,
+			CaptureHostCursorSupport.presentation(for: .resizeSouthWest) == .resizeBottomLeft,
+			CaptureHostCursorSupport.presentation(for: .text) == .iBeam,
+			CaptureHostCursorSupport.cursorIntent(for: .move, active: false) == .grab,
+			CaptureHostCursorSupport.cursorIntent(for: .move, active: true) == .grabbing,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeLeft, active: false)
+				== .resizeWest,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeRight, active: false)
+				== .resizeEast,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeTop, active: false)
+				== .resizeNorth,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeBottom, active: false)
+				== .resizeSouth,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeTopLeft, active: false)
+				== .resizeNorthWest,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeTopRight, active: false)
+				== .resizeNorthEast,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeBottomLeft, active: false)
+				== .resizeSouthWest,
+			CaptureHostCursorSupport.cursorIntent(for: .resizeBottomRight, active: true)
+				== .resizeSouthEast
+		else {
+			fatalError("capture host cursor support should preserve cursor mappings")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- move capture-host cursor presentation and transform-kind mapping into CaptureHostCursorSupport
- keep state-dependent cursor resolution in CaptureHostView
- add native probe coverage for cursor and frozen transform mappings
- update host-kit modularization docs

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check && rg -n "include!|#\[path" packages apps native scripts; test $? -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check
- after skeptic coverage feedback: cargo make fmt-swift && DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift && DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh read-only skeptic review found no blocker; suggested fuller transform mapping probes, which this PR includes.