### PR TITLE
Modularize capture host pointer dispatch

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -85,6 +85,8 @@ The current native-host Swift split is:
   to sample below native overlay windows.
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
   HUD and toolbar rendering, and native pointer/key event routing into the session controller.
+- `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
+  with per-track throttling state, and AppKit-to-controller pointer delivery support.
 - `LiveOverlayRenderer.swift`: live overlay layer composition for HUD, loupe, scrims, and selection
   affordances.
 - `LiveChromePlacement.swift`: live HUD/loupe text metrics, pending color text, and deterministic
@@ -96,9 +98,10 @@ The current native-host Swift split is:
   hit-test geometry used by AppKit drawing, Liquid Glass toolbar content, and native probes.
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content.
-- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, capture-host cursor presentation and NSCursor adaptation,
+- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry,
+  capture-host cursor presentation and NSCursor adaptation, pointer dispatch queue throttling,
   Rust-backed frozen image effects, live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -189,6 +189,8 @@ The main host-kit files are split by responsibility:
 - `CaptureOverlayController.swift`: overlay window set, focus, stream preparation, and below-overlay
   capture source management
 - `CaptureHostView.swift`: AppKit view rendering, hit testing, and native pointer/key routing
+- `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
+  with per-track throttling state, and AppKit-to-controller pointer delivery
 - `LiveOverlayRenderer.swift`: live overlay layer composition for HUD, loupe, scrims, and selection
   affordances
 - `LiveChromePlacement.swift`: live HUD/loupe text metrics, pending color text, and deterministic
@@ -200,9 +202,10 @@ The main host-kit files are split by responsibility:
   hit-test geometry shared by classic drawing, Liquid Glass content, and native probes
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content
-- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostFrozenImageEffects.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, capture-host cursor presentation and NSCursor adaptation,
+- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry,
+  capture-host cursor presentation and NSCursor adaptation, pointer dispatch queue throttling,
   Rust-backed frozen image effects, live-chrome telemetry identity, and shared native text
   measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostPointerDispatch.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostPointerDispatch.swift
@@ -1,0 +1,109 @@
+import CoreGraphics
+import Foundation
+
+package enum CaptureHostPointerDispatchTrack: Equatable {
+	case hover
+	case drag
+}
+
+package enum CaptureHostPointerDispatchEvent: Equatable {
+	case moved(CGPoint)
+	case liveDragged(CGPoint)
+
+	package var track: CaptureHostPointerDispatchTrack {
+		switch self {
+		case .moved:
+			return .hover
+		case .liveDragged:
+			return .drag
+		}
+	}
+}
+
+package enum CaptureHostPointerDispatchTiming {
+	package static func delay(
+		now: TimeInterval,
+		targetInterval: TimeInterval,
+		lastDispatchUptime: TimeInterval
+	) -> TimeInterval {
+		max(0, targetInterval - (now - lastDispatchUptime))
+	}
+}
+
+@MainActor
+final class CaptureHostPointerDispatchQueue {
+	private var queuedEvent: CaptureHostPointerDispatchEvent?
+	private var queuedWorkItem: DispatchWorkItem?
+	private var lastHoverDispatchUptime: TimeInterval = 0
+	private var lastDragDispatchUptime: TimeInterval = 0
+	private let targetInterval: () -> TimeInterval
+	private let dispatchEvent: (CaptureHostPointerDispatchEvent) -> Void
+
+	init(
+		targetInterval: @escaping () -> TimeInterval,
+		dispatchEvent: @escaping (CaptureHostPointerDispatchEvent) -> Void
+	) {
+		self.targetInterval = targetInterval
+		self.dispatchEvent = dispatchEvent
+	}
+
+	func enqueue(_ event: CaptureHostPointerDispatchEvent) {
+		let now = ProcessInfo.processInfo.systemUptime
+		let delay = CaptureHostPointerDispatchTiming.delay(
+			now: now,
+			targetInterval: targetInterval(),
+			lastDispatchUptime: lastDispatchUptime(for: event)
+		)
+
+		queuedEvent = event
+		guard queuedWorkItem == nil else {
+			return
+		}
+
+		let workItem = DispatchWorkItem { [weak self] in
+			guard let self else {
+				return
+			}
+			self.queuedWorkItem = nil
+			guard let event = self.queuedEvent else {
+				return
+			}
+			self.queuedEvent = nil
+			self.setLastDispatchUptime(ProcessInfo.processInfo.systemUptime, for: event)
+			self.dispatchEvent(event)
+		}
+		queuedWorkItem = workItem
+		if delay <= 0 {
+			DispatchQueue.main.async(execute: workItem)
+		} else {
+			DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+		}
+	}
+
+	func cancel() {
+		queuedWorkItem?.cancel()
+		queuedWorkItem = nil
+		queuedEvent = nil
+	}
+
+	private func lastDispatchUptime(for event: CaptureHostPointerDispatchEvent) -> TimeInterval {
+		switch event.track {
+		case .hover:
+			return lastHoverDispatchUptime
+		case .drag:
+			return lastDragDispatchUptime
+		}
+	}
+
+	private func setLastDispatchUptime(
+		_ uptime: TimeInterval,
+		for event: CaptureHostPointerDispatchEvent
+	) {
+		switch event.track {
+		case .hover:
+			lastHoverDispatchUptime = uptime
+		case .drag:
+			lastDragDispatchUptime = uptime
+		}
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -13,11 +13,6 @@ final class CaptureHostView: NSView {
 	private static let scrollToolbarBackdropCaptureMinimumInterval: TimeInterval = 1.0 / 60.0
 	private static let scrollToolbarBackdropFallbackMinimumInterval: TimeInterval = 1.0 / 20.0
 
-	private enum QueuedPointerEvent {
-		case moved(CGPoint)
-		case liveDragged(CGPoint)
-	}
-
 	private enum GlassSurfaceKind: Hashable {
 		case hud
 		case loupe
@@ -99,10 +94,6 @@ final class CaptureHostView: NSView {
 	private var annotationStyleWheelLastStepTimestamp: TimeInterval?
 	private var lastCursorPresentation: CaptureHostCursorPresentation?
 	private var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
-	private var queuedPointerEvent: QueuedPointerEvent?
-	private var queuedPointerWorkItem: DispatchWorkItem?
-	private var lastHoverPointerDispatchUptime: TimeInterval = 0
-	private var lastDragPointerDispatchUptime: TimeInterval = 0
 	private var liveDragStartGlobal: CGPoint?
 	private var liveDragReleasedGlobal: CGPoint?
 	private var liveDragExceededThreshold = false
@@ -128,6 +119,19 @@ final class CaptureHostView: NSView {
 	private var latestLiveRgbSample: LiveRgbSample?
 	private var latestLiveRgbSamplePoint: CGPoint?
 	private var glassPatchCache: [GlassSurfaceKind: GlassPatchCache] = [:]
+	private lazy var pointerDispatchQueue = CaptureHostPointerDispatchQueue(
+		targetInterval: { [weak self] in
+			guard let self else {
+				return NativeHostDisplayRefresh.frameInterval(
+					forTargetFramesPerSecond:
+						NativeHostDisplayRefresh.maximumTargetFramesPerSecond)
+			}
+			return self.pointerDispatchInterval()
+		},
+		dispatchEvent: { [weak self] event in
+			self?.dispatchPointerEvent(event)
+		}
+	)
 	private lazy var liveRenderer = LiveOverlayRenderer(hostView: self)
 	private var liveRendererInstalled = false
 	private var deferredLiveShutdownWorkItem: DispatchWorkItem?
@@ -1269,9 +1273,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func cancelQueuedPointerDispatch() {
-		queuedPointerWorkItem?.cancel()
-		queuedPointerWorkItem = nil
-		queuedPointerEvent = nil
+		pointerDispatchQueue.cancel()
 	}
 
 	private func updateLivePointerPreview(
@@ -3473,38 +3475,11 @@ final class CaptureHostView: NSView {
 		theme == .dark ? 0.015 : -0.01
 	}
 
-	private func queuePointerEvent(_ event: QueuedPointerEvent) {
-		let now = ProcessInfo.processInfo.systemUptime
-		let targetInterval = pointerDispatchInterval()
-		let elapsed = now - lastPointerDispatchUptime(for: event)
-
-		queuedPointerEvent = event
-		guard queuedPointerWorkItem == nil else {
-			return
-		}
-
-		let delay = max(0, targetInterval - elapsed)
-		let workItem = DispatchWorkItem { [weak self] in
-			guard let self else {
-				return
-			}
-			self.queuedPointerWorkItem = nil
-			guard let event = self.queuedPointerEvent else {
-				return
-			}
-			self.queuedPointerEvent = nil
-			self.setLastPointerDispatchUptime(ProcessInfo.processInfo.systemUptime, for: event)
-			self.dispatchPointerEvent(event)
-		}
-		queuedPointerWorkItem = workItem
-		if delay <= 0 {
-			DispatchQueue.main.async(execute: workItem)
-		} else {
-			DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
-		}
+	private func queuePointerEvent(_ event: CaptureHostPointerDispatchEvent) {
+		pointerDispatchQueue.enqueue(event)
 	}
 
-	private func dispatchPointerEvent(_ event: QueuedPointerEvent) {
+	private func dispatchPointerEvent(_ event: CaptureHostPointerDispatchEvent) {
 		switch event {
 		case .moved(let point):
 			controller?.pointerMoved(to: point)
@@ -3519,25 +3494,6 @@ final class CaptureHostView: NSView {
 	private func pointerDispatchInterval() -> TimeInterval {
 		NativeHostDisplayRefresh.frameInterval(
 			forTargetFramesPerSecond: currentDisplayTargetFramesPerSecond())
-	}
-
-	private func lastPointerDispatchUptime(for event: QueuedPointerEvent) -> TimeInterval {
-		switch event {
-		case .moved:
-			return lastHoverPointerDispatchUptime
-		case .liveDragged:
-			return lastDragPointerDispatchUptime
-		}
-	}
-
-	private func setLastPointerDispatchUptime(_ uptime: TimeInterval, for event: QueuedPointerEvent)
-	{
-		switch event {
-		case .moved:
-			lastHoverPointerDispatchUptime = uptime
-		case .liveDragged:
-			lastDragPointerDispatchUptime = uptime
-		}
 	}
 
 }

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 import RsnapHostBridge
 import RsnapNativeHostKit
 
@@ -19,6 +20,7 @@ enum RsnapNativeHostKitProbe {
 		assertManualUpdateCheckRemainsAvailable()
 		assertImmediateInstallGateWaitsForCaptureIdle()
 		assertCaptureHostCursorMapping()
+		assertCaptureHostPointerDispatchSupport()
 		let minimapExportSize = CGSize(width: 100, height: 200)
 		guard
 			let rightMinimap = scrollCaptureMinimapPlan(
@@ -166,6 +168,33 @@ enum RsnapNativeHostKitProbe {
 		else {
 			fatalError("capture host cursor support should preserve cursor mappings")
 		}
+	}
+
+	private static func assertCaptureHostPointerDispatchSupport() {
+		guard
+			CaptureHostPointerDispatchEvent.moved(.zero).track == .hover,
+			CaptureHostPointerDispatchEvent.liveDragged(.zero).track == .drag,
+			approximatelyEqual(
+				CaptureHostPointerDispatchTiming.delay(
+					now: 10,
+					targetInterval: 0.25,
+					lastDispatchUptime: 9.90),
+				0.15),
+			CaptureHostPointerDispatchTiming.delay(
+				now: 10,
+				targetInterval: 0.25,
+				lastDispatchUptime: 9.50) == 0
+		else {
+			fatalError("capture host pointer dispatch support should preserve throttling")
+		}
+	}
+
+	private static func approximatelyEqual(
+		_ lhs: TimeInterval,
+		_ rhs: TimeInterval,
+		tolerance: TimeInterval = 0.000_001
+	) -> Bool {
+		abs(lhs - rhs) <= tolerance
 	}
 
 	private static func assertFrozenToolbarPlannerDisablesEditingDuringScroll() {


### PR DESCRIPTION
## Summary
- extract CaptureHostView pointer dispatch events, queue state, and throttling into CaptureHostPointerDispatch
- keep CaptureHostView responsible for controller-specific event handling only
- add native probe coverage for pointer dispatch track mapping and timing math, and update host layout docs

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check && rg -n "include!|#\[path" packages apps native scripts; test $? -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Skeptic
- Fresh read-only skeptic found one blocker: new Swift file was untracked. Resolved by explicit staging before commit. No behavior, actor/concurrency, or module-boundary blocker remained.