### PR TITLE
Modularize capture host annotation wheel gate

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -83,6 +83,8 @@ The current native-host Swift split is:
 - `CaptureOverlayController.swift`: AppKit overlay-window set management, focus/first-responder
   routing, capture-stream preparation, mouse passthrough, and CoreGraphics capture sources needed
   to sample below native overlay windows.
+- `CaptureHostAnnotationStyleWheelGate.swift`: frozen annotation-size wheel dead-zone and
+  per-gesture step throttling.
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
   HUD and toolbar rendering, and native pointer/key event routing into the session controller.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
@@ -100,13 +102,14 @@ The current native-host Swift split is:
   hit-test geometry used by AppKit drawing, Liquid Glass toolbar content, and native probes.
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content.
-- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
-  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry,
-  capture-host cursor presentation and NSCursor adaptation, live primary interaction state,
-  pointer dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry
-  identity, and native text measurement.
+- `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
+  `CaptureHostCursorSupport.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, frozen annotation-size wheel gating, capture-host cursor
+  presentation and NSCursor adaptation, live primary interaction state, pointer dispatch queue
+  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and native text
+  measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -188,6 +188,8 @@ The main host-kit files are split by responsibility:
 - `CaptureOverlayWindow.swift`: AppKit `NSPanel` wrapper for capture overlay windows
 - `CaptureOverlayController.swift`: overlay window set, focus, stream preparation, and below-overlay
   capture source management
+- `CaptureHostAnnotationStyleWheelGate.swift`: frozen annotation-size wheel dead-zone and
+  per-gesture step throttling
 - `CaptureHostView.swift`: AppKit view rendering, hit testing, and native pointer/key routing
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions
@@ -204,13 +206,14 @@ The main host-kit files are split by responsibility:
   hit-test geometry shared by classic drawing, Liquid Glass content, and native probes
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content
-- `CaptureGeometry.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
-  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry,
-  capture-host cursor presentation and NSCursor adaptation, live primary interaction state,
-  pointer dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry
-  identity, and shared native text measurement
+- `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
+  `CaptureHostCursorSupport.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, frozen annotation-size wheel gating, capture-host cursor
+  presentation and NSCursor adaptation, live primary interaction state, pointer dispatch queue
+  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and shared native
+  text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostAnnotationStyleWheelGate.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostAnnotationStyleWheelGate.swift
@@ -1,0 +1,49 @@
+import CoreGraphics
+import Foundation
+
+package struct CaptureHostAnnotationStyleWheelGate: Equatable {
+	package static let deadZone: CGFloat = 0.05
+	package static let preciseStepInterval: TimeInterval = 0.18
+	package static let discreteStepInterval: TimeInterval = 0.04
+
+	private var lastStepTimestamp: TimeInterval?
+
+	package init() {}
+
+	package mutating func steps(
+		timestamp: TimeInterval,
+		deltaY: CGFloat,
+		hasPreciseScrollingDeltas: Bool,
+		phaseActive: Bool,
+		phaseEndedOrCancelled: Bool,
+		momentumActive: Bool
+	) -> Int {
+		guard momentumActive == false else {
+			return 0
+		}
+		if phaseEndedOrCancelled {
+			reset()
+			return 0
+		}
+		guard abs(deltaY) > .ulpOfOne else {
+			return 0
+		}
+		guard abs(deltaY) >= Self.deadZone else {
+			return 0
+		}
+
+		let minimumInterval =
+			hasPreciseScrollingDeltas || phaseActive
+			? Self.preciseStepInterval
+			: Self.discreteStepInterval
+		if let lastStepTimestamp, timestamp - lastStepTimestamp < minimumInterval {
+			return 0
+		}
+		lastStepTimestamp = timestamp
+		return deltaY > 0 ? 1 : -1
+	}
+
+	package mutating func reset() {
+		lastStepTimestamp = nil
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -91,7 +91,7 @@ final class CaptureHostView: NSView {
 	private var pointerOverFrozenToolbar = false
 	private var hoveredToolbarAction: ToolbarItemKind?
 	private var hoveredAnnotationStyleAction: FrozenAnnotationStyleAction?
-	private var annotationStyleWheelLastStepTimestamp: TimeInterval?
+	private var annotationStyleWheelGate = CaptureHostAnnotationStyleWheelGate()
 	private var lastCursorPresentation: CaptureHostCursorPresentation?
 	private var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
 	private var livePrimaryInteraction = CaptureHostLivePrimaryInteractionState()
@@ -753,43 +753,20 @@ final class CaptureHostView: NSView {
 			&& flags.contains(.shift) == false
 	}
 
-	private static let annotationStyleWheelDeadZone: CGFloat = 0.05
-	private static let annotationStylePreciseWheelStepInterval: TimeInterval = 0.18
-	private static let annotationStyleDiscreteWheelStepInterval: TimeInterval = 0.04
-
 	private func annotationStyleWheelSteps(from event: NSEvent) -> Int {
-		guard event.momentumPhase == [] else {
-			return 0
-		}
 		let phase = event.phase
-		if phase.contains(.ended) || phase.contains(.cancelled) {
-			resetAnnotationStyleWheelGate()
-			return 0
-		}
-		let deltaY = event.scrollingDeltaY
-		guard abs(deltaY) > .ulpOfOne else {
-			return 0
-		}
-		guard abs(deltaY) >= Self.annotationStyleWheelDeadZone else {
-			return 0
-		}
-		let direction = deltaY > 0 ? 1 : -1
-		let isSmoothScroll = event.hasPreciseScrollingDeltas || phase != []
-		let minimumInterval =
-			isSmoothScroll
-			? Self.annotationStylePreciseWheelStepInterval
-			: Self.annotationStyleDiscreteWheelStepInterval
-		if let lastStepTimestamp = annotationStyleWheelLastStepTimestamp,
-			event.timestamp - lastStepTimestamp < minimumInterval
-		{
-			return 0
-		}
-		annotationStyleWheelLastStepTimestamp = event.timestamp
-		return direction
+		return annotationStyleWheelGate.steps(
+			timestamp: event.timestamp,
+			deltaY: event.scrollingDeltaY,
+			hasPreciseScrollingDeltas: event.hasPreciseScrollingDeltas,
+			phaseActive: phase != [],
+			phaseEndedOrCancelled: phase.contains(.ended) || phase.contains(.cancelled),
+			momentumActive: event.momentumPhase != []
+		)
 	}
 
 	private func resetAnnotationStyleWheelGate() {
-		annotationStyleWheelLastStepTimestamp = nil
+		annotationStyleWheelGate.reset()
 	}
 
 	override func draw(_ dirtyRect: NSRect) {

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -22,6 +22,7 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureHostCursorMapping()
 		assertCaptureHostPointerDispatchSupport()
 		assertCaptureHostLivePrimaryInteractionState()
+		assertCaptureHostAnnotationStyleWheelGate()
 		let minimapExportSize = CGSize(width: 100, height: 200)
 		guard
 			let rightMinimap = scrollCaptureMinimapPlan(
@@ -232,6 +233,105 @@ enum RsnapNativeHostKitProbe {
 		state.reset()
 		guard state == CaptureHostLivePrimaryInteractionState() else {
 			fatalError("live primary state should reset to idle")
+		}
+	}
+
+	private static func assertCaptureHostAnnotationStyleWheelGate() {
+		var gate = CaptureHostAnnotationStyleWheelGate()
+		guard
+			gate.steps(
+				timestamp: 1,
+				deltaY: 0.01,
+				hasPreciseScrollingDeltas: false,
+				phaseActive: false,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == 0,
+			gate.steps(
+				timestamp: 1,
+				deltaY: 1,
+				hasPreciseScrollingDeltas: false,
+				phaseActive: false,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == 1,
+			gate.steps(
+				timestamp: 1.02,
+				deltaY: -1,
+				hasPreciseScrollingDeltas: false,
+				phaseActive: false,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == 0,
+			gate.steps(
+				timestamp: 1.05,
+				deltaY: -1,
+				hasPreciseScrollingDeltas: false,
+				phaseActive: false,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == -1
+		else {
+			fatalError("annotation style wheel gate should throttle discrete wheel steps")
+		}
+
+		gate.reset()
+		guard
+			gate.steps(
+				timestamp: 2,
+				deltaY: 1,
+				hasPreciseScrollingDeltas: true,
+				phaseActive: true,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == 1,
+			gate.steps(
+				timestamp: 2.10,
+				deltaY: 1,
+				hasPreciseScrollingDeltas: true,
+				phaseActive: true,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == 0,
+			gate.steps(
+				timestamp: 2.19,
+				deltaY: 1,
+				hasPreciseScrollingDeltas: true,
+				phaseActive: true,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == 1,
+			gate.steps(
+				timestamp: 2.20,
+				deltaY: 1,
+				hasPreciseScrollingDeltas: false,
+				phaseActive: false,
+				phaseEndedOrCancelled: false,
+				momentumActive: true
+			) == 0
+		else {
+			fatalError("annotation style wheel gate should throttle precise wheel steps")
+		}
+
+		guard
+			gate.steps(
+				timestamp: 2.21,
+				deltaY: 1,
+				hasPreciseScrollingDeltas: false,
+				phaseActive: false,
+				phaseEndedOrCancelled: true,
+				momentumActive: false
+			) == 0,
+			gate.steps(
+				timestamp: 2.22,
+				deltaY: -1,
+				hasPreciseScrollingDeltas: false,
+				phaseActive: false,
+				phaseEndedOrCancelled: false,
+				momentumActive: false
+			) == -1
+		else {
+			fatalError("annotation style wheel gate should reset on ended phases")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Extract frozen annotation-size scroll wheel gating from CaptureHostView into CaptureHostAnnotationStyleWheelGate
- Add NativeHostKitProbe coverage for dead-zone, discrete/precise throttling, momentum suppression, and phase reset behavior
- Update host split docs to record the new support boundary

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check && rg -n "include!|#\[path" packages apps native scripts; test $? -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift run RsnapNativeHostKitProbe

## Review
- Fresh read-only skeptic review found no blockers. Static review confirmed staged state, behavior-equivalent gate extraction, no include!/#[path] matches, and docs/probe coverage.