### PR TITLE
Modularize capture host toolbar hover state

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -85,6 +85,8 @@ The current native-host Swift split is:
   to sample below native overlay windows.
 - `CaptureHostAnnotationStyleWheelGate.swift`: frozen annotation-size wheel dead-zone and
   per-gesture step throttling.
+- `CaptureHostToolbarHoverState.swift`: frozen toolbar hover target state, change detection, and
+  clearing behavior.
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
   HUD and toolbar rendering, and native pointer/key event routing into the session controller.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
@@ -103,13 +105,13 @@ The current native-host Swift split is:
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content.
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
-  `CaptureHostCursorSupport.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, frozen annotation-size wheel gating, capture-host cursor
-  presentation and NSCursor adaptation, live primary interaction state, pointer dispatch queue
-  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and native text
-  measurement.
+  `CaptureHostToolbarHoverState.swift`, `CaptureHostCursorSupport.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
+  annotation-size wheel gating, frozen toolbar hover state, capture-host cursor presentation and
+  NSCursor adaptation, live primary interaction state, pointer dispatch queue throttling,
+  Rust-backed frozen image effects, live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -190,6 +190,8 @@ The main host-kit files are split by responsibility:
   capture source management
 - `CaptureHostAnnotationStyleWheelGate.swift`: frozen annotation-size wheel dead-zone and
   per-gesture step throttling
+- `CaptureHostToolbarHoverState.swift`: frozen toolbar hover target state, change detection, and
+  clearing behavior
 - `CaptureHostView.swift`: AppKit view rendering, hit testing, and native pointer/key routing
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions
@@ -207,13 +209,14 @@ The main host-kit files are split by responsibility:
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
-  `CaptureHostCursorSupport.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, frozen annotation-size wheel gating, capture-host cursor
-  presentation and NSCursor adaptation, live primary interaction state, pointer dispatch queue
-  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and shared native
-  text measurement
+  `CaptureHostToolbarHoverState.swift`, `CaptureHostCursorSupport.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
+  annotation-size wheel gating, frozen toolbar hover state, capture-host cursor presentation and
+  NSCursor adaptation, live primary interaction state, pointer dispatch queue throttling,
+  Rust-backed frozen image effects, live-chrome telemetry identity, and shared native text
+  measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostToolbarHoverState.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostToolbarHoverState.swift
@@ -1,0 +1,39 @@
+import RsnapHostBridge
+
+package struct CaptureHostToolbarHoverState: Equatable {
+	package private(set) var pointerOverToolbar = false
+	package private(set) var toolbarAction: ToolbarItemKind?
+	package private(set) var annotationStyleAction: FrozenAnnotationStyleAction?
+
+	package init() {}
+
+	package var isActive: Bool {
+		pointerOverToolbar || toolbarAction != nil || annotationStyleAction != nil
+	}
+
+	@discardableResult
+	package mutating func update(to hitState: FrozenToolbarHitState) -> Bool {
+		guard
+			pointerOverToolbar != hitState.pointerOverToolbar
+				|| toolbarAction != hitState.toolbarAction
+				|| annotationStyleAction != hitState.annotationStyleAction
+		else {
+			return false
+		}
+		pointerOverToolbar = hitState.pointerOverToolbar
+		toolbarAction = hitState.toolbarAction
+		annotationStyleAction = hitState.annotationStyleAction
+		return true
+	}
+
+	@discardableResult
+	package mutating func clear() -> Bool {
+		guard isActive else {
+			return false
+		}
+		pointerOverToolbar = false
+		toolbarAction = nil
+		annotationStyleAction = nil
+		return true
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -88,9 +88,7 @@ final class CaptureHostView: NSView {
 	private var lastScrollToolbarBackdropChangedUptime: TimeInterval = 0
 	private var lastScrollToolbarBackdropFallbackCaptureStartedUptime: TimeInterval = 0
 	private var trackingAreaRef: NSTrackingArea?
-	private var pointerOverFrozenToolbar = false
-	private var hoveredToolbarAction: ToolbarItemKind?
-	private var hoveredAnnotationStyleAction: FrozenAnnotationStyleAction?
+	private var toolbarHoverState = CaptureHostToolbarHoverState()
 	private var annotationStyleWheelGate = CaptureHostAnnotationStyleWheelGate()
 	private var lastCursorPresentation: CaptureHostCursorPresentation?
 	private var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
@@ -1343,7 +1341,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func currentCursorPresentation() -> CaptureHostCursorPresentation {
-		if pointerOverFrozenToolbar || hoveredToolbarAction != nil {
+		if toolbarHoverState.pointerOverToolbar || toolbarHoverState.toolbarAction != nil {
 			return .arrow
 		}
 		if scene.mode == .frozen {
@@ -1891,15 +1889,9 @@ final class CaptureHostView: NSView {
 	}
 
 	private func clearHoveredToolbarAction() {
-		guard
-			pointerOverFrozenToolbar || hoveredToolbarAction != nil
-				|| hoveredAnnotationStyleAction != nil
-		else {
+		guard toolbarHoverState.clear() else {
 			return
 		}
-		pointerOverFrozenToolbar = false
-		hoveredToolbarAction = nil
-		hoveredAnnotationStyleAction = nil
 	}
 
 	private func refreshHoveredToolbarAction(for localPoint: CGPoint? = nil) {
@@ -1914,16 +1906,7 @@ final class CaptureHostView: NSView {
 				annotationStyleAction: nil
 			)
 		}
-		let pointerOverToolbar = hitState.pointerOverToolbar
-		let hoveredAction = hitState.toolbarAction
-		let hoveredStyleAction = hitState.annotationStyleAction
-		if hoveredToolbarAction != hoveredAction
-			|| hoveredAnnotationStyleAction != hoveredStyleAction
-			|| pointerOverFrozenToolbar != pointerOverToolbar
-		{
-			pointerOverFrozenToolbar = pointerOverToolbar
-			hoveredToolbarAction = hoveredAction
-			hoveredAnnotationStyleAction = hoveredStyleAction
+		if toolbarHoverState.update(to: hitState) {
 			syncVisibleCursor()
 			updateChromeMaterialViews()
 			needsDisplay = true
@@ -1952,11 +1935,11 @@ final class CaptureHostView: NSView {
 		)
 		FrozenToolbarDrawing.drawToolbarContent(
 			items: layout.items,
-			hoveredToolbarAction: hoveredToolbarAction,
+			hoveredToolbarAction: toolbarHoverState.toolbarAction,
 			toolbarScale: layout.scale,
 			annotationStyleState: chrome.annotationStyle,
 			annotationStyleLayout: layout.annotationStyle,
-			hoveredAnnotationStyleAction: hoveredAnnotationStyleAction,
+			hoveredAnnotationStyleAction: toolbarHoverState.annotationStyleAction,
 			palette: palette,
 			in: context
 		)
@@ -3344,8 +3327,8 @@ final class CaptureHostView: NSView {
 		let changed = contentView.update(
 			theme: chromeTheme(),
 			settings: settings,
-			hoveredToolbarAction: hoveredToolbarAction,
-			hoveredAnnotationStyleAction: hoveredAnnotationStyleAction,
+			hoveredToolbarAction: toolbarHoverState.toolbarAction,
+			hoveredAnnotationStyleAction: toolbarHoverState.annotationStyleAction,
 			toolbarScale: layout.scale,
 			annotationStyleState: chrome.annotationStyle,
 			annotationStyleLayout: layout.annotationStyle.map {

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -23,6 +23,7 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureHostPointerDispatchSupport()
 		assertCaptureHostLivePrimaryInteractionState()
 		assertCaptureHostAnnotationStyleWheelGate()
+		assertCaptureHostToolbarHoverState()
 		let minimapExportSize = CGSize(width: 100, height: 200)
 		guard
 			let rightMinimap = scrollCaptureMinimapPlan(
@@ -332,6 +333,45 @@ enum RsnapNativeHostKitProbe {
 			) == -1
 		else {
 			fatalError("annotation style wheel gate should reset on ended phases")
+		}
+	}
+
+	private static func assertCaptureHostToolbarHoverState() {
+		var state = CaptureHostToolbarHoverState()
+		guard state.isActive == false, state.clear() == false else {
+			fatalError("toolbar hover state should start idle")
+		}
+
+		let toolbarHit = FrozenToolbarHitState(
+			pointerOverToolbar: true,
+			toolbarAction: .copy,
+			annotationStyleAction: nil
+		)
+		guard
+			state.update(to: toolbarHit),
+			state.isActive,
+			state.pointerOverToolbar,
+			state.toolbarAction == .copy,
+			state.annotationStyleAction == nil,
+			state.update(to: toolbarHit) == false
+		else {
+			fatalError("toolbar hover state should update only when toolbar hit state changes")
+		}
+
+		let styleHit = FrozenToolbarHitState(
+			pointerOverToolbar: true,
+			toolbarAction: nil,
+			annotationStyleAction: .decreaseSize
+		)
+		guard
+			state.update(to: styleHit),
+			state.pointerOverToolbar,
+			state.toolbarAction == nil,
+			state.annotationStyleAction == .decreaseSize,
+			state.clear(),
+			state == CaptureHostToolbarHoverState()
+		else {
+			fatalError("toolbar hover state should switch and clear hover targets")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Extract frozen toolbar hover state/change detection from CaptureHostView into CaptureHostToolbarHoverState
- Keep AppKit side effects in CaptureHostView while routing hover reads through the new state boundary
- Add NativeHostKitProbe coverage for idle, update, duplicate no-op, switch, and clear behavior
- Update host split docs to record the new support boundary

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check && rg -n "include!|#\[path" packages apps native scripts; test $? -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh read-only skeptic review found no blockers or material risks. Static review confirmed staged state, behavior-equivalent hover-state extraction, no include!/#[path] matches, and docs/probe coverage.