### PR TITLE
Modularize capture host live sample cache

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -89,6 +89,8 @@ The current native-host Swift split is:
   clearing behavior.
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
   HUD and toolbar rendering, and native pointer/key event routing into the session controller.
+- `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
+  sample matching.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions.
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
@@ -106,12 +108,13 @@ The current native-host Swift split is:
   toolbar rendering and Liquid Glass toolbar content.
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
   `CaptureHostToolbarHoverState.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
-  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
-  annotation-size wheel gating, frozen toolbar hover state, capture-host cursor presentation and
-  NSCursor adaptation, live primary interaction state, pointer dispatch queue throttling,
-  Rust-backed frozen image effects, live-chrome telemetry identity, and native text measurement.
+  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
+  state, capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
+  interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
+  live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -193,6 +193,8 @@ The main host-kit files are split by responsibility:
 - `CaptureHostToolbarHoverState.swift`: frozen toolbar hover target state, change detection, and
   clearing behavior
 - `CaptureHostView.swift`: AppKit view rendering, hit testing, and native pointer/key routing
+- `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
+  sample matching
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
@@ -210,13 +212,13 @@ The main host-kit files are split by responsibility:
   toolbar rendering and Liquid Glass toolbar content
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
   `CaptureHostToolbarHoverState.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
-  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
-  annotation-size wheel gating, frozen toolbar hover state, capture-host cursor presentation and
-  NSCursor adaptation, live primary interaction state, pointer dispatch queue throttling,
-  Rust-backed frozen image effects, live-chrome telemetry identity, and shared native text
-  measurement
+  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
+  state, capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
+  interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
+  live-chrome telemetry identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLiveSampleCache.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLiveSampleCache.swift
@@ -1,0 +1,70 @@
+import CoreGraphics
+
+package struct CaptureHostLiveSampleCache {
+	private var latestChromeSample: LiveChromeSample?
+	private var latestChromeSamplePoint: CGPoint?
+	private var latestRgbSample: LiveRgbSample?
+	private var latestRgbSamplePoint: CGPoint?
+
+	package init() {}
+
+	package var latestChrome: LiveChromeSample? {
+		latestChromeSample
+	}
+
+	package var latestRgb: LiveRgbSample? {
+		latestRgbSample
+	}
+
+	package mutating func reset() {
+		latestChromeSample = nil
+		latestChromeSamplePoint = nil
+		latestRgbSample = nil
+		latestRgbSamplePoint = nil
+	}
+
+	package mutating func seedChrome(_ sample: LiveChromeSample, point: CGPoint?) {
+		latestChromeSample = sample
+		latestChromeSamplePoint = point
+	}
+
+	package mutating func seedRgb(_ rgbSample: LiveRgbSample, point: CGPoint?) {
+		latestRgbSample = rgbSample
+		latestRgbSamplePoint = point
+	}
+
+	package func chromeSample(matching point: CGPoint?) -> LiveChromeSample? {
+		guard Self.pointsMatch(latestChromeSamplePoint, point) else {
+			return nil
+		}
+		guard let latestChromeSample else {
+			return nil
+		}
+		guard latestChromeSample.rgb == nil || latestChromeSample.rgb?.isFresh() == true
+		else {
+			return LiveChromeSample(rgb: nil, loupePatch: latestChromeSample.loupePatch)
+		}
+		return latestChromeSample
+	}
+
+	package func rgbSample(matching point: CGPoint?) -> LiveRgbSample? {
+		guard Self.pointsMatch(latestRgbSamplePoint, point) else {
+			return nil
+		}
+		guard latestRgbSample?.isFresh(maximumAge: LiveRgbSample.maximumReusableAge) == true else {
+			return nil
+		}
+		return latestRgbSample
+	}
+
+	package static func pointsMatch(_ samplePoint: CGPoint?, _ point: CGPoint?) -> Bool {
+		switch (samplePoint, point) {
+		case (nil, nil):
+			return true
+		case (let samplePoint?, let point?):
+			return abs(samplePoint.x - point.x) <= 0.5 && abs(samplePoint.y - point.y) <= 0.5
+		default:
+			return false
+		}
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -108,10 +108,7 @@ final class CaptureHostView: NSView {
 	private var frozenFirstDisplayPendingFrameDisplayed = false
 	private var defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
 	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
-	private var latestLiveChromeSample: LiveChromeSample?
-	private var latestLiveChromeSamplePoint: CGPoint?
-	private var latestLiveRgbSample: LiveRgbSample?
-	private var latestLiveRgbSamplePoint: CGPoint?
+	private var liveSampleCache = CaptureHostLiveSampleCache()
 	private var glassPatchCache: [GlassSurfaceKind: GlassPatchCache] = [:]
 	private lazy var pointerDispatchQueue = CaptureHostPointerDispatchQueue(
 		targetInterval: { [weak self] in
@@ -247,10 +244,7 @@ final class CaptureHostView: NSView {
 				livePrimaryInteraction.clearHoverChromeSuppression()
 				pendingFrozenFirstDisplay = false
 				lastLivePreviewSnapshot = nil
-				latestLiveChromeSample = nil
-				latestLiveChromeSamplePoint = nil
-				latestLiveRgbSample = nil
-				latestLiveRgbSamplePoint = nil
+				liveSampleCache.reset()
 			}
 			resetLivePointerPreview()
 			liveHighlightedWindowPreview = nil
@@ -2026,7 +2020,8 @@ final class CaptureHostView: NSView {
 		guard let dragSelectionLocal = currentImmediateLiveDragSelectionLocal() else {
 			return nil
 		}
-		let rgbSample = cachedLiveRgbSample(matching: livePointerPreviewGlobal ?? scene.pointer)?
+		let rgbSample = liveSampleCache.rgbSample(
+			matching: livePointerPreviewGlobal ?? scene.pointer)?
 			.rgb
 		return LivePreviewSnapshot(
 			bounds: bounds,
@@ -2076,8 +2071,8 @@ final class CaptureHostView: NSView {
 			hudFrame: nil,
 			loupeFrame: nil,
 			positionDisplay: currentPositionDisplay(),
-			colorDisplay: currentLiveColorDisplay(for: latestLiveRgbSample?.rgb),
-			rgbSample: latestLiveRgbSample?.rgb,
+			colorDisplay: currentLiveColorDisplay(for: liveSampleCache.latestRgb?.rgb),
+			rgbSample: liveSampleCache.latestRgb?.rgb,
 			keycapVisible: false,
 			inputUptime: nil,
 			loupePatch: nil,
@@ -2394,14 +2389,14 @@ final class CaptureHostView: NSView {
 			}
 			return resolvedSample
 		}
-		if let cachedSample = cachedLiveChromeSample(matching: point) {
+		if let cachedSample = liveSampleCache.chromeSample(matching: point) {
 			return cachedSample
 		}
 		if chrome.loupePatch != nil,
-			liveSamplePoint(scene.pointer, matches: point)
+			CaptureHostLiveSampleCache.pointsMatch(scene.pointer, point)
 		{
 			seedLiveChromeSampleCache(from: chrome, point: scene.pointer)
-			return cachedLiveChromeSample(matching: point)
+			return liveSampleCache.chromeSample(matching: point)
 		}
 		if wantsLoupePatch, let cachedPatch = reusableLiveLoupePatch() {
 			return LiveChromeSample(rgb: nil, loupePatch: cachedPatch)
@@ -2417,7 +2412,7 @@ final class CaptureHostView: NSView {
 		guard wantsLoupePatch, sample.loupePatch == nil else {
 			return sample
 		}
-		if let cachedSample = cachedLiveChromeSample(matching: point),
+		if let cachedSample = liveSampleCache.chromeSample(matching: point),
 			let cachedPatch = cachedSample.loupePatch
 		{
 			return LiveChromeSample(
@@ -2431,7 +2426,8 @@ final class CaptureHostView: NSView {
 				loupePatch: cachedPatch
 			)
 		}
-		if liveSamplePoint(scene.pointer, matches: point), let chromePatch = chrome.loupePatch,
+		if CaptureHostLiveSampleCache.pointsMatch(scene.pointer, point),
+			let chromePatch = chrome.loupePatch,
 			liveLoupePatchMatchesCurrentSize(chromePatch)
 		{
 			return LiveChromeSample(
@@ -2443,7 +2439,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func reusableLiveLoupePatch() -> CGImage? {
-		if let patch = latestLiveChromeSample?.loupePatch,
+		if let patch = liveSampleCache.latestChrome?.loupePatch,
 			liveLoupePatchMatchesCurrentSize(patch)
 		{
 			return patch
@@ -2468,7 +2464,7 @@ final class CaptureHostView: NSView {
 			seedLiveRgbSampleCache(rgbSample, point: point)
 			return rgbSample.rgb
 		}
-		return cachedLiveRgbSample(matching: point)?.rgb
+		return liveSampleCache.rgbSample(matching: point)?.rgb
 	}
 
 	private func seedLiveChromeSampleCache(from chrome: CaptureChromeState, point: CGPoint?) {
@@ -2485,53 +2481,11 @@ final class CaptureHostView: NSView {
 	}
 
 	private func seedLiveChromeSampleCache(_ sample: LiveChromeSample, point: CGPoint?) {
-		latestLiveChromeSample = sample
-		latestLiveChromeSamplePoint = point
+		liveSampleCache.seedChrome(sample, point: point)
 	}
 
 	private func seedLiveRgbSampleCache(_ rgbSample: LiveRgbSample, point: CGPoint?) {
-		latestLiveRgbSample = rgbSample
-		latestLiveRgbSamplePoint = point
-	}
-
-	private func cachedLiveChromeSample(matching point: CGPoint?) -> LiveChromeSample? {
-		guard liveSamplePoint(latestLiveChromeSamplePoint, matches: point) else {
-			return nil
-		}
-		guard let latestLiveChromeSample else {
-			return nil
-		}
-		guard latestLiveChromeSample.rgb == nil || latestLiveChromeSample.rgb?.isFresh() == true
-		else {
-			return LiveChromeSample(rgb: nil, loupePatch: latestLiveChromeSample.loupePatch)
-		}
-		return latestLiveChromeSample
-	}
-
-	private func cachedLiveRgbSample(matching point: CGPoint?) -> LiveRgbSample? {
-		guard liveSamplePoint(latestLiveRgbSamplePoint, matches: point) else {
-			return nil
-		}
-		guard latestLiveRgbSample?.isFresh(maximumAge: LiveRgbSample.maximumReusableAge) == true
-		else {
-			return nil
-		}
-		return latestLiveRgbSample
-	}
-
-	private func liveSamplePoint(_ samplePoint: CGPoint?, matches point: CGPoint?) -> Bool {
-		switch (samplePoint, point) {
-		case (nil, nil):
-			return true
-		case (let samplePoint?, let point?):
-			return Self.liveSamplePointsEquivalent(samplePoint, point)
-		default:
-			return false
-		}
-	}
-
-	private static func liveSamplePointsEquivalent(_ lhs: CGPoint, _ rhs: CGPoint) -> Bool {
-		abs(lhs.x - rhs.x) <= 0.5 && abs(lhs.y - rhs.y) <= 0.5
+		liveSampleCache.seedRgb(rgbSample, point: point)
 	}
 
 	private func selectionSizeText(for rect: CGRect) -> String {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -8,21 +8,28 @@ import QuartzCore
 import RsnapHostBridge
 import Vision
 
-struct LiveRgbSample: Sendable {
+package struct LiveRgbSample: Sendable {
 	// SCStream may stop emitting while the captured display is static; FrozenFrameAuthority
 	// applies its own strict age budget for authoritative screenshot frames.
-	static let maximumDisplayAge: TimeInterval = 60.0
-	static let maximumReusableAge: TimeInterval = 0.04
+	package static let maximumDisplayAge: TimeInterval = 60.0
+	package static let maximumReusableAge: TimeInterval = 0.04
 
-	let rgb: RGBSample
-	let capturedAtUptime: TimeInterval
-	let source: String
+	package let rgb: RGBSample
+	package let capturedAtUptime: TimeInterval
+	package let source: String
 
-	func ageMilliseconds(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Double {
+	package init(rgb: RGBSample, capturedAtUptime: TimeInterval, source: String) {
+		self.rgb = rgb
+		self.capturedAtUptime = capturedAtUptime
+		self.source = source
+	}
+
+	package func ageMilliseconds(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Double
+	{
 		max(0, now - capturedAtUptime) * 1_000
 	}
 
-	func isFresh(
+	package func isFresh(
 		maximumAge: TimeInterval = Self.maximumDisplayAge,
 		now: TimeInterval = ProcessInfo.processInfo.systemUptime
 	) -> Bool {
@@ -30,20 +37,20 @@ struct LiveRgbSample: Sendable {
 	}
 }
 
-struct LiveChromeSample {
-	let rgb: LiveRgbSample?
-	let loupePatch: CGImage?
+package struct LiveChromeSample {
+	package let rgb: LiveRgbSample?
+	package let loupePatch: CGImage?
 
-	var rgbSample: RGBSample? {
+	package var rgbSample: RGBSample? {
 		rgb?.rgb
 	}
 
-	init(rgb: LiveRgbSample?, loupePatch: CGImage?) {
+	package init(rgb: LiveRgbSample?, loupePatch: CGImage?) {
 		self.rgb = rgb
 		self.loupePatch = loupePatch
 	}
 
-	init(
+	package init(
 		rgbSample: RGBSample?,
 		rgbCapturedAtUptime: TimeInterval? = nil,
 		rgbSource: String = "unqualified",

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -24,6 +24,7 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureHostLivePrimaryInteractionState()
 		assertCaptureHostAnnotationStyleWheelGate()
 		assertCaptureHostToolbarHoverState()
+		assertCaptureHostLiveSampleCachePointMatching()
 		let minimapExportSize = CGSize(width: 100, height: 200)
 		guard
 			let rightMinimap = scrollCaptureMinimapPlan(
@@ -373,6 +374,92 @@ enum RsnapNativeHostKitProbe {
 		else {
 			fatalError("toolbar hover state should switch and clear hover targets")
 		}
+	}
+
+	private static func assertCaptureHostLiveSampleCachePointMatching() {
+		let currentRgb = LiveRgbSample(
+			rgb: RGBSample(r: 1, g: 2, b: 3),
+			capturedAtUptime: ProcessInfo.processInfo.systemUptime,
+			source: "probe"
+		)
+		let staleRgb = LiveRgbSample(
+			rgb: RGBSample(r: 4, g: 5, b: 6),
+			capturedAtUptime:
+				ProcessInfo.processInfo.systemUptime - LiveRgbSample.maximumDisplayAge - 1,
+			source: "probe-stale"
+		)
+		let loupePatch = makeProbeImage()
+		var cache = CaptureHostLiveSampleCache()
+		cache.seedChrome(LiveChromeSample(rgb: currentRgb, loupePatch: nil), point: .zero)
+		cache.seedRgb(currentRgb, point: .zero)
+		guard
+			cache.chromeSample(matching: CGPoint(x: 0.5, y: -0.5))?.rgb?.rgb
+				== RGBSample(r: 1, g: 2, b: 3),
+			cache.rgbSample(matching: CGPoint(x: 0.5, y: -0.5))?.rgb
+				== RGBSample(r: 1, g: 2, b: 3),
+			cache.chromeSample(matching: CGPoint(x: 0.51, y: 0)) == nil,
+			cache.rgbSample(matching: CGPoint(x: 0.51, y: 0)) == nil
+		else {
+			fatalError("live sample cache should reuse fresh samples only at matching points")
+		}
+
+		cache.seedChrome(LiveChromeSample(rgb: staleRgb, loupePatch: loupePatch), point: .zero)
+		cache.seedRgb(staleRgb, point: .zero)
+		guard
+			cache.chromeSample(matching: .zero)?.rgb == nil,
+			cache.chromeSample(matching: .zero)?.loupePatch === loupePatch,
+			cache.rgbSample(matching: .zero) == nil
+		else {
+			fatalError(
+				"live sample cache should preserve stale chrome patch while stripping stale RGB")
+		}
+		cache.reset()
+		guard cache.latestChrome == nil, cache.latestRgb == nil else {
+			fatalError("live sample cache should reset cached samples")
+		}
+
+		guard
+			CaptureHostLiveSampleCache.pointsMatch(nil, nil),
+			CaptureHostLiveSampleCache.pointsMatch(CGPoint(x: 10, y: 20), nil) == false,
+			CaptureHostLiveSampleCache.pointsMatch(nil, CGPoint(x: 10, y: 20)) == false,
+			CaptureHostLiveSampleCache.pointsMatch(
+				CGPoint(x: 10, y: 20),
+				CGPoint(x: 10.5, y: 19.5)
+			),
+			CaptureHostLiveSampleCache.pointsMatch(
+				CGPoint(x: 10, y: 20),
+				CGPoint(x: 10.51, y: 20)
+			) == false,
+			CaptureHostLiveSampleCache.pointsMatch(
+				CGPoint(x: 10, y: 20),
+				CGPoint(x: 10, y: 19.49)
+			) == false
+		else {
+			fatalError("live sample cache should preserve point matching tolerance")
+		}
+	}
+
+	private static func makeProbeImage() -> CGImage {
+		let data = Data([255, 0, 0, 255])
+		guard
+			let provider = CGDataProvider(data: data as CFData),
+			let image = CGImage(
+				width: 1,
+				height: 1,
+				bitsPerComponent: 8,
+				bitsPerPixel: 32,
+				bytesPerRow: 4,
+				space: CGColorSpaceCreateDeviceRGB(),
+				bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+				provider: provider,
+				decode: nil,
+				shouldInterpolate: false,
+				intent: .defaultIntent
+			)
+		else {
+			fatalError("expected probe image")
+		}
+		return image
 	}
 
 	private static func approximatelyEqual(


### PR DESCRIPTION
## Summary
- Extract CaptureHostView live chrome/RGB sample caching and point matching into CaptureHostLiveSampleCache
- Keep controller sampling and loupe patch sizing in CaptureHostView while moving cache ownership into a support boundary
- Add NativeHostKitProbe coverage for point tolerance, fresh reuse, stale RGB stripping/rejection, loupe patch preservation, and reset
- Update host split docs to record the new support boundary

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check && rg -n "include!|#\[path" packages apps native scripts; test $? -eq 1
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh read-only skeptic review found no blockers. Follow-up probe coverage was added for stale RGB plus loupe patch behavior, then the full validation chain was rerun.