### PR TITLE
Modularize capture host first-display handoff state

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -87,6 +87,8 @@ The current native-host Swift split is:
   per-gesture step throttling.
 - `CaptureHostToolbarHoverState.swift`: frozen toolbar hover target state, change detection, and
   clearing behavior.
+- `CaptureHostFrozenFirstDisplayHandoffState.swift`: capture-host frozen-entry first-display
+  handoff state, completion queueing, pending-frame evidence, and deferred classic toolbar glass.
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
   HUD and toolbar rendering, and native pointer/key event routing into the session controller.
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
@@ -107,12 +109,13 @@ The current native-host Swift split is:
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content.
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
-  `CaptureHostToolbarHoverState.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
-  state, capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
+  `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
+  `CaptureHostCursorSupport.swift`, `CaptureHostLiveSampleCache.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
+  annotation-size wheel gating, frozen toolbar hover state, frozen first-display handoff state,
+  capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
   interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
   live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -192,6 +192,8 @@ The main host-kit files are split by responsibility:
   per-gesture step throttling
 - `CaptureHostToolbarHoverState.swift`: frozen toolbar hover target state, change detection, and
   clearing behavior
+- `CaptureHostFrozenFirstDisplayHandoffState.swift`: frozen-entry first-display handoff state,
+  completion queueing, pending-frame evidence, and deferred classic toolbar glass
 - `CaptureHostView.swift`: AppKit view rendering, hit testing, and native pointer/key routing
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
   sample matching
@@ -211,12 +213,13 @@ The main host-kit files are split by responsibility:
 - `FrozenToolbarRenderView.swift`: shared frozen-toolbar content drawing for classic AppKit
   toolbar rendering and Liquid Glass toolbar content
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
-  `CaptureHostToolbarHoverState.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
-  boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
-  state, capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
+  `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
+  `CaptureHostCursorSupport.swift`, `CaptureHostLiveSampleCache.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
+  annotation-size wheel gating, frozen toolbar hover state, frozen first-display handoff state,
+  capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
   interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
   live-chrome telemetry identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostFrozenFirstDisplayHandoffState.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostFrozenFirstDisplayHandoffState.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+package struct CaptureHostFrozenFirstDisplayHandoffCompletion: Equatable {
+	package let startedAt: TimeInterval?
+	package let pendingFrameDisplayed: Bool
+	package let deferredClassicToolbarGlass: Bool
+
+	package init(
+		startedAt: TimeInterval?,
+		pendingFrameDisplayed: Bool,
+		deferredClassicToolbarGlass: Bool
+	) {
+		self.startedAt = startedAt
+		self.pendingFrameDisplayed = pendingFrameDisplayed
+		self.deferredClassicToolbarGlass = deferredClassicToolbarGlass
+	}
+}
+
+package struct CaptureHostFrozenFirstDisplayHandoffState: Equatable {
+	package private(set) var pending = false
+	package private(set) var completionQueued = false
+	package private(set) var startedAt: TimeInterval?
+	package private(set) var pendingFrameDisplayed = false
+	package private(set) var defersClassicToolbarGlassUntilAfterFirstDisplay = false
+
+	package init() {}
+
+	package var allowsClassicToolbarGlass: Bool {
+		!defersClassicToolbarGlassUntilAfterFirstDisplay
+	}
+
+	package mutating func reset() {
+		pending = false
+		completionQueued = false
+		startedAt = nil
+		pendingFrameDisplayed = false
+		defersClassicToolbarGlassUntilAfterFirstDisplay = false
+	}
+
+	package mutating func beginTransitionToFrozen(now: TimeInterval) {
+		pending = true
+		completionQueued = false
+		startedAt = now
+		pendingFrameDisplayed = false
+		defersClassicToolbarGlassUntilAfterFirstDisplay = false
+	}
+
+	package mutating func beginFrozenFirstFrameInstall(
+		pending: Bool,
+		defersClassicToolbarGlass: Bool,
+		now: TimeInterval
+	) {
+		self.pending = pending
+		completionQueued = false
+		startedAt = pending ? now : nil
+		pendingFrameDisplayed = false
+		defersClassicToolbarGlassUntilAfterFirstDisplay = defersClassicToolbarGlass
+	}
+
+	package mutating func markPendingFrameDisplayed() {
+		pendingFrameDisplayed = true
+	}
+
+	package mutating func queueCompletionIfNeeded() -> Bool {
+		guard pending, !completionQueued else {
+			return false
+		}
+		completionQueued = true
+		return true
+	}
+
+	package mutating func finish() -> CaptureHostFrozenFirstDisplayHandoffCompletion? {
+		guard pending else {
+			return nil
+		}
+		let completion = CaptureHostFrozenFirstDisplayHandoffCompletion(
+			startedAt: startedAt,
+			pendingFrameDisplayed: pendingFrameDisplayed,
+			deferredClassicToolbarGlass: defersClassicToolbarGlassUntilAfterFirstDisplay
+		)
+		pending = false
+		completionQueued = false
+		startedAt = nil
+		pendingFrameDisplayed = false
+		return completion
+	}
+
+	package mutating func clearDeferredClassicToolbarGlass() {
+		defersClassicToolbarGlassUntilAfterFirstDisplay = false
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -102,11 +102,7 @@ final class CaptureHostView: NSView {
 	private var lastLivePointerEventUptime: TimeInterval?
 	private var liveHighlightedWindowPreview: WindowSnapshot?
 	private var sampleUpdatedLiveChromeRenderInProgress = false
-	private var pendingFrozenFirstDisplay = false
-	private var frozenFirstDisplayCompletionQueued = false
-	private var frozenFirstDisplayHandoffStartedAt: TimeInterval?
-	private var frozenFirstDisplayPendingFrameDisplayed = false
-	private var defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
+	private var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
 	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
 	private var liveSampleCache = CaptureHostLiveSampleCache()
 	private var glassPatchCache: [GlassSurfaceKind: GlassPatchCache] = [:]
@@ -175,10 +171,7 @@ final class CaptureHostView: NSView {
 		let hostLocalFrozenSelectingEnded =
 			previousChrome.hostLocalFrozenSelecting && !chrome.hostLocalFrozenSelecting
 		if scene.mode != .frozen {
-			frozenFirstDisplayCompletionQueued = false
-			frozenFirstDisplayHandoffStartedAt = nil
-			frozenFirstDisplayPendingFrameDisplayed = false
-			defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
+			frozenFirstDisplayHandoff.reset()
 			scrollToolbarBackdropSeedFrame = nil
 			scrollToolbarBackdropSeedImage = nil
 			scrollToolbarBackdropSeedPatchCache = nil
@@ -226,7 +219,7 @@ final class CaptureHostView: NSView {
 			updateTrackingAreas()
 		}
 		if scene.mode == .live {
-			pendingFrozenFirstDisplay = false
+			frozenFirstDisplayHandoff.reset()
 			if previousMode != .live {
 				livePrimaryInteraction.clearHoverChromeSuppression()
 				resetLiveChromeInputTelemetry()
@@ -242,15 +235,15 @@ final class CaptureHostView: NSView {
 			clearLivePrimaryInteractionState(rendersImmediately: false)
 			if scene.mode == .hidden {
 				livePrimaryInteraction.clearHoverChromeSuppression()
-				pendingFrozenFirstDisplay = false
+				frozenFirstDisplayHandoff.reset()
 				lastLivePreviewSnapshot = nil
 				liveSampleCache.reset()
 			}
 			resetLivePointerPreview()
 			liveHighlightedWindowPreview = nil
 			if transitioningToFrozen {
-				pendingFrozenFirstDisplay = true
-				frozenFirstDisplayHandoffStartedAt = ProcessInfo.processInfo.systemUptime
+				frozenFirstDisplayHandoff.beginTransitionToFrozen(
+					now: ProcessInfo.processInfo.systemUptime)
 			}
 		}
 		refreshHoveredToolbarAction()
@@ -300,7 +293,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func completeFrozenFirstDisplayHandoff() {
-		guard pendingFrozenFirstDisplay else {
+		guard frozenFirstDisplayHandoff.pending else {
 			return
 		}
 		window?.disableScreenUpdatesUntilFlush()
@@ -308,14 +301,9 @@ final class CaptureHostView: NSView {
 	}
 
 	private func finishFrozenFirstDisplayHandoff() {
-		let handoffStartedAt = frozenFirstDisplayHandoffStartedAt
-		pendingFrozenFirstDisplay = false
-		frozenFirstDisplayCompletionQueued = false
-		frozenFirstDisplayHandoffStartedAt = nil
-		let pendingFrameDisplayed = frozenFirstDisplayPendingFrameDisplayed
-		frozenFirstDisplayPendingFrameDisplayed = false
-		let deferredClassicToolbarGlass =
-			defersFrozenToolbarClassicGlassUntilAfterFirstDisplay
+		guard let completion = frozenFirstDisplayHandoff.finish() else {
+			return
+		}
 		let materialStartedAt = ProcessInfo.processInfo.systemUptime
 		updateChromeMaterialViews()
 		let materialMilliseconds = NativeHostTelemetry.milliseconds(since: materialStartedAt)
@@ -335,22 +323,22 @@ final class CaptureHostView: NSView {
 		displayIfNeeded()
 		let displayMilliseconds = NativeHostTelemetry.milliseconds(since: displayStartedAt)
 		CATransaction.commit()
-		if deferredClassicToolbarGlass {
+		if completion.deferredClassicToolbarGlass {
 			DispatchQueue.main.async { [weak self] in
 				guard let self else {
 					return
 				}
-				self.defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
+				self.frozenFirstDisplayHandoff.clearDeferredClassicToolbarGlass()
 				self.needsDisplay = true
 			}
 		}
-		if let handoffStartedAt {
+		if let handoffStartedAt = completion.startedAt {
 			emitFrozenFirstDisplayHandoffTiming(
 				startedAt: handoffStartedAt,
 				materialMilliseconds: materialMilliseconds,
 				liveRendererStopMilliseconds: liveRendererStopMilliseconds,
 				displayMilliseconds: displayMilliseconds,
-				pendingFrameDisplayed: pendingFrameDisplayed
+				pendingFrameDisplayed: completion.pendingFrameDisplayed
 			)
 		}
 	}
@@ -389,11 +377,7 @@ final class CaptureHostView: NSView {
 		self.chrome = chrome
 		self.settings = settings
 		livePrimaryInteraction.clearHoverChromeSuppression()
-		pendingFrozenFirstDisplay = false
-		frozenFirstDisplayCompletionQueued = false
-		frozenFirstDisplayHandoffStartedAt = nil
-		frozenFirstDisplayPendingFrameDisplayed = false
-		defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
+		frozenFirstDisplayHandoff.reset()
 		lastLivePreviewSnapshot = nil
 		if scene.mode == .live {
 			seedLivePointerPreview(scene.pointer, recordsInputLatency: false)
@@ -460,12 +444,11 @@ final class CaptureHostView: NSView {
 		self.chrome = chrome
 		self.settings = settings
 		livePrimaryInteraction.clearHoverChromeSuppression()
-		pendingFrozenFirstDisplay = retainedLivePreview != nil || scene.frozenSelection != nil
-		frozenFirstDisplayCompletionQueued = false
-		frozenFirstDisplayHandoffStartedAt =
-			pendingFrozenFirstDisplay ? ProcessInfo.processInfo.systemUptime : nil
-		frozenFirstDisplayPendingFrameDisplayed = false
-		defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = settings.usesClassicHudGlass
+		frozenFirstDisplayHandoff.beginFrozenFirstFrameInstall(
+			pending: retainedLivePreview != nil || scene.frozenSelection != nil,
+			defersClassicToolbarGlass: settings.usesClassicHudGlass,
+			now: ProcessInfo.processInfo.systemUptime
+		)
 		lastLivePreviewSnapshot = retainedLivePreview
 		clearLivePrimaryInteractionState(rendersImmediately: false)
 		resetLivePointerPreview()
@@ -475,14 +458,14 @@ final class CaptureHostView: NSView {
 		needsDisplay = true
 		controller?.updateLivePreviewDemand(
 			point: nil, settings: settings, includeLoupePatch: false)
-		if rendersPendingFrame, pendingFrozenFirstDisplay {
-			frozenFirstDisplayPendingFrameDisplayed = true
+		if rendersPendingFrame, frozenFirstDisplayHandoff.pending {
+			frozenFirstDisplayHandoff.markPendingFrameDisplayed()
 			liveRenderer.renderNow()
 		}
 	}
 
 	func finishFrozenFirstFrameInstall() {
-		guard pendingFrozenFirstDisplay else {
+		guard frozenFirstDisplayHandoff.pending else {
 			return
 		}
 		window?.disableScreenUpdatesUntilFlush()
@@ -774,8 +757,8 @@ final class CaptureHostView: NSView {
 		case .live:
 			break
 		case .frozen:
-			if pendingFrozenFirstDisplay {
-				frozenFirstDisplayPendingFrameDisplayed = true
+			if frozenFirstDisplayHandoff.pending {
+				frozenFirstDisplayHandoff.markPendingFrameDisplayed()
 				scheduleFrozenFirstFrameInstallCompletionIfNeeded()
 				return
 			}
@@ -821,10 +804,9 @@ final class CaptureHostView: NSView {
 	}
 
 	private func scheduleFrozenFirstFrameInstallCompletionIfNeeded() {
-		guard pendingFrozenFirstDisplay, !frozenFirstDisplayCompletionQueued else {
+		guard frozenFirstDisplayHandoff.queueCompletionIfNeeded() else {
 			return
 		}
-		frozenFirstDisplayCompletionQueued = true
 		DispatchQueue.main.async { [weak self] in
 			self?.finishFrozenFirstFrameInstall()
 		}
@@ -1925,7 +1907,7 @@ final class CaptureHostView: NSView {
 			theme: theme,
 			strongShadow: false,
 			surfaceKind: .toolbar,
-			allowsClassicGlass: !defersFrozenToolbarClassicGlassUntilAfterFirstDisplay
+			allowsClassicGlass: frozenFirstDisplayHandoff.allowsClassicToolbarGlass
 		)
 		FrozenToolbarDrawing.drawToolbarContent(
 			items: layout.items,
@@ -2006,7 +1988,7 @@ final class CaptureHostView: NSView {
 			lastLivePreviewSnapshot = snapshot
 			return snapshot
 		}
-		if pendingFrozenFirstDisplay {
+		if frozenFirstDisplayHandoff.pending {
 			return currentPendingFrozenPreviewSnapshot() ?? lastLivePreviewSnapshot
 		}
 		return nil
@@ -2047,7 +2029,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func currentPendingFrozenPreviewSnapshot() -> LivePreviewSnapshot? {
-		guard pendingFrozenFirstDisplay else {
+		guard frozenFirstDisplayHandoff.pending else {
 			return nil
 		}
 		let frozenSelectionLocal =
@@ -2281,7 +2263,7 @@ final class CaptureHostView: NSView {
 		guard liveRendererInstalled else {
 			return
 		}
-		guard scene.mode == .live || pendingFrozenFirstDisplay else {
+		guard scene.mode == .live || frozenFirstDisplayHandoff.pending else {
 			liveRenderer.suspend()
 			loggedLiveRefreshTarget = nil
 			return
@@ -2320,10 +2302,7 @@ final class CaptureHostView: NSView {
 	private func stopLivePresentationNow() {
 		deferredLiveShutdownWorkItem?.cancel()
 		deferredLiveShutdownWorkItem = nil
-		pendingFrozenFirstDisplay = false
-		frozenFirstDisplayHandoffStartedAt = nil
-		frozenFirstDisplayPendingFrameDisplayed = false
-		defersFrozenToolbarClassicGlassUntilAfterFirstDisplay = false
+		frozenFirstDisplayHandoff.reset()
 		lastLivePreviewSnapshot = nil
 		hideLiveLiquidGlassViews()
 		guard scene.mode != .live else {

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -22,6 +22,7 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureHostCursorMapping()
 		assertCaptureHostPointerDispatchSupport()
 		assertCaptureHostLivePrimaryInteractionState()
+		assertCaptureHostFrozenFirstDisplayHandoffState()
 		assertCaptureHostAnnotationStyleWheelGate()
 		assertCaptureHostToolbarHoverState()
 		assertCaptureHostLiveSampleCachePointMatching()
@@ -235,6 +236,87 @@ enum RsnapNativeHostKitProbe {
 		state.reset()
 		guard state == CaptureHostLivePrimaryInteractionState() else {
 			fatalError("live primary state should reset to idle")
+		}
+	}
+
+	private static func assertCaptureHostFrozenFirstDisplayHandoffState() {
+		var state = CaptureHostFrozenFirstDisplayHandoffState()
+		guard
+			state.pending == false,
+			state.completionQueued == false,
+			state.startedAt == nil,
+			state.pendingFrameDisplayed == false,
+			state.allowsClassicToolbarGlass
+		else {
+			fatalError("frozen first-display handoff should start idle")
+		}
+
+		state.beginTransitionToFrozen(now: 4.25)
+		guard
+			state.pending,
+			state.startedAt == 4.25,
+			state.pendingFrameDisplayed == false,
+			state.queueCompletionIfNeeded(),
+			state.queueCompletionIfNeeded() == false
+		else {
+			fatalError("frozen first-display transition should queue completion once")
+		}
+		state.markPendingFrameDisplayed()
+		guard
+			state.finish()
+				== CaptureHostFrozenFirstDisplayHandoffCompletion(
+					startedAt: 4.25,
+					pendingFrameDisplayed: true,
+					deferredClassicToolbarGlass: false),
+			state.pending == false,
+			state.completionQueued == false,
+			state.startedAt == nil,
+			state.pendingFrameDisplayed == false,
+			state.allowsClassicToolbarGlass
+		else {
+			fatalError("frozen first-display transition should finish with display evidence")
+		}
+
+		state.beginFrozenFirstFrameInstall(
+			pending: true,
+			defersClassicToolbarGlass: true,
+			now: 8.5
+		)
+		guard
+			state.pending,
+			state.startedAt == 8.5,
+			state.allowsClassicToolbarGlass == false,
+			state.finish()
+				== CaptureHostFrozenFirstDisplayHandoffCompletion(
+					startedAt: 8.5,
+					pendingFrameDisplayed: false,
+					deferredClassicToolbarGlass: true),
+			state.allowsClassicToolbarGlass == false
+		else {
+			fatalError("frozen first-frame install should preserve deferred toolbar glass")
+		}
+		state.clearDeferredClassicToolbarGlass()
+		guard state.allowsClassicToolbarGlass else {
+			fatalError("frozen first-frame install should clear deferred toolbar glass later")
+		}
+
+		state.beginFrozenFirstFrameInstall(
+			pending: false,
+			defersClassicToolbarGlass: true,
+			now: 10
+		)
+		guard
+			state.pending == false,
+			state.startedAt == nil,
+			state.queueCompletionIfNeeded() == false,
+			state.finish() == nil
+		else {
+			fatalError("frozen first-frame install should stay idle when no pending frame exists")
+		}
+
+		state.reset()
+		guard state == CaptureHostFrozenFirstDisplayHandoffState() else {
+			fatalError("frozen first-display handoff should reset to idle")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Extract frozen first-display handoff state and completion payloads into CaptureHostFrozenFirstDisplayHandoffState.
- Keep CaptureHostView responsible for AppKit, CATransaction, telemetry, and drawing side effects.
- Add HostKit probe coverage for completion queueing, pending-frame evidence, reset, and deferred classic toolbar glass.
- Update native-host ownership references for the new support boundary.

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check
- include/path scan over packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh read-only skeptic review found no blockers or material gaps.