### PR TITLE
Modularize capture host scroll toolbar backdrop state

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -89,6 +89,8 @@ The current native-host Swift split is:
   clearing behavior.
 - `CaptureHostFrozenFirstDisplayHandoffState.swift`: capture-host frozen-entry first-display
   handoff state, completion queueing, pending-frame evidence, and deferred classic toolbar glass.
+- `CaptureHostScrollToolbarBackdropState.swift`: capture-host scroll toolbar backdrop capture
+  generation, seed-patch cache, active frame, refresh cadence, and change-count state.
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
   HUD and toolbar rendering, and native pointer/key event routing into the session controller.
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
@@ -110,14 +112,15 @@ The current native-host Swift split is:
   toolbar rendering and Liquid Glass toolbar content.
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
-  `CaptureHostCursorSupport.swift`, `CaptureHostLiveSampleCache.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
-  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
-  annotation-size wheel gating, frozen toolbar hover state, frozen first-display handoff state,
-  capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
-  interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
-  live-chrome telemetry identity, and native text measurement.
+  `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
+  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
+  state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
+  presentation and NSCursor adaptation, live sample reuse, live primary interaction state, pointer
+  dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and
+  native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -194,6 +194,8 @@ The main host-kit files are split by responsibility:
   clearing behavior
 - `CaptureHostFrozenFirstDisplayHandoffState.swift`: frozen-entry first-display handoff state,
   completion queueing, pending-frame evidence, and deferred classic toolbar glass
+- `CaptureHostScrollToolbarBackdropState.swift`: scroll toolbar backdrop capture generation,
+  seed-patch cache, active frame, refresh cadence, and change-count state
 - `CaptureHostView.swift`: AppKit view rendering, hit testing, and native pointer/key routing
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
   sample matching
@@ -214,14 +216,15 @@ The main host-kit files are split by responsibility:
   toolbar rendering and Liquid Glass toolbar content
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
-  `CaptureHostCursorSupport.swift`, `CaptureHostLiveSampleCache.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
-  `NativeHostTextMetrics.swift`: focused support boundaries for shared capture geometry, frozen
-  annotation-size wheel gating, frozen toolbar hover state, frozen first-display handoff state,
-  capture-host cursor presentation and NSCursor adaptation, live sample reuse, live primary
-  interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
-  live-chrome telemetry identity, and shared native text measurement
+  `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
+  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
+  state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
+  presentation and NSCursor adaptation, live sample reuse, live primary interaction state, pointer
+  dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and
+  shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollToolbarBackdropState.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollToolbarBackdropState.swift
@@ -1,0 +1,209 @@
+import CoreGraphics
+import Foundation
+
+package struct CaptureHostGlassPatchCache {
+	package let frame: CGRect
+	package let capturedAt: TimeInterval
+	package let image: CGImage
+
+	package init(frame: CGRect, capturedAt: TimeInterval, image: CGImage) {
+		self.frame = frame
+		self.capturedAt = capturedAt
+		self.image = image
+	}
+}
+
+package struct CaptureHostScrollToolbarBackdropCaptureStart: Equatable {
+	package let generation: UInt64
+	package let afterFrameSequence: UInt64
+	package let previousSignature: UInt64?
+	package let fallbackPermitted: Bool
+}
+
+package struct CaptureHostScrollToolbarBackdropChange: Equatable {
+	package let count: UInt64
+	package let gapMilliseconds: Double?
+
+	package init(count: UInt64, gapMilliseconds: Double?) {
+		self.count = count
+		self.gapMilliseconds = gapMilliseconds
+	}
+}
+
+package struct CaptureHostScrollToolbarBackdropRefresh: Equatable {
+	package let gapMilliseconds: Double?
+	package let activeFrame: CGRect?
+	package let activeGlobalFrame: CGRect?
+
+	package init(
+		gapMilliseconds: Double?,
+		activeFrame: CGRect?,
+		activeGlobalFrame: CGRect?
+	) {
+		self.gapMilliseconds = gapMilliseconds
+		self.activeFrame = activeFrame
+		self.activeGlobalFrame = activeGlobalFrame
+	}
+}
+
+package struct CaptureHostScrollToolbarBackdropState {
+	package private(set) var captureInFlight = false
+	package private(set) var captureGeneration: UInt64 = 0
+	package private(set) var seedFrame: CGRect?
+	package private(set) var seedImage: CGImage?
+	package private(set) var seedPatchCache: CaptureHostGlassPatchCache?
+	package private(set) var lastFrameSequence: UInt64 = 0
+	package private(set) var lastSignature: UInt64?
+	package private(set) var changedCount: UInt64 = 0
+	package private(set) var activeFrame: CGRect?
+	package private(set) var activeGlobalFrame: CGRect?
+	package private(set) var lastChangedUptime: TimeInterval = 0
+	package private(set) var lastFallbackCaptureStartedUptime: TimeInterval = 0
+	package private(set) var lastCaptureStartedUptime: TimeInterval = 0
+	package private(set) var lastRefreshUptime: TimeInterval = 0
+
+	package init() {}
+
+	package mutating func resetTracking(seedFrame: CGRect? = nil, seedImage: CGImage? = nil) {
+		self.seedFrame = seedFrame
+		self.seedImage = seedImage
+		seedPatchCache = nil
+		lastFrameSequence = 0
+		lastSignature = nil
+		changedCount = 0
+		activeFrame = nil
+		activeGlobalFrame = nil
+		lastChangedUptime = 0
+		lastFallbackCaptureStartedUptime = 0
+		lastRefreshUptime = 0
+	}
+
+	package mutating func resetAndInvalidateCaptures() {
+		captureGeneration &+= 1
+		captureInFlight = false
+		lastCaptureStartedUptime = 0
+		resetTracking()
+	}
+
+	package mutating func clearActiveFrame() {
+		lastCaptureStartedUptime = 0
+		activeFrame = nil
+		activeGlobalFrame = nil
+	}
+
+	package mutating func updateActiveFrame(_ frame: CGRect, globalFrame: CGRect) {
+		activeFrame = frame
+		activeGlobalFrame = globalFrame
+	}
+
+	package func cachedSeedPatch(matching globalFrame: CGRect) -> CGImage? {
+		guard let seedPatchCache,
+			abs(seedPatchCache.frame.minX - globalFrame.minX) < 1,
+			abs(seedPatchCache.frame.minY - globalFrame.minY) < 1,
+			abs(seedPatchCache.frame.width - globalFrame.width) < 1,
+			abs(seedPatchCache.frame.height - globalFrame.height) < 1
+		else {
+			return nil
+		}
+		return seedPatchCache.image
+	}
+
+	package mutating func storeSeedPatch(
+		frame: CGRect,
+		capturedAt: TimeInterval,
+		image: CGImage
+	) {
+		seedPatchCache = CaptureHostGlassPatchCache(
+			frame: frame,
+			capturedAt: capturedAt,
+			image: image
+		)
+	}
+
+	package mutating func beginCapture(
+		now: TimeInterval,
+		minimumInterval: TimeInterval,
+		fallbackMinimumInterval: TimeInterval
+	) -> CaptureHostScrollToolbarBackdropCaptureStart? {
+		guard captureInFlight == false else {
+			return nil
+		}
+		guard
+			lastCaptureStartedUptime == 0
+				|| now - lastCaptureStartedUptime >= minimumInterval
+		else {
+			return nil
+		}
+		lastCaptureStartedUptime = now
+		let fallbackPermitted =
+			lastFallbackCaptureStartedUptime == 0
+			|| now - lastFallbackCaptureStartedUptime >= fallbackMinimumInterval
+		if fallbackPermitted {
+			lastFallbackCaptureStartedUptime = now
+		}
+		captureInFlight = true
+		captureGeneration &+= 1
+		return CaptureHostScrollToolbarBackdropCaptureStart(
+			generation: captureGeneration,
+			afterFrameSequence: lastFrameSequence,
+			previousSignature: lastSignature,
+			fallbackPermitted: fallbackPermitted
+		)
+	}
+
+	package mutating func clearInFlightForAbandonedCapture() {
+		captureInFlight = false
+	}
+
+	package mutating func finishCapture(
+		generation: UInt64,
+		frameSequence: UInt64?
+	) -> Bool {
+		guard captureGeneration == generation else {
+			return false
+		}
+		captureInFlight = false
+		if let frameSequence {
+			lastFrameSequence = max(lastFrameSequence, frameSequence)
+		}
+		return true
+	}
+
+	package mutating func recordChange(
+		signature: UInt64?,
+		now: TimeInterval
+	) -> CaptureHostScrollToolbarBackdropChange? {
+		guard let signature else {
+			return nil
+		}
+		let previousSignature = lastSignature
+		lastSignature = signature
+		guard previousSignature != signature else {
+			return nil
+		}
+		changedCount &+= 1
+		let gapMilliseconds =
+			lastChangedUptime > 0 ? (now - lastChangedUptime) * 1_000 : nil
+		lastChangedUptime = now
+		return CaptureHostScrollToolbarBackdropChange(
+			count: changedCount,
+			gapMilliseconds: gapMilliseconds
+		)
+	}
+
+	package mutating func beginRefresh(
+		now: TimeInterval,
+		interval: TimeInterval
+	) -> CaptureHostScrollToolbarBackdropRefresh? {
+		guard now - lastRefreshUptime >= interval else {
+			return nil
+		}
+		let gapMilliseconds = lastRefreshUptime > 0 ? (now - lastRefreshUptime) * 1_000 : nil
+		lastRefreshUptime = now
+		return CaptureHostScrollToolbarBackdropRefresh(
+			gapMilliseconds: gapMilliseconds,
+			activeFrame: activeFrame,
+			activeGlobalFrame: activeGlobalFrame
+		)
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -19,12 +19,6 @@ final class CaptureHostView: NSView {
 		case toolbar
 	}
 
-	private struct GlassPatchCache {
-		let frame: CGRect
-		let capturedAt: TimeInterval
-		let image: CGImage
-	}
-
 	private static let liveChromeLiquidGlassZ: CGFloat = 200
 	private static let frozenToolbarLiquidGlassBackdropZ: CGFloat = 295
 	private static let frozenToolbarLiquidGlassZ: CGFloat = 300
@@ -54,8 +48,6 @@ final class CaptureHostView: NSView {
 	private var toolbarLiquidGlassContentView: FrozenToolbarRenderView?
 	private var frozenToolbarLiquidGlassVisible = false
 	private var frozenToolbarLiquidGlassContentDrawn = false
-	private var lastScrollCaptureToolbarBackdropRefreshUptime: TimeInterval = 0
-	private var lastScrollToolbarBackdropCaptureStartedUptime: TimeInterval = 0
 	private let scrollToolbarBackdropRefreshGapMetric = NativeHostTelemetry.distribution(
 		"scroll_capture.toolbar_backdrop_refresh_gap",
 		category: "Capture",
@@ -75,18 +67,7 @@ final class CaptureHostView: NSView {
 		label: "ink.hack.rsnap.scroll-toolbar-backdrop-capture",
 		qos: .userInitiated
 	)
-	private var scrollToolbarBackdropCaptureInFlight = false
-	private var scrollToolbarBackdropCaptureGeneration: UInt64 = 0
-	private var scrollToolbarBackdropSeedFrame: CGRect?
-	private var scrollToolbarBackdropSeedImage: CGImage?
-	private var scrollToolbarBackdropSeedPatchCache: GlassPatchCache?
-	private var scrollToolbarBackdropLastFrameSequence: UInt64 = 0
-	private var scrollToolbarBackdropLastSignature: UInt64?
-	private var scrollToolbarBackdropChangedCount: UInt64 = 0
-	private var scrollToolbarBackdropFrame: CGRect?
-	private var scrollToolbarBackdropGlobalFrame: CGRect?
-	private var lastScrollToolbarBackdropChangedUptime: TimeInterval = 0
-	private var lastScrollToolbarBackdropFallbackCaptureStartedUptime: TimeInterval = 0
+	private var scrollToolbarBackdropState = CaptureHostScrollToolbarBackdropState()
 	private var trackingAreaRef: NSTrackingArea?
 	private var toolbarHoverState = CaptureHostToolbarHoverState()
 	private var annotationStyleWheelGate = CaptureHostAnnotationStyleWheelGate()
@@ -105,7 +86,7 @@ final class CaptureHostView: NSView {
 	private var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
 	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
 	private var liveSampleCache = CaptureHostLiveSampleCache()
-	private var glassPatchCache: [GlassSurfaceKind: GlassPatchCache] = [:]
+	private var glassPatchCache: [GlassSurfaceKind: CaptureHostGlassPatchCache] = [:]
 	private lazy var pointerDispatchQueue = CaptureHostPointerDispatchQueue(
 		targetInterval: { [weak self] in
 			guard let self else {
@@ -172,41 +153,14 @@ final class CaptureHostView: NSView {
 			previousChrome.hostLocalFrozenSelecting && !chrome.hostLocalFrozenSelecting
 		if scene.mode != .frozen {
 			frozenFirstDisplayHandoff.reset()
-			scrollToolbarBackdropSeedFrame = nil
-			scrollToolbarBackdropSeedImage = nil
-			scrollToolbarBackdropSeedPatchCache = nil
-			scrollToolbarBackdropLastFrameSequence = 0
-			scrollToolbarBackdropLastSignature = nil
-			scrollToolbarBackdropChangedCount = 0
-			scrollToolbarBackdropFrame = nil
-			scrollToolbarBackdropGlobalFrame = nil
-			lastScrollToolbarBackdropChangedUptime = 0
-			lastScrollToolbarBackdropFallbackCaptureStartedUptime = 0
-			lastScrollCaptureToolbarBackdropRefreshUptime = 0
+			scrollToolbarBackdropState.resetTracking()
 		} else if previousChrome.scrollMinimapPreview == nil, chrome.scrollMinimapPreview != nil {
-			scrollToolbarBackdropSeedFrame = previousChrome.frozenDisplayFrame
-			scrollToolbarBackdropSeedImage = previousChrome.frozenDisplayImage
-			scrollToolbarBackdropSeedPatchCache = nil
-			scrollToolbarBackdropLastFrameSequence = 0
-			scrollToolbarBackdropLastSignature = nil
-			scrollToolbarBackdropChangedCount = 0
-			scrollToolbarBackdropFrame = nil
-			scrollToolbarBackdropGlobalFrame = nil
-			lastScrollToolbarBackdropChangedUptime = 0
-			lastScrollToolbarBackdropFallbackCaptureStartedUptime = 0
-			lastScrollCaptureToolbarBackdropRefreshUptime = 0
+			scrollToolbarBackdropState.resetTracking(
+				seedFrame: previousChrome.frozenDisplayFrame,
+				seedImage: previousChrome.frozenDisplayImage
+			)
 		} else if previousChrome.scrollMinimapPreview != nil, chrome.scrollMinimapPreview == nil {
-			scrollToolbarBackdropSeedFrame = nil
-			scrollToolbarBackdropSeedImage = nil
-			scrollToolbarBackdropSeedPatchCache = nil
-			scrollToolbarBackdropLastFrameSequence = 0
-			scrollToolbarBackdropLastSignature = nil
-			scrollToolbarBackdropChangedCount = 0
-			scrollToolbarBackdropFrame = nil
-			scrollToolbarBackdropGlobalFrame = nil
-			lastScrollToolbarBackdropChangedUptime = 0
-			lastScrollToolbarBackdropFallbackCaptureStartedUptime = 0
-			lastScrollCaptureToolbarBackdropRefreshUptime = 0
+			scrollToolbarBackdropState.resetTracking()
 		}
 		self.scene = scene
 		self.chrome = chrome
@@ -2592,7 +2546,11 @@ final class CaptureHostView: NSView {
 			return nil
 		}
 
-		glassPatchCache[surfaceKind] = GlassPatchCache(frame: frame, capturedAt: now, image: image)
+		glassPatchCache[surfaceKind] = CaptureHostGlassPatchCache(
+			frame: frame,
+			capturedAt: now,
+			image: image
+		)
 		return image
 	}
 
@@ -2625,24 +2583,19 @@ final class CaptureHostView: NSView {
 	}
 
 	private func scrollToolbarBackdropSeedPatch(in globalFrame: CGRect) -> CGImage? {
-		if let cached = scrollToolbarBackdropSeedPatchCache,
-			abs(cached.frame.minX - globalFrame.minX) < 1,
-			abs(cached.frame.minY - globalFrame.minY) < 1,
-			abs(cached.frame.width - globalFrame.width) < 1,
-			abs(cached.frame.height - globalFrame.height) < 1
-		{
-			return cached.image
+		if let cached = scrollToolbarBackdropState.cachedSeedPatch(matching: globalFrame) {
+			return cached
 		}
 		guard
 			let image = frozenDisplayPatch(
 				in: globalFrame,
-				displayFrame: scrollToolbarBackdropSeedFrame,
-				image: scrollToolbarBackdropSeedImage
+				displayFrame: scrollToolbarBackdropState.seedFrame,
+				image: scrollToolbarBackdropState.seedImage
 			)
 		else {
 			return nil
 		}
-		scrollToolbarBackdropSeedPatchCache = GlassPatchCache(
+		scrollToolbarBackdropState.storeSeedPatch(
 			frame: globalFrame,
 			capturedAt: ProcessInfo.processInfo.systemUptime,
 			image: image
@@ -2913,15 +2866,12 @@ final class CaptureHostView: NSView {
 		guard chrome.scrollMinimapPreview != nil,
 			let globalFrame = globalRect(from: toolbarFrame)
 		else {
-			lastScrollToolbarBackdropCaptureStartedUptime = 0
-			scrollToolbarBackdropFrame = nil
-			scrollToolbarBackdropGlobalFrame = nil
+			scrollToolbarBackdropState.clearActiveFrame()
 			toolbarLiquidGlassBackdropView?.isHidden = true
 			toolbarLiquidGlassBackdropView?.image = nil
 			return
 		}
-		scrollToolbarBackdropFrame = toolbarFrame
-		scrollToolbarBackdropGlobalFrame = globalFrame
+		scrollToolbarBackdropState.updateActiveFrame(toolbarFrame, globalFrame: globalFrame)
 		let existingFrameMatches = toolbarLiquidGlassBackdropView?.frame == toolbarFrame
 		let existingHasImage = toolbarLiquidGlassBackdropView?.image != nil
 		if existingHasImage {
@@ -2954,50 +2904,39 @@ final class CaptureHostView: NSView {
 		toolbarFrame: CGRect,
 		globalFrame: CGRect
 	) {
-		guard scrollToolbarBackdropCaptureInFlight == false,
-			let scrollCaptureState = controller?.scrollCaptureState,
+		guard let scrollCaptureState = controller?.scrollCaptureState,
 			let liveFrameStream = controller?.liveFrameStream
 		else {
 			return
 		}
 		let now = ProcessInfo.processInfo.systemUptime
 		guard
-			lastScrollToolbarBackdropCaptureStartedUptime == 0
-				|| now - lastScrollToolbarBackdropCaptureStartedUptime
-					>= Self.scrollToolbarBackdropCaptureMinimumInterval
+			let capture = scrollToolbarBackdropState.beginCapture(
+				now: now,
+				minimumInterval: Self.scrollToolbarBackdropCaptureMinimumInterval,
+				fallbackMinimumInterval: Self.scrollToolbarBackdropFallbackMinimumInterval
+			)
 		else {
 			return
 		}
-		lastScrollToolbarBackdropCaptureStartedUptime = now
-		let fallbackPermitted =
-			lastScrollToolbarBackdropFallbackCaptureStartedUptime == 0
-			|| now - lastScrollToolbarBackdropFallbackCaptureStartedUptime
-				>= Self.scrollToolbarBackdropFallbackMinimumInterval
-		if fallbackPermitted {
-			lastScrollToolbarBackdropFallbackCaptureStartedUptime = now
-		}
-		scrollToolbarBackdropCaptureInFlight = true
-		scrollToolbarBackdropCaptureGeneration &+= 1
-		let generation = scrollToolbarBackdropCaptureGeneration
-		let afterFrameSequence = scrollToolbarBackdropLastFrameSequence
-		let previousSignature = scrollToolbarBackdropLastSignature
 		let fallbackSource = scrollCaptureState.captureSource
 		let maximumLiveFrameAgeMicroseconds = UInt64(
 			CaptureSessionController.scrollCaptureActiveInputLiveFrameMaxAge * 1_000_000
 		)
 		DispatchQueue.main.async { [weak self] in
-			guard let self, self.scrollToolbarBackdropCaptureGeneration == generation else {
-				self?.scrollToolbarBackdropCaptureInFlight = false
+			guard let self, self.scrollToolbarBackdropState.captureGeneration == capture.generation
+			else {
+				self?.scrollToolbarBackdropState.clearInFlightForAbandonedCapture()
 				return
 			}
 			self.scrollToolbarBackdropCaptureQueue.async {
 				[
-					toolbarFrame, globalFrame, liveFrameStream, afterFrameSequence, fallbackSource,
-					maximumLiveFrameAgeMicroseconds, previousSignature, fallbackPermitted,
+					toolbarFrame, globalFrame, liveFrameStream, fallbackSource,
+					maximumLiveFrameAgeMicroseconds, capture,
 				] in
 				let rawFrame = liveFrameStream.nextRegionFrame(
 					in: globalFrame,
-					afterFrameSequence: afterFrameSequence,
+					afterFrameSequence: capture.afterFrameSequence,
 					waitForFresh: false
 				)
 				let nonblockingFrame: RGBARegionFrameSnapshot? =
@@ -3024,9 +2963,10 @@ final class CaptureHostView: NSView {
 				}
 				let liveWouldRemainStatic =
 					liveSignature == nil
-					|| (previousSignature != nil && liveSignature == previousSignature)
+					|| (capture.previousSignature != nil
+						&& liveSignature == capture.previousSignature)
 				let fallbackPatch =
-					liveWouldRemainStatic && fallbackPermitted
+					liveWouldRemainStatic && capture.fallbackPermitted
 					? CaptureOverlayController.captureImageBelowOverlay(
 						in: globalFrame,
 						source: fallbackSource
@@ -3039,7 +2979,8 @@ final class CaptureHostView: NSView {
 				}
 				let shouldUseFallback =
 					fallbackPatch != nil
-					&& (previousSignature == nil || fallbackSignature != previousSignature)
+					&& (capture.previousSignature == nil
+						|| fallbackSignature != capture.previousSignature)
 				let patch = shouldUseFallback ? fallbackPatch : (livePatch ?? fallbackPatch)
 				let signature =
 					shouldUseFallback ? fallbackSignature : (liveSignature ?? fallbackSignature)
@@ -3047,7 +2988,7 @@ final class CaptureHostView: NSView {
 					self?.finishScrollToolbarBackdropCapture(
 						patch,
 						toolbarFrame: toolbarFrame,
-						generation: generation,
+						generation: capture.generation,
 						frameSequence: frameSequence > 0 ? frameSequence : nil,
 						signature: signature
 					)
@@ -3070,15 +3011,13 @@ final class CaptureHostView: NSView {
 		frameSequence: UInt64?,
 		signature: UInt64?
 	) {
-		guard scrollToolbarBackdropCaptureGeneration == generation else {
-			return
-		}
-		scrollToolbarBackdropCaptureInFlight = false
-		if let frameSequence {
-			scrollToolbarBackdropLastFrameSequence = max(
-				scrollToolbarBackdropLastFrameSequence,
-				frameSequence
+		guard
+			scrollToolbarBackdropState.finishCapture(
+				generation: generation,
+				frameSequence: frameSequence
 			)
+		else {
+			return
 		}
 		guard
 			scene.mode == .frozen,
@@ -3101,31 +3040,22 @@ final class CaptureHostView: NSView {
 	}
 
 	private func recordScrollToolbarBackdropChangeIfNeeded(signature: UInt64?) {
-		guard let signature else {
-			return
-		}
-		let previousSignature = scrollToolbarBackdropLastSignature
-		scrollToolbarBackdropLastSignature = signature
-		guard previousSignature != signature else {
-			return
-		}
 		let now = ProcessInfo.processInfo.systemUptime
-		scrollToolbarBackdropChangedCount &+= 1
-		if lastScrollToolbarBackdropChangedUptime > 0 {
-			let gapMilliseconds = (now - lastScrollToolbarBackdropChangedUptime) * 1_000
+		guard let change = scrollToolbarBackdropState.recordChange(signature: signature, now: now)
+		else {
+			return
+		}
+		if let gapMilliseconds = change.gapMilliseconds {
 			scrollToolbarBackdropChangedGapMetric.record(gapMilliseconds)
-			if scrollToolbarBackdropChangedCount == 2
-				|| scrollToolbarBackdropChangedCount.isMultiple(of: 30)
-			{
+			if change.count == 2 || change.count.isMultiple(of: 30) {
 				NativeHostTelemetry.captureEvent(
 					"capture.scroll_toolbar_backdrop_changed",
 					captureID: controller?.activeTelemetryCaptureID ?? 0,
 					detail:
-						"count=\(scrollToolbarBackdropChangedCount),gapMs=\(String(format: "%.2f", gapMilliseconds))"
+						"count=\(change.count),gapMs=\(String(format: "%.2f", gapMilliseconds))"
 				)
 			}
 		}
-		lastScrollToolbarBackdropChangedUptime = now
 	}
 
 	nonisolated private static func scrollToolbarBackdropSignature(
@@ -3162,19 +3092,18 @@ final class CaptureHostView: NSView {
 		let now = ProcessInfo.processInfo.systemUptime
 		let interval = NativeHostDisplayRefresh.frameInterval(
 			forTargetFramesPerSecond: currentDisplayTargetFramesPerSecond())
-		guard now - lastScrollCaptureToolbarBackdropRefreshUptime >= interval else {
+		guard let refresh = scrollToolbarBackdropState.beginRefresh(now: now, interval: interval)
+		else {
 			return
 		}
-		if lastScrollCaptureToolbarBackdropRefreshUptime > 0 {
-			scrollToolbarBackdropRefreshGapMetric.record(
-				(now - lastScrollCaptureToolbarBackdropRefreshUptime) * 1_000)
+		if let gapMilliseconds = refresh.gapMilliseconds {
+			scrollToolbarBackdropRefreshGapMetric.record(gapMilliseconds)
 		}
-		lastScrollCaptureToolbarBackdropRefreshUptime = now
 		let refreshStartedAt = now
-		if let scrollToolbarBackdropFrame, let scrollToolbarBackdropGlobalFrame {
+		if let toolbarFrame = refresh.activeFrame, let globalFrame = refresh.activeGlobalFrame {
 			scheduleScrollToolbarBackdropCapture(
-				toolbarFrame: scrollToolbarBackdropFrame,
-				globalFrame: scrollToolbarBackdropGlobalFrame
+				toolbarFrame: toolbarFrame,
+				globalFrame: globalFrame
 			)
 		} else {
 			_ = refreshFrozenToolbarBackdropOnly()
@@ -3306,20 +3235,7 @@ final class CaptureHostView: NSView {
 		let wasVisible = frozenToolbarLiquidGlassVisible
 		frozenToolbarLiquidGlassVisible = false
 		frozenToolbarLiquidGlassContentDrawn = false
-		scrollToolbarBackdropCaptureGeneration &+= 1
-		scrollToolbarBackdropCaptureInFlight = false
-		lastScrollToolbarBackdropCaptureStartedUptime = 0
-		scrollToolbarBackdropSeedFrame = nil
-		scrollToolbarBackdropSeedImage = nil
-		scrollToolbarBackdropSeedPatchCache = nil
-		scrollToolbarBackdropLastFrameSequence = 0
-		scrollToolbarBackdropLastSignature = nil
-		scrollToolbarBackdropChangedCount = 0
-		scrollToolbarBackdropFrame = nil
-		scrollToolbarBackdropGlobalFrame = nil
-		lastScrollToolbarBackdropChangedUptime = 0
-		lastScrollToolbarBackdropFallbackCaptureStartedUptime = 0
-		lastScrollCaptureToolbarBackdropRefreshUptime = 0
+		scrollToolbarBackdropState.resetAndInvalidateCaptures()
 		toolbarLiquidGlassBackdropView?.isHidden = true
 		toolbarLiquidGlassBackdropView?.image = nil
 		toolbarLiquidGlassView?.isHidden = true

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -23,6 +23,7 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureHostPointerDispatchSupport()
 		assertCaptureHostLivePrimaryInteractionState()
 		assertCaptureHostFrozenFirstDisplayHandoffState()
+		assertCaptureHostScrollToolbarBackdropState()
 		assertCaptureHostAnnotationStyleWheelGate()
 		assertCaptureHostToolbarHoverState()
 		assertCaptureHostLiveSampleCachePointMatching()
@@ -317,6 +318,103 @@ enum RsnapNativeHostKitProbe {
 		state.reset()
 		guard state == CaptureHostFrozenFirstDisplayHandoffState() else {
 			fatalError("frozen first-display handoff should reset to idle")
+		}
+	}
+
+	private static func assertCaptureHostScrollToolbarBackdropState() {
+		var state = CaptureHostScrollToolbarBackdropState()
+		guard
+			let firstCapture = state.beginCapture(
+				now: 10,
+				minimumInterval: 0.25,
+				fallbackMinimumInterval: 1
+			),
+			firstCapture.generation == 1,
+			firstCapture.afterFrameSequence == 0,
+			firstCapture.previousSignature == nil,
+			firstCapture.fallbackPermitted,
+			state.captureInFlight,
+			state.beginCapture(now: 10.1, minimumInterval: 0.25, fallbackMinimumInterval: 1)
+				== nil,
+			state.finishCapture(generation: firstCapture.generation, frameSequence: 7),
+			state.captureInFlight == false,
+			state.lastFrameSequence == 7,
+			state.beginCapture(now: 10.1, minimumInterval: 0.25, fallbackMinimumInterval: 1)
+				== nil,
+			let secondCapture = state.beginCapture(
+				now: 10.3,
+				minimumInterval: 0.25,
+				fallbackMinimumInterval: 1
+			),
+			secondCapture.generation == 2,
+			secondCapture.afterFrameSequence == 7,
+			secondCapture.fallbackPermitted == false,
+			state.finishCapture(generation: secondCapture.generation, frameSequence: 5),
+			state.lastFrameSequence == 7
+		else {
+			fatalError("scroll toolbar backdrop state should throttle captures and keep sequence")
+		}
+
+		guard
+			state.recordChange(signature: nil, now: 10.4) == nil,
+			state.recordChange(signature: 42, now: 11)
+				== CaptureHostScrollToolbarBackdropChange(count: 1, gapMilliseconds: nil),
+			state.recordChange(signature: 42, now: 11.2) == nil,
+			state.recordChange(signature: 43, now: 12)
+				== CaptureHostScrollToolbarBackdropChange(count: 2, gapMilliseconds: 1_000)
+		else {
+			fatalError("scroll toolbar backdrop state should record signature changes")
+		}
+
+		let frame = CGRect(x: 1, y: 2, width: 30, height: 40)
+		let globalFrame = CGRect(x: 100, y: 200, width: 30, height: 40)
+		state.updateActiveFrame(frame, globalFrame: globalFrame)
+		guard
+			state.beginRefresh(now: 12, interval: 0.5)
+				== CaptureHostScrollToolbarBackdropRefresh(
+					gapMilliseconds: nil,
+					activeFrame: frame,
+					activeGlobalFrame: globalFrame),
+			state.beginRefresh(now: 12.25, interval: 0.5) == nil,
+			state.beginRefresh(now: 12.5, interval: 0.5)
+				== CaptureHostScrollToolbarBackdropRefresh(
+					gapMilliseconds: 500,
+					activeFrame: frame,
+					activeGlobalFrame: globalFrame)
+		else {
+			fatalError("scroll toolbar backdrop state should throttle refresh cadence")
+		}
+
+		let seedFrame = CGRect(x: 5, y: 6, width: 7, height: 8)
+		let seedImage = makeProbeImage()
+		let seedPatchFrame = CGRect(x: 10, y: 20, width: 30, height: 40)
+		state.resetTracking(seedFrame: seedFrame, seedImage: seedImage)
+		state.storeSeedPatch(frame: seedPatchFrame, capturedAt: 13, image: seedImage)
+		guard
+			state.seedFrame == seedFrame,
+			state.seedImage != nil,
+			state.activeFrame == nil,
+			state.changedCount == 0,
+			state.cachedSeedPatch(
+				matching: CGRect(x: 10.5, y: 20.5, width: 30.5, height: 40.5)) != nil,
+			state.cachedSeedPatch(
+				matching: CGRect(x: 12, y: 20, width: 30, height: 40)) == nil
+		else {
+			fatalError("scroll toolbar backdrop state should reset and cache seed patches")
+		}
+
+		let generationBeforeReset = state.captureGeneration
+		state.resetAndInvalidateCaptures()
+		guard
+			state.captureGeneration == generationBeforeReset + 1,
+			state.captureInFlight == false,
+			state.seedFrame == nil,
+			state.seedImage == nil,
+			state.seedPatchCache == nil,
+			state.lastCaptureStartedUptime == 0,
+			state.lastRefreshUptime == 0
+		else {
+			fatalError("scroll toolbar backdrop state should invalidate captures on full reset")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Extract scroll toolbar backdrop bookkeeping into CaptureHostScrollToolbarBackdropState.
- Keep CaptureHostView responsible for AppKit views, capture queue dispatch, image conversion, and telemetry emission.
- Add HostKit probe coverage for capture throttling, generation, frame sequence, signature change counts, refresh cadence, seed patch tolerance, and reset invalidation.
- Update native-host ownership references for the new support boundary.

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check
- include/path scan over packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check

## Review
- Fresh skeptic subagent was unavailable due usage limit; performed inline skeptic fallback over diff, stale field search, behavior transitions, and validation evidence.