### PR TITLE
Modularize capture host scroll minimap renderer

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -97,6 +97,8 @@ The current native-host Swift split is:
   handles, and selection-size badge rendering.
 - `CaptureHostFrozenOverlayRenderer.swift`: frozen annotation overlay rendering for mosaic,
   spotlight, pen, arrow, and text overlays.
+- `CaptureHostScrollMinimapRenderer.swift`: frozen scroll-capture minimap presentation over the
+  Rust-owned minimap layout plan and host-provided preview image.
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
   sample matching.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
@@ -119,14 +121,15 @@ The current native-host Swift split is:
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
-  presentation and NSCursor adaptation, live sample reuse, live primary interaction state, pointer
-  dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and
-  native text measurement.
+  presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live
+  primary interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
+  live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -202,6 +202,8 @@ The main host-kit files are split by responsibility:
   handles, and selection-size badge rendering
 - `CaptureHostFrozenOverlayRenderer.swift`: frozen annotation overlay rendering for mosaic,
   spotlight, pen, arrow, and text overlays
+- `CaptureHostScrollMinimapRenderer.swift`: frozen scroll-capture minimap presentation over the
+  Rust-owned minimap layout plan and host-provided preview image
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
   sample matching
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
@@ -224,14 +226,15 @@ The main host-kit files are split by responsibility:
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostLiveSampleCache.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
-  presentation and NSCursor adaptation, live sample reuse, live primary interaction state, pointer
-  dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and
-  shared native text measurement
+  presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live
+  primary interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
+  live-chrome telemetry identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollMinimapRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollMinimapRenderer.swift
@@ -1,0 +1,71 @@
+import AppKit
+import CoreGraphics
+
+@MainActor
+enum CaptureHostScrollMinimapRenderer {
+	static func render(
+		preview: ScrollCaptureMinimapSnapshot,
+		selection: CGRect,
+		bounds: CGRect,
+		palette: CaptureChromePalette,
+		in context: CGContext
+	) {
+		guard
+			let minimapPlan = scrollCaptureMinimapPlan(
+				for: selection,
+				exportSize: preview.exportSizePixels,
+				in: bounds,
+				preferredWidth: CaptureChrome.scrollMinimapPreferredWidth,
+				minimumWidth: CaptureChrome.scrollMinimapMinimumWidth,
+				gap: CaptureChrome.scrollMinimapGap,
+				margin: CaptureChrome.scrollMinimapScreenMargin,
+				imageInset: CaptureChrome.scrollMinimapImageInset,
+				viewportTopPixels: preview.viewportTopYPixels,
+				viewportHeightPixels: preview.viewportHeightPixels
+			)
+		else {
+			return
+		}
+
+		let frame = minimapPlan.frame
+		let imageFrame = minimapPlan.imageFrame
+		let backgroundPath = NSBezierPath(
+			roundedRect: frame,
+			xRadius: CaptureChrome.scrollMinimapCornerRadius,
+			yRadius: CaptureChrome.scrollMinimapCornerRadius
+		)
+
+		context.saveGState()
+		context.setShadow(
+			offset: CGSize(width: 0, height: -2),
+			blur: 12,
+			color: NSColor.black.withAlphaComponent(0.32).cgColor
+		)
+		context.setFillColor(NSColor.black.withAlphaComponent(0.72).cgColor)
+		backgroundPath.fill()
+		context.restoreGState()
+
+		context.saveGState()
+		let imageClipPath = NSBezierPath(
+			roundedRect: imageFrame,
+			xRadius: max(CaptureChrome.scrollMinimapCornerRadius - 3, 1),
+			yRadius: max(CaptureChrome.scrollMinimapCornerRadius - 3, 1)
+		)
+		imageClipPath.addClip()
+		context.interpolationQuality = .high
+		context.draw(preview.image, in: imageFrame)
+		context.restoreGState()
+
+		if let viewportFrame = minimapPlan.viewportFrame {
+			context.setFillColor(NSColor.white.withAlphaComponent(0.13).cgColor)
+			context.fill(viewportFrame)
+			context.setStrokeColor(NSColor.white.withAlphaComponent(0.88).cgColor)
+			context.setLineWidth(1)
+			context.stroke(viewportFrame)
+		}
+
+		context.setStrokeColor(palette.keycapStroke.withAlphaComponent(0.88).cgColor)
+		context.setLineWidth(1)
+		backgroundPath.stroke()
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -797,65 +797,15 @@ final class CaptureHostView: NSView {
 		guard let preview = chrome.scrollMinimapPreview else {
 			return
 		}
-		guard
-			let minimapPlan = scrollCaptureMinimapPlan(
-				for: selection,
-				exportSize: preview.exportSizePixels,
-				in: bounds,
-				preferredWidth: CaptureChrome.scrollMinimapPreferredWidth,
-				minimumWidth: CaptureChrome.scrollMinimapMinimumWidth,
-				gap: CaptureChrome.scrollMinimapGap,
-				margin: CaptureChrome.scrollMinimapScreenMargin,
-				imageInset: CaptureChrome.scrollMinimapImageInset,
-				viewportTopPixels: preview.viewportTopYPixels,
-				viewportHeightPixels: preview.viewportHeightPixels
-			)
-		else {
-			return
-		}
-
 		let theme = chromeTheme()
 		let palette = CaptureChrome.palette(for: theme, settings: settings)
-		let frame = minimapPlan.frame
-		let imageFrame = minimapPlan.imageFrame
-		let backgroundPath = NSBezierPath(
-			roundedRect: frame,
-			xRadius: CaptureChrome.scrollMinimapCornerRadius,
-			yRadius: CaptureChrome.scrollMinimapCornerRadius
+		CaptureHostScrollMinimapRenderer.render(
+			preview: preview,
+			selection: selection,
+			bounds: bounds,
+			palette: palette,
+			in: context
 		)
-
-		context.saveGState()
-		context.setShadow(
-			offset: CGSize(width: 0, height: -2),
-			blur: 12,
-			color: NSColor.black.withAlphaComponent(0.32).cgColor
-		)
-		context.setFillColor(NSColor.black.withAlphaComponent(0.72).cgColor)
-		backgroundPath.fill()
-		context.restoreGState()
-
-		context.saveGState()
-		let imageClipPath = NSBezierPath(
-			roundedRect: imageFrame,
-			xRadius: max(CaptureChrome.scrollMinimapCornerRadius - 3, 1),
-			yRadius: max(CaptureChrome.scrollMinimapCornerRadius - 3, 1)
-		)
-		imageClipPath.addClip()
-		context.interpolationQuality = .high
-		context.draw(preview.image, in: imageFrame)
-		context.restoreGState()
-
-		if let viewportFrame = minimapPlan.viewportFrame {
-			context.setFillColor(NSColor.white.withAlphaComponent(0.13).cgColor)
-			context.fill(viewportFrame)
-			context.setStrokeColor(NSColor.white.withAlphaComponent(0.88).cgColor)
-			context.setLineWidth(1)
-			context.stroke(viewportFrame)
-		}
-
-		context.setStrokeColor(palette.keycapStroke.withAlphaComponent(0.88).cgColor)
-		context.setLineWidth(1)
-		backgroundPath.stroke()
 	}
 
 	private func localFrozenDisplayFrame() -> CGRect? {


### PR DESCRIPTION
## Summary
- Extract frozen scroll-capture minimap drawing into `CaptureHostScrollMinimapRenderer`.
- Keep `CaptureHostView` responsible for frozen draw orchestration and theme resolution while the renderer owns minimap presentation over the Rust-owned layout plan.
- Update native-host ownership docs for the new renderer boundary.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` returned no matches
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

## Review
- Bounded read-only scouts identified this as a low-risk CaptureHostView extraction candidate; the independent skeptic worker timed out before returning findings, so the final review was a direct diff audit plus full local validation.