### PR TITLE
Modularize capture host live sample resolver

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -101,6 +101,8 @@ The current native-host Swift split is:
   Rust-owned minimap layout plan and host-provided preview image.
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
   sample matching.
+- `CaptureHostLiveSampleResolver.swift`: capture-host live chrome/RGB sample resolution,
+  loupe-patch reuse, and cache seeding policy.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions.
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
@@ -122,14 +124,14 @@ The current native-host Swift split is:
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostLiveSampleResolver.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
-  presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live
-  primary interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
-  live-chrome telemetry identity, and native text measurement.
+  presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
+  resolution, live primary interaction state, pointer dispatch queue throttling, Rust-backed frozen
+  image effects, live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -206,6 +206,8 @@ The main host-kit files are split by responsibility:
   Rust-owned minimap layout plan and host-provided preview image
 - `CaptureHostLiveSampleCache.swift`: capture-host live chrome/RGB sample reuse cache and pointer
   sample matching
+- `CaptureHostLiveSampleResolver.swift`: capture-host live chrome/RGB sample resolution,
+  loupe-patch reuse, and cache seeding policy
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
@@ -227,14 +229,14 @@ The main host-kit files are split by responsibility:
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostLiveSampleResolver.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
-  presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live
-  primary interaction state, pointer dispatch queue throttling, Rust-backed frozen image effects,
-  live-chrome telemetry identity, and shared native text measurement
+  presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
+  resolution, live primary interaction state, pointer dispatch queue throttling, Rust-backed frozen
+  image effects, live-chrome telemetry identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLiveSampleResolver.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLiveSampleResolver.swift
@@ -1,0 +1,152 @@
+import CoreGraphics
+import RsnapHostBridge
+
+enum CaptureHostLiveSampleResolver {
+	static func currentLiveChromeSample(
+		at point: CGPoint?,
+		scenePointer: CGPoint?,
+		loupeVisible: Bool,
+		hoverChromeSuppressed: Bool,
+		settings: NativeHostSettings,
+		chrome: CaptureChromeState,
+		cache: inout CaptureHostLiveSampleCache,
+		sampleProvider: (_ wantsLoupePatch: Bool) -> LiveChromeSample?
+	) -> LiveChromeSample? {
+		let wantsLoupePatch = loupeVisible && !hoverChromeSuppressed
+		let sample = sampleProvider(wantsLoupePatch)
+		if let sample {
+			let resolvedSample = sampleWithCachedLoupePatch(
+				sample,
+				point: point,
+				scenePointer: scenePointer,
+				wantsLoupePatch: wantsLoupePatch,
+				settings: settings,
+				chrome: chrome,
+				cache: cache
+			)
+			cache.seedChrome(resolvedSample, point: point)
+			if let rgbSample = resolvedSample.rgb {
+				cache.seedRgb(rgbSample, point: point)
+			}
+			return resolvedSample
+		}
+		if let cachedSample = cache.chromeSample(matching: point) {
+			return cachedSample
+		}
+		if chrome.loupePatch != nil,
+			CaptureHostLiveSampleCache.pointsMatch(scenePointer, point)
+		{
+			seedChromeSample(from: chrome, point: scenePointer, cache: &cache)
+			return cache.chromeSample(matching: point)
+		}
+		if wantsLoupePatch,
+			let cachedPatch = reusableLiveLoupePatch(
+				cache: cache,
+				chrome: chrome,
+				settings: settings
+			)
+		{
+			return LiveChromeSample(rgb: nil, loupePatch: cachedPatch)
+		}
+		return nil
+	}
+
+	static func reusableLiveLoupePatch(
+		cache: CaptureHostLiveSampleCache,
+		chrome: CaptureChromeState,
+		settings: NativeHostSettings
+	) -> CGImage? {
+		if let patch = cache.latestChrome?.loupePatch,
+			liveLoupePatchMatchesCurrentSize(patch, settings: settings)
+		{
+			return patch
+		}
+		if let patch = chrome.loupePatch,
+			liveLoupePatchMatchesCurrentSize(patch, settings: settings)
+		{
+			return patch
+		}
+		return nil
+	}
+
+	static func liveRgbSample(
+		from sample: LiveChromeSample?,
+		at point: CGPoint?,
+		cache: inout CaptureHostLiveSampleCache
+	) -> RGBSample? {
+		if let rgbSample = sample?.rgb,
+			rgbSample.isFresh()
+		{
+			cache.seedRgb(rgbSample, point: point)
+			return rgbSample.rgb
+		}
+		return cache.rgbSample(matching: point)?.rgb
+	}
+
+	static func seedChromeSample(
+		from chrome: CaptureChromeState,
+		point: CGPoint?,
+		cache: inout CaptureHostLiveSampleCache
+	) {
+		guard chrome.loupePatch != nil else {
+			return
+		}
+		cache.seedChrome(
+			LiveChromeSample(
+				rgb: nil,
+				loupePatch: chrome.loupePatch
+			),
+			point: point
+		)
+	}
+
+	private static func sampleWithCachedLoupePatch(
+		_ sample: LiveChromeSample,
+		point: CGPoint?,
+		scenePointer: CGPoint?,
+		wantsLoupePatch: Bool,
+		settings: NativeHostSettings,
+		chrome: CaptureChromeState,
+		cache: CaptureHostLiveSampleCache
+	) -> LiveChromeSample {
+		guard wantsLoupePatch, sample.loupePatch == nil else {
+			return sample
+		}
+		if let cachedSample = cache.chromeSample(matching: point),
+			let cachedPatch = cachedSample.loupePatch
+		{
+			return LiveChromeSample(
+				rgb: sample.rgb,
+				loupePatch: cachedPatch
+			)
+		}
+		if let cachedPatch = reusableLiveLoupePatch(
+			cache: cache,
+			chrome: chrome,
+			settings: settings
+		) {
+			return LiveChromeSample(
+				rgb: sample.rgb,
+				loupePatch: cachedPatch
+			)
+		}
+		if CaptureHostLiveSampleCache.pointsMatch(scenePointer, point),
+			let chromePatch = chrome.loupePatch,
+			liveLoupePatchMatchesCurrentSize(chromePatch, settings: settings)
+		{
+			return LiveChromeSample(
+				rgb: sample.rgb,
+				loupePatch: chromePatch
+			)
+		}
+		return sample
+	}
+
+	private static func liveLoupePatchMatchesCurrentSize(
+		_ patch: CGImage,
+		settings: NativeHostSettings
+	) -> Bool {
+		let sidePixels = settings.loupeSampleSize.sidePixels
+		return patch.width == sidePixels && patch.height == sidePixels
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -1905,121 +1905,45 @@ final class CaptureHostView: NSView {
 	}
 
 	private func currentLiveChromeSample(at point: CGPoint?) -> LiveChromeSample? {
-		let wantsLoupePatch = scene.loupeVisible && !livePrimaryInteraction.hoverChromeSuppressed
-		let sample = controller?.liveChromeSnapshot(
-			point: point,
+		CaptureHostLiveSampleResolver.currentLiveChromeSample(
+			at: point,
+			scenePointer: scene.pointer,
+			loupeVisible: scene.loupeVisible,
+			hoverChromeSuppressed: livePrimaryInteraction.hoverChromeSuppressed,
 			settings: settings,
-			includeLoupePatch: wantsLoupePatch
-		)
-		if let sample {
-			let resolvedSample = sampleWithCachedLoupePatch(
-				sample,
+			chrome: chrome,
+			cache: &liveSampleCache
+		) { wantsLoupePatch in
+			controller?.liveChromeSnapshot(
 				point: point,
-				wantsLoupePatch: wantsLoupePatch
-			)
-			seedLiveChromeSampleCache(resolvedSample, point: point)
-			if let rgbSample = resolvedSample.rgb {
-				seedLiveRgbSampleCache(rgbSample, point: point)
-			}
-			return resolvedSample
-		}
-		if let cachedSample = liveSampleCache.chromeSample(matching: point) {
-			return cachedSample
-		}
-		if chrome.loupePatch != nil,
-			CaptureHostLiveSampleCache.pointsMatch(scene.pointer, point)
-		{
-			seedLiveChromeSampleCache(from: chrome, point: scene.pointer)
-			return liveSampleCache.chromeSample(matching: point)
-		}
-		if wantsLoupePatch, let cachedPatch = reusableLiveLoupePatch() {
-			return LiveChromeSample(rgb: nil, loupePatch: cachedPatch)
-		}
-		return nil
-	}
-
-	private func sampleWithCachedLoupePatch(
-		_ sample: LiveChromeSample,
-		point: CGPoint?,
-		wantsLoupePatch: Bool
-	) -> LiveChromeSample {
-		guard wantsLoupePatch, sample.loupePatch == nil else {
-			return sample
-		}
-		if let cachedSample = liveSampleCache.chromeSample(matching: point),
-			let cachedPatch = cachedSample.loupePatch
-		{
-			return LiveChromeSample(
-				rgb: sample.rgb,
-				loupePatch: cachedPatch
+				settings: settings,
+				includeLoupePatch: wantsLoupePatch
 			)
 		}
-		if let cachedPatch = reusableLiveLoupePatch() {
-			return LiveChromeSample(
-				rgb: sample.rgb,
-				loupePatch: cachedPatch
-			)
-		}
-		if CaptureHostLiveSampleCache.pointsMatch(scene.pointer, point),
-			let chromePatch = chrome.loupePatch,
-			liveLoupePatchMatchesCurrentSize(chromePatch)
-		{
-			return LiveChromeSample(
-				rgb: sample.rgb,
-				loupePatch: chromePatch
-			)
-		}
-		return sample
 	}
 
 	private func reusableLiveLoupePatch() -> CGImage? {
-		if let patch = liveSampleCache.latestChrome?.loupePatch,
-			liveLoupePatchMatchesCurrentSize(patch)
-		{
-			return patch
-		}
-		if let patch = chrome.loupePatch,
-			liveLoupePatchMatchesCurrentSize(patch)
-		{
-			return patch
-		}
-		return nil
-	}
-
-	private func liveLoupePatchMatchesCurrentSize(_ patch: CGImage) -> Bool {
-		let sidePixels = settings.loupeSampleSize.sidePixels
-		return patch.width == sidePixels && patch.height == sidePixels
-	}
-
-	private func liveRgbSample(from sample: LiveChromeSample?, at point: CGPoint?) -> RGBSample? {
-		if let rgbSample = sample?.rgb,
-			rgbSample.isFresh()
-		{
-			seedLiveRgbSampleCache(rgbSample, point: point)
-			return rgbSample.rgb
-		}
-		return liveSampleCache.rgbSample(matching: point)?.rgb
-	}
-
-	private func seedLiveChromeSampleCache(from chrome: CaptureChromeState, point: CGPoint?) {
-		guard chrome.loupePatch != nil else {
-			return
-		}
-		seedLiveChromeSampleCache(
-			LiveChromeSample(
-				rgb: nil,
-				loupePatch: chrome.loupePatch
-			),
-			point: point
+		CaptureHostLiveSampleResolver.reusableLiveLoupePatch(
+			cache: liveSampleCache,
+			chrome: chrome,
+			settings: settings
 		)
 	}
 
-	private func seedLiveChromeSampleCache(_ sample: LiveChromeSample, point: CGPoint?) {
-		liveSampleCache.seedChrome(sample, point: point)
+	private func liveRgbSample(from sample: LiveChromeSample?, at point: CGPoint?) -> RGBSample? {
+		CaptureHostLiveSampleResolver.liveRgbSample(
+			from: sample,
+			at: point,
+			cache: &liveSampleCache
+		)
 	}
 
-	private func seedLiveRgbSampleCache(_ rgbSample: LiveRgbSample, point: CGPoint?) {
-		liveSampleCache.seedRgb(rgbSample, point: point)
+	private func seedLiveChromeSampleCache(from chrome: CaptureChromeState, point: CGPoint?) {
+		CaptureHostLiveSampleResolver.seedChromeSample(
+			from: chrome,
+			point: point,
+			cache: &liveSampleCache
+		)
 	}
 
 	private func selectionSizeText(for rect: CGRect) -> String {


### PR DESCRIPTION
## Summary
- Extract live chrome/RGB sample resolution into `CaptureHostLiveSampleResolver`.
- Keep `CaptureHostView` as the orchestration owner while the resolver owns loupe-patch reuse and cache seeding policy.
- Update native-host ownership docs for the new live sample resolver boundary.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` returned no matches
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

## Review
- Prior read-only scout identified this as the next low-risk `CaptureHostView` extraction candidate. Local diff audit verified the moved sample/loupe/cache branches remain equivalent after the missing bridge import was fixed.