### PR TITLE
Modularize capture host mouse release recovery

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -105,6 +105,8 @@ The current native-host Swift split is:
   loupe-patch reuse, and cache seeding policy.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions.
+- `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
+  release-watchdog scheduling for AppKit interactions whose mouse-up event can be missed.
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
   with per-track throttling state, and AppKit-to-controller pointer delivery support.
 - `LiveOverlayRenderer.swift`: live overlay render orchestration for HUD, loupe, frozen-pending
@@ -125,13 +127,15 @@ The current native-host Swift split is:
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
-  resolution, live primary interaction state, pointer dispatch queue throttling, Rust-backed frozen
-  image effects, live-chrome telemetry identity, and native text measurement.
+  resolution, live primary interaction state, AppKit mouse-release recovery, pointer dispatch queue
+  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and native text
+  measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -210,6 +210,8 @@ The main host-kit files are split by responsibility:
   loupe-patch reuse, and cache seeding policy
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions
+- `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
+  release-watchdog scheduling for AppKit interactions whose mouse-up event can be missed
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
   with per-track throttling state, and AppKit-to-controller pointer delivery
 - `LiveOverlayRenderer.swift`: live overlay render orchestration for HUD, loupe, frozen-pending
@@ -230,13 +232,15 @@ The main host-kit files are split by responsibility:
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
-  resolution, live primary interaction state, pointer dispatch queue throttling, Rust-backed frozen
-  image effects, live-chrome telemetry identity, and shared native text measurement
+  resolution, live primary interaction state, AppKit mouse-release recovery, pointer dispatch queue
+  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and shared native
+  text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostMouseReleaseRecovery.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostMouseReleaseRecovery.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class CaptureHostMouseReleaseRecovery {
+	typealias WatchdogPoll = () -> Bool
+
+	private var liveMouseUpMonitor: Any?
+	private var liveMouseReleaseWatchdog: DispatchWorkItem?
+	private var frozenMouseReleaseWatchdog: DispatchWorkItem?
+
+	var isPrimaryMouseButtonPressed: Bool {
+		(NSEvent.pressedMouseButtons & 1) == 1
+	}
+
+	func installLiveMouseUpMonitor(onMouseUp: @escaping (NSEvent) -> Void) {
+		removeLiveMouseUpMonitor()
+		liveMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp]) { event in
+			onMouseUp(event)
+			return event
+		}
+	}
+
+	func removeLiveMouseUpMonitor() {
+		cancelLiveMouseReleaseWatchdog()
+		if let liveMouseUpMonitor {
+			NSEvent.removeMonitor(liveMouseUpMonitor)
+			self.liveMouseUpMonitor = nil
+		}
+	}
+
+	func installLiveMouseReleaseWatchdog(onPoll: @escaping WatchdogPoll) {
+		cancelLiveMouseReleaseWatchdog()
+		scheduleLiveMouseReleaseWatchdog(onPoll: onPoll)
+	}
+
+	func cancelLiveMouseReleaseWatchdog() {
+		liveMouseReleaseWatchdog?.cancel()
+		liveMouseReleaseWatchdog = nil
+	}
+
+	func installFrozenMouseReleaseWatchdog(onPoll: @escaping WatchdogPoll) {
+		cancelFrozenMouseReleaseWatchdog()
+		scheduleFrozenMouseReleaseWatchdog(onPoll: onPoll)
+	}
+
+	func cancelFrozenMouseReleaseWatchdog() {
+		frozenMouseReleaseWatchdog?.cancel()
+		frozenMouseReleaseWatchdog = nil
+	}
+
+	private func scheduleLiveMouseReleaseWatchdog(onPoll: @escaping WatchdogPoll) {
+		let workItem = DispatchWorkItem { [weak self] in
+			self?.pollLiveMouseReleaseWatchdog(onPoll: onPoll)
+		}
+		liveMouseReleaseWatchdog = workItem
+		DispatchQueue.main.asyncAfter(deadline: .now() + Self.watchdogInterval, execute: workItem)
+	}
+
+	private func pollLiveMouseReleaseWatchdog(onPoll: @escaping WatchdogPoll) {
+		liveMouseReleaseWatchdog = nil
+		if onPoll() {
+			scheduleLiveMouseReleaseWatchdog(onPoll: onPoll)
+		}
+	}
+
+	private func scheduleFrozenMouseReleaseWatchdog(onPoll: @escaping WatchdogPoll) {
+		let workItem = DispatchWorkItem { [weak self] in
+			self?.pollFrozenMouseReleaseWatchdog(onPoll: onPoll)
+		}
+		frozenMouseReleaseWatchdog = workItem
+		DispatchQueue.main.asyncAfter(deadline: .now() + Self.watchdogInterval, execute: workItem)
+	}
+
+	private func pollFrozenMouseReleaseWatchdog(onPoll: @escaping WatchdogPoll) {
+		frozenMouseReleaseWatchdog = nil
+		if onPoll() {
+			scheduleFrozenMouseReleaseWatchdog(onPoll: onPoll)
+		}
+	}
+
+	private static var watchdogInterval: TimeInterval {
+		NativeHostDisplayRefresh.frameInterval(
+			forTargetFramesPerSecond: NativeHostDisplayRefresh.maximumTargetFramesPerSecond)
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -74,9 +74,7 @@ final class CaptureHostView: NSView {
 	private var lastCursorPresentation: CaptureHostCursorPresentation?
 	private var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
 	private var livePrimaryInteraction = CaptureHostLivePrimaryInteractionState()
-	private var liveMouseUpMonitor: Any?
-	private var liveMouseReleaseWatchdog: DispatchWorkItem?
-	private var frozenMouseReleaseWatchdog: DispatchWorkItem?
+	private let mouseReleaseRecovery = CaptureHostMouseReleaseRecovery()
 	private var livePointerPreviewGlobal: CGPoint?
 	private var livePointerPreviewInputUptime: TimeInterval?
 	private var livePointerPreviewInputSequence: UInt64 = 0
@@ -956,7 +954,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func isPrimaryMouseButtonPressed() -> Bool {
-		(NSEvent.pressedMouseButtons & 1) == 1
+		mouseReleaseRecovery.isPrimaryMouseButtonPressed
 	}
 
 	func clearLivePrimaryInteractionState(rendersImmediately: Bool) {
@@ -969,20 +967,13 @@ final class CaptureHostView: NSView {
 	}
 
 	private func installLiveMouseUpMonitor() {
-		removeLiveMouseUpMonitor()
-		liveMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp]) {
-			[weak self] event in
+		mouseReleaseRecovery.installLiveMouseUpMonitor { [weak self] event in
 			self?.completeLivePrimaryInteractionFromMouseUp(event)
-			return event
 		}
 	}
 
 	private func removeLiveMouseUpMonitor() {
-		cancelLiveMouseReleaseWatchdog()
-		if let liveMouseUpMonitor {
-			NSEvent.removeMonitor(liveMouseUpMonitor)
-			self.liveMouseUpMonitor = nil
-		}
+		mouseReleaseRecovery.removeLiveMouseUpMonitor()
 	}
 
 	private func completeLivePrimaryInteractionFromMouseUp(_ event: NSEvent) {
@@ -1014,65 +1005,39 @@ final class CaptureHostView: NSView {
 	}
 
 	private func installLiveMouseReleaseWatchdog() {
-		cancelLiveMouseReleaseWatchdog()
-		scheduleLiveMouseReleaseWatchdog()
-	}
-
-	private func scheduleLiveMouseReleaseWatchdog() {
-		let workItem = DispatchWorkItem { [weak self] in
-			self?.pollLiveMouseReleaseWatchdog()
+		mouseReleaseRecovery.installLiveMouseReleaseWatchdog { [weak self] in
+			self?.pollLiveMouseReleaseWatchdog() ?? false
 		}
-		liveMouseReleaseWatchdog = workItem
-		DispatchQueue.main.asyncAfter(
-			deadline: .now()
-				+ NativeHostDisplayRefresh.frameInterval(
-					forTargetFramesPerSecond: NativeHostDisplayRefresh.maximumTargetFramesPerSecond),
-			execute: workItem
-		)
 	}
 
-	private func pollLiveMouseReleaseWatchdog() {
-		liveMouseReleaseWatchdog = nil
+	private func pollLiveMouseReleaseWatchdog() -> Bool {
 		guard
 			scene.mode == .live,
 			livePrimaryInteraction.canCompleteInteraction
 		else {
-			return
+			return false
 		}
 		if isPrimaryMouseButtonPressed() == false {
 			let point = NSEvent.mouseLocation
 			logLivePrimaryInputEvent("capture.live_primary_release_watchdog", point: point)
 			completeLivePrimaryInteractionFromSystemMouseUp(at: point, source: "watchdog")
-			return
+			return false
 		}
-		scheduleLiveMouseReleaseWatchdog()
+		return true
 	}
 
 	private func installFrozenMouseReleaseWatchdog() {
-		cancelFrozenMouseReleaseWatchdog()
-		scheduleFrozenMouseReleaseWatchdog()
-	}
-
-	private func scheduleFrozenMouseReleaseWatchdog() {
-		let workItem = DispatchWorkItem { [weak self] in
-			self?.pollFrozenMouseReleaseWatchdog()
+		mouseReleaseRecovery.installFrozenMouseReleaseWatchdog { [weak self] in
+			self?.pollFrozenMouseReleaseWatchdog() ?? false
 		}
-		frozenMouseReleaseWatchdog = workItem
-		DispatchQueue.main.asyncAfter(
-			deadline: .now()
-				+ NativeHostDisplayRefresh.frameInterval(
-					forTargetFramesPerSecond: NativeHostDisplayRefresh.maximumTargetFramesPerSecond),
-			execute: workItem
-		)
 	}
 
-	private func pollFrozenMouseReleaseWatchdog() {
-		frozenMouseReleaseWatchdog = nil
+	private func pollFrozenMouseReleaseWatchdog() -> Bool {
 		guard
 			scene.mode == .frozen,
 			controller?.hasFrozenOverlayActiveInteraction == true
 		else {
-			return
+			return false
 		}
 		if isPrimaryMouseButtonPressed() == false {
 			let point = currentGlobalMousePoint() ?? NSEvent.mouseLocation
@@ -1083,9 +1048,9 @@ final class CaptureHostView: NSView {
 			)
 			controller?.completeFrozenInteraction(at: point)
 			syncVisibleCursor()
-			return
+			return false
 		}
-		scheduleFrozenMouseReleaseWatchdog()
+		return true
 	}
 
 	private func logLivePrimaryInputEvent(
@@ -1102,13 +1067,11 @@ final class CaptureHostView: NSView {
 	}
 
 	private func cancelLiveMouseReleaseWatchdog() {
-		liveMouseReleaseWatchdog?.cancel()
-		liveMouseReleaseWatchdog = nil
+		mouseReleaseRecovery.cancelLiveMouseReleaseWatchdog()
 	}
 
 	private func cancelFrozenMouseReleaseWatchdog() {
-		frozenMouseReleaseWatchdog?.cancel()
-		frozenMouseReleaseWatchdog = nil
+		mouseReleaseRecovery.cancelFrozenMouseReleaseWatchdog()
 	}
 
 	private func cancelQueuedPointerDispatch() {


### PR DESCRIPTION
## Summary
- Extract capture-host local mouse-up monitor and live/frozen release-watchdog scheduling into `CaptureHostMouseReleaseRecovery.swift`.
- Keep `CaptureHostView.swift` focused on event decisions while delegating monitor/watchdog ownership to a dedicated support boundary.
- Update host-core reset and workspace layout docs for the new capture-host support module.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` returned no matches
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

## Review
- Inline skeptic fallback checked monitor ownership, watchdog rescheduling semantics, actor isolation, docs drift, and the no-physical-split invariant. Dynamic subagent tools were not used because the active AGENTS instructions only allow subagents where explicitly appropriate and this local evidence pass did not need further read-only delegation.