### PR TITLE
Modularize capture host live input telemetry

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -103,6 +103,8 @@ The current native-host Swift split is:
   sample matching.
 - `CaptureHostLiveSampleResolver.swift`: capture-host live chrome/RGB sample resolution,
   loupe-patch reuse, and cache seeding policy.
+- `CaptureHostLiveInputTelemetry.swift`: capture-host live pointer/mouse input telemetry,
+  pointer-event gap recording, and live-chrome input summary emission.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions.
 - `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
@@ -126,16 +128,16 @@ The current native-host Swift split is:
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
-  `CaptureHostLiveSampleResolver.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostMouseReleaseRecovery.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
-  resolution, live primary interaction state, AppKit mouse-release recovery, pointer dispatch queue
-  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and native text
-  measurement.
+  resolution, live input telemetry, live primary interaction state, AppKit mouse-release recovery,
+  pointer dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry
+  identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -208,6 +208,8 @@ The main host-kit files are split by responsibility:
   sample matching
 - `CaptureHostLiveSampleResolver.swift`: capture-host live chrome/RGB sample resolution,
   loupe-patch reuse, and cache seeding policy
+- `CaptureHostLiveInputTelemetry.swift`: capture-host live pointer/mouse input telemetry,
+  pointer-event gap recording, and live-chrome input summary emission
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions
 - `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
@@ -231,16 +233,16 @@ The main host-kit files are split by responsibility:
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
-  `CaptureHostLiveSampleResolver.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
-  `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
+  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostMouseReleaseRecovery.swift`,
+  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
-  resolution, live primary interaction state, AppKit mouse-release recovery, pointer dispatch queue
-  throttling, Rust-backed frozen image effects, live-chrome telemetry identity, and shared native
-  text measurement
+  resolution, live input telemetry, live primary interaction state, AppKit mouse-release recovery,
+  pointer dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry
+  identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLiveInputTelemetry.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLiveInputTelemetry.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@MainActor
+final class CaptureHostLiveInputTelemetry {
+	private let pointerEventGapMetric = NativeHostTelemetry.distribution(
+		"live_chrome.pointer_event_gap",
+		category: "LiveChromeTelemetry"
+	)
+	private var mouseEventCount = 0
+	private var lastPointerEventUptime: TimeInterval?
+	private var didEmitInputSummary = false
+
+	func recordMouseEvent() {
+		mouseEventCount += 1
+	}
+
+	func recordPointerEvent() {
+		let now = ProcessInfo.processInfo.systemUptime
+		if let lastPointerEventUptime {
+			let gapMilliseconds = (now - lastPointerEventUptime) * 1_000
+			if gapMilliseconds >= 0, gapMilliseconds < 250 {
+				pointerEventGapMetric.record(gapMilliseconds)
+			}
+		}
+		lastPointerEventUptime = now
+	}
+
+	func reset() {
+		mouseEventCount = 0
+		lastPointerEventUptime = nil
+		didEmitInputSummary = false
+	}
+
+	func emitInputSummary(
+		reason: String,
+		captureID: UInt64,
+		pointerInputSequence: UInt64
+	) {
+		guard didEmitInputSummary == false else {
+			return
+		}
+		let observedMouseEvents = max(
+			mouseEventCount,
+			Int(min(pointerInputSequence, UInt64(Int.max)))
+		)
+		guard observedMouseEvents > 0 else {
+			return
+		}
+		didEmitInputSummary = true
+		NativeHostTelemetry.liveChromeInputSummary(
+			captureID: captureID,
+			reason: reason,
+			mouseEvents: observedMouseEvents,
+			followTicks: 0,
+			fastMoveAttempts: 0,
+			fastMoveSuccesses: 0,
+			loupeFastMoveAttempts: 0,
+			loupeFastMoveSuccesses: 0,
+			predictedMoves: 0,
+			fallbackRefreshes: 0,
+			immediateRefreshes: 0
+		)
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -78,7 +78,6 @@ final class CaptureHostView: NSView {
 	private var livePointerPreviewGlobal: CGPoint?
 	private var livePointerPreviewInputUptime: TimeInterval?
 	private var livePointerPreviewInputSequence: UInt64 = 0
-	private var lastLivePointerEventUptime: TimeInterval?
 	private var liveHighlightedWindowPreview: WindowSnapshot?
 	private var sampleUpdatedLiveChromeRenderInProgress = false
 	private var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
@@ -102,12 +101,7 @@ final class CaptureHostView: NSView {
 	private var liveRendererInstalled = false
 	private var deferredLiveShutdownWorkItem: DispatchWorkItem?
 	private var loggedLiveRefreshTarget: LiveChromeRefreshTelemetryKey?
-	private let livePointerEventGapMetric = NativeHostTelemetry.distribution(
-		"live_chrome.pointer_event_gap",
-		category: "LiveChromeTelemetry"
-	)
-	private var liveChromeMouseEventCount = 0
-	private var didEmitLiveChromeInputSummary = false
+	private let liveInputTelemetry = CaptureHostLiveInputTelemetry()
 
 	override var acceptsFirstResponder: Bool { true }
 	override var isOpaque: Bool { false }
@@ -174,7 +168,7 @@ final class CaptureHostView: NSView {
 			frozenFirstDisplayHandoff.reset()
 			if previousMode != .live {
 				livePrimaryInteraction.clearHoverChromeSuppression()
-				resetLiveChromeInputTelemetry()
+				liveInputTelemetry.reset()
 				seedLiveChromeSampleCache(from: chrome, point: scene.pointer)
 			}
 			if livePointerPreviewGlobal == nil {
@@ -485,7 +479,7 @@ final class CaptureHostView: NSView {
 			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
 				return
 			}
-			liveChromeMouseEventCount += 1
+			liveInputTelemetry.recordMouseEvent()
 			updateLivePointerPreview(to: point, rendersImmediately: true)
 			return
 		}
@@ -869,12 +863,11 @@ final class CaptureHostView: NSView {
 	}
 
 	private func resetLivePointerPreview() {
-		emitLiveChromeInputSummary(reason: "reset")
-		resetLiveChromeInputTelemetry()
+		finishLivePresentationTelemetry(reason: "reset")
+		liveInputTelemetry.reset()
 		livePointerPreviewGlobal = nil
 		livePointerPreviewInputUptime = nil
 		livePointerPreviewInputSequence = 0
-		lastLivePointerEventUptime = nil
 	}
 
 	func markLivePrimaryInteractionReleased(at point: CGPoint) {
@@ -1086,7 +1079,7 @@ final class CaptureHostView: NSView {
 		guard scene.mode == .live else {
 			return
 		}
-		recordLivePointerEventGap()
+		liveInputTelemetry.recordPointerEvent()
 		let pointerChanged = setLivePointerPreview(to: globalPoint)
 		let hoverTargetChanged = refreshLiveHighlightedWindowPreviewForFastPath(at: globalPoint)
 		if pointerChanged || rendersImmediately || hoverTargetChanged {
@@ -1100,50 +1093,11 @@ final class CaptureHostView: NSView {
 		}
 	}
 
-	private func recordLivePointerEventGap() {
-		let now = ProcessInfo.processInfo.systemUptime
-		if let lastLivePointerEventUptime {
-			let gapMilliseconds = (now - lastLivePointerEventUptime) * 1_000
-			if gapMilliseconds >= 0, gapMilliseconds < 250 {
-				livePointerEventGapMetric.record(gapMilliseconds)
-			}
-		}
-		lastLivePointerEventUptime = now
-	}
-
 	func finishLivePresentationTelemetry(reason: String) {
-		emitLiveChromeInputSummary(reason: reason)
-	}
-
-	private func resetLiveChromeInputTelemetry() {
-		liveChromeMouseEventCount = 0
-		didEmitLiveChromeInputSummary = false
-	}
-
-	private func emitLiveChromeInputSummary(reason: String) {
-		guard didEmitLiveChromeInputSummary == false else {
-			return
-		}
-		let observedMouseEvents = max(
-			liveChromeMouseEventCount,
-			Int(min(livePointerPreviewInputSequence, UInt64(Int.max)))
-		)
-		guard observedMouseEvents > 0 else {
-			return
-		}
-		didEmitLiveChromeInputSummary = true
-		NativeHostTelemetry.liveChromeInputSummary(
-			captureID: controller?.activeTelemetryCaptureID ?? 0,
+		liveInputTelemetry.emitInputSummary(
 			reason: reason,
-			mouseEvents: observedMouseEvents,
-			followTicks: 0,
-			fastMoveAttempts: 0,
-			fastMoveSuccesses: 0,
-			loupeFastMoveAttempts: 0,
-			loupeFastMoveSuccesses: 0,
-			predictedMoves: 0,
-			fallbackRefreshes: 0,
-			immediateRefreshes: 0
+			captureID: controller?.activeTelemetryCaptureID ?? 0,
+			pointerInputSequence: livePointerPreviewInputSequence
 		)
 	}
 


### PR DESCRIPTION
## Summary
- Extract capture-host live pointer/mouse telemetry into `CaptureHostLiveInputTelemetry.swift`.
- Keep `CaptureHostView.swift` responsible for input timing while delegating event-gap metrics and input summary emission to a dedicated support boundary.
- Update host-core reset and workspace layout docs for the new host-kit module.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` returned no matches
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

## Review
- Inline skeptic fallback checked reset ordering, input-count preservation, pointer gap metric ownership, docs drift, and the no-physical-split invariant.