### PR TITLE
Modularize capture host live pointer preview state

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -105,6 +105,8 @@ The current native-host Swift split is:
   loupe-patch reuse, and cache seeding policy.
 - `CaptureHostLiveInputTelemetry.swift`: capture-host live pointer/mouse input telemetry,
   pointer-event gap recording, and live-chrome input summary emission.
+- `CaptureHostLivePointerPreviewState.swift`: capture-host live pointer preview point,
+  input-latency timestamp, sequence, and duplicate-move suppression state.
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions.
 - `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
@@ -129,15 +131,16 @@ The current native-host Swift split is:
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostMouseReleaseRecovery.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostLivePointerPreviewState.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
-  resolution, live input telemetry, live primary interaction state, AppKit mouse-release recovery,
-  pointer dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry
-  identity, and native text measurement.
+  resolution, live input telemetry, live pointer preview state, live primary interaction state,
+  AppKit mouse-release recovery, pointer dispatch queue throttling, Rust-backed frozen image
+  effects, live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -210,6 +210,8 @@ The main host-kit files are split by responsibility:
   loupe-patch reuse, and cache seeding policy
 - `CaptureHostLiveInputTelemetry.swift`: capture-host live pointer/mouse input telemetry,
   pointer-event gap recording, and live-chrome input summary emission
+- `CaptureHostLivePointerPreviewState.swift`: capture-host live pointer preview point,
+  input-latency timestamp, sequence, and duplicate-move suppression state
 - `CaptureHostLivePrimaryInteractionState.swift`: capture-host live primary drag, release,
   completion, and hover-suppression state transitions
 - `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
@@ -234,15 +236,16 @@ The main host-kit files are split by responsibility:
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
   `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
-  `CaptureHostLivePrimaryInteractionState.swift`, `CaptureHostMouseReleaseRecovery.swift`,
-  `CaptureHostPointerDispatch.swift`, `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostLivePointerPreviewState.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
+  `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
+  `CaptureHostFrozenImageEffects.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
-  resolution, live input telemetry, live primary interaction state, AppKit mouse-release recovery,
-  pointer dispatch queue throttling, Rust-backed frozen image effects, live-chrome telemetry
-  identity, and shared native text measurement
+  resolution, live input telemetry, live pointer preview state, live primary interaction state,
+  AppKit mouse-release recovery, pointer dispatch queue throttling, Rust-backed frozen image
+  effects, live-chrome telemetry identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLivePointerPreviewState.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostLivePointerPreviewState.swift
@@ -1,0 +1,45 @@
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class CaptureHostLivePointerPreviewState {
+	private(set) var globalPoint: CGPoint?
+	private(set) var inputUptime: TimeInterval?
+	private(set) var inputSequence: UInt64 = 0
+
+	func currentPoint(fallback: CGPoint?) -> CGPoint? {
+		globalPoint ?? fallback
+	}
+
+	func seed(
+		_ point: CGPoint,
+		recordsInputLatency: Bool = true
+	) {
+		globalPoint = point
+		if recordsInputLatency {
+			inputUptime = ProcessInfo.processInfo.systemUptime
+			inputSequence &+= 1
+		} else {
+			inputUptime = nil
+			inputSequence = 0
+		}
+	}
+
+	@discardableResult
+	func set(
+		to point: CGPoint,
+		recordsInputLatency: Bool = true
+	) -> Bool {
+		if let globalPoint, hypot(globalPoint.x - point.x, globalPoint.y - point.y) < 0.05 {
+			return false
+		}
+		seed(point, recordsInputLatency: recordsInputLatency)
+		return true
+	}
+
+	func reset() {
+		globalPoint = nil
+		inputUptime = nil
+		inputSequence = 0
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -75,9 +75,7 @@ final class CaptureHostView: NSView {
 	private var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
 	private var livePrimaryInteraction = CaptureHostLivePrimaryInteractionState()
 	private let mouseReleaseRecovery = CaptureHostMouseReleaseRecovery()
-	private var livePointerPreviewGlobal: CGPoint?
-	private var livePointerPreviewInputUptime: TimeInterval?
-	private var livePointerPreviewInputSequence: UInt64 = 0
+	private let livePointerPreview = CaptureHostLivePointerPreviewState()
 	private var liveHighlightedWindowPreview: WindowSnapshot?
 	private var sampleUpdatedLiveChromeRenderInProgress = false
 	private var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
@@ -171,7 +169,7 @@ final class CaptureHostView: NSView {
 				liveInputTelemetry.reset()
 				seedLiveChromeSampleCache(from: chrome, point: scene.pointer)
 			}
-			if livePointerPreviewGlobal == nil {
+			if livePointerPreview.globalPoint == nil {
 				seedLivePointerPreview(scene.pointer, recordsInputLatency: false)
 			}
 			if liveHighlightedWindowPreview == nil {
@@ -810,7 +808,7 @@ final class CaptureHostView: NSView {
 		}
 		guard
 			let globalRect = livePrimaryInteraction.immediateDragSelectionGlobal(
-				current: livePointerPreviewGlobal ?? scene.pointer,
+				current: livePointerPreview.currentPoint(fallback: scene.pointer),
 				in: window.frame
 			)
 		else {
@@ -824,7 +822,7 @@ final class CaptureHostView: NSView {
 	}
 
 	private func localPointer() -> CGPoint? {
-		guard let globalPoint = livePointerPreviewGlobal ?? scene.pointer else {
+		guard let globalPoint = livePointerPreview.currentPoint(fallback: scene.pointer) else {
 			return nil
 		}
 		return localPoint(from: globalPoint)
@@ -838,14 +836,7 @@ final class CaptureHostView: NSView {
 			resetLivePointerPreview()
 			return
 		}
-		livePointerPreviewGlobal = globalPoint
-		if recordsInputLatency {
-			livePointerPreviewInputUptime = ProcessInfo.processInfo.systemUptime
-			livePointerPreviewInputSequence &+= 1
-		} else {
-			livePointerPreviewInputUptime = nil
-			livePointerPreviewInputSequence = 0
-		}
+		livePointerPreview.seed(globalPoint, recordsInputLatency: recordsInputLatency)
 	}
 
 	@discardableResult
@@ -853,21 +844,13 @@ final class CaptureHostView: NSView {
 		to globalPoint: CGPoint,
 		recordsInputLatency: Bool = true
 	) -> Bool {
-		if let current = livePointerPreviewGlobal,
-			hypot(current.x - globalPoint.x, current.y - globalPoint.y) < 0.05
-		{
-			return false
-		}
-		seedLivePointerPreview(globalPoint, recordsInputLatency: recordsInputLatency)
-		return true
+		livePointerPreview.set(to: globalPoint, recordsInputLatency: recordsInputLatency)
 	}
 
 	private func resetLivePointerPreview() {
 		finishLivePresentationTelemetry(reason: "reset")
 		liveInputTelemetry.reset()
-		livePointerPreviewGlobal = nil
-		livePointerPreviewInputUptime = nil
-		livePointerPreviewInputSequence = 0
+		livePointerPreview.reset()
 	}
 
 	func markLivePrimaryInteractionReleased(at point: CGPoint) {
@@ -1097,7 +1080,7 @@ final class CaptureHostView: NSView {
 		liveInputTelemetry.emitInputSummary(
 			reason: reason,
 			captureID: controller?.activeTelemetryCaptureID ?? 0,
-			pointerInputSequence: livePointerPreviewInputSequence
+			pointerInputSequence: livePointerPreview.inputSequence
 		)
 	}
 
@@ -1475,7 +1458,7 @@ final class CaptureHostView: NSView {
 			return nil
 		}
 		let rgbSample = liveSampleCache.rgbSample(
-			matching: livePointerPreviewGlobal ?? scene.pointer)?
+			matching: livePointerPreview.currentPoint(fallback: scene.pointer))?
 			.rgb
 		return LivePreviewSnapshot(
 			bounds: bounds,
@@ -1543,7 +1526,7 @@ final class CaptureHostView: NSView {
 
 		if livePrimaryInteraction.completionInFlight == false {
 			let polledPoint = currentGlobalMousePoint() ?? NSEvent.mouseLocation
-			if let currentPreview = livePointerPreviewGlobal {
+			if let currentPreview = livePointerPreview.globalPoint {
 				if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y)
 					>= 0.5
 				{
@@ -1554,10 +1537,11 @@ final class CaptureHostView: NSView {
 			}
 		}
 
-		refreshLiveHighlightedWindowPreview(at: livePointerPreviewGlobal ?? scene.pointer)
+		refreshLiveHighlightedWindowPreview(
+			at: livePointerPreview.currentPoint(fallback: scene.pointer))
 		updateLivePreviewDemands()
 
-		let point = livePointerPreviewGlobal ?? scene.pointer
+		let point = livePointerPreview.currentPoint(fallback: scene.pointer)
 		let chromeSample = currentLiveChromeSample(at: point)
 		let rgbSample = liveRgbSample(from: chromeSample, at: point)
 		let loupePatch = scene.loupeVisible ? chromeSample?.loupePatch : nil
@@ -1605,7 +1589,7 @@ final class CaptureHostView: NSView {
 			rgbSample: rgbSample,
 			keycapVisible: settings.showAltHintKeycap,
 			inputUptime: sampleUpdatedLiveChromeRenderInProgress
-				? nil : livePointerPreviewInputUptime,
+				? nil : livePointerPreview.inputUptime,
 			loupePatch: loupePatch,
 			glassPatches: [:]
 		)
@@ -1800,7 +1784,7 @@ final class CaptureHostView: NSView {
 				point: nil, settings: settings, includeLoupePatch: false)
 			return
 		}
-		let point = livePointerPreviewGlobal ?? scene.pointer
+		let point = livePointerPreview.currentPoint(fallback: scene.pointer)
 		controller?.updateLivePreviewDemand(
 			point: point,
 			settings: settings,
@@ -1876,7 +1860,7 @@ final class CaptureHostView: NSView {
 
 	private func currentPositionDisplay() -> LivePositionDisplay {
 		let metrics = LiveChromePlacementPlanner.metrics
-		guard let pointer = livePointerPreviewGlobal ?? scene.pointer else {
+		guard let pointer = livePointerPreview.currentPoint(fallback: scene.pointer) else {
 			return LivePositionDisplay(
 				xValueText: "?",
 				yValueText: "?",


### PR DESCRIPTION
## Summary
- Extract capture-host live pointer preview point, input latency timestamp, sequence, and duplicate-move suppression into `CaptureHostLivePointerPreviewState.swift`.
- Keep `CaptureHostView.swift` responsible for preview timing, telemetry reset, and render decisions while delegating pointer-preview state ownership.
- Update host-core reset and workspace layout docs for the new support module.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` returned no matches
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

## Review
- Inline skeptic fallback checked seed/reset ordering, duplicate-move suppression, input sequence preservation, docs drift, and the no-physical-split invariant.