### PR TITLE
Modularize frozen frame pixel-buffer bridge

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -83,6 +83,10 @@ The current native-host Swift split is:
 - `CaptureOverlayController.swift`: AppKit overlay-window set management, focus/first-responder
   routing, capture-stream preparation, mouse passthrough, and CoreGraphics capture sources needed
   to sample below native overlay windows.
+- `FrozenFrameAuthority.swift`: ScreenCaptureKit frozen-frame stream lifecycle, latch-token
+  resolution, self-capture filter completeness, and fresh-frame authority decisions.
+- `FrozenFramePixelBufferBridge.swift`: CVPixelBuffer lock/lifetime adaptation for frozen-frame
+  CGImage creation, RGB sampling, and loupe patch extraction.
 - `CaptureHostAnnotationStyleWheelGate.swift`: frozen annotation-size wheel dead-zone and
   per-gesture step throttling.
 - `CaptureHostToolbarHoverState.swift`: frozen toolbar hover target state, change detection, and
@@ -133,14 +137,15 @@ The current native-host Swift split is:
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
   `CaptureHostLivePointerPreviewState.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
   `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `FrozenFramePixelBufferBridge.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
   resolution, live input telemetry, live pointer preview state, live primary interaction state,
   AppKit mouse-release recovery, pointer dispatch queue throttling, Rust-backed frozen image
-  effects, live-chrome telemetry identity, and native text measurement.
+  effects, frozen-frame pixel-buffer image/sampling adaptation, live-chrome telemetry identity, and
+  native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -188,6 +188,10 @@ The main host-kit files are split by responsibility:
 - `CaptureOverlayWindow.swift`: AppKit `NSPanel` wrapper for capture overlay windows
 - `CaptureOverlayController.swift`: overlay window set, focus, stream preparation, and below-overlay
   capture source management
+- `FrozenFrameAuthority.swift`: ScreenCaptureKit frozen-frame stream lifecycle, latch-token
+  resolution, self-capture filter completeness, and fresh-frame authority decisions
+- `FrozenFramePixelBufferBridge.swift`: CVPixelBuffer lock/lifetime adaptation for frozen-frame
+  CGImage creation, RGB sampling, and loupe patch extraction
 - `CaptureHostAnnotationStyleWheelGate.swift`: frozen annotation-size wheel dead-zone and
   per-gesture step throttling
 - `CaptureHostToolbarHoverState.swift`: frozen toolbar hover target state, change detection, and
@@ -238,14 +242,15 @@ The main host-kit files are split by responsibility:
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
   `CaptureHostLivePointerPreviewState.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
   `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`,
+  `CaptureHostFrozenImageEffects.swift`, `FrozenFramePixelBufferBridge.swift`,
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
   resolution, live input telemetry, live pointer preview state, live primary interaction state,
   AppKit mouse-release recovery, pointer dispatch queue throttling, Rust-backed frozen image
-  effects, live-chrome telemetry identity, and shared native text measurement
+  effects, frozen-frame pixel-buffer image/sampling adaptation, live-chrome telemetry identity, and
+  shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -97,36 +97,6 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let startedAtUptime: TimeInterval
 	}
 
-	private final class PixelBufferImageBacking {
-		let pixelBuffer: CVPixelBuffer
-		let baseAddress: UnsafeMutableRawPointer
-		let byteCount: Int
-		let unlockFlags = CVPixelBufferLockFlags.readOnly
-
-		init?(_ pixelBuffer: CVPixelBuffer) {
-			guard CVPixelBufferLockBaseAddress(pixelBuffer, unlockFlags) == kCVReturnSuccess else {
-				return nil
-			}
-			guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
-				CVPixelBufferUnlockBaseAddress(pixelBuffer, unlockFlags)
-				return nil
-			}
-			let height = CVPixelBufferGetHeight(pixelBuffer)
-			let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-			guard height > 0, bytesPerRow > 0 else {
-				CVPixelBufferUnlockBaseAddress(pixelBuffer, unlockFlags)
-				return nil
-			}
-			self.pixelBuffer = pixelBuffer
-			self.baseAddress = baseAddress
-			self.byteCount = bytesPerRow * height
-		}
-
-		deinit {
-			CVPixelBufferUnlockBaseAddress(pixelBuffer, unlockFlags)
-		}
-	}
-
 	private struct PreparedContentFilter {
 		let filter: SCContentFilter
 		let selfCaptureFilterComplete: Bool
@@ -854,7 +824,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 			return nil
 		}
 		guard
-			let rgb = Self.rgbSample(
+			let rgb = FrozenFramePixelBufferBridge.rgbSample(
 				from: record.pixelBuffer,
 				point: point,
 				displayFrame: record.displayFrame
@@ -878,7 +848,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		guard let record else {
 			return nil
 		}
-		return Self.loupePatch(
+		return FrozenFramePixelBufferBridge.loupePatch(
 			from: record.pixelBuffer,
 			point: point,
 			displayFrame: record.displayFrame,
@@ -926,7 +896,9 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 		stateLock.unlock()
 
-		guard let record, let image = Self.makeImage(from: record.pixelBuffer) else {
+		guard let record,
+			let image = FrozenFramePixelBufferBridge.makeImage(from: record.pixelBuffer)
+		else {
 			return nil
 		}
 		return FrozenFrameSnapshot(
@@ -1401,123 +1373,6 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		)
 	}
 
-	private static func makeImage(from pixelBuffer: CVPixelBuffer) -> CGImage? {
-		guard let backing = PixelBufferImageBacking(pixelBuffer) else {
-			return nil
-		}
-		let width = CVPixelBufferGetWidth(pixelBuffer)
-		let height = CVPixelBufferGetHeight(pixelBuffer)
-		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-		guard width > 0, height > 0, bytesPerRow >= width * 4 else {
-			return nil
-		}
-		let retainedBacking = Unmanaged.passRetained(backing)
-		guard
-			let provider = CGDataProvider(
-				dataInfo: retainedBacking.toOpaque(),
-				data: backing.baseAddress,
-				size: backing.byteCount,
-				releaseData: { info, _, _ in
-					guard let info else {
-						return
-					}
-					Unmanaged<PixelBufferImageBacking>.fromOpaque(info).release()
-				}
-			)
-		else {
-			retainedBacking.release()
-			return nil
-		}
-		let bitmapInfo = CGBitmapInfo.byteOrder32Little
-			.union(CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue))
-		return CGImage(
-			width: width,
-			height: height,
-			bitsPerComponent: 8,
-			bitsPerPixel: 32,
-			bytesPerRow: bytesPerRow,
-			space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
-			bitmapInfo: bitmapInfo,
-			provider: provider,
-			decode: nil,
-			shouldInterpolate: false,
-			intent: .defaultIntent
-		)
-	}
-
-	private static func rgbSample(
-		from pixelBuffer: CVPixelBuffer,
-		point: CGPoint,
-		displayFrame: CGRect
-	) -> RGBSample? {
-		let width = CVPixelBufferGetWidth(pixelBuffer)
-		let height = CVPixelBufferGetHeight(pixelBuffer)
-		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-		guard width > 0, height > 0, bytesPerRow >= width * 4 else {
-			return nil
-		}
-		guard CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly) == kCVReturnSuccess else {
-			return nil
-		}
-		defer {
-			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
-		}
-		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
-			return nil
-		}
-		return try? RsnapBgraFrameSampler.rgbSample(
-			width: width,
-			height: height,
-			bytesPerRow: bytesPerRow,
-			baseAddress: baseAddress,
-			byteCount: bytesPerRow * height,
-			displayFrame: displayFrame,
-			point: point
-		)
-	}
-
-	private static func loupePatch(
-		from pixelBuffer: CVPixelBuffer,
-		point: CGPoint,
-		displayFrame: CGRect,
-		sidePixels: Int
-	) -> CGImage? {
-		let width = CVPixelBufferGetWidth(pixelBuffer)
-		let height = CVPixelBufferGetHeight(pixelBuffer)
-		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-		let side = max(sidePixels, 1)
-		guard width > 0, height > 0, bytesPerRow >= width * 4 else {
-			return nil
-		}
-		guard CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly) == kCVReturnSuccess else {
-			return nil
-		}
-		defer {
-			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
-		}
-		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
-			return nil
-		}
-		guard
-			let patch = try? RsnapBgraFrameSampler.loupePatch(
-				width: width,
-				height: height,
-				bytesPerRow: bytesPerRow,
-				baseAddress: baseAddress,
-				byteCount: bytesPerRow * height,
-				displayFrame: displayFrame,
-				point: point,
-				sidePixels: side
-			)
-		else {
-			return nil
-		}
-		return NativeHostImageBridge.cgImage(
-			width: patch.width,
-			height: patch.height,
-			rgba: patch.rgba
-		)
-	}
 }
 
 private final class FrozenFrameStreamOutput: NSObject, SCStreamOutput, SCStreamDelegate,

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFramePixelBufferBridge.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFramePixelBufferBridge.swift
@@ -1,0 +1,154 @@
+import CoreGraphics
+import CoreVideo
+import Foundation
+import RsnapHostBridge
+
+enum FrozenFramePixelBufferBridge {
+	static func makeImage(from pixelBuffer: CVPixelBuffer) -> CGImage? {
+		guard let backing = PixelBufferImageBacking(pixelBuffer) else {
+			return nil
+		}
+		let width = CVPixelBufferGetWidth(pixelBuffer)
+		let height = CVPixelBufferGetHeight(pixelBuffer)
+		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+		guard width > 0, height > 0, bytesPerRow >= width * 4 else {
+			return nil
+		}
+		let retainedBacking = Unmanaged.passRetained(backing)
+		guard
+			let provider = CGDataProvider(
+				dataInfo: retainedBacking.toOpaque(),
+				data: backing.baseAddress,
+				size: backing.byteCount,
+				releaseData: { info, _, _ in
+					guard let info else {
+						return
+					}
+					Unmanaged<PixelBufferImageBacking>.fromOpaque(info).release()
+				}
+			)
+		else {
+			retainedBacking.release()
+			return nil
+		}
+		let bitmapInfo = CGBitmapInfo.byteOrder32Little
+			.union(CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue))
+		return CGImage(
+			width: width,
+			height: height,
+			bitsPerComponent: 8,
+			bitsPerPixel: 32,
+			bytesPerRow: bytesPerRow,
+			space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+			bitmapInfo: bitmapInfo,
+			provider: provider,
+			decode: nil,
+			shouldInterpolate: false,
+			intent: .defaultIntent
+		)
+	}
+
+	static func rgbSample(
+		from pixelBuffer: CVPixelBuffer,
+		point: CGPoint,
+		displayFrame: CGRect
+	) -> RGBSample? {
+		let width = CVPixelBufferGetWidth(pixelBuffer)
+		let height = CVPixelBufferGetHeight(pixelBuffer)
+		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+		guard width > 0, height > 0, bytesPerRow >= width * 4 else {
+			return nil
+		}
+		guard CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly) == kCVReturnSuccess else {
+			return nil
+		}
+		defer {
+			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
+		}
+		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+			return nil
+		}
+		return try? RsnapBgraFrameSampler.rgbSample(
+			width: width,
+			height: height,
+			bytesPerRow: bytesPerRow,
+			baseAddress: baseAddress,
+			byteCount: bytesPerRow * height,
+			displayFrame: displayFrame,
+			point: point
+		)
+	}
+
+	static func loupePatch(
+		from pixelBuffer: CVPixelBuffer,
+		point: CGPoint,
+		displayFrame: CGRect,
+		sidePixels: Int
+	) -> CGImage? {
+		let width = CVPixelBufferGetWidth(pixelBuffer)
+		let height = CVPixelBufferGetHeight(pixelBuffer)
+		let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+		let side = max(sidePixels, 1)
+		guard width > 0, height > 0, bytesPerRow >= width * 4 else {
+			return nil
+		}
+		guard CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly) == kCVReturnSuccess else {
+			return nil
+		}
+		defer {
+			CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
+		}
+		guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+			return nil
+		}
+		guard
+			let patch = try? RsnapBgraFrameSampler.loupePatch(
+				width: width,
+				height: height,
+				bytesPerRow: bytesPerRow,
+				baseAddress: baseAddress,
+				byteCount: bytesPerRow * height,
+				displayFrame: displayFrame,
+				point: point,
+				sidePixels: side
+			)
+		else {
+			return nil
+		}
+		return NativeHostImageBridge.cgImage(
+			width: patch.width,
+			height: patch.height,
+			rgba: patch.rgba
+		)
+	}
+
+	private final class PixelBufferImageBacking {
+		let pixelBuffer: CVPixelBuffer
+		let baseAddress: UnsafeMutableRawPointer
+		let byteCount: Int
+		let unlockFlags = CVPixelBufferLockFlags.readOnly
+
+		init?(_ pixelBuffer: CVPixelBuffer) {
+			guard CVPixelBufferLockBaseAddress(pixelBuffer, unlockFlags) == kCVReturnSuccess else {
+				return nil
+			}
+			guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+				CVPixelBufferUnlockBaseAddress(pixelBuffer, unlockFlags)
+				return nil
+			}
+			let height = CVPixelBufferGetHeight(pixelBuffer)
+			let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+			guard height > 0, bytesPerRow > 0 else {
+				CVPixelBufferUnlockBaseAddress(pixelBuffer, unlockFlags)
+				return nil
+			}
+			self.pixelBuffer = pixelBuffer
+			self.baseAddress = baseAddress
+			self.byteCount = bytesPerRow * height
+		}
+
+		deinit {
+			CVPixelBufferUnlockBaseAddress(pixelBuffer, unlockFlags)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Extract frozen-frame CVPixelBuffer image, RGB sample, and loupe-patch adaptation into `FrozenFramePixelBufferBridge.swift`.
- Keep `FrozenFrameAuthority.swift` focused on ScreenCaptureKit stream lifecycle, latch resolution, and fresh-frame authority decisions.
- Update host-core reset and workspace layout docs for the new bridge boundary.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` returned no matches
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

## Review
- Inline skeptic fallback checked CVPixelBuffer lock lifetime, CGDataProvider retained backing release, RGB/loupe sampling coordinate preservation, docs drift, and the no-physical-split invariant.