### PR TITLE
Modularize capture host glass patch resolver

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -97,6 +97,8 @@ The current native-host Swift split is:
   generation, seed-patch cache, active frame, refresh cadence, and change-count state.
 - `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, Liquid Glass surfaces, live/frozen
   HUD and toolbar orchestration, and native pointer/key event routing into the session controller.
+- `CaptureHostGlassPatchResolver.swift`: capture-host classic glass patch cache lookup, frozen
+  display crop extraction, and CoreImage blur/tint adaptation for HUD, loupe, and toolbar surfaces.
 - `CaptureHostFrozenSelectionChromeRenderer.swift`: frozen selection scrim, dashed border, resize
   handles, and selection-size badge rendering.
 - `CaptureHostFrozenOverlayRenderer.swift`: frozen annotation overlay rendering for mosaic,
@@ -137,15 +139,16 @@ The current native-host Swift split is:
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
   `CaptureHostLivePointerPreviewState.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
   `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `FrozenFramePixelBufferBridge.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  `CaptureHostFrozenImageEffects.swift`, `CaptureHostGlassPatchResolver.swift`,
+  `FrozenFramePixelBufferBridge.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
   resolution, live input telemetry, live pointer preview state, live primary interaction state,
   AppKit mouse-release recovery, pointer dispatch queue throttling, Rust-backed frozen image
-  effects, frozen-frame pixel-buffer image/sampling adaptation, live-chrome telemetry identity, and
-  native text measurement.
+  effects, capture-host glass patch caching and blur/tint adaptation, frozen-frame pixel-buffer
+  image/sampling adaptation, live-chrome telemetry identity, and native text measurement.
 - `FrozenCaptureModels.swift`: Swift view-adapter state for Rust-owned frozen overlay editing,
   including conversion from Rust edit snapshots into AppKit draw models.
 - `NativeHostFeedbackSound.swift`: host-side `NSSound` lookup/playback for capture and OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -202,6 +202,8 @@ The main host-kit files are split by responsibility:
   seed-patch cache, active frame, refresh cadence, and change-count state
 - `CaptureHostView.swift`: AppKit view rendering orchestration, hit testing, and native pointer/key
   routing
+- `CaptureHostGlassPatchResolver.swift`: classic glass patch cache lookup, frozen display crop
+  extraction, and CoreImage blur/tint adaptation for capture-host HUD, loupe, and toolbar surfaces
 - `CaptureHostFrozenSelectionChromeRenderer.swift`: frozen selection scrim, dashed border, resize
   handles, and selection-size badge rendering
 - `CaptureHostFrozenOverlayRenderer.swift`: frozen annotation overlay rendering for mosaic,
@@ -242,15 +244,16 @@ The main host-kit files are split by responsibility:
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
   `CaptureHostLivePointerPreviewState.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
   `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
-  `CaptureHostFrozenImageEffects.swift`, `FrozenFramePixelBufferBridge.swift`,
-  `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
+  `CaptureHostFrozenImageEffects.swift`, `CaptureHostGlassPatchResolver.swift`,
+  `FrozenFramePixelBufferBridge.swift`, `LiveChromeRefreshTelemetryKey.swift`, and
+  `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
   presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
   resolution, live input telemetry, live pointer preview state, live primary interaction state,
   AppKit mouse-release recovery, pointer dispatch queue throttling, Rust-backed frozen image
-  effects, frozen-frame pixel-buffer image/sampling adaptation, live-chrome telemetry identity, and
-  shared native text measurement
+  effects, capture-host glass patch caching and blur/tint adaptation, frozen-frame pixel-buffer
+  image/sampling adaptation, live-chrome telemetry identity, and shared native text measurement
 - `FrozenCaptureModels.swift`: Swift adapter models for Rust-owned frozen overlay editing
 - `NativeHostFeedbackSound.swift`: host-side sound lookup/playback for completion effects
 - `NativeHostImageBridge.swift`: RGBA/CoreGraphics image conversion used by the FFI bridge

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostGlassPatchResolver.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostGlassPatchResolver.swift
@@ -1,0 +1,139 @@
+import CoreGraphics
+import CoreImage
+import Foundation
+
+@MainActor private let captureHostGlassPatchCIContext = CIContext(options: nil)
+
+enum CaptureHostGlassSurfaceKind: Hashable {
+	case hud
+	case loupe
+	case toolbar
+}
+
+@MainActor
+struct CaptureHostGlassPatchResolver {
+	private var cache: [CaptureHostGlassSurfaceKind: CaptureHostGlassPatchCache] = [:]
+
+	mutating func patch(
+		for surfaceKind: CaptureHostGlassSurfaceKind,
+		frame: CGRect,
+		globalFrame: CGRect,
+		now: TimeInterval,
+		cacheInterval: TimeInterval,
+		theme: CaptureChromeTheme,
+		settings: NativeHostSettings,
+		sourcePatch: (CGRect) -> CGImage?
+	) -> CGImage? {
+		if let cached = cache[surfaceKind],
+			now - cached.capturedAt < cacheInterval,
+			framesMatch(cached.frame, frame)
+		{
+			return cached.image
+		}
+
+		guard let patch = sourcePatch(globalFrame) else {
+			return nil
+		}
+		guard
+			let image = Self.blurredPatch(
+				from: patch,
+				surfaceKind: surfaceKind,
+				theme: theme,
+				settings: settings
+			)
+		else {
+			return nil
+		}
+
+		cache[surfaceKind] = CaptureHostGlassPatchCache(
+			frame: frame,
+			capturedAt: now,
+			image: image
+		)
+		return image
+	}
+
+	static func frozenDisplayPatch(
+		in globalFrame: CGRect,
+		displayFrame: CGRect?,
+		image: CGImage?
+	) -> CGImage? {
+		guard
+			let displayFrame,
+			let image
+		else {
+			return nil
+		}
+		let cropRect = CGRect(
+			x: ((globalFrame.minX - displayFrame.minX) / max(displayFrame.width, 1))
+				* CGFloat(image.width),
+			y: ((displayFrame.maxY - globalFrame.maxY) / max(displayFrame.height, 1))
+				* CGFloat(image.height),
+			width: (globalFrame.width / max(displayFrame.width, 1)) * CGFloat(image.width),
+			height: (globalFrame.height / max(displayFrame.height, 1)) * CGFloat(image.height)
+		).integral.intersection(CGRect(x: 0, y: 0, width: image.width, height: image.height))
+		guard cropRect.width > 0, cropRect.height > 0 else {
+			return nil
+		}
+		return image.cropping(to: cropRect)
+	}
+
+	private static func blurredPatch(
+		from image: CGImage,
+		surfaceKind: CaptureHostGlassSurfaceKind,
+		theme: CaptureChromeTheme,
+		settings: NativeHostSettings
+	) -> CGImage? {
+		let ciImage = CIImage(cgImage: image)
+		let clampedImage = ciImage.clampedToExtent()
+		guard let filter = CIFilter(name: "CIGaussianBlur") else {
+			return image
+		}
+		let blurAmount = CGFloat(settings.hudBlur.clamped(to: 0...1))
+		let blurRadius: CGFloat =
+			switch surfaceKind {
+			case .hud, .loupe, .toolbar:
+				14 + blurAmount * 32.0
+			}
+		filter.setValue(clampedImage, forKey: kCIInputImageKey)
+		filter.setValue(blurRadius, forKey: kCIInputRadiusKey)
+		guard let blurredImage = filter.outputImage?.cropped(to: ciImage.extent) else {
+			return image
+		}
+		let colorAdjustedImage: CIImage
+		if let colorControls = CIFilter(name: "CIColorControls") {
+			colorControls.setValue(blurredImage, forKey: kCIInputImageKey)
+			switch surfaceKind {
+			case .hud, .loupe, .toolbar:
+				colorControls.setValue(
+					1.18 + settings.hudTint.clamped(to: 0...1) * 0.42,
+					forKey: kCIInputSaturationKey
+				)
+				colorControls.setValue(1.04, forKey: kCIInputContrastKey)
+				colorControls.setValue(
+					themeBrightnessBias(for: theme),
+					forKey: kCIInputBrightnessKey
+				)
+			}
+			colorAdjustedImage =
+				colorControls.outputImage?.cropped(to: ciImage.extent) ?? blurredImage
+		} else {
+			colorAdjustedImage = blurredImage
+		}
+		return captureHostGlassPatchCIContext.createCGImage(
+			colorAdjustedImage,
+			from: colorAdjustedImage.extent
+		) ?? image
+	}
+
+	private func framesMatch(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+		abs(lhs.minX - rhs.minX) < 1
+			&& abs(lhs.minY - rhs.minY) < 1
+			&& abs(lhs.width - rhs.width) < 1
+			&& abs(lhs.height - rhs.height) < 1
+	}
+
+	private static func themeBrightnessBias(for theme: CaptureChromeTheme) -> Double {
+		theme == .dark ? 0.015 : -0.01
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -1,23 +1,14 @@
 import AppKit
 import CoreGraphics
-import CoreImage
 import Foundation
 import QuartzCore
 import RsnapHostBridge
-
-@MainActor private let frozenEffectCIContext = CIContext(options: nil)
 
 @MainActor
 final class CaptureHostView: NSView {
 	private static let liveDragIntentThreshold: CGFloat = 3
 	private static let scrollToolbarBackdropCaptureMinimumInterval: TimeInterval = 1.0 / 60.0
 	private static let scrollToolbarBackdropFallbackMinimumInterval: TimeInterval = 1.0 / 20.0
-
-	private enum GlassSurfaceKind: Hashable {
-		case hud
-		case loupe
-		case toolbar
-	}
 
 	private static let liveChromeLiquidGlassZ: CGFloat = 200
 	private static let frozenToolbarLiquidGlassBackdropZ: CGFloat = 295
@@ -81,7 +72,7 @@ final class CaptureHostView: NSView {
 	private var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
 	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
 	private var liveSampleCache = CaptureHostLiveSampleCache()
-	private var glassPatchCache: [GlassSurfaceKind: CaptureHostGlassPatchCache] = [:]
+	private var glassPatchResolver = CaptureHostGlassPatchResolver()
 	private lazy var pointerDispatchQueue = CaptureHostPointerDispatchQueue(
 		targetInterval: { [weak self] in
 			guard let self else {
@@ -1904,7 +1895,7 @@ final class CaptureHostView: NSView {
 		context: CGContext,
 		theme: CaptureChromeTheme,
 		strongShadow: Bool,
-		surfaceKind: GlassSurfaceKind,
+		surfaceKind: CaptureHostGlassSurfaceKind,
 		allowsLiquidGlassClearFill: Bool = true,
 		allowsClassicGlass: Bool = true
 	) {
@@ -1950,34 +1941,24 @@ final class CaptureHostView: NSView {
 		pillPath.stroke()
 	}
 
-	private func glassPatch(for surfaceKind: GlassSurfaceKind, frame: CGRect) -> CGImage? {
-		let now = ProcessInfo.processInfo.systemUptime
-		if let cached = glassPatchCache[surfaceKind],
-			now - cached.capturedAt < glassPatchCacheInterval(),
-			abs(cached.frame.minX - frame.minX) < 1,
-			abs(cached.frame.minY - frame.minY) < 1,
-			abs(cached.frame.width - frame.width) < 1,
-			abs(cached.frame.height - frame.height) < 1
-		{
-			return cached.image
-		}
-
+	private func glassPatch(
+		for surfaceKind: CaptureHostGlassSurfaceKind,
+		frame: CGRect
+	) -> CGImage? {
 		guard let globalFrame = globalRect(from: frame) else {
 			return nil
 		}
-		guard let patch = glassSourcePatch(in: globalFrame) else {
-			return nil
-		}
-		guard let image = blurredGlassPatch(from: patch, surfaceKind: surfaceKind) else {
-			return nil
-		}
-
-		glassPatchCache[surfaceKind] = CaptureHostGlassPatchCache(
+		return glassPatchResolver.patch(
+			for: surfaceKind,
 			frame: frame,
-			capturedAt: now,
-			image: image
-		)
-		return image
+			globalFrame: globalFrame,
+			now: ProcessInfo.processInfo.systemUptime,
+			cacheInterval: glassPatchCacheInterval(),
+			theme: chromeTheme(),
+			settings: settings
+		) { [weak self] globalFrame in
+			self?.glassSourcePatch(in: globalFrame)
+		}
 	}
 
 	private func glassPatchCacheInterval() -> TimeInterval {
@@ -2034,61 +2015,11 @@ final class CaptureHostView: NSView {
 		displayFrame: CGRect?,
 		image: CGImage?
 	) -> CGImage? {
-		guard
-			let displayFrame,
-			let image
-		else {
-			return nil
-		}
-		let cropRect = CGRect(
-			x: ((globalFrame.minX - displayFrame.minX) / max(displayFrame.width, 1))
-				* CGFloat(image.width),
-			y: ((displayFrame.maxY - globalFrame.maxY) / max(displayFrame.height, 1))
-				* CGFloat(image.height),
-			width: (globalFrame.width / max(displayFrame.width, 1)) * CGFloat(image.width),
-			height: (globalFrame.height / max(displayFrame.height, 1)) * CGFloat(image.height)
-		).integral.intersection(CGRect(x: 0, y: 0, width: image.width, height: image.height))
-		guard cropRect.width > 0, cropRect.height > 0 else {
-			return nil
-		}
-		return image.cropping(to: cropRect)
-	}
-
-	private func blurredGlassPatch(from image: CGImage, surfaceKind: GlassSurfaceKind) -> CGImage? {
-		let ciImage = CIImage(cgImage: image)
-		let clampedImage = ciImage.clampedToExtent()
-		guard let filter = CIFilter(name: "CIGaussianBlur") else {
-			return image
-		}
-		let blurAmount = CGFloat(settings.hudBlur.clamped(to: 0...1))
-		let blurRadius: CGFloat =
-			switch surfaceKind {
-			case .hud, .loupe, .toolbar:
-				14 + blurAmount * 32.0
-			}
-		filter.setValue(clampedImage, forKey: kCIInputImageKey)
-		filter.setValue(blurRadius, forKey: kCIInputRadiusKey)
-		guard let blurredImage = filter.outputImage?.cropped(to: ciImage.extent) else {
-			return image
-		}
-		let colorAdjustedImage: CIImage
-		if let colorControls = CIFilter(name: "CIColorControls") {
-			colorControls.setValue(blurredImage, forKey: kCIInputImageKey)
-			switch surfaceKind {
-			case .hud, .loupe, .toolbar:
-				colorControls.setValue(
-					1.18 + settings.hudTint.clamped(to: 0...1) * 0.42, forKey: kCIInputSaturationKey
-				)
-				colorControls.setValue(1.04, forKey: kCIInputContrastKey)
-				colorControls.setValue(themeBrightnessBias(), forKey: kCIInputBrightnessKey)
-			}
-			colorAdjustedImage =
-				colorControls.outputImage?.cropped(to: ciImage.extent) ?? blurredImage
-		} else {
-			colorAdjustedImage = blurredImage
-		}
-		return frozenEffectCIContext.createCGImage(
-			colorAdjustedImage, from: colorAdjustedImage.extent) ?? image
+		CaptureHostGlassPatchResolver.frozenDisplayPatch(
+			in: globalFrame,
+			displayFrame: displayFrame,
+			image: image
+		)
 	}
 
 	private func chromeTheme() -> CaptureChromeTheme {
@@ -2672,10 +2603,6 @@ final class CaptureHostView: NSView {
 
 	private func themeBrightnessBias() -> Double {
 		chromeTheme() == .dark ? 0.015 : -0.01
-	}
-
-	private func themeBrightnessBias(for theme: CaptureChromeTheme) -> Double {
-		theme == .dark ? 0.015 : -0.01
 	}
 
 	private func queuePointerEvent(_ event: CaptureHostPointerDispatchEvent) {


### PR DESCRIPTION
## Summary
- Extract capture-host classic glass patch cache lookup, frozen-display crop mapping, and CoreImage blur/tint adaptation into `CaptureHostGlassPatchResolver.swift`.
- Keep `CaptureHostView.swift` responsible for controller/window source selection, view lifecycle, and material surface placement.
- Update host-core reset and workspace layout docs for the new glass patch boundary.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` returned no matches
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`

## Review
- Inline skeptic fallback checked cache-key preservation, frozen-display crop coordinate preservation, CoreImage blur/tint parity, docs drift, and the no-physical-split invariant.