### PR TITLE
Extract frozen capture presentation renderer

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -98,14 +98,16 @@ The current native-host Swift split is:
   handoff state, completion queueing, pending-frame evidence, and deferred classic toolbar glass.
 - `CaptureHostScrollToolbarBackdropState.swift`: capture-host scroll toolbar backdrop capture
   generation, seed-patch cache, active frame, refresh cadence, and change-count state.
-- `CaptureHostView.swift`: AppKit/Quartz drawing, hit testing, live/frozen HUD and toolbar
-  orchestration, and native pointer/key event routing into the session controller.
+- `CaptureHostView.swift`: AppKit view orchestration, hit testing, and native pointer/key event
+  routing into the session controller.
 - `CaptureHostMaterialViewCoordinator.swift`: capture-host Liquid Glass/material subview ownership,
   classic glass patch resolution, and scroll-toolbar backdrop refresh/capture scheduling.
 - `CaptureHostGlassPatchResolver.swift`: capture-host classic glass patch cache lookup, frozen
   display crop extraction, and CoreImage blur/tint adaptation for HUD, loupe, and toolbar surfaces.
 - `FrozenPreparedExportStore.swift`: frozen export render requests, prepared export cache keys,
   copy/save/recognize-text job result models, and thread-safe prepared image stores.
+- `CaptureHostFrozenPresentationRenderer.swift`: frozen display surface, selection chrome, overlay,
+  minimap, size badge, and classic toolbar drawing orchestration from an explicit host context.
 - `CaptureHostFrozenSelectionChromeRenderer.swift`: frozen selection scrim, dashed border, resize
   handles, and selection-size badge rendering.
 - `CaptureHostFrozenOverlayRenderer.swift`: frozen annotation overlay rendering for mosaic,

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -203,14 +203,15 @@ The main host-kit files are split by responsibility:
   completion queueing, pending-frame evidence, and deferred classic toolbar glass
 - `CaptureHostScrollToolbarBackdropState.swift`: scroll toolbar backdrop capture generation,
   seed-patch cache, active frame, refresh cadence, and change-count state
-- `CaptureHostView.swift`: AppKit view rendering orchestration, hit testing, and native pointer/key
-  routing
+- `CaptureHostView.swift`: AppKit view orchestration, hit testing, and native pointer/key routing
 - `CaptureHostMaterialViewCoordinator.swift`: Liquid Glass/material subview ownership, classic glass
   patch resolution, and scroll-toolbar backdrop refresh/capture scheduling
 - `CaptureHostGlassPatchResolver.swift`: classic glass patch cache lookup, frozen display crop
   extraction, and CoreImage blur/tint adaptation for capture-host HUD, loupe, and toolbar surfaces
 - `FrozenPreparedExportStore.swift`: frozen export render requests, prepared export cache keys,
   copy/save/recognize-text job result models, and thread-safe prepared image stores
+- `CaptureHostFrozenPresentationRenderer.swift`: frozen display surface, selection chrome, overlay,
+  minimap, size badge, and classic toolbar drawing orchestration from an explicit host context
 - `CaptureHostFrozenSelectionChromeRenderer.swift`: frozen selection scrim, dashed border, resize
   handles, and selection-size badge rendering
 - `CaptureHostFrozenOverlayRenderer.swift`: frozen annotation overlay rendering for mosaic,

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostFrozenPresentationRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostFrozenPresentationRenderer.swift
@@ -1,0 +1,295 @@
+import AppKit
+import CoreGraphics
+
+@MainActor
+struct CaptureHostFrozenPresentationMaterialState {
+	let toolbarLiquidGlassVisible: Bool
+	let toolbarLiquidGlassContentDrawn: Bool
+	let allowsClassicToolbarGlass: Bool
+}
+
+@MainActor
+struct CaptureHostFrozenPresentationRenderer {
+	static func render(
+		selection: CGRect,
+		bounds: CGRect,
+		backingScaleFactor: CGFloat,
+		theme: CaptureChromeTheme,
+		settings: NativeHostSettings,
+		chrome: CaptureChromeState,
+		toolbarLayout: FrozenToolbarLayout?,
+		toolbarHoverState: CaptureHostToolbarHoverState,
+		materialState: CaptureHostFrozenPresentationMaterialState,
+		frozenDisplayFrame: CGRect?,
+		frozenDisplayImage: CGImage?,
+		windowFrame: CGRect?,
+		selectionSizeText: String,
+		glassPatch: (CaptureHostGlassSurfaceKind, CGRect) -> CGImage?,
+		in context: CGContext
+	) {
+		drawFrozenDisplaySurface(
+			frame: frozenDisplayFrame,
+			image: frozenDisplayImage,
+			bounds: bounds,
+			in: context
+		)
+		let toolbarScrimExclusionPath = frozenToolbarScrimExclusionPath(
+			for: selection,
+			bounds: bounds,
+			settings: settings,
+			chrome: chrome,
+			toolbarLayout: toolbarLayout,
+			materialState: materialState
+		)
+		CaptureHostFrozenSelectionChromeRenderer.drawSelectionScrim(
+			for: selection,
+			bounds: bounds,
+			in: context,
+			alpha: CaptureChrome.frozenScrimAlpha,
+			excluding: toolbarScrimExclusionPath
+		)
+		CaptureHostFrozenSelectionChromeRenderer.drawDashedSelectionBorder(
+			around: selection,
+			in: context,
+			lineWidth: CaptureChrome.frozenDashedBorderWidth,
+			pixelsPerPoint: backingScaleFactor
+		)
+		if chrome.frozenSelectionTransformAllowed {
+			CaptureHostFrozenSelectionChromeRenderer.drawFrozenResizeHandles(
+				for: selection,
+				orientation: settings.frozenResizeHandleOrientation,
+				in: context
+			)
+		}
+		drawFrozenOverlays(
+			for: selection,
+			chrome: chrome,
+			windowFrame: windowFrame,
+			bounds: bounds,
+			in: context
+		)
+		drawScrollCaptureMinimap(
+			for: selection,
+			bounds: bounds,
+			theme: theme,
+			settings: settings,
+			chrome: chrome,
+			in: context
+		)
+		CaptureHostFrozenSelectionChromeRenderer.drawSelectionSizeBadge(
+			for: selection,
+			text: selectionSizeText,
+			bounds: bounds,
+			avoiding: toolbarLayout?.frame,
+			in: context
+		)
+		drawFrozenToolbar(
+			layout: toolbarLayout,
+			theme: theme,
+			settings: settings,
+			chrome: chrome,
+			toolbarHoverState: toolbarHoverState,
+			materialState: materialState,
+			glassPatch: glassPatch,
+			in: context
+		)
+	}
+
+	static func pixelAlignedSelectionRect(_ rect: CGRect, backingScaleFactor: CGFloat) -> CGRect {
+		let scale = max(backingScaleFactor, 1)
+		let minX = floor(rect.minX * scale) / scale
+		let minY = floor(rect.minY * scale) / scale
+		let maxX = ceil(rect.maxX * scale) / scale
+		let maxY = ceil(rect.maxY * scale) / scale
+		return CGRect(
+			x: minX,
+			y: minY,
+			width: max(0, maxX - minX),
+			height: max(0, maxY - minY)
+		)
+	}
+
+	private static func drawFrozenDisplaySurface(
+		frame: CGRect?,
+		image: CGImage?,
+		bounds: CGRect,
+		in context: CGContext
+	) {
+		guard let frame, let image else {
+			return
+		}
+
+		context.saveGState()
+		context.interpolationQuality = .high
+		context.clip(to: bounds)
+		context.draw(image, in: frame)
+		context.restoreGState()
+	}
+
+	private static func drawScrollCaptureMinimap(
+		for selection: CGRect,
+		bounds: CGRect,
+		theme: CaptureChromeTheme,
+		settings: NativeHostSettings,
+		chrome: CaptureChromeState,
+		in context: CGContext
+	) {
+		guard let preview = chrome.scrollMinimapPreview else {
+			return
+		}
+		let palette = CaptureChrome.palette(for: theme, settings: settings)
+		CaptureHostScrollMinimapRenderer.render(
+			preview: preview,
+			selection: selection,
+			bounds: bounds,
+			palette: palette,
+			in: context
+		)
+	}
+
+	private static func drawFrozenOverlays(
+		for selection: CGRect,
+		chrome: CaptureChromeState,
+		windowFrame: CGRect?,
+		bounds: CGRect,
+		in context: CGContext
+	) {
+		guard let windowFrame else {
+			return
+		}
+		CaptureHostFrozenOverlayRenderer.render(
+			selection: selection,
+			chrome: chrome,
+			windowFrame: windowFrame,
+			bounds: bounds,
+			in: context
+		)
+	}
+
+	private static func frozenToolbarScrimExclusionPath(
+		for selection: CGRect,
+		bounds: CGRect,
+		settings: NativeHostSettings,
+		chrome: CaptureChromeState,
+		toolbarLayout: FrozenToolbarLayout?,
+		materialState: CaptureHostFrozenPresentationMaterialState
+	) -> CGPath? {
+		guard settings.usesLiquidHudGlass,
+			let toolbarFrame = toolbarLayout?.frame
+		else {
+			return nil
+		}
+		guard
+			chrome.scrollMinimapPreview != nil
+				|| (materialState.toolbarLiquidGlassVisible
+					&& materialState.toolbarLiquidGlassContentDrawn)
+		else {
+			return nil
+		}
+		let visibleSelection = selection.intersection(bounds)
+		if visibleSelection.isNull == false, toolbarFrame.intersects(visibleSelection) {
+			return nil
+		}
+		return CGPath(
+			roundedRect: toolbarFrame,
+			cornerWidth: CaptureChrome.hudCornerRadius,
+			cornerHeight: CaptureChrome.hudCornerRadius,
+			transform: nil
+		)
+	}
+
+	private static func drawFrozenToolbar(
+		layout: FrozenToolbarLayout?,
+		theme: CaptureChromeTheme,
+		settings: NativeHostSettings,
+		chrome: CaptureChromeState,
+		toolbarHoverState: CaptureHostToolbarHoverState,
+		materialState: CaptureHostFrozenPresentationMaterialState,
+		glassPatch: (CaptureHostGlassSurfaceKind, CGRect) -> CGImage?,
+		in context: CGContext
+	) {
+		guard
+			!settings.usesLiquidHudGlass || !materialState.toolbarLiquidGlassVisible
+				|| !materialState.toolbarLiquidGlassContentDrawn
+		else {
+			return
+		}
+		guard let layout else {
+			return
+		}
+		let palette = CaptureChrome.palette(for: theme, settings: settings)
+		drawPill(
+			in: layout.frame,
+			context: context,
+			theme: theme,
+			settings: settings,
+			strongShadow: false,
+			surfaceKind: .toolbar,
+			allowsClassicGlass: materialState.allowsClassicToolbarGlass,
+			glassPatch: glassPatch
+		)
+		FrozenToolbarDrawing.drawToolbarContent(
+			items: layout.items,
+			hoveredToolbarAction: toolbarHoverState.toolbarAction,
+			toolbarScale: layout.scale,
+			annotationStyleState: chrome.annotationStyle,
+			annotationStyleLayout: layout.annotationStyle,
+			hoveredAnnotationStyleAction: toolbarHoverState.annotationStyleAction,
+			palette: palette,
+			in: context
+		)
+	}
+
+	private static func drawPill(
+		in frame: CGRect,
+		context: CGContext,
+		theme: CaptureChromeTheme,
+		settings: NativeHostSettings,
+		strongShadow: Bool,
+		surfaceKind: CaptureHostGlassSurfaceKind,
+		allowsLiquidGlassClearFill: Bool = true,
+		allowsClassicGlass: Bool = true,
+		glassPatch: (CaptureHostGlassSurfaceKind, CGRect) -> CGImage?
+	) {
+		let palette = CaptureChrome.palette(for: theme, settings: settings)
+		let pillPath = NSBezierPath(
+			roundedRect: frame,
+			xRadius: CaptureChrome.hudCornerRadius,
+			yRadius: CaptureChrome.hudCornerRadius
+		)
+		let glassImage =
+			settings.usesClassicHudGlass && allowsClassicGlass
+			? glassPatch(surfaceKind, frame) : nil
+		let hasGlass = glassImage != nil
+		context.saveGState()
+		if strongShadow {
+			context.setShadow(offset: .zero, blur: 10, color: palette.shadow.cgColor)
+		}
+		if hasGlass,
+			let clipPath = pillPath.copy() as? NSBezierPath,
+			let glassImage
+		{
+			clipPath.addClip()
+			context.saveGState()
+			context.setAlpha(CGFloat(CaptureChrome.glassOpacity(settings: settings)))
+			context.draw(glassImage, in: frame)
+			context.restoreGState()
+		}
+		let usesLiquidGlass = allowsLiquidGlassClearFill && settings.usesLiquidHudGlass
+		let fillColor =
+			usesLiquidGlass
+			? NSColor.clear
+			: CaptureChrome.effectiveBodyFill(
+				palette: palette,
+				settings: settings,
+				hasGlass: hasGlass
+			)
+		context.setFillColor(fillColor.cgColor)
+		pillPath.fill()
+		context.restoreGState()
+
+		context.setStrokeColor(palette.outerStroke.cgColor)
+		context.setLineWidth(1)
+		pillPath.stroke()
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -664,57 +664,42 @@ final class CaptureHostView: NSView {
 				scheduleFrozenFirstFrameInstallCompletionIfNeeded()
 				return
 			}
-			if let selection = localFrozenSelectionRect().map(pixelAlignedSelectionRect) {
-				drawFrozenDisplaySurface(in: context)
-				let toolbarScrimExclusionPath = frozenToolbarScrimExclusionPath(for: selection)
-				CaptureHostFrozenSelectionChromeRenderer.drawSelectionScrim(
-					for: selection,
-					bounds: bounds,
-					in: context,
-					alpha: CaptureChrome.frozenScrimAlpha,
-					excluding: toolbarScrimExclusionPath
+			if let selection = localFrozenSelectionRect().map({
+				CaptureHostFrozenPresentationRenderer.pixelAlignedSelectionRect(
+					$0,
+					backingScaleFactor: window?.screen?.backingScaleFactor ?? 1
 				)
-				CaptureHostFrozenSelectionChromeRenderer.drawDashedSelectionBorder(
-					around: selection,
-					in: context,
-					lineWidth: CaptureChrome.frozenDashedBorderWidth,
-					pixelsPerPoint: window?.screen?.backingScaleFactor ?? 1
-				)
-				if chrome.frozenSelectionTransformAllowed {
-					CaptureHostFrozenSelectionChromeRenderer.drawFrozenResizeHandles(
-						for: selection,
-						orientation: settings.frozenResizeHandleOrientation,
-						in: context
-					)
-				}
-				drawFrozenOverlays(for: selection, in: context)
-				drawScrollCaptureMinimap(for: selection, in: context)
-				CaptureHostFrozenSelectionChromeRenderer.drawSelectionSizeBadge(
-					for: selection,
-					text: selectionSizeText(for: selection),
+			}) {
+				let toolbarLayout = toolbarLayout(for: selection)
+				CaptureHostFrozenPresentationRenderer.render(
+					selection: selection,
 					bounds: bounds,
-					avoiding: toolbarLayout(for: selection)?.frame,
+					backingScaleFactor: window?.screen?.backingScaleFactor ?? 1,
+					theme: chromeTheme(),
+					settings: settings,
+					chrome: chrome,
+					toolbarLayout: toolbarLayout,
+					toolbarHoverState: toolbarHoverState,
+					materialState: CaptureHostFrozenPresentationMaterialState(
+						toolbarLiquidGlassVisible: materialViews.isFrozenToolbarLiquidGlassVisible,
+						toolbarLiquidGlassContentDrawn: materialViews
+							.isFrozenToolbarLiquidGlassContentDrawn,
+						allowsClassicToolbarGlass: frozenFirstDisplayHandoff
+							.allowsClassicToolbarGlass
+					),
+					frozenDisplayFrame: localFrozenDisplayFrame(),
+					frozenDisplayImage: chrome.frozenDisplayImage,
+					windowFrame: window?.frame,
+					selectionSizeText: selectionSizeText(for: selection),
+					glassPatch: { [weak self] surfaceKind, frame in
+						self?.materialViews.glassPatch(for: surfaceKind, frame: frame)
+					},
 					in: context
 				)
-				drawFrozenToolbar(for: selection, in: context)
 			}
 			scheduleFrozenFirstFrameInstallCompletionIfNeeded()
 		}
 
-	}
-
-	private func pixelAlignedSelectionRect(_ rect: CGRect) -> CGRect {
-		let scale = max(window?.screen?.backingScaleFactor ?? 1, 1)
-		let minX = floor(rect.minX * scale) / scale
-		let minY = floor(rect.minY * scale) / scale
-		let maxX = ceil(rect.maxX * scale) / scale
-		let maxY = ceil(rect.maxY * scale) / scale
-		return CGRect(
-			x: minX,
-			y: minY,
-			width: max(0, maxX - minX),
-			height: max(0, maxY - minY)
-		)
 	}
 
 	private func scheduleFrozenFirstFrameInstallCompletionIfNeeded() {
@@ -724,36 +709,6 @@ final class CaptureHostView: NSView {
 		DispatchQueue.main.async { [weak self] in
 			self?.finishFrozenFirstFrameInstall()
 		}
-	}
-
-	private func drawFrozenDisplaySurface(in context: CGContext) {
-		guard scene.mode == .frozen else {
-			return
-		}
-		guard let frame = localFrozenDisplayFrame(), let image = chrome.frozenDisplayImage else {
-			return
-		}
-
-		context.saveGState()
-		context.interpolationQuality = .high
-		context.clip(to: bounds)
-		context.draw(image, in: frame)
-		context.restoreGState()
-	}
-
-	private func drawScrollCaptureMinimap(for selection: CGRect, in context: CGContext) {
-		guard let preview = chrome.scrollMinimapPreview else {
-			return
-		}
-		let theme = chromeTheme()
-		let palette = CaptureChrome.palette(for: theme, settings: settings)
-		CaptureHostScrollMinimapRenderer.render(
-			preview: preview,
-			selection: selection,
-			bounds: bounds,
-			palette: palette,
-			in: context
-		)
 	}
 
 	private func localFrozenDisplayFrame() -> CGRect? {
@@ -1149,19 +1104,6 @@ final class CaptureHostView: NSView {
 			? globalPoint : nil
 	}
 
-	private func drawFrozenOverlays(for selection: CGRect, in context: CGContext) {
-		guard let window else {
-			return
-		}
-		CaptureHostFrozenOverlayRenderer.render(
-			selection: selection,
-			chrome: chrome,
-			windowFrame: window.frame,
-			bounds: bounds,
-			in: context
-		)
-	}
-
 	func toolbarLayout(for selection: CGRect) -> FrozenToolbarLayout? {
 		FrozenToolbarLayoutPlanner.layout(
 			selection: selection,
@@ -1169,31 +1111,6 @@ final class CaptureHostView: NSView {
 			prefersTopPlacement: settings.toolbarPlacement == .top,
 			items: visibleToolbarItems(),
 			annotationStyle: chrome.annotationStyle
-		)
-	}
-
-	private func frozenToolbarScrimExclusionPath(for selection: CGRect) -> CGPath? {
-		guard settings.usesLiquidHudGlass,
-			let toolbarFrame = toolbarLayout(for: selection)?.frame
-		else {
-			return nil
-		}
-		guard
-			chrome.scrollMinimapPreview != nil
-				|| (materialViews.isFrozenToolbarLiquidGlassVisible
-					&& materialViews.isFrozenToolbarLiquidGlassContentDrawn)
-		else {
-			return nil
-		}
-		let visibleSelection = selection.intersection(bounds)
-		if visibleSelection.isNull == false, toolbarFrame.intersects(visibleSelection) {
-			return nil
-		}
-		return CGPath(
-			roundedRect: toolbarFrame,
-			cornerWidth: CaptureChrome.hudCornerRadius,
-			cornerHeight: CaptureChrome.hudCornerRadius,
-			transform: nil
 		)
 	}
 
@@ -1302,38 +1219,6 @@ final class CaptureHostView: NSView {
 			updateChromeMaterialViews()
 			needsDisplay = true
 		}
-	}
-
-	private func drawFrozenToolbar(for selection: CGRect, in context: CGContext) {
-		guard
-			!settings.usesLiquidHudGlass || !materialViews.isFrozenToolbarLiquidGlassVisible
-				|| !materialViews.isFrozenToolbarLiquidGlassContentDrawn
-		else {
-			return
-		}
-		guard let layout = toolbarLayout(for: selection) else {
-			return
-		}
-		let theme = chromeTheme()
-		let palette = CaptureChrome.palette(for: theme, settings: settings)
-		drawPill(
-			in: layout.frame,
-			context: context,
-			theme: theme,
-			strongShadow: false,
-			surfaceKind: .toolbar,
-			allowsClassicGlass: frozenFirstDisplayHandoff.allowsClassicToolbarGlass
-		)
-		FrozenToolbarDrawing.drawToolbarContent(
-			items: layout.items,
-			hoveredToolbarAction: toolbarHoverState.toolbarAction,
-			toolbarScale: layout.scale,
-			annotationStyleState: chrome.annotationStyle,
-			annotationStyleLayout: layout.annotationStyle,
-			hoveredAnnotationStyleAction: toolbarHoverState.annotationStyleAction,
-			palette: palette,
-			in: context
-		)
 	}
 
 	private func syncVisibleCursor() {
@@ -1856,64 +1741,6 @@ final class CaptureHostView: NSView {
 
 	private func pendingLiveColorHexText() -> String {
 		LiveChromePendingColorText.hexText()
-	}
-
-	private func drawPill(
-		in frame: CGRect,
-		context: CGContext,
-		theme: CaptureChromeTheme,
-		strongShadow: Bool,
-		surfaceKind: CaptureHostGlassSurfaceKind,
-		allowsLiquidGlassClearFill: Bool = true,
-		allowsClassicGlass: Bool = true
-	) {
-		let palette = CaptureChrome.palette(for: theme, settings: settings)
-		let pillPath = NSBezierPath(
-			roundedRect: frame,
-			xRadius: CaptureChrome.hudCornerRadius,
-			yRadius: CaptureChrome.hudCornerRadius
-		)
-		let glassImage =
-			settings.usesClassicHudGlass && allowsClassicGlass
-			? glassPatch(for: surfaceKind, frame: frame) : nil
-		let hasGlass = glassImage != nil
-		context.saveGState()
-		if strongShadow {
-			context.setShadow(offset: .zero, blur: 10, color: palette.shadow.cgColor)
-		}
-		if hasGlass,
-			let clipPath = pillPath.copy() as? NSBezierPath,
-			let glassImage
-		{
-			clipPath.addClip()
-			context.saveGState()
-			context.setAlpha(CGFloat(CaptureChrome.glassOpacity(settings: settings)))
-			context.draw(glassImage, in: frame)
-			context.restoreGState()
-		}
-		let usesLiquidGlass = allowsLiquidGlassClearFill && settings.usesLiquidHudGlass
-		let fillColor =
-			usesLiquidGlass
-			? NSColor.clear
-			: CaptureChrome.effectiveBodyFill(
-				palette: palette,
-				settings: settings,
-				hasGlass: hasGlass
-			)
-		context.setFillColor(fillColor.cgColor)
-		pillPath.fill()
-		context.restoreGState()
-
-		context.setStrokeColor(palette.outerStroke.cgColor)
-		context.setLineWidth(1)
-		pillPath.stroke()
-	}
-
-	private func glassPatch(
-		for surfaceKind: CaptureHostGlassSurfaceKind,
-		frame: CGRect
-	) -> CGImage? {
-		materialViews.glassPatch(for: surfaceKind, frame: frame)
 	}
 
 	func chromeTheme() -> CaptureChromeTheme {


### PR DESCRIPTION
## Summary
- Extract frozen display surface, selection chrome, overlay, minimap, size badge, and classic toolbar drawing into `CaptureHostFrozenPresentationRenderer`
- Keep `CaptureHostView` responsible for draw scheduling, host context collection, hit testing, and input routing
- Update host-core and workspace-layout references for the new presentation ownership boundary

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\\[path" packages apps native scripts` (no matches)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`
