### PR TITLE
Extract frozen selection image renderer

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -108,6 +108,9 @@ The current native-host Swift split is:
   display crop extraction, and CoreImage blur/tint adaptation for HUD, loupe, and toolbar surfaces.
 - `FrozenPreparedExportStore.swift`: frozen export render requests, prepared export cache keys,
   copy/save/recognize-text job result models, and thread-safe prepared image stores.
+- `FrozenSelectionImageRenderer.swift`: frozen selection render jobs, capture-frame effect
+  application, overlay composition, display cropping, and PNG encoding for copy/save/OCR
+  preparation.
 - `CaptureHostFrozenPresentationRenderer.swift`: frozen display surface, selection chrome, overlay,
   minimap, size badge, and classic toolbar drawing orchestration from an explicit host context.
 - `CaptureHostFrozenSelectionChromeRenderer.swift`: frozen selection scrim, dashed border, resize

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -178,8 +178,8 @@ The main host-kit files are split by responsibility:
   forwarding, viewport sampling, and scroll minimap preview refresh
 - `NativeScrollCaptureObservationPipeline.swift`: conversion of ordered native samples and
   fallback frames into Rust scroll observations plus preview export batches
-- `CaptureSessionController+Export.swift`: copy/save host effects, output naming, capture-image
-  export, capture-frame effect application, and Rust-backed PNG encoding
+- `CaptureSessionController+Export.swift`: copy/save host effects, output naming, prepared export
+  scheduling, and capture-image export orchestration
 - `CaptureSessionController+TextRecognition.swift`: Vision OCR request execution and recognized
   text pasteboard publication
 - `CaptureSessionController+Runtime.swift`: shared monitor/window lookup, overlay refresh,
@@ -212,6 +212,9 @@ The main host-kit files are split by responsibility:
   extraction, and CoreImage blur/tint adaptation for capture-host HUD, loupe, and toolbar surfaces
 - `FrozenPreparedExportStore.swift`: frozen export render requests, prepared export cache keys,
   copy/save/recognize-text job result models, and thread-safe prepared image stores
+- `FrozenSelectionImageRenderer.swift`: frozen selection render jobs, capture-frame effect
+  application, overlay composition, display cropping, and PNG encoding for copy/save/OCR
+  preparation
 - `CaptureHostFrozenPresentationRenderer.swift`: frozen display surface, selection chrome, overlay,
   minimap, size badge, and classic toolbar drawing orchestration from an explicit host context
 - `CaptureHostFrozenSelectionChromeRenderer.swift`: frozen selection scrim, dashed border, resize

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Export.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+Export.swift
@@ -1,6 +1,5 @@
 import AppKit
 import CoreGraphics
-import Darwin
 import Foundation
 import RsnapHostBridge
 
@@ -42,7 +41,7 @@ extension CaptureSessionController {
 		frozenImageRenderQueue.async { [weak self] in
 			let result =
 				preparedExportStore.result(matching: request)
-				?? Self.renderCopyCaptureJob(request: request)
+				?? FrozenSelectionImageRenderer.renderCopyCaptureJob(request: request)
 			DispatchQueue.main.async {
 				self?.finishCopyCaptureJob(
 					result,
@@ -71,7 +70,7 @@ extension CaptureSessionController {
 
 		let preparedExportStore = frozenPreparedExportStore
 		frozenImageRenderQueue.async { [weak self] in
-			let result = Self.renderSaveCaptureJob(
+			let result = FrozenSelectionImageRenderer.renderSaveCaptureJob(
 				request: request,
 				outputURL: outputURL,
 				preparedExportStore: preparedExportStore
@@ -259,7 +258,8 @@ extension CaptureSessionController {
 					return
 				}
 				let startedAt = ProcessInfo.processInfo.systemUptime
-				let result = Self.renderPreparedRecognizeTextImageJob(request: request)
+				let result = FrozenSelectionImageRenderer.renderPreparedRecognizeTextImageJob(
+					request: request)
 				preparedImageStore.finishPreparing(
 					for: request,
 					generation: preparationGeneration,
@@ -294,7 +294,8 @@ extension CaptureSessionController {
 			)
 		}
 
-		let result = Self.renderPreparedRecognizeTextImageJob(request: request)
+		let result = FrozenSelectionImageRenderer.renderPreparedRecognizeTextImageJob(
+			request: request)
 		if let baseImage = result.baseImage,
 			chromeState.frozenSelectionSnapshot == request.selection,
 			chromeState.frozenBaseImage == nil
@@ -331,7 +332,7 @@ extension CaptureSessionController {
 				return
 			}
 			let startedAt = ProcessInfo.processInfo.systemUptime
-			let result = Self.renderCopyCaptureJob(request: request)
+			let result = FrozenSelectionImageRenderer.renderCopyCaptureJob(request: request)
 			preparedExportStore.finishPreparing(
 				for: request,
 				generation: preparationGeneration,
@@ -346,252 +347,6 @@ extension CaptureSessionController {
 				reason: reason,
 				width: result.width,
 				height: result.height
-			)
-		}
-	}
-
-	nonisolated private static func renderPreparedRecognizeTextImageJob(
-		request: FrozenSelectionImageRenderRequest
-	) -> PreparedRecognizeTextImageJobResult {
-		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
-		let renderResult: FrozenSelectionImageRenderResult
-		do {
-			renderResult = try renderFrozenSelectionImage(
-				from: request,
-				applyingCaptureFrameEffect: false,
-				prefersPixelSnapshot: false
-			)
-		} catch {
-			return PreparedRecognizeTextImageJobResult(
-				image: nil,
-				baseImage: nil,
-				captureImageMilliseconds: NativeHostTelemetry.milliseconds(
-					since: captureImageStartedAt),
-				width: 0,
-				height: 0
-			)
-		}
-
-		let captureImageMilliseconds =
-			NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
-		let image =
-			renderResult.image
-			?? renderResult.rgbaSnapshot.flatMap { NativeHostImageBridge.cgImage(from: $0) }
-		return PreparedRecognizeTextImageJobResult(
-			image: image,
-			baseImage: renderResult.baseImage,
-			captureImageMilliseconds: captureImageMilliseconds,
-			width: renderResult.width,
-			height: renderResult.height
-		)
-	}
-
-	nonisolated private static func renderCopyCaptureJob(
-		request: FrozenSelectionImageRenderRequest
-	) -> CopyCaptureJobResult {
-		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
-		let renderResult: FrozenSelectionImageRenderResult
-		do {
-			renderResult = try renderFrozenSelectionImage(
-				from: request,
-				applyingCaptureFrameEffect: true,
-				prefersPixelSnapshot: true
-			)
-		} catch {
-			let captureImageMilliseconds =
-				NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
-			return CopyCaptureJobResult(
-				pngData: nil,
-				failureStage: "capture_image",
-				failureMessage: "Could not capture the frozen selection.",
-				captureImageMilliseconds: captureImageMilliseconds,
-				makeImageMilliseconds: 0,
-				width: 0,
-				height: 0,
-				cacheHit: false
-			)
-		}
-		let captureImageMilliseconds =
-			NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
-		guard renderResult.rgbaSnapshot != nil || renderResult.image != nil else {
-			return CopyCaptureJobResult(
-				pngData: nil,
-				failureStage: renderResult.failureStage ?? "capture_image",
-				failureMessage: "Could not capture the frozen selection.",
-				captureImageMilliseconds: captureImageMilliseconds,
-				makeImageMilliseconds: 0,
-				width: renderResult.width,
-				height: renderResult.height,
-				cacheHit: false
-			)
-		}
-
-		let makeImageStartedAt = ProcessInfo.processInfo.systemUptime
-		let pngData: Data?
-		let screenScaleFactor = request.captureFrameEnvironment.screenScaleFactor
-		if let snapshot = renderResult.rgbaSnapshot {
-			pngData = try? RsnapExportEncoder.pngData(
-				from: snapshot,
-				screenScaleFactor: screenScaleFactor
-			)
-		} else if let cgImage = renderResult.image {
-			pngData = try? losslessPNGData(
-				from: cgImage,
-				screenScaleFactor: screenScaleFactor
-			)
-		} else {
-			pngData = nil
-		}
-		let makeImageMilliseconds = NativeHostTelemetry.milliseconds(since: makeImageStartedAt)
-		let width = renderResult.rgbaSnapshot?.width ?? renderResult.image?.width ?? 0
-		let height = renderResult.rgbaSnapshot?.height ?? renderResult.image?.height ?? 0
-		guard let pngData else {
-			return CopyCaptureJobResult(
-				pngData: nil,
-				failureStage: "encode_image",
-				failureMessage: "Could not encode the captured image.",
-				captureImageMilliseconds: captureImageMilliseconds,
-				makeImageMilliseconds: makeImageMilliseconds,
-				width: width,
-				height: height,
-				cacheHit: false
-			)
-		}
-		return CopyCaptureJobResult(
-			pngData: pngData,
-			failureStage: "none",
-			failureMessage: "",
-			captureImageMilliseconds: captureImageMilliseconds,
-			makeImageMilliseconds: makeImageMilliseconds,
-			width: width,
-			height: height,
-			cacheHit: false
-		)
-	}
-
-	nonisolated private static func renderSaveCaptureJob(
-		request: FrozenSelectionImageRenderRequest,
-		outputURL: URL,
-		preparedExportStore: FrozenPreparedExportStore
-	) -> SaveCaptureJobResult {
-		if let preparedResult = preparedExportStore.result(matching: request),
-			let pngData = preparedResult.pngData
-		{
-			let writeStartedAt = ProcessInfo.processInfo.systemUptime
-			do {
-				try pngData.write(to: outputURL, options: .atomic)
-				return SaveCaptureJobResult(
-					outputURL: outputURL,
-					failureMessage: "",
-					failureStage: "none",
-					captureImageMilliseconds: 0,
-					makeImageMilliseconds: 0,
-					writeFileMilliseconds: NativeHostTelemetry.milliseconds(
-						since: writeStartedAt),
-					width: preparedResult.width,
-					height: preparedResult.height,
-					cacheHit: true
-				)
-			} catch {
-				return SaveCaptureJobResult(
-					outputURL: nil,
-					failureMessage: "Could not save the capture.",
-					failureStage: "file_write",
-					captureImageMilliseconds: 0,
-					makeImageMilliseconds: 0,
-					writeFileMilliseconds: NativeHostTelemetry.milliseconds(
-						since: writeStartedAt),
-					width: preparedResult.width,
-					height: preparedResult.height,
-					cacheHit: true
-				)
-			}
-		}
-		return renderSaveCaptureJob(request: request, outputURL: outputURL)
-	}
-
-	nonisolated private static func renderSaveCaptureJob(
-		request: FrozenSelectionImageRenderRequest,
-		outputURL: URL
-	) -> SaveCaptureJobResult {
-		do {
-			let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
-			let renderResult = try renderFrozenSelectionImage(
-				from: request,
-				applyingCaptureFrameEffect: true,
-				prefersPixelSnapshot: true
-			)
-			let captureImageMilliseconds =
-				NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
-			guard renderResult.rgbaSnapshot != nil || renderResult.image != nil else {
-				return SaveCaptureJobResult(
-					outputURL: nil,
-					failureMessage: "Could not capture the frozen selection.",
-					failureStage: renderResult.failureStage ?? "capture_image",
-					captureImageMilliseconds: captureImageMilliseconds,
-					makeImageMilliseconds: 0,
-					writeFileMilliseconds: 0,
-					width: renderResult.width,
-					height: renderResult.height,
-					cacheHit: false
-				)
-			}
-			let makeImageStartedAt = ProcessInfo.processInfo.systemUptime
-			let pngData: Data?
-			let screenScaleFactor = request.captureFrameEnvironment.screenScaleFactor
-			if let snapshot = renderResult.rgbaSnapshot {
-				pngData = try RsnapExportEncoder.pngData(
-					from: snapshot,
-					screenScaleFactor: screenScaleFactor
-				)
-			} else if let cgImage = renderResult.image {
-				pngData = try losslessPNGData(
-					from: cgImage,
-					screenScaleFactor: screenScaleFactor
-				)
-			} else {
-				pngData = nil
-			}
-			let makeImageMilliseconds = NativeHostTelemetry.milliseconds(since: makeImageStartedAt)
-			let width = renderResult.rgbaSnapshot?.width ?? renderResult.image?.width ?? 0
-			let height = renderResult.rgbaSnapshot?.height ?? renderResult.image?.height ?? 0
-			guard let pngData else {
-				return SaveCaptureJobResult(
-					outputURL: nil,
-					failureMessage: "Could not encode the captured image.",
-					failureStage: "encode_image",
-					captureImageMilliseconds: captureImageMilliseconds,
-					makeImageMilliseconds: makeImageMilliseconds,
-					writeFileMilliseconds: 0,
-					width: width,
-					height: height,
-					cacheHit: false
-				)
-			}
-			let writeStartedAt = ProcessInfo.processInfo.systemUptime
-			try pngData.write(to: outputURL, options: .atomic)
-			return SaveCaptureJobResult(
-				outputURL: outputURL,
-				failureMessage: "",
-				failureStage: "none",
-				captureImageMilliseconds: captureImageMilliseconds,
-				makeImageMilliseconds: makeImageMilliseconds,
-				writeFileMilliseconds: NativeHostTelemetry.milliseconds(since: writeStartedAt),
-				width: width,
-				height: height,
-				cacheHit: false
-			)
-		} catch {
-			return SaveCaptureJobResult(
-				outputURL: nil,
-				failureMessage: "Could not save the capture.",
-				failureStage: "file_write",
-				captureImageMilliseconds: 0,
-				makeImageMilliseconds: 0,
-				writeFileMilliseconds: 0,
-				width: 0,
-				height: 0,
-				cacheHit: false
 			)
 		}
 	}
@@ -771,7 +526,7 @@ extension CaptureSessionController {
 			)
 			return nil
 		}
-		let result = try Self.renderFrozenSelectionImage(
+		let result = try FrozenSelectionImageRenderer.renderFrozenSelectionImage(
 			from: request,
 			applyingCaptureFrameEffect: applyingCaptureFrameEffect,
 			prefersPixelSnapshot: false
@@ -783,352 +538,6 @@ extension CaptureSessionController {
 			chromeState.frozenBaseImage = baseImage
 		}
 		return result.image
-	}
-
-	nonisolated private static func renderFrozenSelectionImage(
-		from request: FrozenSelectionImageRenderRequest,
-		applyingCaptureFrameEffect: Bool,
-		prefersPixelSnapshot: Bool = false
-	) throws -> FrozenSelectionImageRenderResult {
-		let captureStartedAt = ProcessInfo.processInfo.systemUptime
-		if let scrollExport = request.scrollExportSnapshot {
-			return renderScrollExportImage(
-				scrollExport,
-				request: request,
-				captureStartedAt: captureStartedAt,
-				applyingCaptureFrameEffect: applyingCaptureFrameEffect,
-				prefersPixelSnapshot: prefersPixelSnapshot
-			)
-		}
-		return try renderDisplayFrozenSelectionImage(
-			from: request,
-			captureStartedAt: captureStartedAt,
-			applyingCaptureFrameEffect: applyingCaptureFrameEffect,
-			prefersPixelSnapshot: prefersPixelSnapshot
-		)
-	}
-
-	nonisolated private static func renderScrollExportImage(
-		_ scrollExport: RGBARegionSnapshot,
-		request: FrozenSelectionImageRenderRequest,
-		captureStartedAt: TimeInterval,
-		applyingCaptureFrameEffect: Bool,
-		prefersPixelSnapshot: Bool
-	) -> FrozenSelectionImageRenderResult {
-		let base = FrozenRenderedImage(image: nil, rgbaSnapshot: scrollExport)
-		let result =
-			applyingCaptureFrameEffect
-			? applyCaptureFrameEffectIfNeeded(
-				to: base,
-				request: request,
-				hasOverlayEdits: false,
-				prefersPixelSnapshot: prefersPixelSnapshot
-			)
-			: resolvedRenderedImage(base, prefersPixelSnapshot: prefersPixelSnapshot)
-		logFrozenSelectionImageTiming(
-			request: request,
-			captureStartedAt: captureStartedAt,
-			ensureMilliseconds: 0,
-			refreshMilliseconds: 0,
-			compositeMilliseconds: 0,
-			source: "scroll_capture_export",
-			success: true,
-			width: result.width,
-			height: result.height,
-			hasOverlayEdits: false
-		)
-		return FrozenSelectionImageRenderResult(
-			image: result.image,
-			rgbaSnapshot: result.rgbaSnapshot,
-			baseImage: nil,
-			failureStage: nil,
-			ensureMilliseconds: 0,
-			refreshMilliseconds: 0,
-			compositeMilliseconds: 0,
-			source: "scroll_capture_export",
-			hasOverlayEdits: false,
-			width: result.width,
-			height: result.height
-		)
-	}
-
-	nonisolated private static func renderDisplayFrozenSelectionImage(
-		from request: FrozenSelectionImageRenderRequest,
-		captureStartedAt: TimeInterval,
-		applyingCaptureFrameEffect: Bool,
-		prefersPixelSnapshot: Bool
-	) throws -> FrozenSelectionImageRenderResult {
-		let snapshotMatchedBefore = request.frozenSelectionSnapshot == request.selection
-		let hadBaseImageBefore = request.frozenBaseImage != nil
-		let hadFrozenDisplayImageBefore = request.frozenDisplayImage != nil
-		let ensureStartedAt = ProcessInfo.processInfo.systemUptime
-		let baseImage =
-			snapshotMatchedBefore
-			? request.frozenBaseImage
-				?? frozenBaseImageFromDisplay(
-					displayFrame: request.frozenDisplayFrame,
-					displayImage: request.frozenDisplayImage,
-					selection: request.selection
-				)
-			: frozenBaseImageFromDisplay(
-				displayFrame: request.frozenDisplayFrame,
-				displayImage: request.frozenDisplayImage,
-				selection: request.selection
-			)
-		let ensureMilliseconds = NativeHostTelemetry.milliseconds(since: ensureStartedAt)
-		guard let baseImage else {
-			logFrozenSelectionImageTiming(
-				request: request,
-				captureStartedAt: captureStartedAt,
-				ensureMilliseconds: ensureMilliseconds,
-				refreshMilliseconds: 0,
-				compositeMilliseconds: 0,
-				source: "missing_base",
-				success: false,
-				width: 0,
-				height: 0,
-				hasOverlayEdits: request.hasOverlayEdits
-			)
-			return FrozenSelectionImageRenderResult(
-				image: nil,
-				rgbaSnapshot: nil,
-				baseImage: nil,
-				failureStage: "capture_image",
-				ensureMilliseconds: ensureMilliseconds,
-				refreshMilliseconds: 0,
-				compositeMilliseconds: 0,
-				source: "missing_base",
-				hasOverlayEdits: request.hasOverlayEdits,
-				width: 0,
-				height: 0
-			)
-		}
-
-		let compositeStartedAt = ProcessInfo.processInfo.systemUptime
-		let composited = try compositeFrozenOverlay(
-			on: baseImage,
-			selection: request.selection,
-			elements: request.overlayElements,
-			prefersPixelSnapshot: prefersPixelSnapshot || applyingCaptureFrameEffect
-		)
-		let result =
-			applyingCaptureFrameEffect
-			? applyCaptureFrameEffectIfNeeded(
-				to: composited,
-				request: request,
-				hasOverlayEdits: request.hasOverlayEdits,
-				prefersPixelSnapshot: prefersPixelSnapshot
-			)
-			: composited
-		let compositeMilliseconds = NativeHostTelemetry.milliseconds(since: compositeStartedAt)
-		let imageSource: String
-		if snapshotMatchedBefore, hadBaseImageBefore {
-			imageSource = "cached_base"
-		} else if hadFrozenDisplayImageBefore {
-			imageSource = "frozen_display_crop"
-		} else {
-			imageSource = "unknown_base"
-		}
-		logFrozenSelectionImageTiming(
-			request: request,
-			captureStartedAt: captureStartedAt,
-			ensureMilliseconds: ensureMilliseconds,
-			refreshMilliseconds: 0,
-			compositeMilliseconds: compositeMilliseconds,
-			source: imageSource,
-			success: true,
-			width: result.width,
-			height: result.height,
-			hasOverlayEdits: request.hasOverlayEdits
-		)
-		return FrozenSelectionImageRenderResult(
-			image: result.image,
-			rgbaSnapshot: result.rgbaSnapshot,
-			baseImage: baseImage,
-			failureStage: nil,
-			ensureMilliseconds: ensureMilliseconds,
-			refreshMilliseconds: 0,
-			compositeMilliseconds: compositeMilliseconds,
-			source: imageSource,
-			hasOverlayEdits: request.hasOverlayEdits,
-			width: result.width,
-			height: result.height
-		)
-	}
-
-	nonisolated private static func frozenBaseImageFromDisplay(
-		displayFrame: CGRect?,
-		displayImage: CGImage?,
-		selection: CGRect
-	) -> CGImage? {
-		guard let displayFrame, let displayImage else {
-			return nil
-		}
-		return cropFrozenDisplayImage(
-			displayImage,
-			displayFrame: displayFrame,
-			selection: selection
-		)
-	}
-
-	nonisolated private static func logFrozenSelectionImageTiming(
-		request: FrozenSelectionImageRenderRequest,
-		captureStartedAt: TimeInterval,
-		ensureMilliseconds: Double,
-		refreshMilliseconds: Double,
-		compositeMilliseconds: Double,
-		source: String,
-		success: Bool,
-		width: Int,
-		height: Int,
-		hasOverlayEdits: Bool
-	) {
-		NativeHostTelemetry.frozenSelectionImageTiming(
-			captureID: request.captureID,
-			totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
-			ensureMilliseconds: ensureMilliseconds,
-			refreshMilliseconds: refreshMilliseconds,
-			compositeMilliseconds: compositeMilliseconds,
-			source: source,
-			success: success,
-			width: width,
-			height: height,
-			hasOverlayEdits: hasOverlayEdits
-		)
-	}
-
-	nonisolated private static func applyCaptureFrameEffectIfNeeded(
-		to image: CGImage,
-		request: FrozenSelectionImageRenderRequest,
-		hasOverlayEdits: Bool,
-		prefersPixelSnapshot: Bool
-	) -> FrozenRenderedImage {
-		applyCaptureFrameEffectIfNeeded(
-			to: FrozenRenderedImage(image: image, rgbaSnapshot: nil),
-			request: request,
-			hasOverlayEdits: hasOverlayEdits,
-			prefersPixelSnapshot: prefersPixelSnapshot
-		)
-	}
-
-	nonisolated private static func applyCaptureFrameEffectIfNeeded(
-		to image: FrozenRenderedImage,
-		request: FrozenSelectionImageRenderRequest,
-		hasOverlayEdits: Bool,
-		prefersPixelSnapshot: Bool
-	) -> FrozenRenderedImage {
-		guard request.captureFrameEffectEnabled,
-			request.captureFrameApplicability.includes(request.captureFrameSource)
-		else {
-			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
-		}
-		if hasOverlayEdits == false,
-			request.captureFrameSource == .window,
-			let windowID = request.captureFrameWindowID,
-			let windowImage = captureFrameWindowImage(windowID: windowID)
-		{
-			guard
-				let snapshot = CaptureFrameEffectRenderer.renderWindowSnapshotSnapshot(
-					image: windowImage,
-					background: request.captureFrameBackground,
-					environment: request.captureFrameEnvironment
-				)
-			else {
-				return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
-			}
-
-			let renderedImage =
-				prefersPixelSnapshot
-				? nil
-				: NativeHostImageBridge.cgImage(from: snapshot, shouldInterpolate: true)
-			if prefersPixelSnapshot == false, renderedImage == nil {
-				return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
-			}
-			return FrozenRenderedImage(
-				image: renderedImage,
-				rgbaSnapshot: snapshot
-			)
-		}
-		let renderedSnapshot: RGBARegionSnapshot?
-		if let sourceSnapshot = image.rgbaSnapshot {
-			renderedSnapshot = CaptureFrameEffectRenderer.renderSnapshot(
-				source: sourceSnapshot,
-				background: request.captureFrameBackground,
-				sourceKind: request.captureFrameSource,
-				environment: request.captureFrameEnvironment
-			)
-		} else if let sourceImage = image.image {
-			renderedSnapshot = CaptureFrameEffectRenderer.renderSnapshot(
-				image: sourceImage,
-				background: request.captureFrameBackground,
-				source: request.captureFrameSource,
-				environment: request.captureFrameEnvironment
-			)
-		} else {
-			renderedSnapshot = nil
-		}
-		guard let renderedSnapshot else {
-			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
-		}
-
-		let renderedImage =
-			prefersPixelSnapshot
-			? nil
-			: NativeHostImageBridge.cgImage(from: renderedSnapshot, shouldInterpolate: true)
-		if prefersPixelSnapshot == false, renderedImage == nil {
-			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
-		}
-		return FrozenRenderedImage(
-			image: renderedImage,
-			rgbaSnapshot: renderedSnapshot
-		)
-	}
-
-	nonisolated private static func resolvedRenderedImage(
-		_ image: FrozenRenderedImage,
-		prefersPixelSnapshot: Bool
-	) -> FrozenRenderedImage {
-		if prefersPixelSnapshot || image.image != nil {
-			return image
-		}
-		guard let snapshot = image.rgbaSnapshot else {
-			return image
-		}
-		return FrozenRenderedImage(
-			image: NativeHostImageBridge.cgImage(from: snapshot),
-			rgbaSnapshot: snapshot
-		)
-	}
-
-	nonisolated private static func compositeFrozenOverlay(
-		on image: CGImage,
-		selection: CGRect,
-		elements: [FrozenOverlayExportElement],
-		prefersPixelSnapshot: Bool
-	) throws -> FrozenRenderedImage {
-		guard elements.isEmpty == false else {
-			return FrozenRenderedImage(image: image, rgbaSnapshot: nil)
-		}
-
-		guard
-			let snapshot = NativeHostImageBridge.rgbaSnapshot(from: image),
-			let renderedSnapshot = try? RsnapExportEncoder.frozenOverlayExportImage(
-				from: snapshot,
-				selection: selection,
-				elements: elements
-			)
-		else {
-			throw HostBridgeError.ffiStatus(
-				context: "converting frozen overlay export image",
-				code: 4)
-		}
-
-		return FrozenRenderedImage(
-			image: prefersPixelSnapshot
-				? nil
-				: NativeHostImageBridge.cgImage(from: renderedSnapshot),
-			rgbaSnapshot: renderedSnapshot
-		)
 	}
 
 	func applyCaptureFrameEffectIfNeeded(
@@ -1164,45 +573,12 @@ extension CaptureSessionController {
 		guard let windowID = chromeState.captureFrameWindowID else {
 			return nil
 		}
-		return Self.captureFrameWindowImage(windowID: windowID)
+		return FrozenSelectionImageRenderer.captureFrameWindowImage(windowID: windowID)
 	}
 
 	nonisolated static func captureFrameWindowImage(windowID: CGWindowID) -> CGImage? {
-		guard let createImage = Self.captureFrameWindowListCreateImage else {
-			return nil
-		}
-		return createImage(
-			CGRect.null,
-			CGWindowListOption.optionIncludingWindow.rawValue,
-			windowID,
-			CGWindowImageOption.bestResolution.rawValue
-		)?
-		.takeRetainedValue()
+		FrozenSelectionImageRenderer.captureFrameWindowImage(windowID: windowID)
 	}
-
-	typealias CaptureFrameWindowListCreateImage =
-		@convention(c) (
-			CGRect,
-			UInt32,
-			CGWindowID,
-			UInt32
-		) -> Unmanaged<CGImage>?
-
-	nonisolated static let captureFrameWindowListCreateImage: CaptureFrameWindowListCreateImage? = {
-		guard
-			let coreGraphics = dlopen(
-				"/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
-				RTLD_LAZY
-			)
-		else {
-			return nil
-		}
-		guard let symbol = dlsym(coreGraphics, "CGWindowListCreateImage") else {
-			dlclose(coreGraphics)
-			return nil
-		}
-		return unsafeBitCast(symbol, to: CaptureFrameWindowListCreateImage.self)
-	}()
 
 	@discardableResult
 	func refreshFrozenBaseImageFromDisplay(for selection: CGRect) -> Bool {
@@ -1228,7 +604,7 @@ extension CaptureSessionController {
 		else {
 			return nil
 		}
-		return Self.cropFrozenDisplayImage(
+		return FrozenSelectionImageRenderer.cropFrozenDisplayImage(
 			displayImage,
 			displayFrame: displayFrame,
 			selection: selection
@@ -1240,29 +616,19 @@ extension CaptureSessionController {
 		displayFrame: CGRect,
 		selection: CGRect
 	) -> CGImage? {
-		guard
-			let cropRect = try? RsnapExportEncoder.frozenDisplayCropRect(
-				imageWidth: image.width,
-				imageHeight: image.height,
-				displayFrame: displayFrame,
-				selection: selection
-			)
-		else {
-			return nil
-		}
-		return image.cropping(to: cropRect)
+		FrozenSelectionImageRenderer.cropFrozenDisplayImage(
+			image,
+			displayFrame: displayFrame,
+			selection: selection
+		)
 	}
 
 	nonisolated static func losslessPNGData(
 		from image: CGImage,
 		screenScaleFactor: CGFloat
 	) throws -> Data? {
-		guard let snapshot = NativeHostImageBridge.rgbaSnapshot(from: image) else {
-			return nil
-		}
-
-		return try RsnapExportEncoder.pngData(
-			from: snapshot,
+		try FrozenSelectionImageRenderer.losslessPNGData(
+			from: image,
 			screenScaleFactor: screenScaleFactor
 		)
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenSelectionImageRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenSelectionImageRenderer.swift
@@ -1,0 +1,668 @@
+import AppKit
+import CoreGraphics
+import Darwin
+import Foundation
+import RsnapHostBridge
+
+enum FrozenSelectionImageRenderer {
+	static func renderPreparedRecognizeTextImageJob(
+		request: FrozenSelectionImageRenderRequest
+	) -> PreparedRecognizeTextImageJobResult {
+		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
+		let renderResult: FrozenSelectionImageRenderResult
+		do {
+			renderResult = try renderFrozenSelectionImage(
+				from: request,
+				applyingCaptureFrameEffect: false,
+				prefersPixelSnapshot: false
+			)
+		} catch {
+			return PreparedRecognizeTextImageJobResult(
+				image: nil,
+				baseImage: nil,
+				captureImageMilliseconds: NativeHostTelemetry.milliseconds(
+					since: captureImageStartedAt),
+				width: 0,
+				height: 0
+			)
+		}
+
+		let captureImageMilliseconds =
+			NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
+		let image =
+			renderResult.image
+			?? renderResult.rgbaSnapshot.flatMap { NativeHostImageBridge.cgImage(from: $0) }
+		return PreparedRecognizeTextImageJobResult(
+			image: image,
+			baseImage: renderResult.baseImage,
+			captureImageMilliseconds: captureImageMilliseconds,
+			width: renderResult.width,
+			height: renderResult.height
+		)
+	}
+
+	static func renderCopyCaptureJob(
+		request: FrozenSelectionImageRenderRequest
+	) -> CopyCaptureJobResult {
+		let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
+		let renderResult: FrozenSelectionImageRenderResult
+		do {
+			renderResult = try renderFrozenSelectionImage(
+				from: request,
+				applyingCaptureFrameEffect: true,
+				prefersPixelSnapshot: true
+			)
+		} catch {
+			let captureImageMilliseconds =
+				NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
+			return CopyCaptureJobResult(
+				pngData: nil,
+				failureStage: "capture_image",
+				failureMessage: "Could not capture the frozen selection.",
+				captureImageMilliseconds: captureImageMilliseconds,
+				makeImageMilliseconds: 0,
+				width: 0,
+				height: 0,
+				cacheHit: false
+			)
+		}
+		let captureImageMilliseconds =
+			NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
+		guard renderResult.rgbaSnapshot != nil || renderResult.image != nil else {
+			return CopyCaptureJobResult(
+				pngData: nil,
+				failureStage: renderResult.failureStage ?? "capture_image",
+				failureMessage: "Could not capture the frozen selection.",
+				captureImageMilliseconds: captureImageMilliseconds,
+				makeImageMilliseconds: 0,
+				width: renderResult.width,
+				height: renderResult.height,
+				cacheHit: false
+			)
+		}
+
+		let makeImageStartedAt = ProcessInfo.processInfo.systemUptime
+		let pngData: Data?
+		let screenScaleFactor = request.captureFrameEnvironment.screenScaleFactor
+		if let snapshot = renderResult.rgbaSnapshot {
+			pngData = try? RsnapExportEncoder.pngData(
+				from: snapshot,
+				screenScaleFactor: screenScaleFactor
+			)
+		} else if let cgImage = renderResult.image {
+			pngData = try? losslessPNGData(
+				from: cgImage,
+				screenScaleFactor: screenScaleFactor
+			)
+		} else {
+			pngData = nil
+		}
+		let makeImageMilliseconds = NativeHostTelemetry.milliseconds(since: makeImageStartedAt)
+		let width = renderResult.rgbaSnapshot?.width ?? renderResult.image?.width ?? 0
+		let height = renderResult.rgbaSnapshot?.height ?? renderResult.image?.height ?? 0
+		guard let pngData else {
+			return CopyCaptureJobResult(
+				pngData: nil,
+				failureStage: "encode_image",
+				failureMessage: "Could not encode the captured image.",
+				captureImageMilliseconds: captureImageMilliseconds,
+				makeImageMilliseconds: makeImageMilliseconds,
+				width: width,
+				height: height,
+				cacheHit: false
+			)
+		}
+		return CopyCaptureJobResult(
+			pngData: pngData,
+			failureStage: "none",
+			failureMessage: "",
+			captureImageMilliseconds: captureImageMilliseconds,
+			makeImageMilliseconds: makeImageMilliseconds,
+			width: width,
+			height: height,
+			cacheHit: false
+		)
+	}
+
+	static func renderSaveCaptureJob(
+		request: FrozenSelectionImageRenderRequest,
+		outputURL: URL,
+		preparedExportStore: FrozenPreparedExportStore
+	) -> SaveCaptureJobResult {
+		if let preparedResult = preparedExportStore.result(matching: request),
+			let pngData = preparedResult.pngData
+		{
+			let writeStartedAt = ProcessInfo.processInfo.systemUptime
+			do {
+				try pngData.write(to: outputURL, options: .atomic)
+				return SaveCaptureJobResult(
+					outputURL: outputURL,
+					failureMessage: "",
+					failureStage: "none",
+					captureImageMilliseconds: 0,
+					makeImageMilliseconds: 0,
+					writeFileMilliseconds: NativeHostTelemetry.milliseconds(
+						since: writeStartedAt),
+					width: preparedResult.width,
+					height: preparedResult.height,
+					cacheHit: true
+				)
+			} catch {
+				return SaveCaptureJobResult(
+					outputURL: nil,
+					failureMessage: "Could not save the capture.",
+					failureStage: "file_write",
+					captureImageMilliseconds: 0,
+					makeImageMilliseconds: 0,
+					writeFileMilliseconds: NativeHostTelemetry.milliseconds(
+						since: writeStartedAt),
+					width: preparedResult.width,
+					height: preparedResult.height,
+					cacheHit: true
+				)
+			}
+		}
+		return renderSaveCaptureJob(request: request, outputURL: outputURL)
+	}
+
+	static func renderSaveCaptureJob(
+		request: FrozenSelectionImageRenderRequest,
+		outputURL: URL
+	) -> SaveCaptureJobResult {
+		do {
+			let captureImageStartedAt = ProcessInfo.processInfo.systemUptime
+			let renderResult = try renderFrozenSelectionImage(
+				from: request,
+				applyingCaptureFrameEffect: true,
+				prefersPixelSnapshot: true
+			)
+			let captureImageMilliseconds =
+				NativeHostTelemetry.milliseconds(since: captureImageStartedAt)
+			guard renderResult.rgbaSnapshot != nil || renderResult.image != nil else {
+				return SaveCaptureJobResult(
+					outputURL: nil,
+					failureMessage: "Could not capture the frozen selection.",
+					failureStage: renderResult.failureStage ?? "capture_image",
+					captureImageMilliseconds: captureImageMilliseconds,
+					makeImageMilliseconds: 0,
+					writeFileMilliseconds: 0,
+					width: renderResult.width,
+					height: renderResult.height,
+					cacheHit: false
+				)
+			}
+			let makeImageStartedAt = ProcessInfo.processInfo.systemUptime
+			let pngData: Data?
+			let screenScaleFactor = request.captureFrameEnvironment.screenScaleFactor
+			if let snapshot = renderResult.rgbaSnapshot {
+				pngData = try RsnapExportEncoder.pngData(
+					from: snapshot,
+					screenScaleFactor: screenScaleFactor
+				)
+			} else if let cgImage = renderResult.image {
+				pngData = try losslessPNGData(
+					from: cgImage,
+					screenScaleFactor: screenScaleFactor
+				)
+			} else {
+				pngData = nil
+			}
+			let makeImageMilliseconds = NativeHostTelemetry.milliseconds(since: makeImageStartedAt)
+			let width = renderResult.rgbaSnapshot?.width ?? renderResult.image?.width ?? 0
+			let height = renderResult.rgbaSnapshot?.height ?? renderResult.image?.height ?? 0
+			guard let pngData else {
+				return SaveCaptureJobResult(
+					outputURL: nil,
+					failureMessage: "Could not encode the captured image.",
+					failureStage: "encode_image",
+					captureImageMilliseconds: captureImageMilliseconds,
+					makeImageMilliseconds: makeImageMilliseconds,
+					writeFileMilliseconds: 0,
+					width: width,
+					height: height,
+					cacheHit: false
+				)
+			}
+			let writeStartedAt = ProcessInfo.processInfo.systemUptime
+			try pngData.write(to: outputURL, options: .atomic)
+			return SaveCaptureJobResult(
+				outputURL: outputURL,
+				failureMessage: "",
+				failureStage: "none",
+				captureImageMilliseconds: captureImageMilliseconds,
+				makeImageMilliseconds: makeImageMilliseconds,
+				writeFileMilliseconds: NativeHostTelemetry.milliseconds(since: writeStartedAt),
+				width: width,
+				height: height,
+				cacheHit: false
+			)
+		} catch {
+			return SaveCaptureJobResult(
+				outputURL: nil,
+				failureMessage: "Could not save the capture.",
+				failureStage: "file_write",
+				captureImageMilliseconds: 0,
+				makeImageMilliseconds: 0,
+				writeFileMilliseconds: 0,
+				width: 0,
+				height: 0,
+				cacheHit: false
+			)
+		}
+	}
+
+	static func renderFrozenSelectionImage(
+		from request: FrozenSelectionImageRenderRequest,
+		applyingCaptureFrameEffect: Bool,
+		prefersPixelSnapshot: Bool = false
+	) throws -> FrozenSelectionImageRenderResult {
+		let captureStartedAt = ProcessInfo.processInfo.systemUptime
+		if let scrollExport = request.scrollExportSnapshot {
+			return renderScrollExportImage(
+				scrollExport,
+				request: request,
+				captureStartedAt: captureStartedAt,
+				applyingCaptureFrameEffect: applyingCaptureFrameEffect,
+				prefersPixelSnapshot: prefersPixelSnapshot
+			)
+		}
+		return try renderDisplayFrozenSelectionImage(
+			from: request,
+			captureStartedAt: captureStartedAt,
+			applyingCaptureFrameEffect: applyingCaptureFrameEffect,
+			prefersPixelSnapshot: prefersPixelSnapshot
+		)
+	}
+
+	private static func renderScrollExportImage(
+		_ scrollExport: RGBARegionSnapshot,
+		request: FrozenSelectionImageRenderRequest,
+		captureStartedAt: TimeInterval,
+		applyingCaptureFrameEffect: Bool,
+		prefersPixelSnapshot: Bool
+	) -> FrozenSelectionImageRenderResult {
+		let base = FrozenRenderedImage(image: nil, rgbaSnapshot: scrollExport)
+		let result =
+			applyingCaptureFrameEffect
+			? applyCaptureFrameEffectIfNeeded(
+				to: base,
+				request: request,
+				hasOverlayEdits: false,
+				prefersPixelSnapshot: prefersPixelSnapshot
+			)
+			: resolvedRenderedImage(base, prefersPixelSnapshot: prefersPixelSnapshot)
+		logFrozenSelectionImageTiming(
+			request: request,
+			captureStartedAt: captureStartedAt,
+			ensureMilliseconds: 0,
+			refreshMilliseconds: 0,
+			compositeMilliseconds: 0,
+			source: "scroll_capture_export",
+			success: true,
+			width: result.width,
+			height: result.height,
+			hasOverlayEdits: false
+		)
+		return FrozenSelectionImageRenderResult(
+			image: result.image,
+			rgbaSnapshot: result.rgbaSnapshot,
+			baseImage: nil,
+			failureStage: nil,
+			ensureMilliseconds: 0,
+			refreshMilliseconds: 0,
+			compositeMilliseconds: 0,
+			source: "scroll_capture_export",
+			hasOverlayEdits: false,
+			width: result.width,
+			height: result.height
+		)
+	}
+
+	private static func renderDisplayFrozenSelectionImage(
+		from request: FrozenSelectionImageRenderRequest,
+		captureStartedAt: TimeInterval,
+		applyingCaptureFrameEffect: Bool,
+		prefersPixelSnapshot: Bool
+	) throws -> FrozenSelectionImageRenderResult {
+		let snapshotMatchedBefore = request.frozenSelectionSnapshot == request.selection
+		let hadBaseImageBefore = request.frozenBaseImage != nil
+		let hadFrozenDisplayImageBefore = request.frozenDisplayImage != nil
+		let ensureStartedAt = ProcessInfo.processInfo.systemUptime
+		let baseImage =
+			snapshotMatchedBefore
+			? request.frozenBaseImage
+				?? frozenBaseImageFromDisplay(
+					displayFrame: request.frozenDisplayFrame,
+					displayImage: request.frozenDisplayImage,
+					selection: request.selection
+				)
+			: frozenBaseImageFromDisplay(
+				displayFrame: request.frozenDisplayFrame,
+				displayImage: request.frozenDisplayImage,
+				selection: request.selection
+			)
+		let ensureMilliseconds = NativeHostTelemetry.milliseconds(since: ensureStartedAt)
+		guard let baseImage else {
+			logFrozenSelectionImageTiming(
+				request: request,
+				captureStartedAt: captureStartedAt,
+				ensureMilliseconds: ensureMilliseconds,
+				refreshMilliseconds: 0,
+				compositeMilliseconds: 0,
+				source: "missing_base",
+				success: false,
+				width: 0,
+				height: 0,
+				hasOverlayEdits: request.hasOverlayEdits
+			)
+			return FrozenSelectionImageRenderResult(
+				image: nil,
+				rgbaSnapshot: nil,
+				baseImage: nil,
+				failureStage: "capture_image",
+				ensureMilliseconds: ensureMilliseconds,
+				refreshMilliseconds: 0,
+				compositeMilliseconds: 0,
+				source: "missing_base",
+				hasOverlayEdits: request.hasOverlayEdits,
+				width: 0,
+				height: 0
+			)
+		}
+
+		let compositeStartedAt = ProcessInfo.processInfo.systemUptime
+		let composited = try compositeFrozenOverlay(
+			on: baseImage,
+			selection: request.selection,
+			elements: request.overlayElements,
+			prefersPixelSnapshot: prefersPixelSnapshot || applyingCaptureFrameEffect
+		)
+		let result =
+			applyingCaptureFrameEffect
+			? applyCaptureFrameEffectIfNeeded(
+				to: composited,
+				request: request,
+				hasOverlayEdits: request.hasOverlayEdits,
+				prefersPixelSnapshot: prefersPixelSnapshot
+			)
+			: composited
+		let compositeMilliseconds = NativeHostTelemetry.milliseconds(since: compositeStartedAt)
+		let imageSource: String
+		if snapshotMatchedBefore, hadBaseImageBefore {
+			imageSource = "cached_base"
+		} else if hadFrozenDisplayImageBefore {
+			imageSource = "frozen_display_crop"
+		} else {
+			imageSource = "unknown_base"
+		}
+		logFrozenSelectionImageTiming(
+			request: request,
+			captureStartedAt: captureStartedAt,
+			ensureMilliseconds: ensureMilliseconds,
+			refreshMilliseconds: 0,
+			compositeMilliseconds: compositeMilliseconds,
+			source: imageSource,
+			success: true,
+			width: result.width,
+			height: result.height,
+			hasOverlayEdits: request.hasOverlayEdits
+		)
+		return FrozenSelectionImageRenderResult(
+			image: result.image,
+			rgbaSnapshot: result.rgbaSnapshot,
+			baseImage: baseImage,
+			failureStage: nil,
+			ensureMilliseconds: ensureMilliseconds,
+			refreshMilliseconds: 0,
+			compositeMilliseconds: compositeMilliseconds,
+			source: imageSource,
+			hasOverlayEdits: request.hasOverlayEdits,
+			width: result.width,
+			height: result.height
+		)
+	}
+
+	private static func frozenBaseImageFromDisplay(
+		displayFrame: CGRect?,
+		displayImage: CGImage?,
+		selection: CGRect
+	) -> CGImage? {
+		guard let displayFrame, let displayImage else {
+			return nil
+		}
+		return cropFrozenDisplayImage(
+			displayImage,
+			displayFrame: displayFrame,
+			selection: selection
+		)
+	}
+
+	private static func logFrozenSelectionImageTiming(
+		request: FrozenSelectionImageRenderRequest,
+		captureStartedAt: TimeInterval,
+		ensureMilliseconds: Double,
+		refreshMilliseconds: Double,
+		compositeMilliseconds: Double,
+		source: String,
+		success: Bool,
+		width: Int,
+		height: Int,
+		hasOverlayEdits: Bool
+	) {
+		NativeHostTelemetry.frozenSelectionImageTiming(
+			captureID: request.captureID,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: captureStartedAt),
+			ensureMilliseconds: ensureMilliseconds,
+			refreshMilliseconds: refreshMilliseconds,
+			compositeMilliseconds: compositeMilliseconds,
+			source: source,
+			success: success,
+			width: width,
+			height: height,
+			hasOverlayEdits: hasOverlayEdits
+		)
+	}
+
+	private static func applyCaptureFrameEffectIfNeeded(
+		to image: CGImage,
+		request: FrozenSelectionImageRenderRequest,
+		hasOverlayEdits: Bool,
+		prefersPixelSnapshot: Bool
+	) -> FrozenRenderedImage {
+		applyCaptureFrameEffectIfNeeded(
+			to: FrozenRenderedImage(image: image, rgbaSnapshot: nil),
+			request: request,
+			hasOverlayEdits: hasOverlayEdits,
+			prefersPixelSnapshot: prefersPixelSnapshot
+		)
+	}
+
+	private static func applyCaptureFrameEffectIfNeeded(
+		to image: FrozenRenderedImage,
+		request: FrozenSelectionImageRenderRequest,
+		hasOverlayEdits: Bool,
+		prefersPixelSnapshot: Bool
+	) -> FrozenRenderedImage {
+		guard request.captureFrameEffectEnabled,
+			request.captureFrameApplicability.includes(request.captureFrameSource)
+		else {
+			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+		}
+		if hasOverlayEdits == false,
+			request.captureFrameSource == .window,
+			let windowID = request.captureFrameWindowID,
+			let windowImage = captureFrameWindowImage(windowID: windowID)
+		{
+			guard
+				let snapshot = CaptureFrameEffectRenderer.renderWindowSnapshotSnapshot(
+					image: windowImage,
+					background: request.captureFrameBackground,
+					environment: request.captureFrameEnvironment
+				)
+			else {
+				return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+			}
+
+			let renderedImage =
+				prefersPixelSnapshot
+				? nil
+				: NativeHostImageBridge.cgImage(from: snapshot, shouldInterpolate: true)
+			if prefersPixelSnapshot == false, renderedImage == nil {
+				return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+			}
+			return FrozenRenderedImage(
+				image: renderedImage,
+				rgbaSnapshot: snapshot
+			)
+		}
+		let renderedSnapshot: RGBARegionSnapshot?
+		if let sourceSnapshot = image.rgbaSnapshot {
+			renderedSnapshot = CaptureFrameEffectRenderer.renderSnapshot(
+				source: sourceSnapshot,
+				background: request.captureFrameBackground,
+				sourceKind: request.captureFrameSource,
+				environment: request.captureFrameEnvironment
+			)
+		} else if let sourceImage = image.image {
+			renderedSnapshot = CaptureFrameEffectRenderer.renderSnapshot(
+				image: sourceImage,
+				background: request.captureFrameBackground,
+				source: request.captureFrameSource,
+				environment: request.captureFrameEnvironment
+			)
+		} else {
+			renderedSnapshot = nil
+		}
+		guard let renderedSnapshot else {
+			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+		}
+
+		let renderedImage =
+			prefersPixelSnapshot
+			? nil
+			: NativeHostImageBridge.cgImage(from: renderedSnapshot, shouldInterpolate: true)
+		if prefersPixelSnapshot == false, renderedImage == nil {
+			return resolvedRenderedImage(image, prefersPixelSnapshot: prefersPixelSnapshot)
+		}
+		return FrozenRenderedImage(
+			image: renderedImage,
+			rgbaSnapshot: renderedSnapshot
+		)
+	}
+
+	private static func resolvedRenderedImage(
+		_ image: FrozenRenderedImage,
+		prefersPixelSnapshot: Bool
+	) -> FrozenRenderedImage {
+		if prefersPixelSnapshot || image.image != nil {
+			return image
+		}
+		guard let snapshot = image.rgbaSnapshot else {
+			return image
+		}
+		return FrozenRenderedImage(
+			image: NativeHostImageBridge.cgImage(from: snapshot),
+			rgbaSnapshot: snapshot
+		)
+	}
+
+	private static func compositeFrozenOverlay(
+		on image: CGImage,
+		selection: CGRect,
+		elements: [FrozenOverlayExportElement],
+		prefersPixelSnapshot: Bool
+	) throws -> FrozenRenderedImage {
+		guard elements.isEmpty == false else {
+			return FrozenRenderedImage(image: image, rgbaSnapshot: nil)
+		}
+
+		guard
+			let snapshot = NativeHostImageBridge.rgbaSnapshot(from: image),
+			let renderedSnapshot = try? RsnapExportEncoder.frozenOverlayExportImage(
+				from: snapshot,
+				selection: selection,
+				elements: elements
+			)
+		else {
+			throw HostBridgeError.ffiStatus(
+				context: "converting frozen overlay export image",
+				code: 4)
+		}
+
+		return FrozenRenderedImage(
+			image: prefersPixelSnapshot
+				? nil
+				: NativeHostImageBridge.cgImage(from: renderedSnapshot),
+			rgbaSnapshot: renderedSnapshot
+		)
+	}
+
+	static func captureFrameWindowImage(windowID: CGWindowID) -> CGImage? {
+		guard let createImage = captureFrameWindowListCreateImage else {
+			return nil
+		}
+		return createImage(
+			CGRect.null,
+			CGWindowListOption.optionIncludingWindow.rawValue,
+			windowID,
+			CGWindowImageOption.bestResolution.rawValue
+		)?
+		.takeRetainedValue()
+	}
+
+	typealias CaptureFrameWindowListCreateImage =
+		@convention(c) (
+			CGRect,
+			UInt32,
+			CGWindowID,
+			UInt32
+		) -> Unmanaged<CGImage>?
+
+	private static let captureFrameWindowListCreateImage: CaptureFrameWindowListCreateImage? = {
+		guard
+			let coreGraphics = dlopen(
+				"/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+				RTLD_LAZY
+			)
+		else {
+			return nil
+		}
+		guard let symbol = dlsym(coreGraphics, "CGWindowListCreateImage") else {
+			dlclose(coreGraphics)
+			return nil
+		}
+		return unsafeBitCast(symbol, to: CaptureFrameWindowListCreateImage.self)
+	}()
+
+	static func cropFrozenDisplayImage(
+		_ image: CGImage,
+		displayFrame: CGRect,
+		selection: CGRect
+	) -> CGImage? {
+		guard
+			let cropRect = try? RsnapExportEncoder.frozenDisplayCropRect(
+				imageWidth: image.width,
+				imageHeight: image.height,
+				displayFrame: displayFrame,
+				selection: selection
+			)
+		else {
+			return nil
+		}
+		return image.cropping(to: cropRect)
+	}
+
+	static func losslessPNGData(
+		from image: CGImage,
+		screenScaleFactor: CGFloat
+	) throws -> Data? {
+		guard let snapshot = NativeHostImageBridge.rgbaSnapshot(from: image) else {
+			return nil
+		}
+
+		return try RsnapExportEncoder.pngData(
+			from: snapshot,
+			screenScaleFactor: screenScaleFactor
+		)
+	}
+}


### PR DESCRIPTION
## Summary
- Extract nonisolated frozen selection render/copy/save/OCR-prep image jobs into `FrozenSelectionImageRenderer`
- Keep `CaptureSessionController+Export` focused on copy/save orchestration, prepared export scheduling, host status, and output naming
- Update host-core and workspace-layout references for the new frozen image renderer owner boundary

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\[path" packages apps native scripts` (no matches)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`