### PR TITLE
Extract capture host live preview

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -140,6 +140,8 @@ The current native-host Swift split is:
   with per-track throttling state, and AppKit-to-controller pointer delivery support.
 - `CaptureHostView+LivePrimaryInteraction.swift`: capture-host live primary interaction release
   recovery, pointer-preview mutation, mouse-up monitor wiring, and release-watchdog orchestration.
+- `CaptureHostView+LivePreview.swift`: capture-host live preview snapshots, HUD/loupe placement,
+  live sample-cache use, and controller preview-demand updates.
 - `LiveOverlayRenderer.swift`: live overlay render orchestration for HUD, loupe, frozen-pending
   preview, and live chrome layers.
 - `LiveHudColorRollCoordinator.swift`: live HUD color swatch/hex presentation, pending color roll

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -245,6 +245,8 @@ The main host-kit files are split by responsibility:
   with per-track throttling state, and AppKit-to-controller pointer delivery
 - `CaptureHostView+LivePrimaryInteraction.swift`: capture-host live primary interaction release
   recovery, pointer-preview mutation, mouse-up monitor wiring, and release-watchdog orchestration
+- `CaptureHostView+LivePreview.swift`: capture-host live preview snapshots, HUD/loupe placement,
+  live sample-cache use, and controller preview-demand updates
 - `LiveOverlayRenderer.swift`: live overlay render orchestration for HUD, loupe, frozen-pending
   preview, and live chrome layers
 - `LiveHudColorRollCoordinator.swift`: live HUD color swatch/hex presentation, pending color roll

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+LivePreview.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+LivePreview.swift
@@ -1,0 +1,375 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import RsnapHostBridge
+
+extension CaptureHostView {
+	func currentHudPlacement() -> LiveChromeFloatingPlacement? {
+		guard scene.mode == .live, let anchor = localPointer() else {
+			return nil
+		}
+		return LiveChromePlacementPlanner.hudPlacement(
+			bounds: bounds,
+			anchor: anchor,
+			positionDisplay: currentPositionDisplay(),
+			keycapVisible: settings.showAltHintKeycap
+		)
+	}
+
+	func currentLoupeFrame(
+		hudFrame: CGRect,
+		patch: CGImage?,
+		alignTrailing: Bool
+	) -> CGRect? {
+		LiveChromePlacementPlanner.loupeFrame(
+			bounds: bounds,
+			hudFrame: hudFrame,
+			patch: patch,
+			alignTrailing: alignTrailing
+		)
+	}
+
+	func currentLoupeFrame(hudFrame: CGRect) -> CGRect? {
+		currentLoupeFrame(
+			hudFrame: hudFrame,
+			patch: reusableLiveLoupePatch(),
+			alignTrailing: currentHudPlacement()?.flippedHorizontally ?? false
+		)
+	}
+
+	func currentRendererPreviewSnapshot() -> LivePreviewSnapshot? {
+		if scene.mode == .live {
+			let snapshot: LivePreviewSnapshot?
+			if chrome.hostLocalFrozenSelecting {
+				snapshot =
+					currentHostLocalFrozenSelectingPreviewSnapshot()
+					?? lastLivePreviewSnapshot
+					?? currentLivePreviewSnapshot(usesSceneDragPreview: false)
+			} else {
+				snapshot = currentLivePreviewSnapshot()
+			}
+			lastLivePreviewSnapshot = snapshot
+			return snapshot
+		}
+		if frozenFirstDisplayHandoff.pending {
+			return currentPendingFrozenPreviewSnapshot() ?? lastLivePreviewSnapshot
+		}
+		return nil
+	}
+
+	func currentLivePreviewSnapshot(
+		usesSceneDragPreview: Bool = true
+	) -> LivePreviewSnapshot? {
+		guard scene.mode == .live else {
+			return nil
+		}
+
+		if livePrimaryInteraction.completionInFlight == false {
+			let polledPoint = currentGlobalMousePoint() ?? NSEvent.mouseLocation
+			if let currentPreview = livePointerPreview.globalPoint {
+				if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y)
+					>= 0.5
+				{
+					applyPolledLivePointerPreview(polledPoint)
+				}
+			} else {
+				applyPolledLivePointerPreview(polledPoint, recordsInputLatency: false)
+			}
+		}
+
+		refreshLiveHighlightedWindowPreview(
+			at: livePointerPreview.currentPoint(fallback: scene.pointer))
+		updateLivePreviewDemands()
+
+		let point = livePointerPreview.currentPoint(fallback: scene.pointer)
+		let chromeSample = currentLiveChromeSample(at: point)
+		let rgbSample = liveRgbSample(from: chromeSample, at: point)
+		let loupePatch = scene.loupeVisible ? chromeSample?.loupePatch : nil
+		let dragSelectionLocal =
+			currentImmediateLiveDragSelectionLocal()
+			?? (usesSceneDragPreview && livePrimaryInteraction.hasInteraction
+				&& livePrimaryInteraction.dragExceededThreshold
+				? localRect(from: scene.liveSelectionPreview) : nil)
+		let hoverSelectionLocal =
+			dragSelectionLocal == nil
+			? localRect(from: liveHighlightedWindowPreview?.frame)
+			: nil
+		let positionDisplay = currentPositionDisplay()
+		let colorDisplay = currentLiveColorDisplay(for: rgbSample)
+		let hudPlacement =
+			livePrimaryInteraction.hoverChromeSuppressed ? nil : currentHudPlacement()
+		let hudFrame = hudPlacement?.frame
+		let loupeFrame =
+			!livePrimaryInteraction.hoverChromeSuppressed && scene.loupeVisible
+			? hudPlacement.flatMap {
+				currentLoupeFrame(
+					hudFrame: $0.frame,
+					patch: chromeSample?.loupePatch,
+					alignTrailing: $0.flippedHorizontally
+				)
+			}
+			: nil
+		updateLiveLiquidGlassViews(hudFrame: hudFrame, loupeFrame: loupeFrame)
+
+		return LivePreviewSnapshot(
+			bounds: bounds,
+			theme: chromeTheme(),
+			settings: settings,
+			frozenPending: false,
+			frozenDisplayFrame: nil,
+			frozenDisplayImage: nil,
+			pointerLocal: localPointer(),
+			dragSelectionLocal: dragSelectionLocal,
+			hoverSelectionLocal: hoverSelectionLocal,
+			selectionSizeText: dragSelectionLocal.map(selectionSizeText(for:)),
+			hudFrame: hudFrame,
+			loupeFrame: loupeFrame,
+			positionDisplay: positionDisplay,
+			colorDisplay: colorDisplay,
+			rgbSample: rgbSample,
+			keycapVisible: settings.showAltHintKeycap,
+			inputUptime: sampleUpdatedLiveChromeRenderInProgress
+				? nil : livePointerPreview.inputUptime,
+			loupePatch: loupePatch,
+			glassPatches: [:]
+		)
+	}
+
+	func refreshLiveHighlightedWindowPreviewForFastPath(at globalPoint: CGPoint) -> Bool {
+		guard
+			livePrimaryInteraction.hasInteraction == false,
+			livePrimaryInteraction.hoverChromeSuppressed == false
+		else {
+			return false
+		}
+		let previousPreview = liveHighlightedWindowPreview
+		refreshLiveHighlightedWindowPreview(at: globalPoint)
+		return Self.windowSnapshotsEquivalent(previousPreview, liveHighlightedWindowPreview)
+			== false
+	}
+
+	func updateLivePreviewSampleDemand() {
+		guard scene.mode == .live else {
+			controller?.updateLivePreviewDemand(
+				point: nil, settings: settings, includeLoupePatch: false)
+			return
+		}
+		let point = livePointerPreview.currentPoint(fallback: scene.pointer)
+		controller?.updateLivePreviewDemand(
+			point: point,
+			settings: settings,
+			includeLoupePatch: scene.loupeVisible && !livePrimaryInteraction.hoverChromeSuppressed
+		)
+	}
+
+	func updateLivePreviewDemands() {
+		guard scene.mode == .live else {
+			controller?.updateLivePreviewDemand(
+				point: nil, settings: settings, includeLoupePatch: false)
+			controller?.updateLiveChromeBackdrops(nil)
+			return
+		}
+		updateLivePreviewSampleDemand()
+		updateLiveChromeBackdrops()
+	}
+
+	func seedLiveChromeSampleCache(from chrome: CaptureChromeState, point: CGPoint?) {
+		CaptureHostLiveSampleResolver.seedChromeSample(
+			from: chrome,
+			point: point,
+			cache: &liveSampleCache
+		)
+	}
+
+	func selectionSizeText(for rect: CGRect) -> String {
+		let scale = window?.screen?.backingScaleFactor ?? 1
+		let sizeText = "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))px"
+
+		if abs(scale - 1) <= 0.005 {
+			return sizeText
+		}
+
+		return "\(sizeText) @\(String(format: "%g", Double(scale)))x"
+	}
+
+	private func currentHostLocalFrozenSelectingPreviewSnapshot() -> LivePreviewSnapshot? {
+		guard scene.mode == .live, chrome.hostLocalFrozenSelecting else {
+			return nil
+		}
+
+		guard let dragSelectionLocal = currentImmediateLiveDragSelectionLocal() else {
+			return nil
+		}
+		let rgbSample = liveSampleCache.rgbSample(
+			matching: livePointerPreview.currentPoint(fallback: scene.pointer))?
+			.rgb
+		return LivePreviewSnapshot(
+			bounds: bounds,
+			theme: chromeTheme(),
+			settings: settings,
+			frozenPending: false,
+			frozenDisplayFrame: localFrozenDisplayFrame(),
+			frozenDisplayImage: chrome.frozenDisplayImage,
+			pointerLocal: nil,
+			dragSelectionLocal: dragSelectionLocal,
+			hoverSelectionLocal: nil,
+			selectionSizeText: selectionSizeText(for: dragSelectionLocal),
+			hudFrame: nil,
+			loupeFrame: nil,
+			positionDisplay: currentPositionDisplay(),
+			colorDisplay: currentLiveColorDisplay(for: rgbSample),
+			rgbSample: rgbSample,
+			keycapVisible: false,
+			inputUptime: nil,
+			loupePatch: nil,
+			glassPatches: [:]
+		)
+	}
+
+	private func currentPendingFrozenPreviewSnapshot() -> LivePreviewSnapshot? {
+		guard frozenFirstDisplayHandoff.pending else {
+			return nil
+		}
+		let frozenSelectionLocal =
+			localFrozenSelectionRect()
+			?? lastLivePreviewSnapshot?.dragSelectionLocal
+			?? lastLivePreviewSnapshot?.hoverSelectionLocal
+		guard let frozenSelectionLocal else {
+			return nil
+		}
+		return LivePreviewSnapshot(
+			bounds: bounds,
+			theme: chromeTheme(),
+			settings: settings,
+			frozenPending: true,
+			frozenDisplayFrame: localFrozenDisplayFrame(),
+			frozenDisplayImage: chrome.frozenDisplayImage,
+			pointerLocal: nil,
+			dragSelectionLocal: frozenSelectionLocal,
+			hoverSelectionLocal: nil,
+			selectionSizeText: nil,
+			hudFrame: nil,
+			loupeFrame: nil,
+			positionDisplay: currentPositionDisplay(),
+			colorDisplay: currentLiveColorDisplay(for: liveSampleCache.latestRgb?.rgb),
+			rgbSample: liveSampleCache.latestRgb?.rgb,
+			keycapVisible: false,
+			inputUptime: nil,
+			loupePatch: nil,
+			glassPatches: [:]
+		)
+	}
+
+	private func applyPolledLivePointerPreview(
+		_ globalPoint: CGPoint,
+		recordsInputLatency: Bool = true
+	) {
+		_ = setLivePointerPreview(
+			to: globalPoint,
+			recordsInputLatency: recordsInputLatency
+		)
+	}
+
+	private func refreshLiveHighlightedWindowPreview(at globalPoint: CGPoint?) {
+		guard let globalPoint else {
+			liveHighlightedWindowPreview = nil
+			return
+		}
+		liveHighlightedWindowPreview = controller?.previewHighlightedWindow(at: globalPoint)
+	}
+
+	private static func windowSnapshotsEquivalent(_ lhs: WindowSnapshot?, _ rhs: WindowSnapshot?)
+		-> Bool
+	{
+		switch (lhs, rhs) {
+		case (nil, nil):
+			return true
+		case (let lhs?, let rhs?):
+			return lhs.windowID == rhs.windowID && windowFramesEquivalent(lhs.frame, rhs.frame)
+		default:
+			return false
+		}
+	}
+
+	private static func windowFramesEquivalent(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+		abs(lhs.minX - rhs.minX) <= 0.5
+			&& abs(lhs.minY - rhs.minY) <= 0.5
+			&& abs(lhs.width - rhs.width) <= 0.5
+			&& abs(lhs.height - rhs.height) <= 0.5
+	}
+
+	private func currentLiveChromeSample(at point: CGPoint?) -> LiveChromeSample? {
+		CaptureHostLiveSampleResolver.currentLiveChromeSample(
+			at: point,
+			scenePointer: scene.pointer,
+			loupeVisible: scene.loupeVisible,
+			hoverChromeSuppressed: livePrimaryInteraction.hoverChromeSuppressed,
+			settings: settings,
+			chrome: chrome,
+			cache: &liveSampleCache
+		) { wantsLoupePatch in
+			controller?.liveChromeSnapshot(
+				point: point,
+				settings: settings,
+				includeLoupePatch: wantsLoupePatch
+			)
+		}
+	}
+
+	func reusableLiveLoupePatch() -> CGImage? {
+		CaptureHostLiveSampleResolver.reusableLiveLoupePatch(
+			cache: liveSampleCache,
+			chrome: chrome,
+			settings: settings
+		)
+	}
+
+	private func liveRgbSample(from sample: LiveChromeSample?, at point: CGPoint?) -> RGBSample? {
+		CaptureHostLiveSampleResolver.liveRgbSample(
+			from: sample,
+			at: point,
+			cache: &liveSampleCache
+		)
+	}
+
+	private func currentPositionDisplay() -> LivePositionDisplay {
+		let metrics = LiveChromePlacementPlanner.metrics
+		guard let pointer = livePointerPreview.currentPoint(fallback: scene.pointer) else {
+			return LivePositionDisplay(
+				xValueText: "?",
+				yValueText: "?",
+				xSlotWidth: metrics.placeholderXSlotWidth,
+				ySlotWidth: metrics.placeholderYSlotWidth
+			)
+		}
+		let xValueText = String(Int(pointer.x.rounded()))
+		let yValueText = String(Int(pointer.y.rounded()))
+		return LivePositionDisplay(
+			xValueText: xValueText,
+			yValueText: yValueText,
+			xSlotWidth: metrics.coordinateSlotWidth(
+				prefixWidth: metrics.xPrefixWidth,
+				valueText: xValueText
+			),
+			ySlotWidth: metrics.coordinateSlotWidth(
+				prefixWidth: metrics.yPrefixWidth,
+				valueText: yValueText
+			)
+		)
+	}
+
+	private func currentLiveColorDisplay(for sample: RGBSample?) -> LiveColorDisplay {
+		let hexText =
+			sample.map { String(format: "#%02X%02X%02X", $0.r, $0.g, $0.b) }
+			?? pendingLiveColorHexText()
+		return LiveColorDisplay(
+			hexText: hexText,
+			hexSlotWidth: LiveChromePlacementPlanner.metrics.hexSlotWidth,
+			isPending: sample == nil
+		)
+	}
+
+	private func pendingLiveColorHexText() -> String {
+		LiveChromePendingColorText.hexText()
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -33,10 +33,10 @@ final class CaptureHostView: NSView {
 	let mouseReleaseRecovery = CaptureHostMouseReleaseRecovery()
 	let livePointerPreview = CaptureHostLivePointerPreviewState()
 	var liveHighlightedWindowPreview: WindowSnapshot?
-	private var sampleUpdatedLiveChromeRenderInProgress = false
-	private var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
-	private var lastLivePreviewSnapshot: LivePreviewSnapshot?
-	private var liveSampleCache = CaptureHostLiveSampleCache()
+	var sampleUpdatedLiveChromeRenderInProgress = false
+	var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
+	var lastLivePreviewSnapshot: LivePreviewSnapshot?
+	var liveSampleCache = CaptureHostLiveSampleCache()
 	private lazy var frozenToolbar = CaptureHostFrozenToolbarCoordinator(hostView: self)
 	private lazy var materialViews = CaptureHostMaterialViewCoordinator(hostView: self)
 	lazy var pointerDispatchQueue = CaptureHostPointerDispatchQueue(
@@ -713,11 +713,11 @@ final class CaptureHostView: NSView {
 		}
 	}
 
-	private func localFrozenDisplayFrame() -> CGRect? {
+	func localFrozenDisplayFrame() -> CGRect? {
 		localRect(from: chrome.frozenDisplayFrame)
 	}
 
-	private func currentImmediateLiveDragSelectionLocal() -> CGRect? {
+	func currentImmediateLiveDragSelectionLocal() -> CGRect? {
 		guard scene.mode == .live, let window else {
 			return nil
 		}
@@ -732,7 +732,7 @@ final class CaptureHostView: NSView {
 		return localRect(from: globalRect)
 	}
 
-	private func localPointer() -> CGPoint? {
+	func localPointer() -> CGPoint? {
 		guard let globalPoint = livePointerPreview.currentPoint(fallback: scene.pointer) else {
 			return nil
 		}
@@ -743,7 +743,7 @@ final class CaptureHostView: NSView {
 		localRect(from: chrome.frozenSelectionSnapshot ?? scene.frozenSelection)
 	}
 
-	private func localRect(from globalRect: CGRect?) -> CGRect? {
+	func localRect(from globalRect: CGRect?) -> CGRect? {
 		guard let selection = globalRect, let window else {
 			return nil
 		}
@@ -885,256 +885,6 @@ final class CaptureHostView: NSView {
 		CaptureHostCursorSupport.cursor(for: cursorPresentation).set()
 	}
 
-	private func currentHudPlacement() -> LiveChromeFloatingPlacement? {
-		guard scene.mode == .live, let anchor = localPointer() else {
-			return nil
-		}
-		return LiveChromePlacementPlanner.hudPlacement(
-			bounds: bounds,
-			anchor: anchor,
-			positionDisplay: currentPositionDisplay(),
-			keycapVisible: settings.showAltHintKeycap
-		)
-	}
-
-	private func currentLoupeFrame(
-		hudFrame: CGRect,
-		patch: CGImage?,
-		alignTrailing: Bool
-	) -> CGRect? {
-		LiveChromePlacementPlanner.loupeFrame(
-			bounds: bounds,
-			hudFrame: hudFrame,
-			patch: patch,
-			alignTrailing: alignTrailing
-		)
-	}
-
-	private func currentLoupeFrame(hudFrame: CGRect) -> CGRect? {
-		currentLoupeFrame(
-			hudFrame: hudFrame,
-			patch: reusableLiveLoupePatch(),
-			alignTrailing: currentHudPlacement()?.flippedHorizontally ?? false
-		)
-	}
-
-	private func currentRendererPreviewSnapshot() -> LivePreviewSnapshot? {
-		if scene.mode == .live {
-			let snapshot: LivePreviewSnapshot?
-			if chrome.hostLocalFrozenSelecting {
-				snapshot =
-					currentHostLocalFrozenSelectingPreviewSnapshot()
-					?? lastLivePreviewSnapshot
-					?? currentLivePreviewSnapshot(usesSceneDragPreview: false)
-			} else {
-				snapshot = currentLivePreviewSnapshot()
-			}
-			lastLivePreviewSnapshot = snapshot
-			return snapshot
-		}
-		if frozenFirstDisplayHandoff.pending {
-			return currentPendingFrozenPreviewSnapshot() ?? lastLivePreviewSnapshot
-		}
-		return nil
-	}
-
-	private func currentHostLocalFrozenSelectingPreviewSnapshot() -> LivePreviewSnapshot? {
-		guard scene.mode == .live, chrome.hostLocalFrozenSelecting else {
-			return nil
-		}
-
-		guard let dragSelectionLocal = currentImmediateLiveDragSelectionLocal() else {
-			return nil
-		}
-		let rgbSample = liveSampleCache.rgbSample(
-			matching: livePointerPreview.currentPoint(fallback: scene.pointer))?
-			.rgb
-		return LivePreviewSnapshot(
-			bounds: bounds,
-			theme: chromeTheme(),
-			settings: settings,
-			frozenPending: false,
-			frozenDisplayFrame: localFrozenDisplayFrame(),
-			frozenDisplayImage: chrome.frozenDisplayImage,
-			pointerLocal: nil,
-			dragSelectionLocal: dragSelectionLocal,
-			hoverSelectionLocal: nil,
-			selectionSizeText: selectionSizeText(for: dragSelectionLocal),
-			hudFrame: nil,
-			loupeFrame: nil,
-			positionDisplay: currentPositionDisplay(),
-			colorDisplay: currentLiveColorDisplay(for: rgbSample),
-			rgbSample: rgbSample,
-			keycapVisible: false,
-			inputUptime: nil,
-			loupePatch: nil,
-			glassPatches: [:]
-		)
-	}
-
-	private func currentPendingFrozenPreviewSnapshot() -> LivePreviewSnapshot? {
-		guard frozenFirstDisplayHandoff.pending else {
-			return nil
-		}
-		let frozenSelectionLocal =
-			localFrozenSelectionRect()
-			?? lastLivePreviewSnapshot?.dragSelectionLocal
-			?? lastLivePreviewSnapshot?.hoverSelectionLocal
-		guard let frozenSelectionLocal else {
-			return nil
-		}
-		return LivePreviewSnapshot(
-			bounds: bounds,
-			theme: chromeTheme(),
-			settings: settings,
-			frozenPending: true,
-			frozenDisplayFrame: localFrozenDisplayFrame(),
-			frozenDisplayImage: chrome.frozenDisplayImage,
-			pointerLocal: nil,
-			dragSelectionLocal: frozenSelectionLocal,
-			hoverSelectionLocal: nil,
-			selectionSizeText: nil,
-			hudFrame: nil,
-			loupeFrame: nil,
-			positionDisplay: currentPositionDisplay(),
-			colorDisplay: currentLiveColorDisplay(for: liveSampleCache.latestRgb?.rgb),
-			rgbSample: liveSampleCache.latestRgb?.rgb,
-			keycapVisible: false,
-			inputUptime: nil,
-			loupePatch: nil,
-			glassPatches: [:]
-		)
-	}
-
-	private func currentLivePreviewSnapshot(
-		usesSceneDragPreview: Bool = true
-	) -> LivePreviewSnapshot? {
-		guard scene.mode == .live else {
-			return nil
-		}
-
-		if livePrimaryInteraction.completionInFlight == false {
-			let polledPoint = currentGlobalMousePoint() ?? NSEvent.mouseLocation
-			if let currentPreview = livePointerPreview.globalPoint {
-				if hypot(currentPreview.x - polledPoint.x, currentPreview.y - polledPoint.y)
-					>= 0.5
-				{
-					applyPolledLivePointerPreview(polledPoint)
-				}
-			} else {
-				applyPolledLivePointerPreview(polledPoint, recordsInputLatency: false)
-			}
-		}
-
-		refreshLiveHighlightedWindowPreview(
-			at: livePointerPreview.currentPoint(fallback: scene.pointer))
-		updateLivePreviewDemands()
-
-		let point = livePointerPreview.currentPoint(fallback: scene.pointer)
-		let chromeSample = currentLiveChromeSample(at: point)
-		let rgbSample = liveRgbSample(from: chromeSample, at: point)
-		let loupePatch = scene.loupeVisible ? chromeSample?.loupePatch : nil
-		let dragSelectionLocal =
-			currentImmediateLiveDragSelectionLocal()
-			?? (usesSceneDragPreview && livePrimaryInteraction.hasInteraction
-				&& livePrimaryInteraction.dragExceededThreshold
-				? localRect(from: scene.liveSelectionPreview) : nil)
-		let hoverSelectionLocal =
-			dragSelectionLocal == nil
-			? localRect(from: liveHighlightedWindowPreview?.frame)
-			: nil
-		let positionDisplay = currentPositionDisplay()
-		let colorDisplay = currentLiveColorDisplay(for: rgbSample)
-		let hudPlacement =
-			livePrimaryInteraction.hoverChromeSuppressed ? nil : currentHudPlacement()
-		let hudFrame = hudPlacement?.frame
-		let loupeFrame =
-			!livePrimaryInteraction.hoverChromeSuppressed && scene.loupeVisible
-			? hudPlacement.flatMap {
-				currentLoupeFrame(
-					hudFrame: $0.frame,
-					patch: chromeSample?.loupePatch,
-					alignTrailing: $0.flippedHorizontally
-				)
-			}
-			: nil
-		updateLiveLiquidGlassViews(hudFrame: hudFrame, loupeFrame: loupeFrame)
-
-		return LivePreviewSnapshot(
-			bounds: bounds,
-			theme: chromeTheme(),
-			settings: settings,
-			frozenPending: false,
-			frozenDisplayFrame: nil,
-			frozenDisplayImage: nil,
-			pointerLocal: localPointer(),
-			dragSelectionLocal: dragSelectionLocal,
-			hoverSelectionLocal: hoverSelectionLocal,
-			selectionSizeText: dragSelectionLocal.map(selectionSizeText(for:)),
-			hudFrame: hudFrame,
-			loupeFrame: loupeFrame,
-			positionDisplay: positionDisplay,
-			colorDisplay: colorDisplay,
-			rgbSample: rgbSample,
-			keycapVisible: settings.showAltHintKeycap,
-			inputUptime: sampleUpdatedLiveChromeRenderInProgress
-				? nil : livePointerPreview.inputUptime,
-			loupePatch: loupePatch,
-			glassPatches: [:]
-		)
-	}
-
-	private func applyPolledLivePointerPreview(
-		_ globalPoint: CGPoint,
-		recordsInputLatency: Bool = true
-	) {
-		_ = setLivePointerPreview(
-			to: globalPoint,
-			recordsInputLatency: recordsInputLatency
-		)
-	}
-
-	private func refreshLiveHighlightedWindowPreview(at globalPoint: CGPoint?) {
-		guard let globalPoint else {
-			liveHighlightedWindowPreview = nil
-			return
-		}
-		liveHighlightedWindowPreview = controller?.previewHighlightedWindow(at: globalPoint)
-	}
-
-	func refreshLiveHighlightedWindowPreviewForFastPath(at globalPoint: CGPoint) -> Bool {
-		guard
-			livePrimaryInteraction.hasInteraction == false,
-			livePrimaryInteraction.hoverChromeSuppressed == false
-		else {
-			return false
-		}
-		let previousPreview = liveHighlightedWindowPreview
-		refreshLiveHighlightedWindowPreview(at: globalPoint)
-		return Self.windowSnapshotsEquivalent(previousPreview, liveHighlightedWindowPreview)
-			== false
-	}
-
-	private static func windowSnapshotsEquivalent(_ lhs: WindowSnapshot?, _ rhs: WindowSnapshot?)
-		-> Bool
-	{
-		switch (lhs, rhs) {
-		case (nil, nil):
-			return true
-		case (let lhs?, let rhs?):
-			return lhs.windowID == rhs.windowID && windowFramesEquivalent(lhs.frame, rhs.frame)
-		default:
-			return false
-		}
-	}
-
-	private static func windowFramesEquivalent(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
-		abs(lhs.minX - rhs.minX) <= 0.5
-			&& abs(lhs.minY - rhs.minY) <= 0.5
-			&& abs(lhs.width - rhs.width) <= 0.5
-			&& abs(lhs.height - rhs.height) <= 0.5
-	}
-
 	func updateLiveChromeBackdrops() {
 		let frames = currentLiveChromeLayerFrames()
 		updateLiveChromeBackdrops(hudFrame: frames.hud, loupeFrame: frames.loupe)
@@ -1256,31 +1006,6 @@ final class CaptureHostView: NSView {
 		liveRenderer.stop()
 	}
 
-	private func updateLivePreviewDemands() {
-		guard scene.mode == .live else {
-			controller?.updateLivePreviewDemand(
-				point: nil, settings: settings, includeLoupePatch: false)
-			controller?.updateLiveChromeBackdrops(nil)
-			return
-		}
-		updateLivePreviewSampleDemand()
-		updateLiveChromeBackdrops()
-	}
-
-	func updateLivePreviewSampleDemand() {
-		guard scene.mode == .live else {
-			controller?.updateLivePreviewDemand(
-				point: nil, settings: settings, includeLoupePatch: false)
-			return
-		}
-		let point = livePointerPreview.currentPoint(fallback: scene.pointer)
-		controller?.updateLivePreviewDemand(
-			point: point,
-			settings: settings,
-			includeLoupePatch: scene.loupeVisible && !livePrimaryInteraction.hoverChromeSuppressed
-		)
-	}
-
 	private func currentDisplayID() -> CGDirectDisplayID? {
 		window?.screen?.nativeDisplayID
 	}
@@ -1293,100 +1018,6 @@ final class CaptureHostView: NSView {
 		NativeHostDisplayRefresh.pointerFollowFramesPerSecond(for: window?.screen)
 	}
 
-	private func currentLiveChromeSample(at point: CGPoint?) -> LiveChromeSample? {
-		CaptureHostLiveSampleResolver.currentLiveChromeSample(
-			at: point,
-			scenePointer: scene.pointer,
-			loupeVisible: scene.loupeVisible,
-			hoverChromeSuppressed: livePrimaryInteraction.hoverChromeSuppressed,
-			settings: settings,
-			chrome: chrome,
-			cache: &liveSampleCache
-		) { wantsLoupePatch in
-			controller?.liveChromeSnapshot(
-				point: point,
-				settings: settings,
-				includeLoupePatch: wantsLoupePatch
-			)
-		}
-	}
-
-	private func reusableLiveLoupePatch() -> CGImage? {
-		CaptureHostLiveSampleResolver.reusableLiveLoupePatch(
-			cache: liveSampleCache,
-			chrome: chrome,
-			settings: settings
-		)
-	}
-
-	private func liveRgbSample(from sample: LiveChromeSample?, at point: CGPoint?) -> RGBSample? {
-		CaptureHostLiveSampleResolver.liveRgbSample(
-			from: sample,
-			at: point,
-			cache: &liveSampleCache
-		)
-	}
-
-	private func seedLiveChromeSampleCache(from chrome: CaptureChromeState, point: CGPoint?) {
-		CaptureHostLiveSampleResolver.seedChromeSample(
-			from: chrome,
-			point: point,
-			cache: &liveSampleCache
-		)
-	}
-
-	private func selectionSizeText(for rect: CGRect) -> String {
-		let scale = window?.screen?.backingScaleFactor ?? 1
-		let sizeText = "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))px"
-
-		if abs(scale - 1) <= 0.005 {
-			return sizeText
-		}
-
-		return "\(sizeText) @\(String(format: "%g", Double(scale)))x"
-	}
-
-	private func currentPositionDisplay() -> LivePositionDisplay {
-		let metrics = LiveChromePlacementPlanner.metrics
-		guard let pointer = livePointerPreview.currentPoint(fallback: scene.pointer) else {
-			return LivePositionDisplay(
-				xValueText: "?",
-				yValueText: "?",
-				xSlotWidth: metrics.placeholderXSlotWidth,
-				ySlotWidth: metrics.placeholderYSlotWidth
-			)
-		}
-		let xValueText = String(Int(pointer.x.rounded()))
-		let yValueText = String(Int(pointer.y.rounded()))
-		return LivePositionDisplay(
-			xValueText: xValueText,
-			yValueText: yValueText,
-			xSlotWidth: metrics.coordinateSlotWidth(
-				prefixWidth: metrics.xPrefixWidth,
-				valueText: xValueText
-			),
-			ySlotWidth: metrics.coordinateSlotWidth(
-				prefixWidth: metrics.yPrefixWidth,
-				valueText: yValueText
-			)
-		)
-	}
-
-	private func currentLiveColorDisplay(for sample: RGBSample?) -> LiveColorDisplay {
-		let hexText =
-			sample.map { String(format: "#%02X%02X%02X", $0.r, $0.g, $0.b) }
-			?? pendingLiveColorHexText()
-		return LiveColorDisplay(
-			hexText: hexText,
-			hexSlotWidth: LiveChromePlacementPlanner.metrics.hexSlotWidth,
-			isPending: sample == nil
-		)
-	}
-
-	private func pendingLiveColorHexText() -> String {
-		LiveChromePendingColorText.hexText()
-	}
-
 	func chromeTheme() -> CaptureChromeTheme {
 		effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .aqua ? .light : .dark
 	}
@@ -1395,7 +1026,7 @@ final class CaptureHostView: NSView {
 		materialViews.updateChromeMaterialViews()
 	}
 
-	private func updateLiveLiquidGlassViews(hudFrame: CGRect?, loupeFrame: CGRect?) {
+	func updateLiveLiquidGlassViews(hudFrame: CGRect?, loupeFrame: CGRect?) {
 		materialViews.updateLiveLiquidGlassViews(hudFrame: hudFrame, loupeFrame: loupeFrame)
 	}
 


### PR DESCRIPTION
## Summary\n- extract CaptureHostView live preview snapshot and demand handling into CaptureHostView+LivePreview\n- keep CaptureHostView focused on AppKit event/render orchestration while preserving live HUD/loupe sampling behavior\n- update host layout reference docs for the new boundary\n\n## Validation\n- cargo make fmt-swift\n- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift\n- cargo make fmt-swift-check\n- cargo make check-vstyle-swift\n- git diff --check\n- rg -n "include!|#\[path" packages apps native scripts\n- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header\n- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check