### PR TITLE
Extract capture host input routing

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -107,8 +107,8 @@ The current native-host Swift split is:
   handoff state, completion queueing, pending-frame evidence, and deferred classic toolbar glass.
 - `CaptureHostScrollToolbarBackdropState.swift`: capture-host scroll toolbar backdrop capture
   generation, seed-patch cache, active frame, refresh cadence, and change-count state.
-- `CaptureHostView.swift`: AppKit view orchestration, hit testing, and native pointer/key event
-  routing into the session controller.
+- `CaptureHostView.swift`: AppKit view orchestration, hit testing, and frozen presentation
+  rendering.
 - `CaptureHostMaterialViewCoordinator.swift`: capture-host Liquid Glass/material subview ownership,
   classic glass patch resolution, and scroll-toolbar backdrop refresh/capture scheduling.
 - `CaptureHostGlassPatchResolver.swift`: capture-host classic glass patch cache lookup, frozen
@@ -140,6 +140,8 @@ The current native-host Swift split is:
   release-watchdog scheduling for AppKit interactions whose mouse-up event can be missed.
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
   with per-track throttling state, and AppKit-to-controller pointer delivery support.
+- `CaptureHostView+InputRouting.swift`: capture-host AppKit mouse, wheel, key, cursor, toolbar
+  shortcut, and pointer-dispatch routing into the session controller.
 - `CaptureHostView+LivePrimaryInteraction.swift`: capture-host live primary interaction release
   recovery, pointer-preview mutation, mouse-up monitor wiring, and release-watchdog orchestration.
 - `CaptureHostView+LivePreview.swift`: capture-host live preview snapshots, HUD/loupe placement,

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -213,7 +213,8 @@ The main host-kit files are split by responsibility:
   completion queueing, pending-frame evidence, and deferred classic toolbar glass
 - `CaptureHostScrollToolbarBackdropState.swift`: scroll toolbar backdrop capture generation,
   seed-patch cache, active frame, refresh cadence, and change-count state
-- `CaptureHostView.swift`: AppKit view orchestration, hit testing, and native pointer/key routing
+- `CaptureHostView.swift`: AppKit view orchestration, hit testing, and frozen presentation
+  rendering
 - `CaptureHostMaterialViewCoordinator.swift`: Liquid Glass/material subview ownership, classic glass
   patch resolution, and scroll-toolbar backdrop refresh/capture scheduling
 - `CaptureHostGlassPatchResolver.swift`: classic glass patch cache lookup, frozen display crop
@@ -245,6 +246,8 @@ The main host-kit files are split by responsibility:
   release-watchdog scheduling for AppKit interactions whose mouse-up event can be missed
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
   with per-track throttling state, and AppKit-to-controller pointer delivery
+- `CaptureHostView+InputRouting.swift`: capture-host AppKit mouse, wheel, key, cursor, toolbar
+  shortcut, and pointer-dispatch routing into the session controller
 - `CaptureHostView+LivePrimaryInteraction.swift`: capture-host live primary interaction release
   recovery, pointer-preview mutation, mouse-up monitor wiring, and release-watchdog orchestration
 - `CaptureHostView+LivePreview.swift`: capture-host live preview snapshots, HUD/loupe placement,

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
@@ -1,0 +1,345 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import RsnapHostBridge
+
+extension CaptureHostView {
+	func routeCursorUpdate(with event: NSEvent) {
+		if scene.mode == .frozen {
+			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
+		}
+		applyVisibleCursorIfNeeded(currentCursorPresentation())
+	}
+
+	func routeMouseMoved(with event: NSEvent) {
+		let point = globalPoint(from: event)
+		if scene.mode == .frozen {
+			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
+			if recoverReleasedFrozenInteractionIfNeeded(at: point) {
+				return
+			}
+		}
+		if scene.mode == .live {
+			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
+				return
+			}
+			liveInputTelemetry.recordMouseEvent()
+			updateLivePointerPreview(to: point, rendersImmediately: true)
+			return
+		}
+		updateLivePointerPreview(to: point, rendersImmediately: false)
+		queuePointerEvent(.moved(point))
+	}
+
+	func routeMouseDragged(with event: NSEvent) {
+		if scene.mode == .frozen {
+			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
+		}
+
+		if scene.mode == .live {
+			let point = globalPoint(from: event)
+			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
+				return
+			}
+			if livePrimaryInteraction.updateDragThreshold(
+				from: point,
+				threshold: Self.liveDragIntentThreshold
+			) {
+				logLivePrimaryInputEvent("capture.live_primary_drag_threshold", point: point)
+			}
+			updateLivePointerPreview(to: point, rendersImmediately: false)
+			queuePointerEvent(
+				livePrimaryInteraction.dragExceededThreshold ? .liveDragged(point) : .moved(point))
+		} else {
+			let point = globalPoint(from: event)
+			if recoverReleasedFrozenInteractionIfNeeded(at: point) {
+				return
+			}
+			controller?.continueFrozenInteraction(to: point)
+			syncVisibleCursor()
+		}
+	}
+
+	func routeMouseDown(with event: NSEvent) {
+		let localPoint = event.locationInWindow
+		let point = globalPoint(from: event)
+		switch scene.mode {
+		case .hidden:
+			break
+		case .live:
+			suppressLiveHoverChrome()
+			livePrimaryInteraction.begin(at: point)
+			logLivePrimaryInputEvent("capture.live_primary_mouse_down", point: point)
+			controller?.registerLivePrimaryInteractionOwner(self)
+			installLiveMouseUpMonitor()
+			installLiveMouseReleaseWatchdog()
+			updateLivePointerPreview(to: point, rendersImmediately: true)
+			controller?.beginPrimaryInteraction(at: point)
+		case .frozen:
+			frozenToolbar.refreshHoveredAction(for: localPoint)
+			if let styleAction = frozenToolbar.annotationStyleAction(at: localPoint) {
+				frozenToolbar.performAnnotationStyleAction(styleAction)
+				return
+			}
+			if let action = frozenToolbar.toolbarAction(at: localPoint) {
+				frozenToolbar.performToolbarAction(action)
+				return
+			}
+			guard chrome.scrollMinimapPreview == nil else {
+				return
+			}
+			controller?.beginFrozenInteraction(at: point)
+			if controller?.hasFrozenOverlayActiveInteraction == true {
+				installFrozenMouseReleaseWatchdog()
+			}
+			syncVisibleCursor()
+		}
+	}
+
+	func routeScrollWheel(with event: NSEvent) -> Bool {
+		guard scene.mode == .frozen else {
+			resetAnnotationStyleWheelGate()
+			return false
+		}
+		if controller?.handleScrollCaptureWheel(event, at: globalPoint(from: event)) == true {
+			resetAnnotationStyleWheelGate()
+			return true
+		}
+		let localPoint = event.locationInWindow
+		guard frozenToolbar.annotationStyleSizeControlContains(localPoint) else {
+			resetAnnotationStyleWheelGate()
+			return false
+		}
+		let steps = annotationStyleWheelSteps(from: event)
+		guard steps != 0 else {
+			return true
+		}
+		controller?.performFrozenAnnotationSizeSteps(steps)
+		frozenToolbar.refreshHoveredAction(for: localPoint)
+		return true
+	}
+
+	func routeMouseUp(with event: NSEvent) {
+		let point = globalPoint(from: event)
+		if scene.mode == .live {
+			logLivePrimaryInputEvent("capture.live_primary_mouse_up", point: point)
+			controller?.completeLivePrimaryInteraction(from: self, at: point)
+		} else if scene.mode == .frozen {
+			cancelFrozenMouseReleaseWatchdog()
+			controller?.completeFrozenInteraction(at: point)
+			syncVisibleCursor()
+		}
+	}
+
+	func routeKeyDown(with event: NSEvent) -> Bool {
+		if controller?.handleFrozenTextKey(event) == true {
+			return true
+		}
+
+		if scene.mode == .frozen, event.modifierFlags.contains(.command),
+			routeFrozenCommandShortcut(with: event)
+		{
+			return true
+		}
+
+		switch event.keyCode {
+		case 53:
+			controller?.cancelCapture()
+			return true
+		case 48:
+			controller?.toggleLoupe()
+			return true
+		case 49:
+			return routeSpaceShortcut()
+		default:
+			if scene.mode == .frozen, plainFrozenShortcutAvailable(event),
+				routePlainFrozenShortcut(with: event)
+			{
+				return true
+			}
+			return false
+		}
+	}
+
+	func syncVisibleCursor() {
+		let cursorPresentation = currentCursorPresentation()
+		guard cursorPresentation != lastCursorPresentation else {
+			return
+		}
+		lastCursorPresentation = cursorPresentation
+		window?.invalidateCursorRects(for: self)
+		if scene.mode == .frozen {
+			applyVisibleCursorIfNeeded(cursorPresentation)
+		}
+	}
+
+	func pointerDispatchInterval() -> TimeInterval {
+		NativeHostDisplayRefresh.frameInterval(
+			forTargetFramesPerSecond: currentDisplayTargetFramesPerSecond())
+	}
+
+	private func routeFrozenCommandShortcut(with event: NSEvent) -> Bool {
+		switch event.charactersIgnoringModifiers?.lowercased() {
+		case "z":
+			if event.modifierFlags.contains(.shift) {
+				guard frozenToolbar.item(.redo)?.enabled == true else {
+					return true
+				}
+				controller?.performFrozenRedo()
+			} else {
+				guard frozenToolbar.item(.undo)?.enabled == true else {
+					return true
+				}
+				controller?.performFrozenUndo()
+			}
+			return true
+		case "s":
+			guard frozenToolbar.item(.save)?.enabled == true else {
+				return true
+			}
+			controller?.saveSelection()
+			return true
+		default:
+			return false
+		}
+	}
+
+	private func routeSpaceShortcut() -> Bool {
+		if scene.mode == .frozen {
+			guard frozenToolbar.item(.copy)?.enabled == true else {
+				return true
+			}
+			controller?.copySelection()
+			return true
+		}
+		if scene.mode == .live {
+			controller?.completePrimaryInteraction(at: scene.pointer ?? NSEvent.mouseLocation)
+			return true
+		}
+		return true
+	}
+
+	private func routePlainFrozenShortcut(with event: NSEvent) -> Bool {
+		switch event.charactersIgnoringModifiers?.lowercased() {
+		case "c":
+			guard frozenToolbar.item(.autoCenter)?.enabled == true else {
+				return true
+			}
+			controller?.performFrozenAutoCenter()
+			return true
+		case "r":
+			guard frozenToolbar.item(.ocr)?.enabled == true else {
+				return true
+			}
+			controller?.recognizeText()
+			return true
+		case "s":
+			guard frozenToolbar.item(.scroll)?.enabled == true else {
+				return true
+			}
+			controller?.startScrollCapture(source: "keyboard_s")
+			return true
+		default:
+			return false
+		}
+	}
+
+	private func plainFrozenShortcutAvailable(_ event: NSEvent) -> Bool {
+		let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+		return flags.contains(.command) == false
+			&& flags.contains(.control) == false
+			&& flags.contains(.option) == false
+			&& flags.contains(.shift) == false
+	}
+
+	private func annotationStyleWheelSteps(from event: NSEvent) -> Int {
+		let phase = event.phase
+		return annotationStyleWheelGate.steps(
+			timestamp: event.timestamp,
+			deltaY: event.scrollingDeltaY,
+			hasPreciseScrollingDeltas: event.hasPreciseScrollingDeltas,
+			phaseActive: phase != [],
+			phaseEndedOrCancelled: phase.contains(.ended) || phase.contains(.cancelled),
+			momentumActive: event.momentumPhase != []
+		)
+	}
+
+	private func resetAnnotationStyleWheelGate() {
+		annotationStyleWheelGate.reset()
+	}
+
+	func currentCursorPresentation() -> CaptureHostCursorPresentation {
+		if toolbarHoverState.pointerOverToolbar || toolbarHoverState.toolbarAction != nil {
+			return .arrow
+		}
+		if scene.mode == .frozen {
+			if let interaction = chrome.frozenSelectionInteraction {
+				return CaptureHostCursorSupport.presentation(
+					for: CaptureHostCursorSupport.cursorIntent(for: interaction.kind, active: true))
+			}
+			if let selection = chrome.frozenSelectionSnapshot ?? scene.frozenSelection,
+				let selectedModeTool = frozenToolbar.visibleItems().first(where: { $0.selected })?
+					.kind
+			{
+				if [ToolbarItemKind.pen, .arrow, .mosaic, .spotlight].contains(selectedModeTool) {
+					return .crosshair
+				}
+				if selectedModeTool == .pointer {
+					if chrome.frozenOverlay.isMovingMovableAnnotation {
+						return .closedHand
+					}
+					if let pointer = currentGlobalMousePoint(),
+						chrome.frozenOverlay.containsMovableAnnotation(at: pointer)
+					{
+						return .openHand
+					}
+					if chrome.frozenSelectionTransformAllowed == false {
+						return .arrow
+					}
+					if let pointer = currentGlobalMousePoint(),
+						let intent = CaptureHostCursorSupport.editableFrozenCursorIntent(
+							at: pointer,
+							selection: selection
+						)
+					{
+						return CaptureHostCursorSupport.presentation(for: intent)
+					}
+				}
+			}
+		}
+
+		return CaptureHostCursorSupport.presentation(for: scene.cursorIntent)
+	}
+
+	private func applyVisibleCursorIfNeeded(_ cursorPresentation: CaptureHostCursorPresentation) {
+		guard cursorPresentation != lastAppliedCursorPresentation else {
+			return
+		}
+		lastAppliedCursorPresentation = cursorPresentation
+		CaptureHostCursorSupport.cursor(for: cursorPresentation).set()
+	}
+
+	private func suppressLiveHoverChrome() {
+		guard scene.mode == .live, livePrimaryInteraction.suppressHoverChrome() else {
+			return
+		}
+		updateLivePreviewDemands()
+		liveRenderer.renderNow()
+	}
+
+	private func queuePointerEvent(_ event: CaptureHostPointerDispatchEvent) {
+		pointerDispatchQueue.enqueue(event)
+	}
+
+	func dispatchPointerEvent(_ event: CaptureHostPointerDispatchEvent) {
+		switch event {
+		case .moved(let point):
+			controller?.pointerMoved(to: point)
+		case .liveDragged(let point):
+			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
+				return
+			}
+			controller?.continuePrimaryInteraction(to: point)
+		}
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -6,7 +6,7 @@ import RsnapHostBridge
 
 @MainActor
 final class CaptureHostView: NSView {
-	private static let liveDragIntentThreshold: CGFloat = 3
+	static let liveDragIntentThreshold: CGFloat = 3
 
 	weak var controller: CaptureSessionController?
 
@@ -26,9 +26,9 @@ final class CaptureHostView: NSView {
 	private(set) var chrome = CaptureChromeState()
 	private(set) var settings = NativeHostSettings.defaults
 	private var trackingAreaRef: NSTrackingArea?
-	private var annotationStyleWheelGate = CaptureHostAnnotationStyleWheelGate()
-	private var lastCursorPresentation: CaptureHostCursorPresentation?
-	private var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
+	var annotationStyleWheelGate = CaptureHostAnnotationStyleWheelGate()
+	var lastCursorPresentation: CaptureHostCursorPresentation?
+	var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
 	var livePrimaryInteraction = CaptureHostLivePrimaryInteractionState()
 	let mouseReleaseRecovery = CaptureHostMouseReleaseRecovery()
 	let livePointerPreview = CaptureHostLivePointerPreviewState()
@@ -37,7 +37,7 @@ final class CaptureHostView: NSView {
 	var frozenFirstDisplayHandoff = CaptureHostFrozenFirstDisplayHandoffState()
 	var lastLivePreviewSnapshot: LivePreviewSnapshot?
 	var liveSampleCache = CaptureHostLiveSampleCache()
-	private lazy var frozenToolbar = CaptureHostFrozenToolbarCoordinator(hostView: self)
+	lazy var frozenToolbar = CaptureHostFrozenToolbarCoordinator(hostView: self)
 	private lazy var materialViews = CaptureHostMaterialViewCoordinator(hostView: self)
 	lazy var pointerDispatchQueue = CaptureHostPointerDispatchQueue(
 		targetInterval: { [weak self] in
@@ -419,119 +419,25 @@ final class CaptureHostView: NSView {
 	}
 
 	override func cursorUpdate(with event: NSEvent) {
-		if scene.mode == .frozen {
-			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
-		}
-		applyVisibleCursorIfNeeded(currentCursorPresentation())
+		routeCursorUpdate(with: event)
 	}
 
 	override func mouseMoved(with event: NSEvent) {
-		let point = globalPoint(from: event)
-		if scene.mode == .frozen {
-			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
-			if recoverReleasedFrozenInteractionIfNeeded(at: point) {
-				return
-			}
-		}
-		if scene.mode == .live {
-			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
-				return
-			}
-			liveInputTelemetry.recordMouseEvent()
-			updateLivePointerPreview(to: point, rendersImmediately: true)
-			return
-		}
-		updateLivePointerPreview(to: point, rendersImmediately: false)
-		queuePointerEvent(.moved(point))
+		routeMouseMoved(with: event)
 	}
 
 	override func mouseDragged(with event: NSEvent) {
-		if scene.mode == .frozen {
-			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
-		}
-
-		if scene.mode == .live {
-			let point = globalPoint(from: event)
-			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
-				return
-			}
-			if livePrimaryInteraction.updateDragThreshold(
-				from: point,
-				threshold: Self.liveDragIntentThreshold
-			) {
-				logLivePrimaryInputEvent("capture.live_primary_drag_threshold", point: point)
-			}
-			updateLivePointerPreview(to: point, rendersImmediately: false)
-			queuePointerEvent(
-				livePrimaryInteraction.dragExceededThreshold ? .liveDragged(point) : .moved(point))
-		} else {
-			let point = globalPoint(from: event)
-			if recoverReleasedFrozenInteractionIfNeeded(at: point) {
-				return
-			}
-			controller?.continueFrozenInteraction(to: point)
-			syncVisibleCursor()
-		}
+		routeMouseDragged(with: event)
 	}
 
 	override func mouseDown(with event: NSEvent) {
-		let localPoint = event.locationInWindow
-		let point = globalPoint(from: event)
-		switch scene.mode {
-		case .hidden:
-			break
-		case .live:
-			suppressLiveHoverChrome()
-			livePrimaryInteraction.begin(at: point)
-			logLivePrimaryInputEvent("capture.live_primary_mouse_down", point: point)
-			controller?.registerLivePrimaryInteractionOwner(self)
-			installLiveMouseUpMonitor()
-			installLiveMouseReleaseWatchdog()
-			updateLivePointerPreview(to: point, rendersImmediately: true)
-			controller?.beginPrimaryInteraction(at: point)
-		case .frozen:
-			frozenToolbar.refreshHoveredAction(for: localPoint)
-			if let styleAction = frozenToolbar.annotationStyleAction(at: localPoint) {
-				frozenToolbar.performAnnotationStyleAction(styleAction)
-				return
-			}
-			if let action = frozenToolbar.toolbarAction(at: localPoint) {
-				frozenToolbar.performToolbarAction(action)
-				return
-			}
-			guard chrome.scrollMinimapPreview == nil else {
-				return
-			}
-			controller?.beginFrozenInteraction(at: point)
-			if controller?.hasFrozenOverlayActiveInteraction == true {
-				installFrozenMouseReleaseWatchdog()
-			}
-			syncVisibleCursor()
-		}
+		routeMouseDown(with: event)
 	}
 
 	override func scrollWheel(with event: NSEvent) {
-		guard scene.mode == .frozen else {
-			resetAnnotationStyleWheelGate()
+		if routeScrollWheel(with: event) == false {
 			super.scrollWheel(with: event)
-			return
 		}
-		if controller?.handleScrollCaptureWheel(event, at: globalPoint(from: event)) == true {
-			resetAnnotationStyleWheelGate()
-			return
-		}
-		let localPoint = event.locationInWindow
-		guard frozenToolbar.annotationStyleSizeControlContains(localPoint) else {
-			resetAnnotationStyleWheelGate()
-			super.scrollWheel(with: event)
-			return
-		}
-		let steps = annotationStyleWheelSteps(from: event)
-		guard steps != 0 else {
-			return
-		}
-		controller?.performFrozenAnnotationSizeSteps(steps)
-		frozenToolbar.refreshHoveredAction(for: localPoint)
 	}
 
 	override func rightMouseDown(with event: NSEvent) {
@@ -539,113 +445,13 @@ final class CaptureHostView: NSView {
 	}
 
 	override func mouseUp(with event: NSEvent) {
-		let point = globalPoint(from: event)
-		if scene.mode == .live {
-			logLivePrimaryInputEvent("capture.live_primary_mouse_up", point: point)
-			controller?.completeLivePrimaryInteraction(from: self, at: point)
-		} else if scene.mode == .frozen {
-			cancelFrozenMouseReleaseWatchdog()
-			controller?.completeFrozenInteraction(at: point)
-			syncVisibleCursor()
-		}
+		routeMouseUp(with: event)
 	}
 
 	override func keyDown(with event: NSEvent) {
-		if controller?.handleFrozenTextKey(event) == true {
-			return
-		}
-
-		if scene.mode == .frozen, event.modifierFlags.contains(.command) {
-			switch event.charactersIgnoringModifiers?.lowercased() {
-			case "z":
-				if event.modifierFlags.contains(.shift) {
-					guard frozenToolbar.item(.redo)?.enabled == true else {
-						return
-					}
-					controller?.performFrozenRedo()
-				} else {
-					guard frozenToolbar.item(.undo)?.enabled == true else {
-						return
-					}
-					controller?.performFrozenUndo()
-				}
-				return
-			case "s":
-				guard frozenToolbar.item(.save)?.enabled == true else {
-					return
-				}
-				controller?.saveSelection()
-				return
-			default:
-				break
-			}
-		}
-
-		switch event.keyCode {
-		case 53:
-			controller?.cancelCapture()
-		case 48:
-			controller?.toggleLoupe()
-		case 49:
-			if scene.mode == .frozen {
-				guard frozenToolbar.item(.copy)?.enabled == true else {
-					return
-				}
-				controller?.copySelection()
-			} else if scene.mode == .live {
-				controller?.completePrimaryInteraction(at: scene.pointer ?? NSEvent.mouseLocation)
-			}
-		default:
-			if scene.mode == .frozen, plainFrozenShortcutAvailable(event) {
-				switch event.charactersIgnoringModifiers?.lowercased() {
-				case "c":
-					guard frozenToolbar.item(.autoCenter)?.enabled == true else {
-						return
-					}
-					controller?.performFrozenAutoCenter()
-					return
-				case "r":
-					guard frozenToolbar.item(.ocr)?.enabled == true else {
-						return
-					}
-					controller?.recognizeText()
-					return
-				case "s":
-					guard frozenToolbar.item(.scroll)?.enabled == true else {
-						return
-					}
-					controller?.startScrollCapture(source: "keyboard_s")
-					return
-				default:
-					break
-				}
-			}
+		if routeKeyDown(with: event) == false {
 			super.keyDown(with: event)
 		}
-	}
-
-	private func plainFrozenShortcutAvailable(_ event: NSEvent) -> Bool {
-		let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-		return flags.contains(.command) == false
-			&& flags.contains(.control) == false
-			&& flags.contains(.option) == false
-			&& flags.contains(.shift) == false
-	}
-
-	private func annotationStyleWheelSteps(from event: NSEvent) -> Int {
-		let phase = event.phase
-		return annotationStyleWheelGate.steps(
-			timestamp: event.timestamp,
-			deltaY: event.scrollingDeltaY,
-			hasPreciseScrollingDeltas: event.hasPreciseScrollingDeltas,
-			phaseActive: phase != [],
-			phaseEndedOrCancelled: phase.contains(.ended) || phase.contains(.cancelled),
-			momentumActive: event.momentumPhase != []
-		)
-	}
-
-	private func resetAnnotationStyleWheelGate() {
-		annotationStyleWheelGate.reset()
 	}
 
 	override func draw(_ dirtyRect: NSRect) {
@@ -787,49 +593,6 @@ final class CaptureHostView: NSView {
 		return bounds.clampedInclusivePoint(localPoint)
 	}
 
-	private func currentCursorPresentation() -> CaptureHostCursorPresentation {
-		if toolbarHoverState.pointerOverToolbar || toolbarHoverState.toolbarAction != nil {
-			return .arrow
-		}
-		if scene.mode == .frozen {
-			if let interaction = chrome.frozenSelectionInteraction {
-				return CaptureHostCursorSupport.presentation(
-					for: CaptureHostCursorSupport.cursorIntent(for: interaction.kind, active: true))
-			}
-			if let selection = chrome.frozenSelectionSnapshot ?? scene.frozenSelection,
-				let selectedModeTool = frozenToolbar.visibleItems().first(where: { $0.selected })?
-					.kind
-			{
-				if [ToolbarItemKind.pen, .arrow, .mosaic, .spotlight].contains(selectedModeTool) {
-					return .crosshair
-				}
-				if selectedModeTool == .pointer {
-					if chrome.frozenOverlay.isMovingMovableAnnotation {
-						return .closedHand
-					}
-					if let pointer = currentGlobalMousePoint(),
-						chrome.frozenOverlay.containsMovableAnnotation(at: pointer)
-					{
-						return .openHand
-					}
-					if chrome.frozenSelectionTransformAllowed == false {
-						return .arrow
-					}
-					if let pointer = currentGlobalMousePoint(),
-						let intent = CaptureHostCursorSupport.editableFrozenCursorIntent(
-							at: pointer,
-							selection: selection
-						)
-					{
-						return CaptureHostCursorSupport.presentation(for: intent)
-					}
-				}
-			}
-		}
-
-		return CaptureHostCursorSupport.presentation(for: scene.cursorIntent)
-	}
-
 	func globalPoint(from event: NSEvent) -> CGPoint {
 		guard let window else {
 			return NSEvent.mouseLocation
@@ -863,26 +626,6 @@ final class CaptureHostView: NSView {
 				&& materialViews.isFrozenToolbarLiquidGlassContentDrawn
 		}
 		return true
-	}
-
-	func syncVisibleCursor() {
-		let cursorPresentation = currentCursorPresentation()
-		guard cursorPresentation != lastCursorPresentation else {
-			return
-		}
-		lastCursorPresentation = cursorPresentation
-		window?.invalidateCursorRects(for: self)
-		if scene.mode == .frozen {
-			applyVisibleCursorIfNeeded(cursorPresentation)
-		}
-	}
-
-	private func applyVisibleCursorIfNeeded(_ cursorPresentation: CaptureHostCursorPresentation) {
-		guard cursorPresentation != lastAppliedCursorPresentation else {
-			return
-		}
-		lastAppliedCursorPresentation = cursorPresentation
-		CaptureHostCursorSupport.cursor(for: cursorPresentation).set()
 	}
 
 	func updateLiveChromeBackdrops() {
@@ -1042,37 +785,8 @@ final class CaptureHostView: NSView {
 		materialViews.refreshScrollCaptureToolbarBackdropNow()
 	}
 
-	private func suppressLiveHoverChrome() {
-		guard scene.mode == .live, livePrimaryInteraction.suppressHoverChrome() else {
-			return
-		}
-		updateLivePreviewDemands()
-		liveRenderer.renderNow()
-	}
-
 	private func themeBrightnessBias() -> Double {
 		chromeTheme() == .dark ? 0.015 : -0.01
-	}
-
-	private func queuePointerEvent(_ event: CaptureHostPointerDispatchEvent) {
-		pointerDispatchQueue.enqueue(event)
-	}
-
-	private func dispatchPointerEvent(_ event: CaptureHostPointerDispatchEvent) {
-		switch event {
-		case .moved(let point):
-			controller?.pointerMoved(to: point)
-		case .liveDragged(let point):
-			if recoverReleasedLivePrimaryInteractionIfNeeded(at: point) {
-				return
-			}
-			controller?.continuePrimaryInteraction(to: point)
-		}
-	}
-
-	private func pointerDispatchInterval() -> TimeInterval {
-		NativeHostDisplayRefresh.frameInterval(
-			forTargetFramesPerSecond: currentDisplayTargetFramesPerSecond())
 	}
 
 }


### PR DESCRIPTION
## Summary
- extract capture host mouse, wheel, key, cursor, shortcut, and pointer dispatch routing into CaptureHostView+InputRouting
- keep CaptureHostView focused on AppKit view orchestration and frozen rendering
- update native host module reference docs

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts (no matches)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check