### PR TITLE
Extract frozen frame stream setup

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -86,8 +86,10 @@ The current native-host Swift split is:
   routing, capture-stream preparation, and mouse passthrough.
 - `CaptureOverlayImageSampler.swift`: CoreGraphics below-overlay capture and display-point sample
   adaptation used by overlay windows, live chrome, and scroll fallback acquisition.
-- `FrozenFrameAuthority.swift`: ScreenCaptureKit frozen-frame stream setup, self-capture-safe
-  stream gating, and lifecycle state.
+- `FrozenFrameAuthority.swift`: frozen-frame authority state, frame storage, setup completion, and
+  telemetry bookkeeping.
+- `FrozenFrameAuthority+StreamSetup.swift`: ScreenCaptureKit frozen-frame stream setup,
+  shareable-content lookup, self-capture-safe stream gating, and lifecycle reset.
 - `FrozenFrameAuthority+SnapshotResolution.swift`: frozen-frame latch-token resolution, RGB/loupe
   sampling, self-capture-safe frame gating, and fresh-frame authority decisions.
 - `FrozenFrameStreamOutput.swift`: ScreenCaptureKit stream-output delegate adaptation,

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -192,8 +192,10 @@ The main host-kit files are split by responsibility:
   passthrough management
 - `CaptureOverlayImageSampler.swift`: CoreGraphics below-overlay capture and display-point sample
   adaptation for live chrome, frozen capture effects, and scroll fallback acquisition
-- `FrozenFrameAuthority.swift`: ScreenCaptureKit frozen-frame stream setup, self-capture-safe
-  stream gating, and lifecycle state
+- `FrozenFrameAuthority.swift`: frozen-frame authority state, frame storage, setup completion, and
+  telemetry bookkeeping
+- `FrozenFrameAuthority+StreamSetup.swift`: ScreenCaptureKit frozen-frame stream setup,
+  shareable-content lookup, self-capture-safe stream gating, and lifecycle reset
 - `FrozenFrameAuthority+SnapshotResolution.swift`: frozen-frame latch-token resolution, RGB/loupe
   sampling, self-capture-safe frame gating, and fresh-frame authority decisions
 - `FrozenFrameStreamOutput.swift`: ScreenCaptureKit stream-output delegate adaptation,

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+StreamSetup.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+StreamSetup.swift
@@ -1,0 +1,692 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+extension FrozenFrameAuthority {
+	func refreshShareableContentCache(captureID: UInt64 = 0, source: String = "cache") {
+		let startedAtUptime = ProcessInfo.processInfo.systemUptime
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
+			content, error in
+			guard let content else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_cache_refresh_failed",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: String(describing: error)
+				)
+				return
+			}
+			guard FrozenFrameContentFilterPlanner.shareableContentHasDisplays(content) else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_cache_refresh_invalid",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
+						content,
+						requiredDisplayIDs: []
+					)
+				)
+				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+					captureID: captureID,
+					source: source,
+					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+					success: false,
+					displayCount: content.displays.count,
+					windowCount: content.windows.count
+				)
+				return
+			}
+			Self.shareableContentCache.store(content)
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: true,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+		}
+	}
+
+	private static func cachedShareableContent(
+		covering displayIDs: Set<CGDirectDisplayID>? = nil
+	) -> SCShareableContent? {
+		shareableContentCache.fresh(
+			maxAge: shareableContentCacheMaxAge,
+			covering: displayIDs
+		)
+	}
+
+	func hasFreshShareableContentCache() -> Bool {
+		Self.cachedShareableContent() != nil
+	}
+
+	func start(
+		for screens: [NSScreen],
+		captureID: UInt64 = 0,
+		source: String = "capture",
+		rebuildContentFilter: Bool = false,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID> = [],
+		includedCurrentProcessWindowIDs: Set<CGWindowID> = []
+	) {
+		let setupStartedAt = ProcessInfo.processInfo.systemUptime
+		let targets = screens.compactMap(FrozenFrameContentFilterPlanner.displayTarget(for:))
+		guard targets.isEmpty == false else {
+			stop()
+			return
+		}
+		let targetIDs = Set(targets.map(\.displayID))
+		let nextTargets = Dictionary(uniqueKeysWithValues: targets.map { ($0.displayID, $0) })
+
+		stateLock.lock()
+		let unchanged = activeDisplayIDs == targetIDs && displayTargets == nextTargets
+		let streamsCoverTargets = Set(streams.keys) == targetIDs
+		let setupInProgressForTargets = setupDisplayIDs == targetIDs
+		displayTargets = nextTargets
+		if rebuildContentFilter {
+			selfCaptureFilterRequired = true
+			selfCaptureUnsafeAfterUptime = setupStartedAt
+		}
+		// When overlay windows become visible, discard pre-overlay streams instead of updating
+		// filters in place. Keep the old stream running until the replacement is configured so a
+		// fast click can still freeze a fresh frame, but only if that frame came from a complete
+		// self-capture-excluding filter.
+		if rebuildContentFilter, unchanged, streamsCoverTargets {
+			setupRequestID &+= 1
+			let requestID = setupRequestID
+			setupDisplayIDs = targetIDs
+			updateTelemetryContextLocked(
+				captureID: captureID,
+				source: source,
+				startedAtUptime: setupStartedAt,
+				targetIDs: targetIDs
+			)
+			stateLock.unlock()
+			rebuildStreamsFromShareableContent(
+				targets: targets,
+				targetIDs: targetIDs,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: setupStartedAt,
+				retryUntilUptime: setupStartedAt + Self.selfCaptureFilterRetryWindow,
+				requestID: requestID
+			)
+			return
+		}
+		if unchanged, streamsCoverTargets || setupInProgressForTargets,
+			rebuildContentFilter == false
+		{
+			updateTelemetryContextLocked(
+				captureID: captureID,
+				source: source,
+				startedAtUptime: setupStartedAt,
+				targetIDs: targetIDs
+			)
+			stateLock.unlock()
+			return
+		}
+		generation &+= 1
+		setupRequestID &+= 1
+		let requestGeneration = generation
+		activeDisplayIDs = targetIDs
+		setupDisplayIDs = targetIDs
+		if rebuildContentFilter == false {
+			selfCaptureFilterRequired = false
+			selfCaptureUnsafeAfterUptime = nil
+		}
+		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
+		updateTelemetryContextLocked(
+			captureID: captureID,
+			source: source,
+			startedAtUptime: setupStartedAt,
+			targetIDs: targetIDs
+		)
+		let staleStreams = streams.values
+		streams.removeAll()
+		stateLock.unlock()
+
+		for staleStream in staleStreams {
+			staleStream.stop()
+		}
+
+		configureStreamsFromShareableContent(
+			targets: targets,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+			generation: requestGeneration,
+			captureID: captureID,
+			source: source,
+			startedAtUptime: setupStartedAt
+		)
+	}
+
+	private func rebuildStreamsFromShareableContent(
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		requestID: UInt64
+	) {
+		if configureStreamsFromCachedShareableContent(
+			targets: targets,
+			targetIDs: targetIDs,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+			captureID: captureID,
+			source: source,
+			startedAtUptime: startedAtUptime,
+			requestID: requestID
+		) {
+			return
+		}
+
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
+			[weak self] content, error in
+			self?.handleShareableContentLookup(
+				content,
+				error: error,
+				targets: targets,
+				targetIDs: targetIDs,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				retryUntilUptime: retryUntilUptime,
+				requestID: requestID
+			)
+		}
+	}
+
+	private func configureStreamsFromCachedShareableContent(
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		requestID: UInt64
+	) -> Bool {
+		guard let content = Self.cachedShareableContent(covering: targetIDs) else {
+			return false
+		}
+		let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
+			for: targets,
+			in: content,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+		)
+		guard FrozenFrameContentFilterPlanner.filtersAreComplete(preparedFilters, for: targets)
+		else {
+			return false
+		}
+		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+			captureID: captureID,
+			source: source,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+			success: true,
+			displayCount: content.displays.count,
+			windowCount: content.windows.count
+		)
+		replaceStreamsFromPreparedFilters(
+			targets: targets,
+			targetIDs: targetIDs,
+			preparedFilters: preparedFilters,
+			captureID: captureID,
+			source: source,
+			startedAtUptime: startedAtUptime,
+			requestID: requestID
+		)
+		return true
+	}
+
+	private func handleShareableContentLookup(
+		_ content: SCShareableContent?,
+		error: Error?,
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		requestID: UInt64
+	) {
+		guard let content else {
+			NativeHostTelemetry.frozenAuthorityWarning(
+				"frozen_authority.content_lookup_failed",
+				captureID: captureID,
+				source: source,
+				displayID: 0,
+				error: String(describing: error)
+			)
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: false,
+				displayCount: targets.count,
+				windowCount: 0
+			)
+			finishSetup(targetIDs: targetIDs)
+			return
+		}
+
+		let contentCoversTargets = FrozenFrameContentFilterPlanner.shareableContent(
+			content, covers: targetIDs)
+		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+			captureID: captureID,
+			source: source,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+			success: contentCoversTargets,
+			displayCount: content.displays.count,
+			windowCount: content.windows.count
+		)
+		guard isCurrentSetupRequest(requestID, targetIDs: targetIDs) else {
+			return
+		}
+		guard contentCoversTargets else {
+			NativeHostTelemetry.frozenAuthorityWarning(
+				"frozen_authority.content_lookup_invalid",
+				captureID: captureID,
+				source: source,
+				displayID: 0,
+				error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
+					content, requiredDisplayIDs: targetIDs)
+			)
+			if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
+				retryRebuildStreamsFromShareableContent(
+					targets: targets,
+					targetIDs: targetIDs,
+					selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+					includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime,
+					retryUntilUptime: retryUntilUptime,
+					requestID: requestID
+				)
+				return
+			}
+			finishSetup(targetIDs: targetIDs)
+			return
+		}
+		Self.shareableContentCache.store(content)
+		let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
+			for: targets,
+			in: content,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+		)
+		guard FrozenFrameContentFilterPlanner.filtersAreComplete(preparedFilters, for: targets)
+		else {
+			if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
+				retryRebuildStreamsFromShareableContent(
+					targets: targets,
+					targetIDs: targetIDs,
+					selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+					includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime,
+					retryUntilUptime: retryUntilUptime,
+					requestID: requestID
+				)
+				return
+			}
+			logIncompleteFilters(
+				preparedFilters, targets: targets, captureID: captureID, source: source)
+			finishSetup(targetIDs: targetIDs)
+			return
+		}
+		replaceStreamsFromPreparedFilters(
+			targets: targets,
+			targetIDs: targetIDs,
+			preparedFilters: preparedFilters,
+			captureID: captureID,
+			source: source,
+			startedAtUptime: startedAtUptime,
+			requestID: requestID
+		)
+	}
+
+	private func retryRebuildStreamsFromShareableContent(
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		requestID: UInt64
+	) {
+		DispatchQueue.global(qos: .userInteractive).asyncAfter(
+			deadline: .now() + Self.selfCaptureFilterRetryInterval
+		) { [weak self] in
+			self?.rebuildStreamsFromShareableContent(
+				targets: targets,
+				targetIDs: targetIDs,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				retryUntilUptime: retryUntilUptime,
+				requestID: requestID
+			)
+		}
+	}
+
+	private func replaceStreamsFromPreparedFilters(
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		requestID: UInt64
+	) {
+		stateLock.lock()
+		guard setupRequestID == requestID, activeDisplayIDs == targetIDs else {
+			stateLock.unlock()
+			return
+		}
+		generation &+= 1
+		let requestGeneration = generation
+		setupDisplayIDs = targetIDs
+		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
+		updateTelemetryContextLocked(
+			captureID: captureID,
+			source: source,
+			startedAtUptime: startedAtUptime,
+			targetIDs: targetIDs
+		)
+		let staleStreams = streams.values
+		streams.removeAll()
+		stateLock.unlock()
+
+		for staleStream in staleStreams {
+			staleStream.stop()
+		}
+
+		configureStreams(
+			targets: targets,
+			preparedFilters: preparedFilters,
+			generation: requestGeneration,
+			captureID: captureID,
+			source: source
+		)
+	}
+
+	private func configureStreamsFromShareableContent(
+		targets: [FrozenFrameDisplayTarget],
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		generation requestGeneration: UInt64,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval
+	) {
+		let targetIDs = Set(targets.map(\.displayID))
+		if let content = Self.cachedShareableContent(covering: targetIDs) {
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: true,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+			let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
+				for: targets,
+				in: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+			)
+			configureStreams(
+				targets: targets,
+				preparedFilters: preparedFilters,
+				generation: requestGeneration,
+				captureID: captureID,
+				source: source
+			)
+			return
+		}
+		let retryUntilUptime = startedAtUptime + Self.selfCaptureFilterRetryWindow
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
+			[weak self] content, error in
+			guard let self else {
+				return
+			}
+			guard self.isCurrentGeneration(requestGeneration) else {
+				return
+			}
+			guard let content else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_lookup_failed",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: String(describing: error)
+				)
+				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+					captureID: captureID,
+					source: source,
+					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+					success: false,
+					displayCount: targets.count,
+					windowCount: 0
+				)
+				self.finishSetup(generation: requestGeneration)
+				return
+			}
+			let contentCoversTargets = FrozenFrameContentFilterPlanner.shareableContent(
+				content, covers: targetIDs)
+			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+				captureID: captureID,
+				source: source,
+				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+				success: contentCoversTargets,
+				displayCount: content.displays.count,
+				windowCount: content.windows.count
+			)
+			guard contentCoversTargets else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_lookup_invalid",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
+						content,
+						requiredDisplayIDs: targetIDs
+					)
+				)
+				if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
+					DispatchQueue.global(qos: .userInteractive).asyncAfter(
+						deadline: .now() + Self.selfCaptureFilterRetryInterval
+					) { [weak self] in
+						self?.configureStreamsFromShareableContent(
+							targets: targets,
+							selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+							includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+							generation: requestGeneration,
+							captureID: captureID,
+							source: source,
+							startedAtUptime: startedAtUptime
+						)
+					}
+					return
+				}
+				self.finishSetup(generation: requestGeneration)
+				return
+			}
+			Self.shareableContentCache.store(content)
+			let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
+				for: targets,
+				in: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+			)
+			self.configureStreams(
+				targets: targets,
+				preparedFilters: preparedFilters,
+				generation: requestGeneration,
+				captureID: captureID,
+				source: source
+			)
+		}
+	}
+
+	func stop() {
+		stateLock.lock()
+		generation &+= 1
+		setupRequestID &+= 1
+		activeDisplayIDs.removeAll()
+		setupDisplayIDs = nil
+		selfCaptureFilterRequired = false
+		selfCaptureUnsafeAfterUptime = nil
+		displayTargets.removeAll()
+		latestFrames.removeAll()
+		firstFrameStartUptimes.removeAll()
+		firstFrameLoggedDisplayIDs.removeAll()
+		telemetryContext = TelemetryContext(
+			captureID: 0, source: "capture", startedAtUptime: 0)
+		let staleStreams = streams.values
+		streams.removeAll()
+		stateLock.unlock()
+
+		for staleStream in staleStreams {
+			staleStream.stop()
+		}
+	}
+
+	private func configureStreams(
+		targets: [FrozenFrameDisplayTarget],
+		preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
+		generation requestGeneration: UInt64,
+		captureID: UInt64,
+		source: String
+	) {
+		for target in targets {
+			guard let preparedFilter = preparedFilters[target.displayID] else {
+				continue
+			}
+
+			let output = FrozenFrameStreamOutput(
+				displayID: target.displayID,
+				displayFrame: target.frame,
+				generation: requestGeneration,
+				selfCaptureFilterComplete: preparedFilter.selfCaptureFilterComplete
+			) { [weak self] frame in
+				self?.store(frame: frame, generation: requestGeneration)
+			} onStop: { [weak self] displayID, generation in
+				self?.handleStreamStopped(displayID: displayID, generation: generation)
+			} telemetrySnapshot: { [weak self] in
+				self?.currentTelemetrySnapshot() ?? (captureID: captureID, source: source)
+			}
+			let stream = SCStream(
+				filter: preparedFilter.filter,
+				configuration: FrozenFrameContentFilterPlanner.streamConfiguration(for: target),
+				delegate: output)
+			do {
+				try stream.addStreamOutput(
+					output, type: SCStreamOutputType.screen, sampleHandlerQueue: outputQueue)
+			} catch {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.output_install_failed",
+					captureID: captureID,
+					source: source,
+					displayID: target.displayID,
+					error: String(describing: error)
+				)
+				continue
+			}
+
+			stateLock.lock()
+			let shouldStart =
+				generation == requestGeneration
+				&& (!selfCaptureFilterRequired || preparedFilter.selfCaptureFilterComplete)
+			if shouldStart {
+				streams[target.displayID] = DisplayStream(
+					stream: stream,
+					output: output,
+					selfCaptureFilterComplete: preparedFilter.selfCaptureFilterComplete
+				)
+			}
+			stateLock.unlock()
+			if selfCaptureFilterRequired, !preparedFilter.selfCaptureFilterComplete {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.self_capture_filter_incomplete",
+					captureID: captureID,
+					source: source,
+					displayID: target.displayID,
+					error:
+						"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
+				)
+			}
+			guard shouldStart else {
+				continue
+			}
+
+			stream.startCapture { [weak self] error in
+				if let error {
+					NativeHostTelemetry.frozenAuthorityWarning(
+						"frozen_authority.stream_start_failed",
+						captureID: captureID,
+						source: source,
+						displayID: target.displayID,
+						error: String(describing: error)
+					)
+					self?.handleStreamStopped(
+						displayID: target.displayID,
+						generation: requestGeneration
+					)
+				}
+			}
+		}
+		finishSetup(generation: requestGeneration)
+	}
+
+	private func logIncompleteFilters(
+		_ preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
+		targets: [FrozenFrameDisplayTarget],
+		captureID: UInt64,
+		source: String
+	) {
+		for target in targets {
+			guard let preparedFilter = preparedFilters[target.displayID] else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.self_capture_filter_incomplete",
+					captureID: captureID,
+					source: source,
+					displayID: target.displayID,
+					error: "missingFilter"
+				)
+				continue
+			}
+			guard preparedFilter.selfCaptureFilterComplete == false else {
+				continue
+			}
+			NativeHostTelemetry.frozenAuthorityWarning(
+				"frozen_authority.self_capture_filter_incomplete",
+				captureID: captureID,
+				source: source,
+				displayID: target.displayID,
+				error:
+					"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
+			)
+		}
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -38,8 +38,8 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	static let maximumSnapshotAgeMilliseconds = 150.0
 	static let maximumLiveRgbAgeMilliseconds =
 		LiveRgbSample.maximumDisplayAge * 1_000
-	private static let selfCaptureFilterRetryInterval: TimeInterval = 0.035
-	private static let selfCaptureFilterRetryWindow: TimeInterval = 2.5
+	static let selfCaptureFilterRetryInterval: TimeInterval = 0.035
+	static let selfCaptureFilterRetryWindow: TimeInterval = 2.5
 
 	struct FrameRecord: @unchecked Sendable {
 		let displayID: CGDirectDisplayID
@@ -81,720 +81,34 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 	}
 
-	private struct TelemetryContext {
+	struct TelemetryContext {
 		let captureID: UInt64
 		let source: String
 		let startedAtUptime: TimeInterval
 	}
 
 	let stateLock = NSCondition()
-	private let outputQueue = DispatchQueue(
+	let outputQueue = DispatchQueue(
 		label: "ink.hack.rsnap.native-host.frozen-frame-authority-output",
 		qos: .userInteractive
 	)
-	private static let shareableContentCacheMaxAge: TimeInterval = 3_600
-	private static let shareableContentCache = FrozenFrameShareableContentCache()
-	private var generation: UInt64 = 0
-	private var setupRequestID: UInt64 = 0
-	private var setupDisplayIDs: Set<CGDirectDisplayID>?
+	static let shareableContentCacheMaxAge: TimeInterval = 3_600
+	static let shareableContentCache = FrozenFrameShareableContentCache()
+	var generation: UInt64 = 0
+	var setupRequestID: UInt64 = 0
+	var setupDisplayIDs: Set<CGDirectDisplayID>?
 	var selfCaptureFilterRequired = false
 	var selfCaptureUnsafeAfterUptime: TimeInterval?
-	private var activeDisplayIDs: Set<CGDirectDisplayID> = []
+	var activeDisplayIDs: Set<CGDirectDisplayID> = []
 	var displayTargets: [CGDirectDisplayID: FrozenFrameDisplayTarget] = [:]
 	var streams: [CGDirectDisplayID: DisplayStream] = [:]
 	var latestFrames: [CGDirectDisplayID: FrameRecord] = [:]
-	private var firstFrameStartUptimes: [CGDirectDisplayID: TimeInterval] = [:]
-	private var firstFrameLoggedDisplayIDs: Set<CGDirectDisplayID> = []
-	private var telemetryContext = TelemetryContext(
+	var firstFrameStartUptimes: [CGDirectDisplayID: TimeInterval] = [:]
+	var firstFrameLoggedDisplayIDs: Set<CGDirectDisplayID> = []
+	var telemetryContext = TelemetryContext(
 		captureID: 0, source: "capture", startedAtUptime: 0)
 
-	func refreshShareableContentCache(captureID: UInt64 = 0, source: String = "cache") {
-		let startedAtUptime = ProcessInfo.processInfo.systemUptime
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
-			content, error in
-			guard let content else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_cache_refresh_failed",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: String(describing: error)
-				)
-				return
-			}
-			guard FrozenFrameContentFilterPlanner.shareableContentHasDisplays(content) else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_cache_refresh_invalid",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
-						content,
-						requiredDisplayIDs: []
-					)
-				)
-				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-					captureID: captureID,
-					source: source,
-					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-					success: false,
-					displayCount: content.displays.count,
-					windowCount: content.windows.count
-				)
-				return
-			}
-			Self.shareableContentCache.store(content)
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: true,
-				displayCount: content.displays.count,
-				windowCount: content.windows.count
-			)
-		}
-	}
-
-	private static func cachedShareableContent(
-		covering displayIDs: Set<CGDirectDisplayID>? = nil
-	) -> SCShareableContent? {
-		shareableContentCache.fresh(
-			maxAge: shareableContentCacheMaxAge,
-			covering: displayIDs
-		)
-	}
-
-	func hasFreshShareableContentCache() -> Bool {
-		Self.cachedShareableContent() != nil
-	}
-
-	func start(
-		for screens: [NSScreen],
-		captureID: UInt64 = 0,
-		source: String = "capture",
-		rebuildContentFilter: Bool = false,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID> = [],
-		includedCurrentProcessWindowIDs: Set<CGWindowID> = []
-	) {
-		let setupStartedAt = ProcessInfo.processInfo.systemUptime
-		let targets = screens.compactMap(FrozenFrameContentFilterPlanner.displayTarget(for:))
-		guard targets.isEmpty == false else {
-			stop()
-			return
-		}
-		let targetIDs = Set(targets.map(\.displayID))
-		let nextTargets = Dictionary(uniqueKeysWithValues: targets.map { ($0.displayID, $0) })
-
-		stateLock.lock()
-		let unchanged = activeDisplayIDs == targetIDs && displayTargets == nextTargets
-		let streamsCoverTargets = Set(streams.keys) == targetIDs
-		let setupInProgressForTargets = setupDisplayIDs == targetIDs
-		displayTargets = nextTargets
-		if rebuildContentFilter {
-			selfCaptureFilterRequired = true
-			selfCaptureUnsafeAfterUptime = setupStartedAt
-		}
-		// When overlay windows become visible, discard pre-overlay streams instead of updating
-		// filters in place. Keep the old stream running until the replacement is configured so a
-		// fast click can still freeze a fresh frame, but only if that frame came from a complete
-		// self-capture-excluding filter.
-		if rebuildContentFilter, unchanged, streamsCoverTargets {
-			setupRequestID &+= 1
-			let requestID = setupRequestID
-			setupDisplayIDs = targetIDs
-			updateTelemetryContextLocked(
-				captureID: captureID,
-				source: source,
-				startedAtUptime: setupStartedAt,
-				targetIDs: targetIDs
-			)
-			stateLock.unlock()
-			rebuildStreamsFromShareableContent(
-				targets: targets,
-				targetIDs: targetIDs,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-				captureID: captureID,
-				source: source,
-				startedAtUptime: setupStartedAt,
-				retryUntilUptime: setupStartedAt + Self.selfCaptureFilterRetryWindow,
-				requestID: requestID
-			)
-			return
-		}
-		if unchanged, streamsCoverTargets || setupInProgressForTargets,
-			rebuildContentFilter == false
-		{
-			updateTelemetryContextLocked(
-				captureID: captureID,
-				source: source,
-				startedAtUptime: setupStartedAt,
-				targetIDs: targetIDs
-			)
-			stateLock.unlock()
-			return
-		}
-		generation &+= 1
-		setupRequestID &+= 1
-		let requestGeneration = generation
-		activeDisplayIDs = targetIDs
-		setupDisplayIDs = targetIDs
-		if rebuildContentFilter == false {
-			selfCaptureFilterRequired = false
-			selfCaptureUnsafeAfterUptime = nil
-		}
-		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
-		updateTelemetryContextLocked(
-			captureID: captureID,
-			source: source,
-			startedAtUptime: setupStartedAt,
-			targetIDs: targetIDs
-		)
-		let staleStreams = streams.values
-		streams.removeAll()
-		stateLock.unlock()
-
-		for staleStream in staleStreams {
-			staleStream.stop()
-		}
-
-		configureStreamsFromShareableContent(
-			targets: targets,
-			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-			generation: requestGeneration,
-			captureID: captureID,
-			source: source,
-			startedAtUptime: setupStartedAt
-		)
-	}
-
-	private func rebuildStreamsFromShareableContent(
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		retryUntilUptime: TimeInterval,
-		requestID: UInt64
-	) {
-		if configureStreamsFromCachedShareableContent(
-			targets: targets,
-			targetIDs: targetIDs,
-			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-			captureID: captureID,
-			source: source,
-			startedAtUptime: startedAtUptime,
-			requestID: requestID
-		) {
-			return
-		}
-
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
-			[weak self] content, error in
-			self?.handleShareableContentLookup(
-				content,
-				error: error,
-				targets: targets,
-				targetIDs: targetIDs,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-				captureID: captureID,
-				source: source,
-				startedAtUptime: startedAtUptime,
-				retryUntilUptime: retryUntilUptime,
-				requestID: requestID
-			)
-		}
-	}
-
-	private func configureStreamsFromCachedShareableContent(
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		requestID: UInt64
-	) -> Bool {
-		guard let content = Self.cachedShareableContent(covering: targetIDs) else {
-			return false
-		}
-		let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-			for: targets,
-			in: content,
-			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-		)
-		guard FrozenFrameContentFilterPlanner.filtersAreComplete(preparedFilters, for: targets)
-		else {
-			return false
-		}
-		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-			captureID: captureID,
-			source: source,
-			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-			success: true,
-			displayCount: content.displays.count,
-			windowCount: content.windows.count
-		)
-		replaceStreamsFromPreparedFilters(
-			targets: targets,
-			targetIDs: targetIDs,
-			preparedFilters: preparedFilters,
-			captureID: captureID,
-			source: source,
-			startedAtUptime: startedAtUptime,
-			requestID: requestID
-		)
-		return true
-	}
-
-	private func handleShareableContentLookup(
-		_ content: SCShareableContent?,
-		error: Error?,
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		retryUntilUptime: TimeInterval,
-		requestID: UInt64
-	) {
-		guard let content else {
-			NativeHostTelemetry.frozenAuthorityWarning(
-				"frozen_authority.content_lookup_failed",
-				captureID: captureID,
-				source: source,
-				displayID: 0,
-				error: String(describing: error)
-			)
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: false,
-				displayCount: targets.count,
-				windowCount: 0
-			)
-			finishSetup(targetIDs: targetIDs)
-			return
-		}
-
-		let contentCoversTargets = FrozenFrameContentFilterPlanner.shareableContent(
-			content, covers: targetIDs)
-		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-			captureID: captureID,
-			source: source,
-			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-			success: contentCoversTargets,
-			displayCount: content.displays.count,
-			windowCount: content.windows.count
-		)
-		guard isCurrentSetupRequest(requestID, targetIDs: targetIDs) else {
-			return
-		}
-		guard contentCoversTargets else {
-			NativeHostTelemetry.frozenAuthorityWarning(
-				"frozen_authority.content_lookup_invalid",
-				captureID: captureID,
-				source: source,
-				displayID: 0,
-				error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
-					content, requiredDisplayIDs: targetIDs)
-			)
-			if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
-				retryRebuildStreamsFromShareableContent(
-					targets: targets,
-					targetIDs: targetIDs,
-					selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-					includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-					captureID: captureID,
-					source: source,
-					startedAtUptime: startedAtUptime,
-					retryUntilUptime: retryUntilUptime,
-					requestID: requestID
-				)
-				return
-			}
-			finishSetup(targetIDs: targetIDs)
-			return
-		}
-		Self.shareableContentCache.store(content)
-		let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-			for: targets,
-			in: content,
-			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-		)
-		guard FrozenFrameContentFilterPlanner.filtersAreComplete(preparedFilters, for: targets)
-		else {
-			if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
-				retryRebuildStreamsFromShareableContent(
-					targets: targets,
-					targetIDs: targetIDs,
-					selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-					includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-					captureID: captureID,
-					source: source,
-					startedAtUptime: startedAtUptime,
-					retryUntilUptime: retryUntilUptime,
-					requestID: requestID
-				)
-				return
-			}
-			logIncompleteFilters(
-				preparedFilters, targets: targets, captureID: captureID, source: source)
-			finishSetup(targetIDs: targetIDs)
-			return
-		}
-		replaceStreamsFromPreparedFilters(
-			targets: targets,
-			targetIDs: targetIDs,
-			preparedFilters: preparedFilters,
-			captureID: captureID,
-			source: source,
-			startedAtUptime: startedAtUptime,
-			requestID: requestID
-		)
-	}
-
-	private func retryRebuildStreamsFromShareableContent(
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		retryUntilUptime: TimeInterval,
-		requestID: UInt64
-	) {
-		DispatchQueue.global(qos: .userInteractive).asyncAfter(
-			deadline: .now() + Self.selfCaptureFilterRetryInterval
-		) { [weak self] in
-			self?.rebuildStreamsFromShareableContent(
-				targets: targets,
-				targetIDs: targetIDs,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-				captureID: captureID,
-				source: source,
-				startedAtUptime: startedAtUptime,
-				retryUntilUptime: retryUntilUptime,
-				requestID: requestID
-			)
-		}
-	}
-
-	private func replaceStreamsFromPreparedFilters(
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		requestID: UInt64
-	) {
-		stateLock.lock()
-		guard setupRequestID == requestID, activeDisplayIDs == targetIDs else {
-			stateLock.unlock()
-			return
-		}
-		generation &+= 1
-		let requestGeneration = generation
-		setupDisplayIDs = targetIDs
-		latestFrames = latestFrames.filter { targetIDs.contains($0.key) }
-		updateTelemetryContextLocked(
-			captureID: captureID,
-			source: source,
-			startedAtUptime: startedAtUptime,
-			targetIDs: targetIDs
-		)
-		let staleStreams = streams.values
-		streams.removeAll()
-		stateLock.unlock()
-
-		for staleStream in staleStreams {
-			staleStream.stop()
-		}
-
-		configureStreams(
-			targets: targets,
-			preparedFilters: preparedFilters,
-			generation: requestGeneration,
-			captureID: captureID,
-			source: source
-		)
-	}
-
-	private func configureStreamsFromShareableContent(
-		targets: [FrozenFrameDisplayTarget],
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		generation requestGeneration: UInt64,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval
-	) {
-		let targetIDs = Set(targets.map(\.displayID))
-		if let content = Self.cachedShareableContent(covering: targetIDs) {
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: true,
-				displayCount: content.displays.count,
-				windowCount: content.windows.count
-			)
-			let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-				for: targets,
-				in: content,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-			)
-			configureStreams(
-				targets: targets,
-				preparedFilters: preparedFilters,
-				generation: requestGeneration,
-				captureID: captureID,
-				source: source
-			)
-			return
-		}
-		let retryUntilUptime = startedAtUptime + Self.selfCaptureFilterRetryWindow
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
-			[weak self] content, error in
-			guard let self else {
-				return
-			}
-			guard self.isCurrentGeneration(requestGeneration) else {
-				return
-			}
-			guard let content else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_lookup_failed",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: String(describing: error)
-				)
-				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-					captureID: captureID,
-					source: source,
-					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-					success: false,
-					displayCount: targets.count,
-					windowCount: 0
-				)
-				self.finishSetup(generation: requestGeneration)
-				return
-			}
-			let contentCoversTargets = FrozenFrameContentFilterPlanner.shareableContent(
-				content, covers: targetIDs)
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: contentCoversTargets,
-				displayCount: content.displays.count,
-				windowCount: content.windows.count
-			)
-			guard contentCoversTargets else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_lookup_invalid",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
-						content,
-						requiredDisplayIDs: targetIDs
-					)
-				)
-				if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
-					DispatchQueue.global(qos: .userInteractive).asyncAfter(
-						deadline: .now() + Self.selfCaptureFilterRetryInterval
-					) { [weak self] in
-						self?.configureStreamsFromShareableContent(
-							targets: targets,
-							selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-							includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-							generation: requestGeneration,
-							captureID: captureID,
-							source: source,
-							startedAtUptime: startedAtUptime
-						)
-					}
-					return
-				}
-				self.finishSetup(generation: requestGeneration)
-				return
-			}
-			Self.shareableContentCache.store(content)
-			let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-				for: targets,
-				in: content,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-			)
-			self.configureStreams(
-				targets: targets,
-				preparedFilters: preparedFilters,
-				generation: requestGeneration,
-				captureID: captureID,
-				source: source
-			)
-		}
-	}
-
-	func stop() {
-		stateLock.lock()
-		generation &+= 1
-		setupRequestID &+= 1
-		activeDisplayIDs.removeAll()
-		setupDisplayIDs = nil
-		selfCaptureFilterRequired = false
-		selfCaptureUnsafeAfterUptime = nil
-		displayTargets.removeAll()
-		latestFrames.removeAll()
-		firstFrameStartUptimes.removeAll()
-		firstFrameLoggedDisplayIDs.removeAll()
-		telemetryContext = TelemetryContext(
-			captureID: 0, source: "capture", startedAtUptime: 0)
-		let staleStreams = streams.values
-		streams.removeAll()
-		stateLock.unlock()
-
-		for staleStream in staleStreams {
-			staleStream.stop()
-		}
-	}
-
-	private func configureStreams(
-		targets: [FrozenFrameDisplayTarget],
-		preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
-		generation requestGeneration: UInt64,
-		captureID: UInt64,
-		source: String
-	) {
-		for target in targets {
-			guard let preparedFilter = preparedFilters[target.displayID] else {
-				continue
-			}
-
-			let output = FrozenFrameStreamOutput(
-				displayID: target.displayID,
-				displayFrame: target.frame,
-				generation: requestGeneration,
-				selfCaptureFilterComplete: preparedFilter.selfCaptureFilterComplete
-			) { [weak self] frame in
-				self?.store(frame: frame, generation: requestGeneration)
-			} onStop: { [weak self] displayID, generation in
-				self?.handleStreamStopped(displayID: displayID, generation: generation)
-			} telemetrySnapshot: { [weak self] in
-				self?.currentTelemetrySnapshot() ?? (captureID: captureID, source: source)
-			}
-			let stream = SCStream(
-				filter: preparedFilter.filter,
-				configuration: FrozenFrameContentFilterPlanner.streamConfiguration(for: target),
-				delegate: output)
-			do {
-				try stream.addStreamOutput(
-					output, type: SCStreamOutputType.screen, sampleHandlerQueue: outputQueue)
-			} catch {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.output_install_failed",
-					captureID: captureID,
-					source: source,
-					displayID: target.displayID,
-					error: String(describing: error)
-				)
-				continue
-			}
-
-			stateLock.lock()
-			let shouldStart =
-				generation == requestGeneration
-				&& (!selfCaptureFilterRequired || preparedFilter.selfCaptureFilterComplete)
-			if shouldStart {
-				streams[target.displayID] = DisplayStream(
-					stream: stream,
-					output: output,
-					selfCaptureFilterComplete: preparedFilter.selfCaptureFilterComplete
-				)
-			}
-			stateLock.unlock()
-			if selfCaptureFilterRequired, !preparedFilter.selfCaptureFilterComplete {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.self_capture_filter_incomplete",
-					captureID: captureID,
-					source: source,
-					displayID: target.displayID,
-					error:
-						"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
-				)
-			}
-			guard shouldStart else {
-				continue
-			}
-
-			stream.startCapture { [weak self] error in
-				if let error {
-					NativeHostTelemetry.frozenAuthorityWarning(
-						"frozen_authority.stream_start_failed",
-						captureID: captureID,
-						source: source,
-						displayID: target.displayID,
-						error: String(describing: error)
-					)
-					self?.handleStreamStopped(
-						displayID: target.displayID,
-						generation: requestGeneration
-					)
-				}
-			}
-		}
-		finishSetup(generation: requestGeneration)
-	}
-
-	private func logIncompleteFilters(
-		_ preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
-		targets: [FrozenFrameDisplayTarget],
-		captureID: UInt64,
-		source: String
-	) {
-		for target in targets {
-			guard let preparedFilter = preparedFilters[target.displayID] else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.self_capture_filter_incomplete",
-					captureID: captureID,
-					source: source,
-					displayID: target.displayID,
-					error: "missingFilter"
-				)
-				continue
-			}
-			guard preparedFilter.selfCaptureFilterComplete == false else {
-				continue
-			}
-			NativeHostTelemetry.frozenAuthorityWarning(
-				"frozen_authority.self_capture_filter_incomplete",
-				captureID: captureID,
-				source: source,
-				displayID: target.displayID,
-				error:
-					"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
-			)
-		}
-	}
-
-	private func store(
+	func store(
 		frame: FrameRecord,
 		generation requestGeneration: UInt64
 	) {
@@ -833,7 +147,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 	}
 
-	private func handleStreamStopped(
+	func handleStreamStopped(
 		displayID: CGDirectDisplayID,
 		generation stoppedGeneration: UInt64
 	) {
@@ -847,7 +161,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		stateLock.unlock()
 	}
 
-	private func finishSetup(generation requestGeneration: UInt64) {
+	func finishSetup(generation requestGeneration: UInt64) {
 		stateLock.lock()
 		if generation == requestGeneration {
 			setupDisplayIDs = nil
@@ -856,7 +170,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		stateLock.unlock()
 	}
 
-	private func finishSetup(targetIDs: Set<CGDirectDisplayID>) {
+	func finishSetup(targetIDs: Set<CGDirectDisplayID>) {
 		stateLock.lock()
 		if setupDisplayIDs == targetIDs {
 			setupDisplayIDs = nil
@@ -865,14 +179,14 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		stateLock.unlock()
 	}
 
-	private func isCurrentGeneration(_ requestGeneration: UInt64) -> Bool {
+	func isCurrentGeneration(_ requestGeneration: UInt64) -> Bool {
 		stateLock.lock()
 		let isCurrent = generation == requestGeneration
 		stateLock.unlock()
 		return isCurrent
 	}
 
-	private func isCurrentSetupRequest(_ requestID: UInt64, targetIDs: Set<CGDirectDisplayID>)
+	func isCurrentSetupRequest(_ requestID: UInt64, targetIDs: Set<CGDirectDisplayID>)
 		-> Bool
 	{
 		stateLock.lock()
@@ -881,7 +195,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		return isCurrent
 	}
 
-	private func updateTelemetryContextLocked(
+	func updateTelemetryContextLocked(
 		captureID: UInt64,
 		source: String,
 		startedAtUptime: TimeInterval,
@@ -899,7 +213,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		}
 	}
 
-	private func currentTelemetrySnapshot() -> (captureID: UInt64, source: String) {
+	func currentTelemetrySnapshot() -> (captureID: UInt64, source: String) {
 		stateLock.lock()
 		let snapshot = (captureID: telemetryContext.captureID, source: telemetryContext.source)
 		stateLock.unlock()


### PR DESCRIPTION
## Summary
- extract ScreenCaptureKit stream setup and shareable-content lookup from FrozenFrameAuthority into FrozenFrameAuthority+StreamSetup
- leave FrozenFrameAuthority focused on authority state, frame storage, setup completion, and telemetry bookkeeping
- update native host module reference docs

## Validation
- cargo make fmt-swift
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift
- cargo make fmt-swift-check
- cargo make check-vstyle-swift
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts (no matches)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check