### PR TITLE
Extract scroll toolbar backdrop worker

### DIFF
--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -109,10 +109,13 @@ The current native-host Swift split is:
   handoff state, completion queueing, pending-frame evidence, and deferred classic toolbar glass.
 - `CaptureHostScrollToolbarBackdropState.swift`: capture-host scroll toolbar backdrop capture
   generation, seed-patch cache, active frame, refresh cadence, and change-count state.
+- `CaptureHostScrollToolbarBackdropWorker.swift`: capture-host scroll toolbar backdrop live-frame
+  freshness, signature hashing, fallback capture selection, and capture result shaping.
 - `CaptureHostView.swift`: AppKit view orchestration, hit testing, and frozen presentation
   rendering.
 - `CaptureHostMaterialViewCoordinator.swift`: capture-host Liquid Glass/material subview ownership,
-  classic glass patch resolution, and scroll-toolbar backdrop refresh/capture scheduling.
+  classic glass patch resolution, and scroll-toolbar backdrop refresh scheduling plus view
+  installation.
 - `CaptureHostGlassPatchResolver.swift`: capture-host classic glass patch cache lookup, frozen
   display crop extraction, and CoreImage blur/tint adaptation for HUD, loupe, and toolbar surfaces.
 - `FrozenPreparedExportStore.swift`: frozen export render requests, prepared export cache keys,

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -217,10 +217,12 @@ The main host-kit files are split by responsibility:
   completion queueing, pending-frame evidence, and deferred classic toolbar glass
 - `CaptureHostScrollToolbarBackdropState.swift`: scroll toolbar backdrop capture generation,
   seed-patch cache, active frame, refresh cadence, and change-count state
+- `CaptureHostScrollToolbarBackdropWorker.swift`: scroll toolbar backdrop live-frame freshness,
+  signature hashing, fallback capture selection, and capture result shaping
 - `CaptureHostView.swift`: AppKit view orchestration, hit testing, and frozen presentation
   rendering
 - `CaptureHostMaterialViewCoordinator.swift`: Liquid Glass/material subview ownership, classic glass
-  patch resolution, and scroll-toolbar backdrop refresh/capture scheduling
+  patch resolution, and scroll-toolbar backdrop refresh scheduling plus view installation
 - `CaptureHostGlassPatchResolver.swift`: classic glass patch cache lookup, frozen display crop
   extraction, and CoreImage blur/tint adaptation for capture-host HUD, loupe, and toolbar surfaces
 - `FrozenPreparedExportStore.swift`: frozen export render requests, prepared export cache keys,

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostMaterialViewCoordinator.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostMaterialViewCoordinator.swift
@@ -429,74 +429,24 @@ final class CaptureHostMaterialViewCoordinator {
 					toolbarFrame, globalFrame, liveFrameStream, fallbackSource,
 					maximumLiveFrameAgeMicroseconds, capture,
 				] in
-				let rawFrame = liveFrameStream.nextRegionFrame(
+				let result = CaptureHostScrollToolbarBackdropWorker.captureResult(
 					in: globalFrame,
-					afterFrameSequence: capture.afterFrameSequence,
-					waitForFresh: false
+					liveFrameStream: liveFrameStream,
+					fallbackSource: fallbackSource,
+					maximumLiveFrameAgeMicroseconds: maximumLiveFrameAgeMicroseconds,
+					capture: capture
 				)
-				let nonblockingFrame: RGBARegionFrameSnapshot? =
-					if let rawFrame,
-						Self.scrollToolbarBackdropFrameIsFresh(
-							rawFrame,
-							maximumAgeMicroseconds: maximumLiveFrameAgeMicroseconds
-						)
-					{
-						rawFrame
-					} else {
-						nil
-					}
-				let freshFrame = nonblockingFrame
-				let frameSequence = max(
-					rawFrame?.frameSequence ?? 0,
-					freshFrame?.frameSequence ?? 0
-				)
-				let livePatch = freshFrame.flatMap {
-					NativeHostImageBridge.cgImage(from: $0.region)
-				}
-				let liveSignature = freshFrame.map {
-					Self.scrollToolbarBackdropSignature($0.region)
-				}
-				let liveWouldRemainStatic =
-					liveSignature == nil
-					|| (capture.previousSignature != nil
-						&& liveSignature == capture.previousSignature)
-				let fallbackPatch =
-					liveWouldRemainStatic && capture.fallbackPermitted
-					? CaptureOverlayImageSampler.captureBelowOverlay(
-						in: globalFrame,
-						source: fallbackSource
-					) : nil
-				let fallbackSnapshot = fallbackPatch.flatMap {
-					NativeHostImageBridge.rgbaSnapshot(from: $0)
-				}
-				let fallbackSignature = fallbackSnapshot.map {
-					Self.scrollToolbarBackdropSignature($0)
-				}
-				let shouldUseFallback =
-					fallbackPatch != nil
-					&& (capture.previousSignature == nil
-						|| fallbackSignature != capture.previousSignature)
-				let patch = shouldUseFallback ? fallbackPatch : (livePatch ?? fallbackPatch)
-				let signature =
-					shouldUseFallback ? fallbackSignature : (liveSignature ?? fallbackSignature)
 				DispatchQueue.main.async { [weak self = self] in
 					self?.finishScrollToolbarBackdropCapture(
-						patch,
+						result.patch,
 						toolbarFrame: toolbarFrame,
 						generation: capture.generation,
-						frameSequence: frameSequence > 0 ? frameSequence : nil,
-						signature: signature
+						frameSequence: result.frameSequence,
+						signature: result.signature
 					)
 				}
 			}
 		}
-	}
-
-	nonisolated private static func scrollToolbarBackdropFrameIsFresh(
-		_ frame: RGBARegionFrameSnapshot,
-		maximumAgeMicroseconds: UInt64
-	) -> Bool {
-		frame.frameAgeMicroseconds <= maximumAgeMicroseconds
 	}
 
 	private func finishScrollToolbarBackdropCapture(
@@ -551,28 +501,6 @@ final class CaptureHostMaterialViewCoordinator {
 				)
 			}
 		}
-	}
-
-	nonisolated private static func scrollToolbarBackdropSignature(
-		_ region: RGBARegionSnapshot
-	) -> UInt64 {
-		var hash: UInt64 = 14_695_981_039_346_656_037
-		let stride = max(region.rgba.count / 256, 4)
-		region.rgba.withUnsafeBytes { rawBuffer in
-			guard let bytes = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
-				return
-			}
-			var index = 0
-			while index < region.rgba.count {
-				hash ^= UInt64(bytes[index])
-				hash &*= 1_099_511_628_211
-				index += stride
-			}
-		}
-		hash ^= UInt64(max(region.width, 0))
-		hash &*= 1_099_511_628_211
-		hash ^= UInt64(max(region.height, 0))
-		return hash
 	}
 
 	func refreshScrollCaptureToolbarBackdropNow() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollToolbarBackdropState.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollToolbarBackdropState.swift
@@ -18,6 +18,18 @@ package struct CaptureHostScrollToolbarBackdropCaptureStart: Equatable {
 	package let afterFrameSequence: UInt64
 	package let previousSignature: UInt64?
 	package let fallbackPermitted: Bool
+
+	package init(
+		generation: UInt64,
+		afterFrameSequence: UInt64,
+		previousSignature: UInt64?,
+		fallbackPermitted: Bool
+	) {
+		self.generation = generation
+		self.afterFrameSequence = afterFrameSequence
+		self.previousSignature = previousSignature
+		self.fallbackPermitted = fallbackPermitted
+	}
 }
 
 package struct CaptureHostScrollToolbarBackdropChange: Equatable {

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollToolbarBackdropWorker.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostScrollToolbarBackdropWorker.swift
@@ -1,0 +1,127 @@
+import CoreGraphics
+import Foundation
+import RsnapHostBridge
+
+package struct CaptureHostScrollToolbarBackdropCaptureResult {
+	package let patch: CGImage?
+	package let frameSequence: UInt64?
+	package let signature: UInt64?
+
+	package init(patch: CGImage?, frameSequence: UInt64?, signature: UInt64?) {
+		self.patch = patch
+		self.frameSequence = frameSequence
+		self.signature = signature
+	}
+}
+
+package enum CaptureHostScrollToolbarBackdropWorker {
+	nonisolated static func captureResult(
+		in globalFrame: CGRect,
+		liveFrameStream: LiveFrameStreamBroker,
+		fallbackSource: CaptureSessionController.FrozenCaptureJobSource,
+		maximumLiveFrameAgeMicroseconds: UInt64,
+		capture: CaptureHostScrollToolbarBackdropCaptureStart
+	) -> CaptureHostScrollToolbarBackdropCaptureResult {
+		let rawFrame = liveFrameStream.nextRegionFrame(
+			in: globalFrame,
+			afterFrameSequence: capture.afterFrameSequence,
+			waitForFresh: false
+		)
+		return captureResult(
+			rawFrame: rawFrame,
+			maximumLiveFrameAgeMicroseconds: maximumLiveFrameAgeMicroseconds,
+			capture: capture,
+			fallbackPatch: {
+				CaptureOverlayImageSampler.captureBelowOverlay(
+					in: globalFrame,
+					source: fallbackSource
+				)
+			},
+			fallbackSnapshot: {
+				NativeHostImageBridge.rgbaSnapshot(from: $0)
+			}
+		)
+	}
+
+	nonisolated package static func captureResult(
+		rawFrame: RGBARegionFrameSnapshot?,
+		maximumLiveFrameAgeMicroseconds: UInt64,
+		capture: CaptureHostScrollToolbarBackdropCaptureStart,
+		fallbackPatch: () -> CGImage?,
+		fallbackSnapshot: (CGImage) -> RGBARegionSnapshot?
+	) -> CaptureHostScrollToolbarBackdropCaptureResult {
+		let freshFrame: RGBARegionFrameSnapshot? =
+			if let rawFrame,
+				frameIsFresh(
+					rawFrame,
+					maximumAgeMicroseconds: maximumLiveFrameAgeMicroseconds
+				)
+			{
+				rawFrame
+			} else {
+				nil
+			}
+		let frameSequence = max(
+			rawFrame?.frameSequence ?? 0,
+			freshFrame?.frameSequence ?? 0
+		)
+		let livePatch = freshFrame.flatMap {
+			NativeHostImageBridge.cgImage(from: $0.region)
+		}
+		let liveSignature = freshFrame.map {
+			signature($0.region)
+		}
+		let liveWouldRemainStatic =
+			liveSignature == nil
+			|| (capture.previousSignature != nil
+				&& liveSignature == capture.previousSignature)
+		let fallbackPatch =
+			liveWouldRemainStatic && capture.fallbackPermitted
+			? fallbackPatch() : nil
+		let fallbackSnapshot = fallbackPatch.flatMap {
+			fallbackSnapshot($0)
+		}
+		let fallbackSignature = fallbackSnapshot.map {
+			signature($0)
+		}
+		let shouldUseFallback =
+			fallbackPatch != nil
+			&& (capture.previousSignature == nil
+				|| fallbackSignature != capture.previousSignature)
+		let patch = shouldUseFallback ? fallbackPatch : (livePatch ?? fallbackPatch)
+		let resultSignature =
+			shouldUseFallback ? fallbackSignature : (liveSignature ?? fallbackSignature)
+		return CaptureHostScrollToolbarBackdropCaptureResult(
+			patch: patch,
+			frameSequence: frameSequence > 0 ? frameSequence : nil,
+			signature: resultSignature
+		)
+	}
+
+	nonisolated package static func frameIsFresh(
+		_ frame: RGBARegionFrameSnapshot,
+		maximumAgeMicroseconds: UInt64
+	) -> Bool {
+		frame.frameAgeMicroseconds <= maximumAgeMicroseconds
+	}
+
+	nonisolated package static func signature(_ region: RGBARegionSnapshot) -> UInt64 {
+		var hash: UInt64 = 14_695_981_039_346_656_037
+		let stride = max(region.rgba.count / 256, 4)
+		region.rgba.withUnsafeBytes { rawBuffer in
+			guard let bytes = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+				return
+			}
+			var index = 0
+			while index < region.rgba.count {
+				hash ^= UInt64(bytes[index])
+				hash &*= 1_099_511_628_211
+				index += stride
+			}
+		}
+		hash ^= UInt64(max(region.width, 0))
+		hash &*= 1_099_511_628_211
+		hash ^= UInt64(max(region.height, 0))
+		return hash
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -24,6 +24,7 @@ enum RsnapNativeHostKitProbe {
 		assertCaptureHostLivePrimaryInteractionState()
 		assertCaptureHostFrozenFirstDisplayHandoffState()
 		assertCaptureHostScrollToolbarBackdropState()
+		assertCaptureHostScrollToolbarBackdropWorker()
 		assertCaptureHostAnnotationStyleWheelGate()
 		assertCaptureHostToolbarHoverState()
 		assertCaptureHostLiveSampleCachePointMatching()
@@ -415,6 +416,85 @@ enum RsnapNativeHostKitProbe {
 			state.lastRefreshUptime == 0
 		else {
 			fatalError("scroll toolbar backdrop state should invalidate captures on full reset")
+		}
+	}
+
+	private static func assertCaptureHostScrollToolbarBackdropWorker() {
+		let liveRegion = RGBARegionSnapshot(
+			width: 2,
+			height: 1,
+			rgba: Data([1, 2, 3, 4, 5, 6, 7, 8])
+		)
+		let fallbackRegion = RGBARegionSnapshot(
+			width: 2,
+			height: 1,
+			rgba: Data([8, 7, 6, 5, 4, 3, 2, 1])
+		)
+		let liveSignature = CaptureHostScrollToolbarBackdropWorker.signature(liveRegion)
+		let fallbackSignature =
+			CaptureHostScrollToolbarBackdropWorker.signature(fallbackRegion)
+		let freshFrame = RGBARegionFrameSnapshot(
+			frameSequence: 9,
+			frameAgeMicroseconds: 10,
+			region: liveRegion
+		)
+		let fallbackImage = makeProbeImage()
+		var fallbackCalls = 0
+		let fallbackResult = CaptureHostScrollToolbarBackdropWorker.captureResult(
+			rawFrame: freshFrame,
+			maximumLiveFrameAgeMicroseconds: 10,
+			capture: CaptureHostScrollToolbarBackdropCaptureStart(
+				generation: 1,
+				afterFrameSequence: 3,
+				previousSignature: liveSignature,
+				fallbackPermitted: true
+			),
+			fallbackPatch: {
+				fallbackCalls += 1
+				return fallbackImage
+			},
+			fallbackSnapshot: { _ in fallbackRegion }
+		)
+		guard
+			fallbackCalls == 1,
+			fallbackResult.patch != nil,
+			fallbackResult.frameSequence == 9,
+			fallbackResult.signature == fallbackSignature
+		else {
+			fatalError("scroll toolbar backdrop worker should replace static live frames")
+		}
+
+		fallbackCalls = 0
+		let staleResult = CaptureHostScrollToolbarBackdropWorker.captureResult(
+			rawFrame: RGBARegionFrameSnapshot(
+				frameSequence: 10,
+				frameAgeMicroseconds: 11,
+				region: liveRegion
+			),
+			maximumLiveFrameAgeMicroseconds: 10,
+			capture: CaptureHostScrollToolbarBackdropCaptureStart(
+				generation: 2,
+				afterFrameSequence: 9,
+				previousSignature: nil,
+				fallbackPermitted: false
+			),
+			fallbackPatch: {
+				fallbackCalls += 1
+				return fallbackImage
+			},
+			fallbackSnapshot: { _ in fallbackRegion }
+		)
+		guard
+			fallbackCalls == 0,
+			staleResult.patch == nil,
+			staleResult.frameSequence == 10,
+			staleResult.signature == nil,
+			CaptureHostScrollToolbarBackdropWorker.frameIsFresh(
+				freshFrame,
+				maximumAgeMicroseconds: 10
+			)
+		else {
+			fatalError("scroll toolbar backdrop worker should reject stale live frames")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Extract scroll-toolbar backdrop live-frame freshness, signature hashing, fallback selection, and result shaping into `CaptureHostScrollToolbarBackdropWorker`.
- Keep `CaptureHostMaterialViewCoordinator` focused on material subview ownership, refresh scheduling, and view installation.
- Add probe coverage for static live-frame fallback replacement and stale-frame rejection; update module ownership docs.

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\\[path" packages apps native scripts` (no matches)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`
