### PR TITLE
Extract frozen shareable content lookup owner

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+ShareableContentCache.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+ShareableContentCache.swift
@@ -1,0 +1,13 @@
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+extension FrozenFrameAuthority {
+	func refreshShareableContentCache(captureID: UInt64 = 0, source: String = "cache") {
+		FrozenFrameShareableContentLookup.refreshCache(captureID: captureID, source: source)
+	}
+
+	func hasFreshShareableContentCache() -> Bool {
+		FrozenFrameShareableContentLookup.hasFreshCache()
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+StreamSetup.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+StreamSetup.swift
@@ -4,66 +4,6 @@ import Foundation
 import ScreenCaptureKit
 
 extension FrozenFrameAuthority {
-	func refreshShareableContentCache(captureID: UInt64 = 0, source: String = "cache") {
-		let startedAtUptime = ProcessInfo.processInfo.systemUptime
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
-			content, error in
-			guard let content else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_cache_refresh_failed",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: String(describing: error)
-				)
-				return
-			}
-			guard FrozenFrameContentFilterPlanner.shareableContentHasDisplays(content) else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_cache_refresh_invalid",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
-						content,
-						requiredDisplayIDs: []
-					)
-				)
-				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-					captureID: captureID,
-					source: source,
-					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-					success: false,
-					displayCount: content.displays.count,
-					windowCount: content.windows.count
-				)
-				return
-			}
-			Self.shareableContentCache.store(content)
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: true,
-				displayCount: content.displays.count,
-				windowCount: content.windows.count
-			)
-		}
-	}
-
-	private static func cachedShareableContent(
-		covering displayIDs: Set<CGDirectDisplayID>? = nil
-	) -> SCShareableContent? {
-		shareableContentCache.fresh(
-			maxAge: shareableContentCacheMaxAge,
-			covering: displayIDs
-		)
-	}
-
-	func hasFreshShareableContentCache() -> Bool {
-		Self.cachedShareableContent() != nil
-	}
-
 	func start(
 		for screens: [NSScreen],
 		captureID: UInt64 = 0,
@@ -176,7 +116,7 @@ extension FrozenFrameAuthority {
 		retryUntilUptime: TimeInterval,
 		requestID: UInt64
 	) {
-		if configureStreamsFromCachedShareableContent(
+		FrozenFrameShareableContentLookup.resolveCompleteFilters(
 			targets: targets,
 			targetIDs: targetIDs,
 			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
@@ -184,208 +124,24 @@ extension FrozenFrameAuthority {
 			captureID: captureID,
 			source: source,
 			startedAtUptime: startedAtUptime,
-			requestID: requestID
-		) {
-			return
-		}
-
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
-			[weak self] content, error in
-			self?.handleShareableContentLookup(
-				content,
-				error: error,
-				targets: targets,
-				targetIDs: targetIDs,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-				captureID: captureID,
-				source: source,
-				startedAtUptime: startedAtUptime,
-				retryUntilUptime: retryUntilUptime,
-				requestID: requestID
-			)
-		}
-	}
-
-	private func configureStreamsFromCachedShareableContent(
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		requestID: UInt64
-	) -> Bool {
-		guard let content = Self.cachedShareableContent(covering: targetIDs) else {
-			return false
-		}
-		let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-			for: targets,
-			in: content,
-			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-		)
-		guard FrozenFrameContentFilterPlanner.filtersAreComplete(preparedFilters, for: targets)
-		else {
-			return false
-		}
-		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-			captureID: captureID,
-			source: source,
-			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-			success: true,
-			displayCount: content.displays.count,
-			windowCount: content.windows.count
-		)
-		replaceStreamsFromPreparedFilters(
-			targets: targets,
-			targetIDs: targetIDs,
-			preparedFilters: preparedFilters,
-			captureID: captureID,
-			source: source,
-			startedAtUptime: startedAtUptime,
-			requestID: requestID
-		)
-		return true
-	}
-
-	private func handleShareableContentLookup(
-		_ content: SCShareableContent?,
-		error: Error?,
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		retryUntilUptime: TimeInterval,
-		requestID: UInt64
-	) {
-		guard let content else {
-			NativeHostTelemetry.frozenAuthorityWarning(
-				"frozen_authority.content_lookup_failed",
-				captureID: captureID,
-				source: source,
-				displayID: 0,
-				error: String(describing: error)
-			)
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: false,
-				displayCount: targets.count,
-				windowCount: 0
-			)
-			finishSetup(targetIDs: targetIDs)
-			return
-		}
-
-		let contentCoversTargets = FrozenFrameContentFilterPlanner.shareableContent(
-			content, covers: targetIDs)
-		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-			captureID: captureID,
-			source: source,
-			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-			success: contentCoversTargets,
-			displayCount: content.displays.count,
-			windowCount: content.windows.count
-		)
-		guard isCurrentSetupRequest(requestID, targetIDs: targetIDs) else {
-			return
-		}
-		guard contentCoversTargets else {
-			NativeHostTelemetry.frozenAuthorityWarning(
-				"frozen_authority.content_lookup_invalid",
-				captureID: captureID,
-				source: source,
-				displayID: 0,
-				error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
-					content, requiredDisplayIDs: targetIDs)
-			)
-			if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
-				retryRebuildStreamsFromShareableContent(
-					targets: targets,
-					targetIDs: targetIDs,
-					selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-					includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-					captureID: captureID,
-					source: source,
-					startedAtUptime: startedAtUptime,
-					retryUntilUptime: retryUntilUptime,
-					requestID: requestID
-				)
-				return
-			}
-			finishSetup(targetIDs: targetIDs)
-			return
-		}
-		Self.shareableContentCache.store(content)
-		let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-			for: targets,
-			in: content,
-			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-		)
-		guard FrozenFrameContentFilterPlanner.filtersAreComplete(preparedFilters, for: targets)
-		else {
-			if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
-				retryRebuildStreamsFromShareableContent(
-					targets: targets,
-					targetIDs: targetIDs,
-					selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-					includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-					captureID: captureID,
-					source: source,
-					startedAtUptime: startedAtUptime,
-					retryUntilUptime: retryUntilUptime,
-					requestID: requestID
-				)
-				return
-			}
-			logIncompleteFilters(
-				preparedFilters, targets: targets, captureID: captureID, source: source)
-			finishSetup(targetIDs: targetIDs)
-			return
-		}
-		replaceStreamsFromPreparedFilters(
-			targets: targets,
-			targetIDs: targetIDs,
-			preparedFilters: preparedFilters,
-			captureID: captureID,
-			source: source,
-			startedAtUptime: startedAtUptime,
-			requestID: requestID
-		)
-	}
-
-	private func retryRebuildStreamsFromShareableContent(
-		targets: [FrozenFrameDisplayTarget],
-		targetIDs: Set<CGDirectDisplayID>,
-		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
-		includedCurrentProcessWindowIDs: Set<CGWindowID>,
-		captureID: UInt64,
-		source: String,
-		startedAtUptime: TimeInterval,
-		retryUntilUptime: TimeInterval,
-		requestID: UInt64
-	) {
-		DispatchQueue.global(qos: .userInteractive).asyncAfter(
-			deadline: .now() + Self.selfCaptureFilterRetryInterval
+			retryUntilUptime: retryUntilUptime
 		) { [weak self] in
-			self?.rebuildStreamsFromShareableContent(
-				targets: targets,
-				targetIDs: targetIDs,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-				captureID: captureID,
-				source: source,
-				startedAtUptime: startedAtUptime,
-				retryUntilUptime: retryUntilUptime,
-				requestID: requestID
-			)
+			self?.isCurrentSetupRequest(requestID, targetIDs: targetIDs) == true
+		} completion: { [weak self] outcome in
+			switch outcome {
+			case .prepared(let preparedFilters):
+				self?.replaceStreamsFromPreparedFilters(
+					targets: targets,
+					targetIDs: targetIDs,
+					preparedFilters: preparedFilters,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime,
+					requestID: requestID
+				)
+			case .unavailable:
+				self?.finishSetup(targetIDs: targetIDs)
+			}
 		}
 	}
 
@@ -439,113 +195,29 @@ extension FrozenFrameAuthority {
 		source: String,
 		startedAtUptime: TimeInterval
 	) {
-		let targetIDs = Set(targets.map(\.displayID))
-		if let content = Self.cachedShareableContent(covering: targetIDs) {
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: true,
-				displayCount: content.displays.count,
-				windowCount: content.windows.count
-			)
-			let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-				for: targets,
-				in: content,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-			)
-			configureStreams(
-				targets: targets,
-				preparedFilters: preparedFilters,
-				generation: requestGeneration,
-				captureID: captureID,
-				source: source
-			)
-			return
-		}
-		let retryUntilUptime = startedAtUptime + Self.selfCaptureFilterRetryWindow
-		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
-			[weak self] content, error in
-			guard let self else {
-				return
-			}
-			guard self.isCurrentGeneration(requestGeneration) else {
-				return
-			}
-			guard let content else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_lookup_failed",
+		FrozenFrameShareableContentLookup.resolveFilters(
+			targets: targets,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+			captureID: captureID,
+			source: source,
+			startedAtUptime: startedAtUptime,
+			retryUntilUptime: startedAtUptime + Self.selfCaptureFilterRetryWindow
+		) { [weak self] in
+			self?.isCurrentGeneration(requestGeneration) == true
+		} completion: { [weak self] outcome in
+			switch outcome {
+			case .prepared(let preparedFilters):
+				self?.configureStreams(
+					targets: targets,
+					preparedFilters: preparedFilters,
+					generation: requestGeneration,
 					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: String(describing: error)
+					source: source
 				)
-				NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-					captureID: captureID,
-					source: source,
-					totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-					success: false,
-					displayCount: targets.count,
-					windowCount: 0
-				)
-				self.finishSetup(generation: requestGeneration)
-				return
+			case .unavailable:
+				self?.finishSetup(generation: requestGeneration)
 			}
-			let contentCoversTargets = FrozenFrameContentFilterPlanner.shareableContent(
-				content, covers: targetIDs)
-			NativeHostTelemetry.frozenAuthorityContentLookupTiming(
-				captureID: captureID,
-				source: source,
-				totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
-				success: contentCoversTargets,
-				displayCount: content.displays.count,
-				windowCount: content.windows.count
-			)
-			guard contentCoversTargets else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.content_lookup_invalid",
-					captureID: captureID,
-					source: source,
-					displayID: 0,
-					error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
-						content,
-						requiredDisplayIDs: targetIDs
-					)
-				)
-				if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
-					DispatchQueue.global(qos: .userInteractive).asyncAfter(
-						deadline: .now() + Self.selfCaptureFilterRetryInterval
-					) { [weak self] in
-						self?.configureStreamsFromShareableContent(
-							targets: targets,
-							selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-							includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
-							generation: requestGeneration,
-							captureID: captureID,
-							source: source,
-							startedAtUptime: startedAtUptime
-						)
-					}
-					return
-				}
-				self.finishSetup(generation: requestGeneration)
-				return
-			}
-			Self.shareableContentCache.store(content)
-			let preparedFilters = FrozenFrameContentFilterPlanner.contentFilters(
-				for: targets,
-				in: content,
-				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
-				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
-			)
-			self.configureStreams(
-				targets: targets,
-				preparedFilters: preparedFilters,
-				generation: requestGeneration,
-				captureID: captureID,
-				source: source
-			)
 		}
 	}
 
@@ -657,36 +329,5 @@ extension FrozenFrameAuthority {
 			}
 		}
 		finishSetup(generation: requestGeneration)
-	}
-
-	private func logIncompleteFilters(
-		_ preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
-		targets: [FrozenFrameDisplayTarget],
-		captureID: UInt64,
-		source: String
-	) {
-		for target in targets {
-			guard let preparedFilter = preparedFilters[target.displayID] else {
-				NativeHostTelemetry.frozenAuthorityWarning(
-					"frozen_authority.self_capture_filter_incomplete",
-					captureID: captureID,
-					source: source,
-					displayID: target.displayID,
-					error: "missingFilter"
-				)
-				continue
-			}
-			guard preparedFilter.selfCaptureFilterComplete == false else {
-				continue
-			}
-			NativeHostTelemetry.frozenAuthorityWarning(
-				"frozen_authority.self_capture_filter_incomplete",
-				captureID: captureID,
-				source: source,
-				displayID: target.displayID,
-				error:
-					"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
-			)
-		}
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -92,8 +92,6 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		label: "ink.hack.rsnap.native-host.frozen-frame-authority-output",
 		qos: .userInteractive
 	)
-	static let shareableContentCacheMaxAge: TimeInterval = 3_600
-	static let shareableContentCache = FrozenFrameShareableContentCache()
 	var generation: UInt64 = 0
 	var setupRequestID: UInt64 = 0
 	var setupDisplayIDs: Set<CGDirectDisplayID>?

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameContentFilterPlanner.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameContentFilterPlanner.swift
@@ -6,7 +6,7 @@ import Darwin
 import Foundation
 import ScreenCaptureKit
 
-struct FrozenFrameDisplayTarget: Equatable {
+struct FrozenFrameDisplayTarget: Equatable, Sendable {
 	let displayID: CGDirectDisplayID
 	let frame: CGRect
 	let widthPixels: Int
@@ -14,7 +14,7 @@ struct FrozenFrameDisplayTarget: Equatable {
 	let framesPerSecond: Int
 }
 
-struct FrozenFramePreparedContentFilter {
+struct FrozenFramePreparedContentFilter: @unchecked Sendable {
 	let filter: SCContentFilter
 	let selfCaptureFilterComplete: Bool
 	let expectedWindowCount: Int

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameShareableContentLookup.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameShareableContentLookup.swift
@@ -1,0 +1,490 @@
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+enum FrozenFrameShareableContentLookup {
+	enum Outcome {
+		case prepared([CGDirectDisplayID: FrozenFramePreparedContentFilter])
+		case unavailable
+	}
+
+	private static let cacheMaxAge: TimeInterval = 3_600
+	private static let cache = FrozenFrameShareableContentCache()
+
+	static func refreshCache(captureID: UInt64 = 0, source: String = "cache") {
+		let startedAtUptime = ProcessInfo.processInfo.systemUptime
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
+			content, error in
+			guard let content else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_cache_refresh_failed",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: String(describing: error)
+				)
+				return
+			}
+			guard FrozenFrameContentFilterPlanner.shareableContentHasDisplays(content) else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.content_cache_refresh_invalid",
+					captureID: captureID,
+					source: source,
+					displayID: 0,
+					error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
+						content,
+						requiredDisplayIDs: []
+					)
+				)
+				recordLookupTiming(
+					content,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime,
+					success: false
+				)
+				return
+			}
+			cache.store(content)
+			recordLookupTiming(
+				content,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				success: true
+			)
+		}
+	}
+
+	static func hasFreshCache() -> Bool {
+		cachedContent() != nil
+	}
+
+	static func resolveFilters(
+		targets: [FrozenFrameDisplayTarget],
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		shouldContinue: @escaping @Sendable () -> Bool,
+		completion: @escaping @Sendable (Outcome) -> Void
+	) {
+		let targetIDs = Set(targets.map(\.displayID))
+		if let content = cachedContent(covering: targetIDs) {
+			recordLookupTiming(
+				content,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				success: true
+			)
+			completion(
+				.prepared(
+					preparedFilters(
+						targets: targets,
+						content: content,
+						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+						includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+					)
+				)
+			)
+			return
+		}
+
+		lookupContent { content, error in
+			guard shouldContinue() else {
+				return
+			}
+			guard let content else {
+				recordLookupFailure(
+					error,
+					targets: targets,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime
+				)
+				completion(.unavailable)
+				return
+			}
+			let contentCoversTargets = contentCovers(content, targetIDs: targetIDs)
+			recordLookupTiming(
+				content,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				success: contentCoversTargets
+			)
+			guard contentCoversTargets else {
+				recordInvalidContent(
+					content, targetIDs: targetIDs, captureID: captureID, source: source)
+				if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
+					retryResolveFilters(
+						targets: targets,
+						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+						includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+						captureID: captureID,
+						source: source,
+						startedAtUptime: startedAtUptime,
+						retryUntilUptime: retryUntilUptime,
+						shouldContinue: shouldContinue,
+						completion: completion
+					)
+					return
+				}
+				completion(.unavailable)
+				return
+			}
+			cache.store(content)
+			completion(
+				.prepared(
+					preparedFilters(
+						targets: targets,
+						content: content,
+						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+						includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+					)
+				)
+			)
+		}
+	}
+
+	static func resolveCompleteFilters(
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		shouldContinue: @escaping @Sendable () -> Bool,
+		completion: @escaping @Sendable (Outcome) -> Void
+	) {
+		if let content = cachedContent(covering: targetIDs) {
+			let preparedFilters = preparedFilters(
+				targets: targets,
+				content: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+			)
+			guard filtersAreComplete(preparedFilters, targets: targets) else {
+				return lookupCompleteFilters(
+					targets: targets,
+					targetIDs: targetIDs,
+					selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+					includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime,
+					retryUntilUptime: retryUntilUptime,
+					shouldContinue: shouldContinue,
+					completion: completion
+				)
+			}
+			recordLookupTiming(
+				content,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				success: true
+			)
+			completion(.prepared(preparedFilters))
+			return
+		}
+
+		lookupCompleteFilters(
+			targets: targets,
+			targetIDs: targetIDs,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+			captureID: captureID,
+			source: source,
+			startedAtUptime: startedAtUptime,
+			retryUntilUptime: retryUntilUptime,
+			shouldContinue: shouldContinue,
+			completion: completion
+		)
+	}
+
+	private static func lookupCompleteFilters(
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		shouldContinue: @escaping @Sendable () -> Bool,
+		completion: @escaping @Sendable (Outcome) -> Void
+	) {
+		lookupContent { content, error in
+			guard let content else {
+				recordLookupFailure(
+					error,
+					targets: targets,
+					captureID: captureID,
+					source: source,
+					startedAtUptime: startedAtUptime
+				)
+				if shouldContinue() {
+					completion(.unavailable)
+				}
+				return
+			}
+
+			let contentCoversTargets = contentCovers(content, targetIDs: targetIDs)
+			recordLookupTiming(
+				content,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				success: contentCoversTargets
+			)
+			guard shouldContinue() else {
+				return
+			}
+			guard contentCoversTargets else {
+				recordInvalidContent(
+					content, targetIDs: targetIDs, captureID: captureID, source: source)
+				if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
+					retryResolveCompleteFilters(
+						targets: targets,
+						targetIDs: targetIDs,
+						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+						includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+						captureID: captureID,
+						source: source,
+						startedAtUptime: startedAtUptime,
+						retryUntilUptime: retryUntilUptime,
+						shouldContinue: shouldContinue,
+						completion: completion
+					)
+					return
+				}
+				completion(.unavailable)
+				return
+			}
+			cache.store(content)
+			let preparedFilters = preparedFilters(
+				targets: targets,
+				content: content,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+			)
+			guard filtersAreComplete(preparedFilters, targets: targets) else {
+				if ProcessInfo.processInfo.systemUptime < retryUntilUptime {
+					retryResolveCompleteFilters(
+						targets: targets,
+						targetIDs: targetIDs,
+						selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+						includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+						captureID: captureID,
+						source: source,
+						startedAtUptime: startedAtUptime,
+						retryUntilUptime: retryUntilUptime,
+						shouldContinue: shouldContinue,
+						completion: completion
+					)
+					return
+				}
+				recordIncompleteFilters(
+					preparedFilters, targets: targets, captureID: captureID, source: source)
+				completion(.unavailable)
+				return
+			}
+			completion(.prepared(preparedFilters))
+		}
+	}
+
+	private static func retryResolveFilters(
+		targets: [FrozenFrameDisplayTarget],
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		shouldContinue: @escaping @Sendable () -> Bool,
+		completion: @escaping @Sendable (Outcome) -> Void
+	) {
+		DispatchQueue.global(qos: .userInteractive).asyncAfter(
+			deadline: .now() + FrozenFrameAuthority.selfCaptureFilterRetryInterval
+		) {
+			resolveFilters(
+				targets: targets,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				retryUntilUptime: retryUntilUptime,
+				shouldContinue: shouldContinue,
+				completion: completion
+			)
+		}
+	}
+
+	private static func retryResolveCompleteFilters(
+		targets: [FrozenFrameDisplayTarget],
+		targetIDs: Set<CGDirectDisplayID>,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		retryUntilUptime: TimeInterval,
+		shouldContinue: @escaping @Sendable () -> Bool,
+		completion: @escaping @Sendable (Outcome) -> Void
+	) {
+		DispatchQueue.global(qos: .userInteractive).asyncAfter(
+			deadline: .now() + FrozenFrameAuthority.selfCaptureFilterRetryInterval
+		) {
+			resolveCompleteFilters(
+				targets: targets,
+				targetIDs: targetIDs,
+				selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+				includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs,
+				captureID: captureID,
+				source: source,
+				startedAtUptime: startedAtUptime,
+				retryUntilUptime: retryUntilUptime,
+				shouldContinue: shouldContinue,
+				completion: completion
+			)
+		}
+	}
+
+	private static func lookupContent(
+		completion: @escaping @Sendable (SCShareableContent?, Error?) -> Void
+	) {
+		SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) {
+			content, error in
+			completion(content, error)
+		}
+	}
+
+	private static func cachedContent(
+		covering displayIDs: Set<CGDirectDisplayID>? = nil
+	) -> SCShareableContent? {
+		cache.fresh(maxAge: cacheMaxAge, covering: displayIDs)
+	}
+
+	private static func preparedFilters(
+		targets: [FrozenFrameDisplayTarget],
+		content: SCShareableContent,
+		selfCaptureExceptionWindowIDs: Set<CGWindowID>,
+		includedCurrentProcessWindowIDs: Set<CGWindowID>
+	) -> [CGDirectDisplayID: FrozenFramePreparedContentFilter] {
+		FrozenFrameContentFilterPlanner.contentFilters(
+			for: targets,
+			in: content,
+			selfCaptureExceptionWindowIDs: selfCaptureExceptionWindowIDs,
+			includedCurrentProcessWindowIDs: includedCurrentProcessWindowIDs
+		)
+	}
+
+	private static func filtersAreComplete(
+		_ preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
+		targets: [FrozenFrameDisplayTarget]
+	) -> Bool {
+		FrozenFrameContentFilterPlanner.filtersAreComplete(preparedFilters, for: targets)
+	}
+
+	private static func contentCovers(
+		_ content: SCShareableContent,
+		targetIDs: Set<CGDirectDisplayID>
+	) -> Bool {
+		FrozenFrameContentFilterPlanner.shareableContent(content, covers: targetIDs)
+	}
+
+	private static func recordLookupFailure(
+		_ error: Error?,
+		targets: [FrozenFrameDisplayTarget],
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval
+	) {
+		NativeHostTelemetry.frozenAuthorityWarning(
+			"frozen_authority.content_lookup_failed",
+			captureID: captureID,
+			source: source,
+			displayID: 0,
+			error: String(describing: error)
+		)
+		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+			captureID: captureID,
+			source: source,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+			success: false,
+			displayCount: targets.count,
+			windowCount: 0
+		)
+	}
+
+	private static func recordInvalidContent(
+		_ content: SCShareableContent,
+		targetIDs: Set<CGDirectDisplayID>,
+		captureID: UInt64,
+		source: String
+	) {
+		NativeHostTelemetry.frozenAuthorityWarning(
+			"frozen_authority.content_lookup_invalid",
+			captureID: captureID,
+			source: source,
+			displayID: 0,
+			error: FrozenFrameContentFilterPlanner.shareableContentDisplayDetail(
+				content, requiredDisplayIDs: targetIDs)
+		)
+	}
+
+	private static func recordLookupTiming(
+		_ content: SCShareableContent,
+		captureID: UInt64,
+		source: String,
+		startedAtUptime: TimeInterval,
+		success: Bool
+	) {
+		NativeHostTelemetry.frozenAuthorityContentLookupTiming(
+			captureID: captureID,
+			source: source,
+			totalMilliseconds: NativeHostTelemetry.milliseconds(since: startedAtUptime),
+			success: success,
+			displayCount: content.displays.count,
+			windowCount: content.windows.count
+		)
+	}
+
+	private static func recordIncompleteFilters(
+		_ preparedFilters: [CGDirectDisplayID: FrozenFramePreparedContentFilter],
+		targets: [FrozenFrameDisplayTarget],
+		captureID: UInt64,
+		source: String
+	) {
+		for target in targets {
+			guard let preparedFilter = preparedFilters[target.displayID] else {
+				NativeHostTelemetry.frozenAuthorityWarning(
+					"frozen_authority.self_capture_filter_incomplete",
+					captureID: captureID,
+					source: source,
+					displayID: target.displayID,
+					error: "missingFilter"
+				)
+				continue
+			}
+			guard preparedFilter.selfCaptureFilterComplete == false else {
+				continue
+			}
+			NativeHostTelemetry.frozenAuthorityWarning(
+				"frozen_authority.self_capture_filter_incomplete",
+				captureID: captureID,
+				source: source,
+				displayID: target.displayID,
+				error:
+					"expectedWindowCount=\(preparedFilter.expectedWindowCount) matchedWindowCount=\(preparedFilter.matchedWindowCount)"
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- extract shareable-content cache refresh and freshness wrappers from frozen stream setup
- move ScreenCaptureKit shareable-content lookup, retry, cache ownership, and lookup telemetry into `FrozenFrameShareableContentLookup`
- keep stream replacement and SCStream installation private to `FrozenFrameAuthority` while marking async filter payloads Sendable for Swift strict builds

## Validation
- `cargo make fmt-swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-swift`
- `cargo make fmt-swift-check`
- `cargo make check-vstyle-swift`
- `git diff --check`
- `rg -n "include!|#\\[path" packages apps native scripts || true`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`
