### PR TITLE
Extract frozen overlay export bridge owner

### DIFF
--- a/packages/rsnap-host-ffi/src/frozen_overlay.rs
+++ b/packages/rsnap-host-ffi/src/frozen_overlay.rs
@@ -1,17 +1,16 @@
-//! Frozen-overlay edit and export C ABI entrypoints.
+//! Frozen-overlay edit C ABI entrypoints.
 
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::c_char;
 use std::ptr::{self, NonNull};
-use std::slice;
 
 use crate::abi;
 use crate::{
 	RsnapFloatPoint, RsnapFloatRect, RsnapFrozenAnnotationColor,
 	RsnapFrozenOverlayEditSessionHandle, RsnapFrozenOverlayEditSnapshot,
 	RsnapFrozenOverlayEditStyle, RsnapFrozenOverlayExportElement,
-	RsnapFrozenOverlayExportElementKind, RsnapOwnedRgbaRegion, RsnapStatus, RsnapToolbarItemKind,
+	RsnapFrozenOverlayExportElementKind, RsnapStatus, RsnapToolbarItemKind,
 };
 use rsnap_overlay::frozen_edit::{
 	FrozenOverlayEditArrow, FrozenOverlayEditColor, FrozenOverlayEditElement,
@@ -19,12 +18,6 @@ use rsnap_overlay::frozen_edit::{
 	FrozenOverlayEditSession, FrozenOverlayEditSnapshot, FrozenOverlayEditSpotlight,
 	FrozenOverlayEditSpotlightStyle, FrozenOverlayEditStrokeStyle, FrozenOverlayEditStyle,
 	FrozenOverlayEditText, FrozenOverlayEditTextStyle, FrozenOverlayTextEdit,
-};
-use rsnap_overlay::frozen_export::{
-	self, FrozenOverlayExportArrow, FrozenOverlayExportElement, FrozenOverlayExportMosaic,
-	FrozenOverlayExportPen, FrozenOverlayExportPoint, FrozenOverlayExportSpotlight,
-	FrozenOverlayExportSpotlightStyle, FrozenOverlayExportStrokeStyle, FrozenOverlayExportText,
-	FrozenOverlayExportTextStyle,
 };
 
 /// Creates a Rust-owned frozen-overlay edit session.
@@ -396,54 +389,6 @@ pub unsafe extern "C" fn rsnap_frozen_overlay_edit_snapshot_release(
 	*snapshot = RsnapFrozenOverlayEditSnapshot::default();
 }
 
-/// Composites frozen-overlay annotations into a full RGBA export image through Rust.
-///
-/// # Safety
-///
-/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
-/// row-major RGBA data. `elements` must either be null with `elements_len == 0`, or point
-/// to `elements_len` readable element records whose nested point and text pointers stay
-/// valid for the duration of the call. The returned buffer must be released with
-/// `rsnap_owned_rgba_region_release`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rsnap_frozen_overlay_export_render_rgba(
-	width: u32,
-	height: u32,
-	rgba: *const u8,
-	rgba_len: usize,
-	selection: RsnapFloatRect,
-	elements: *const RsnapFrozenOverlayExportElement,
-	elements_len: usize,
-	out_region: *mut RsnapOwnedRgbaRegion,
-) -> RsnapStatus {
-	if out_region.is_null() {
-		return RsnapStatus::NullOutput;
-	}
-
-	let Some(bytes) = (unsafe { crate::rgba_bytes(rgba, rgba_len) }) else {
-		return RsnapStatus::InvalidInput;
-	};
-	let Some(elements) = (unsafe { decode_frozen_overlay_export_elements(elements, elements_len) })
-	else {
-		return RsnapStatus::InvalidInput;
-	};
-	let Ok(image) = frozen_export::render_frozen_overlay_export_rgba(
-		width,
-		height,
-		bytes,
-		crate::decode_float_rect(selection),
-		&elements,
-	) else {
-		return RsnapStatus::InvalidInput;
-	};
-
-	unsafe {
-		ptr::write(out_region, crate::owned_region_from_raw_rgba(width, height, image.into_raw()));
-	}
-
-	RsnapStatus::Ok
-}
-
 unsafe fn frozen_edit_handle_mut<'a>(
 	handle: *mut RsnapFrozenOverlayEditSessionHandle,
 ) -> Option<&'a mut RsnapFrozenOverlayEditSessionHandle> {
@@ -454,128 +399,6 @@ unsafe fn frozen_edit_handle_ref<'a>(
 	handle: *const RsnapFrozenOverlayEditSessionHandle,
 ) -> Option<&'a RsnapFrozenOverlayEditSessionHandle> {
 	unsafe { handle.as_ref() }
-}
-
-unsafe fn decode_frozen_overlay_export_elements(
-	elements: *const RsnapFrozenOverlayExportElement,
-	elements_len: usize,
-) -> Option<Vec<FrozenOverlayExportElement>> {
-	if elements_len == 0 {
-		return Some(Vec::new());
-	}
-	if elements.is_null() {
-		return None;
-	}
-
-	let elements = unsafe { slice::from_raw_parts(elements, elements_len) };
-
-	elements
-		.iter()
-		.map(|element| unsafe { decode_frozen_overlay_export_element(element) })
-		.collect()
-}
-
-unsafe fn decode_frozen_overlay_export_element(
-	element: &RsnapFrozenOverlayExportElement,
-) -> Option<FrozenOverlayExportElement> {
-	let color = decode_frozen_annotation_color(element.color);
-
-	match element.kind {
-		RsnapFrozenOverlayExportElementKind::Pen => {
-			Some(FrozenOverlayExportElement::Pen(FrozenOverlayExportPen {
-				points: unsafe {
-					decode_frozen_overlay_points(element.points, element.points_len)
-				}?,
-				style: FrozenOverlayExportStrokeStyle {
-					stroke_width_points: decode_f32(element.stroke_width_points)?,
-					rgba: color,
-				},
-			}))
-		},
-		RsnapFrozenOverlayExportElementKind::Arrow => {
-			Some(FrozenOverlayExportElement::Arrow(FrozenOverlayExportArrow {
-				start: decode_frozen_overlay_point(element.start)?,
-				end: decode_frozen_overlay_point(element.end)?,
-				style: FrozenOverlayExportStrokeStyle {
-					stroke_width_points: decode_f32(element.stroke_width_points)?,
-					rgba: color,
-				},
-			}))
-		},
-		RsnapFrozenOverlayExportElementKind::Mosaic => {
-			Some(FrozenOverlayExportElement::Mosaic(FrozenOverlayExportMosaic {
-				rect: crate::decode_float_rect(element.rect),
-			}))
-		},
-		RsnapFrozenOverlayExportElementKind::Spotlight => {
-			Some(FrozenOverlayExportElement::Spotlight(FrozenOverlayExportSpotlight {
-				rect: crate::decode_float_rect(element.rect),
-				style: FrozenOverlayExportSpotlightStyle {
-					border_width_points: decode_f32(element.border_width_points)?,
-					border_rgba: color,
-				},
-			}))
-		},
-		RsnapFrozenOverlayExportElementKind::Text => {
-			Some(FrozenOverlayExportElement::Text(FrozenOverlayExportText {
-				anchor: decode_frozen_overlay_point(element.start)?,
-				text: unsafe { decode_optional_utf8(element.text) }?,
-				style: FrozenOverlayExportTextStyle {
-					font_size_points: decode_f32(element.font_size_points)?,
-					rgba: color,
-				},
-			}))
-		},
-	}
-}
-
-unsafe fn decode_frozen_overlay_points(
-	points: *const RsnapFloatPoint,
-	points_len: usize,
-) -> Option<Vec<FrozenOverlayExportPoint>> {
-	if points_len == 0 {
-		return Some(Vec::new());
-	}
-	if points.is_null() {
-		return None;
-	}
-
-	unsafe { slice::from_raw_parts(points, points_len) }
-		.iter()
-		.map(|point| decode_frozen_overlay_point(*point))
-		.collect()
-}
-
-fn decode_frozen_overlay_point(point: RsnapFloatPoint) -> Option<FrozenOverlayExportPoint> {
-	if point.x.is_finite() && point.y.is_finite() {
-		Some(FrozenOverlayExportPoint::new(point.x, point.y))
-	} else {
-		None
-	}
-}
-
-unsafe fn decode_optional_utf8(text: *const c_char) -> Option<String> {
-	if text.is_null() {
-		return Some(String::new());
-	}
-
-	unsafe { CStr::from_ptr(text) }.to_str().ok().map(ToOwned::to_owned)
-}
-
-fn decode_f32(value: f64) -> Option<f32> {
-	(value.is_finite() && value >= f64::from(f32::MIN) && value <= f64::from(f32::MAX))
-		.then_some(value as f32)
-}
-
-fn decode_frozen_annotation_color(color: RsnapFrozenAnnotationColor) -> [u8; 4] {
-	match color {
-		RsnapFrozenAnnotationColor::White => [255, 255, 255, 255],
-		RsnapFrozenAnnotationColor::Yellow => [255, 219, 77, 255],
-		RsnapFrozenAnnotationColor::Green => [92, 214, 149, 255],
-		RsnapFrozenAnnotationColor::Blue => [102, 178, 255, 255],
-		RsnapFrozenAnnotationColor::Red => [255, 107, 107, 255],
-		RsnapFrozenAnnotationColor::Black => [24, 24, 24, 255],
-	}
 }
 
 fn decode_frozen_overlay_edit_style(

--- a/packages/rsnap-host-ffi/src/frozen_overlay_export.rs
+++ b/packages/rsnap-host-ffi/src/frozen_overlay_export.rs
@@ -1,0 +1,187 @@
+//! Frozen-overlay export C ABI entrypoints.
+
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::ptr;
+use std::slice;
+
+use crate::{
+	RsnapFloatPoint, RsnapFloatRect, RsnapFrozenAnnotationColor, RsnapFrozenOverlayExportElement,
+	RsnapFrozenOverlayExportElementKind, RsnapOwnedRgbaRegion, RsnapStatus,
+};
+use rsnap_overlay::frozen_export::{
+	self, FrozenOverlayExportArrow, FrozenOverlayExportElement, FrozenOverlayExportMosaic,
+	FrozenOverlayExportPen, FrozenOverlayExportPoint, FrozenOverlayExportSpotlight,
+	FrozenOverlayExportSpotlightStyle, FrozenOverlayExportStrokeStyle, FrozenOverlayExportText,
+	FrozenOverlayExportTextStyle,
+};
+
+/// Composites frozen-overlay annotations into a full RGBA export image through Rust.
+///
+/// # Safety
+///
+/// `rgba` must point to `rgba_len` readable bytes containing `width * height * 4`
+/// row-major RGBA data. `elements` must either be null with `elements_len == 0`, or point
+/// to `elements_len` readable element records whose nested point and text pointers stay
+/// valid for the duration of the call. The returned buffer must be released with
+/// `rsnap_owned_rgba_region_release`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rsnap_frozen_overlay_export_render_rgba(
+	width: u32,
+	height: u32,
+	rgba: *const u8,
+	rgba_len: usize,
+	selection: RsnapFloatRect,
+	elements: *const RsnapFrozenOverlayExportElement,
+	elements_len: usize,
+	out_region: *mut RsnapOwnedRgbaRegion,
+) -> RsnapStatus {
+	if out_region.is_null() {
+		return RsnapStatus::NullOutput;
+	}
+
+	let Some(bytes) = (unsafe { crate::rgba_bytes(rgba, rgba_len) }) else {
+		return RsnapStatus::InvalidInput;
+	};
+	let Some(elements) = (unsafe { decode_frozen_overlay_export_elements(elements, elements_len) })
+	else {
+		return RsnapStatus::InvalidInput;
+	};
+	let Ok(image) = frozen_export::render_frozen_overlay_export_rgba(
+		width,
+		height,
+		bytes,
+		crate::decode_float_rect(selection),
+		&elements,
+	) else {
+		return RsnapStatus::InvalidInput;
+	};
+
+	unsafe {
+		ptr::write(out_region, crate::owned_region_from_raw_rgba(width, height, image.into_raw()));
+	}
+
+	RsnapStatus::Ok
+}
+
+unsafe fn decode_frozen_overlay_export_elements(
+	elements: *const RsnapFrozenOverlayExportElement,
+	elements_len: usize,
+) -> Option<Vec<FrozenOverlayExportElement>> {
+	if elements_len == 0 {
+		return Some(Vec::new());
+	}
+	if elements.is_null() {
+		return None;
+	}
+
+	let elements = unsafe { slice::from_raw_parts(elements, elements_len) };
+
+	elements
+		.iter()
+		.map(|element| unsafe { decode_frozen_overlay_export_element(element) })
+		.collect()
+}
+
+unsafe fn decode_frozen_overlay_export_element(
+	element: &RsnapFrozenOverlayExportElement,
+) -> Option<FrozenOverlayExportElement> {
+	let color = decode_frozen_annotation_color(element.color);
+
+	match element.kind {
+		RsnapFrozenOverlayExportElementKind::Pen => {
+			Some(FrozenOverlayExportElement::Pen(FrozenOverlayExportPen {
+				points: unsafe {
+					decode_frozen_overlay_points(element.points, element.points_len)
+				}?,
+				style: FrozenOverlayExportStrokeStyle {
+					stroke_width_points: decode_f32(element.stroke_width_points)?,
+					rgba: color,
+				},
+			}))
+		},
+		RsnapFrozenOverlayExportElementKind::Arrow => {
+			Some(FrozenOverlayExportElement::Arrow(FrozenOverlayExportArrow {
+				start: decode_frozen_overlay_point(element.start)?,
+				end: decode_frozen_overlay_point(element.end)?,
+				style: FrozenOverlayExportStrokeStyle {
+					stroke_width_points: decode_f32(element.stroke_width_points)?,
+					rgba: color,
+				},
+			}))
+		},
+		RsnapFrozenOverlayExportElementKind::Mosaic => {
+			Some(FrozenOverlayExportElement::Mosaic(FrozenOverlayExportMosaic {
+				rect: crate::decode_float_rect(element.rect),
+			}))
+		},
+		RsnapFrozenOverlayExportElementKind::Spotlight => {
+			Some(FrozenOverlayExportElement::Spotlight(FrozenOverlayExportSpotlight {
+				rect: crate::decode_float_rect(element.rect),
+				style: FrozenOverlayExportSpotlightStyle {
+					border_width_points: decode_f32(element.border_width_points)?,
+					border_rgba: color,
+				},
+			}))
+		},
+		RsnapFrozenOverlayExportElementKind::Text => {
+			Some(FrozenOverlayExportElement::Text(FrozenOverlayExportText {
+				anchor: decode_frozen_overlay_point(element.start)?,
+				text: unsafe { decode_optional_utf8(element.text) }?,
+				style: FrozenOverlayExportTextStyle {
+					font_size_points: decode_f32(element.font_size_points)?,
+					rgba: color,
+				},
+			}))
+		},
+	}
+}
+
+unsafe fn decode_frozen_overlay_points(
+	points: *const RsnapFloatPoint,
+	points_len: usize,
+) -> Option<Vec<FrozenOverlayExportPoint>> {
+	if points_len == 0 {
+		return Some(Vec::new());
+	}
+	if points.is_null() {
+		return None;
+	}
+
+	unsafe { slice::from_raw_parts(points, points_len) }
+		.iter()
+		.map(|point| decode_frozen_overlay_point(*point))
+		.collect()
+}
+
+fn decode_frozen_overlay_point(point: RsnapFloatPoint) -> Option<FrozenOverlayExportPoint> {
+	if point.x.is_finite() && point.y.is_finite() {
+		Some(FrozenOverlayExportPoint::new(point.x, point.y))
+	} else {
+		None
+	}
+}
+
+unsafe fn decode_optional_utf8(text: *const c_char) -> Option<String> {
+	if text.is_null() {
+		return Some(String::new());
+	}
+
+	unsafe { CStr::from_ptr(text) }.to_str().ok().map(ToOwned::to_owned)
+}
+
+fn decode_f32(value: f64) -> Option<f32> {
+	(value.is_finite() && value >= f64::from(f32::MIN) && value <= f64::from(f32::MAX))
+		.then_some(value as f32)
+}
+
+fn decode_frozen_annotation_color(color: RsnapFrozenAnnotationColor) -> [u8; 4] {
+	match color {
+		RsnapFrozenAnnotationColor::White => [255, 255, 255, 255],
+		RsnapFrozenAnnotationColor::Yellow => [255, 219, 77, 255],
+		RsnapFrozenAnnotationColor::Green => [92, 214, 149, 255],
+		RsnapFrozenAnnotationColor::Blue => [102, 178, 255, 255],
+		RsnapFrozenAnnotationColor::Red => [255, 107, 107, 255],
+		RsnapFrozenAnnotationColor::Black => [24, 24, 24, 255],
+	}
+}

--- a/packages/rsnap-host-ffi/src/lib.rs
+++ b/packages/rsnap-host-ffi/src/lib.rs
@@ -7,6 +7,7 @@
 mod abi;
 mod capture_frame;
 mod frozen_overlay;
+mod frozen_overlay_export;
 #[cfg(target_os = "macos")]
 mod live_sampler;
 mod scroll_session;
@@ -48,8 +49,9 @@ pub use self::frozen_overlay::{
 	rsnap_frozen_overlay_edit_session_destroy, rsnap_frozen_overlay_edit_session_finish,
 	rsnap_frozen_overlay_edit_session_redo, rsnap_frozen_overlay_edit_session_reset,
 	rsnap_frozen_overlay_edit_session_undo, rsnap_frozen_overlay_edit_session_update,
-	rsnap_frozen_overlay_edit_snapshot_release, rsnap_frozen_overlay_export_render_rgba,
+	rsnap_frozen_overlay_edit_snapshot_release,
 };
+pub use self::frozen_overlay_export::rsnap_frozen_overlay_export_render_rgba;
 #[cfg(target_os = "macos")]
 pub use self::live_sampler::{
 	rsnap_live_sampler_create, rsnap_live_sampler_create_with_self_capture_exception_window_ids,


### PR DESCRIPTION
## Summary
- move frozen overlay export rendering FFI into frozen_overlay_export.rs
- keep frozen_overlay.rs focused on edit-session API and snapshot encoding
- preserve the public C ABI through lib.rs re-exports without include/path splitting

## Validation
- cargo fmt
- cargo check -p rsnap-host-ffi --all-targets --all-features
- cargo make fmt-rust-check
- cargo make check-vstyle-rust
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts || true
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-ffi-header
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check