### PR TITLE
Extract perf sweep support owners

### DIFF
--- a/apps/rsnap-perf/src/fixtures.rs
+++ b/apps/rsnap-perf/src/fixtures.rs
@@ -1,0 +1,315 @@
+#![allow(missing_docs)]
+
+use std::env;
+use std::path::PathBuf;
+use std::process;
+use std::{fs, path::Path};
+
+use color_eyre::eyre::{self, Result};
+use image::{Rgba, RgbaImage};
+
+use rsnap_capture_core::{
+	DisplayPointRect, FrozenSelectionTransformInput, FrozenSelectionTransformKind, RectPoints,
+	ScrollMinimapInput, ToolbarItemKind,
+};
+use rsnap_overlay::bench_support::{
+	ScrollCaptureBenchScenario, ScrollCaptureOverlapMetrics, ScrollCaptureSessionMetrics,
+};
+use rsnap_overlay::frozen_edit::{
+	FrozenOverlayEditColor, FrozenOverlayEditPoint, FrozenOverlayEditRect,
+	FrozenOverlayEditSession, FrozenOverlayEditSpotlightStyle, FrozenOverlayEditStrokeStyle,
+	FrozenOverlayEditStyle, FrozenOverlayEditTextStyle,
+};
+use rsnap_overlay::frozen_export::{
+	FrozenOverlayExportArrow, FrozenOverlayExportElement, FrozenOverlayExportMosaic,
+	FrozenOverlayExportPen, FrozenOverlayExportPoint, FrozenOverlayExportSpotlight,
+	FrozenOverlayExportSpotlightStyle, FrozenOverlayExportStrokeStyle, FrozenOverlayExportText,
+	FrozenOverlayExportTextStyle,
+};
+
+pub(crate) fn build_export_fixture(width: u32, height: u32) -> RgbaImage {
+	RgbaImage::from_fn(width, height, |x, y| {
+		let diagonal = x.wrapping_add(y);
+		let r = pattern_byte(x.wrapping_mul(13).wrapping_add(y.wrapping_mul(7)));
+		let g = pattern_byte(x.wrapping_mul(3).wrapping_add(y.wrapping_mul(17)));
+		let b = pattern_byte(diagonal.wrapping_mul(11).wrapping_add((x / 5) * 19));
+		let a = if (x / 32 + y / 32).is_multiple_of(7) { 220 } else { 255 };
+
+		Rgba([r, g, b, a])
+	})
+}
+
+pub(crate) fn frozen_overlay_export_fixture() -> Vec<FrozenOverlayExportElement> {
+	vec![
+		FrozenOverlayExportElement::Mosaic(FrozenOverlayExportMosaic {
+			rect: DisplayPointRect::new(180.0, 160.0, 320.0, 180.0),
+		}),
+		FrozenOverlayExportElement::Spotlight(FrozenOverlayExportSpotlight {
+			rect: DisplayPointRect::new(760.0, 180.0, 360.0, 240.0),
+			style: FrozenOverlayExportSpotlightStyle {
+				border_width_points: 1.5,
+				border_rgba: [255, 255, 255, 255],
+			},
+		}),
+		FrozenOverlayExportElement::Pen(FrozenOverlayExportPen {
+			points: vec![
+				FrozenOverlayExportPoint::new(120.0, 120.0),
+				FrozenOverlayExportPoint::new(360.0, 260.0),
+				FrozenOverlayExportPoint::new(520.0, 220.0),
+			],
+			style: FrozenOverlayExportStrokeStyle {
+				stroke_width_points: 3.0,
+				rgba: [102, 178, 255, 255],
+			},
+		}),
+		FrozenOverlayExportElement::Arrow(FrozenOverlayExportArrow {
+			start: FrozenOverlayExportPoint::new(520.0, 650.0),
+			end: FrozenOverlayExportPoint::new(980.0, 520.0),
+			style: FrozenOverlayExportStrokeStyle {
+				stroke_width_points: 4.0,
+				rgba: [255, 107, 107, 255],
+			},
+		}),
+		FrozenOverlayExportElement::Text(FrozenOverlayExportText {
+			anchor: FrozenOverlayExportPoint::new(120.0, 720.0),
+			text: "Rsnap".to_owned(),
+			style: FrozenOverlayExportTextStyle {
+				font_size_points: 20.0,
+				rgba: [255, 255, 255, 255],
+			},
+		}),
+	]
+}
+
+pub(crate) fn write_wallpaper_fixture_png() -> Result<PathBuf> {
+	let image = build_export_fixture(512, 288);
+	let png = rsnap_capture_core::encode_png_lossless_fast(&image)?;
+	let path = env::temp_dir().join(format!("rsnap-perf-wallpaper-fixture-{}.png", process::id()));
+
+	fs::write(&path, png).map_err(|error| {
+		eyre::eyre!("failed to write wallpaper performance fixture {}: {error}", path.display())
+	})?;
+
+	Ok(path)
+}
+
+pub(crate) fn remove_wallpaper_fixture(path: impl AsRef<Path>) {
+	let _ = fs::remove_file(path);
+}
+
+pub(crate) fn build_auto_center_fixture(width: u32, height: u32, content: RectPoints) -> RgbaImage {
+	RgbaImage::from_fn(width, height, |x, y| {
+		if x >= content.x
+			&& x < content.x + content.width
+			&& y >= content.y
+			&& y < content.y + content.height
+		{
+			return Rgba([24, 32, 40, 255]);
+		}
+
+		Rgba([180, 180, 180, 255])
+	})
+}
+
+pub(crate) fn build_bgra_fixture(width: u32, height: u32, bytes_per_row: usize) -> Vec<u8> {
+	let mut bytes = vec![0xEE; bytes_per_row * height as usize];
+
+	for y in 0..height {
+		for x in 0..width {
+			let offset = y as usize * bytes_per_row + x as usize * 4;
+
+			bytes[offset] = pattern_byte(30 + y * 15 + x);
+			bytes[offset + 1] = pattern_byte(20 + y * 10 + x);
+			bytes[offset + 2] = pattern_byte(10 + y * 5 + x);
+			bytes[offset + 3] = 200 + pattern_byte((x + y) % 55);
+		}
+	}
+
+	bytes
+}
+
+pub(crate) fn scroll_minimap_fixture() -> ScrollMinimapInput {
+	ScrollMinimapInput {
+		selection: DisplayPointRect::new(100.0, 100.0, 100.0, 100.0),
+		export_width: 100.0,
+		export_height: 200.0,
+		bounds: DisplayPointRect::new(0.0, 0.0, 500.0, 500.0),
+		preferred_width: 96.0,
+		minimum_width: 44.0,
+		gap: 10.0,
+		margin: 10.0,
+		image_inset: 3.0,
+		viewport_top_pixels: 20.0,
+		viewport_height_pixels: 100.0,
+	}
+}
+
+pub(crate) fn selection_transform_fixture() -> FrozenSelectionTransformInput {
+	FrozenSelectionTransformInput {
+		kind: FrozenSelectionTransformKind::ResizeBottomRight,
+		initial_selection: DisplayPointRect::new(100.0, 80.0, 240.0, 160.0),
+		monitor_frame: DisplayPointRect::new(0.0, 0.0, 500.0, 400.0),
+		initial_pointer_x: 340.0,
+		initial_pointer_y: 80.0,
+		point_x: 50.0,
+		point_y: 300.0,
+		minimum_size: 12.0,
+	}
+}
+
+pub(crate) fn run_frozen_overlay_edit_lifecycle() -> u64 {
+	let selection = frozen_overlay_edit_selection();
+	let style = frozen_overlay_edit_style();
+	let mut session = FrozenOverlayEditSession::default();
+	let mut checksum = bool_bit(session.begin(
+		ToolbarItemKind::Pen,
+		FrozenOverlayEditPoint::new(20.0, 30.0),
+		selection,
+		style,
+	));
+
+	for offset in 1..=12 {
+		checksum = checksum.wrapping_add(bool_bit(session.update(
+			FrozenOverlayEditPoint::new(20.0 + f64::from(offset * 4), 30.0 + f64::from(offset * 3)),
+			selection,
+		)));
+	}
+
+	checksum = checksum.wrapping_add(bool_bit(session.finish(selection)));
+	checksum = checksum.wrapping_add(bool_bit(session.begin(
+		ToolbarItemKind::Mosaic,
+		FrozenOverlayEditPoint::new(90.0, 80.0),
+		selection,
+		style,
+	)));
+	checksum = checksum.wrapping_add(bool_bit(
+		session.update(FrozenOverlayEditPoint::new(180.0, 150.0), selection),
+	));
+	checksum = checksum.wrapping_add(bool_bit(session.finish(selection)));
+	checksum = checksum.wrapping_add(bool_bit(session.begin(
+		ToolbarItemKind::Text,
+		FrozenOverlayEditPoint::new(210.0, 110.0),
+		selection,
+		style,
+	)));
+	checksum = checksum.wrapping_add(bool_bit(session.append_text("Rsnap")));
+	checksum = checksum.wrapping_add(bool_bit(session.commit_text_edit(style.text)));
+	checksum = checksum.wrapping_add(bool_bit(
+		session.contains_movable_annotation(FrozenOverlayEditPoint::new(212.0, 112.0)),
+	));
+	checksum = checksum.wrapping_add(bool_bit(session.begin(
+		ToolbarItemKind::Pointer,
+		FrozenOverlayEditPoint::new(212.0, 112.0),
+		selection,
+		style,
+	)));
+	checksum = checksum.wrapping_add(bool_bit(
+		session.update(FrozenOverlayEditPoint::new(260.0, 160.0), selection),
+	));
+
+	let moving_snapshot = session.snapshot();
+
+	checksum = checksum
+		.wrapping_add(bool_bit(moving_snapshot.is_moving_movable_annotation))
+		.wrapping_add(moving_snapshot.elements.len() as u64)
+		.wrapping_add(bool_bit(moving_snapshot.preview_text.is_some()) << 8);
+	checksum = checksum.wrapping_add(bool_bit(session.finish(selection)));
+	checksum = checksum.wrapping_add(bool_bit(session.undo()) << 16);
+	checksum = checksum.wrapping_add(bool_bit(session.redo()) << 24);
+
+	let snapshot = session.snapshot();
+
+	checksum
+		.wrapping_add(snapshot.elements.len() as u64)
+		.wrapping_add(bool_bit(snapshot.can_undo) << 32)
+		.wrapping_add(bool_bit(snapshot.can_redo) << 40)
+}
+
+pub(crate) fn checksum_bytes(bytes: &[u8]) -> u64 {
+	bytes.iter().fold(0xcbf2_9ce4_8422_2325_u64, |acc, byte| {
+		acc.wrapping_mul(0x0000_0001_0000_01b3).wrapping_add(u64::from(*byte) + 1)
+	})
+}
+
+pub(crate) fn checksum_f64s(values: &[f64]) -> u64 {
+	values.iter().fold(0xcbf2_9ce4_8422_2325_u64, |acc, value| {
+		acc.wrapping_mul(0x0000_0001_0000_01b3).wrapping_add(value.to_bits())
+	})
+}
+
+pub(crate) fn scroll_overlap_checksum(metrics: ScrollCaptureOverlapMetrics) -> u64 {
+	bool_bit(metrics.matched)
+		.wrapping_add(u64::from(metrics.motion_rows) << 8)
+		.wrapping_add(u64::from(metrics.overlap_rows) << 24)
+		.wrapping_add(u64::from(metrics.mean_abs_diff_x100) << 40)
+}
+
+pub(crate) fn scroll_session_checksum(metrics: ScrollCaptureSessionMetrics) -> u64 {
+	bool_bit(metrics.committed)
+		.wrapping_add(u64::from(metrics.growth_rows) << 8)
+		.wrapping_add(u64::from(metrics.export_height) << 24)
+		.wrapping_add(u64::from(metrics.preview_height) << 40)
+}
+
+pub(crate) fn expected_scroll_fingerprint_checksum(scenario: ScrollCaptureBenchScenario) -> u32 {
+	match scenario {
+		ScrollCaptureBenchScenario::Baseline => 1_186_711_576,
+		ScrollCaptureBenchScenario::Wide => 996_223_489,
+	}
+}
+
+pub(crate) fn expected_scroll_motion_rows(scenario: ScrollCaptureBenchScenario) -> u32 {
+	match scenario {
+		ScrollCaptureBenchScenario::Baseline => 12,
+		ScrollCaptureBenchScenario::Wide => 20,
+	}
+}
+
+pub(crate) fn expected_scroll_overlap_rows(scenario: ScrollCaptureBenchScenario) -> u32 {
+	match scenario {
+		ScrollCaptureBenchScenario::Baseline => 116,
+		ScrollCaptureBenchScenario::Wide => 140,
+	}
+}
+
+pub(crate) fn expected_scroll_export_height(scenario: ScrollCaptureBenchScenario) -> u32 {
+	match scenario {
+		ScrollCaptureBenchScenario::Baseline => 140,
+		ScrollCaptureBenchScenario::Wide => 180,
+	}
+}
+
+pub(crate) fn expected_scroll_preview_height(scenario: ScrollCaptureBenchScenario) -> u32 {
+	expected_scroll_export_height(scenario)
+}
+
+fn frozen_overlay_edit_selection() -> FrozenOverlayEditRect {
+	FrozenOverlayEditRect::new(10.0, 20.0, 420.0, 260.0)
+}
+
+fn frozen_overlay_edit_style() -> FrozenOverlayEditStyle {
+	FrozenOverlayEditStyle {
+		stroke: FrozenOverlayEditStrokeStyle {
+			stroke_width_points: 3.0,
+			color: FrozenOverlayEditColor::Blue,
+		},
+		spotlight: FrozenOverlayEditSpotlightStyle {
+			border_width_points: 1.5,
+			border_color: FrozenOverlayEditColor::White,
+		},
+		text: FrozenOverlayEditTextStyle {
+			font_size_points: 16.0,
+			color: FrozenOverlayEditColor::White,
+		},
+	}
+}
+
+fn bool_bit(value: bool) -> u64 {
+	u64::from(u8::from(value))
+}
+
+fn pattern_byte(value: u32) -> u8 {
+	let reduced = value % 251;
+
+	reduced.to_le_bytes()[0]
+}

--- a/apps/rsnap-perf/src/main.rs
+++ b/apps/rsnap-perf/src/main.rs
@@ -1,70 +1,24 @@
 #![allow(missing_docs)]
 
-use std::env;
-use std::path::PathBuf;
-use std::process;
-use std::{
-	fs, hint,
-	path::Path,
-	time::{Duration, Instant},
-};
+mod fixtures;
+mod measurement;
+
+use std::{path::Path, time::Duration};
 
 use color_eyre::eyre::{self, Result};
-use image::{Rgba, RgbaImage};
+use image::RgbaImage;
 
+use crate::measurement::PerfCaseResult;
 use rsnap_capture_core::{
 	self, BgraFrameView, CaptureFrameBackgroundKind, CaptureFrameRenderImageRef,
-	CaptureFrameRenderKind, CaptureFrameSourceKind, DisplayPointRect,
-	FrozenSelectionTransformInput, FrozenSelectionTransformKind, RectPoints, ScrollMinimapInput,
-	ToolbarItemKind,
+	CaptureFrameRenderKind, CaptureFrameSourceKind, DisplayPointRect, FrozenSelectionTransformKind,
+	RectPoints,
 };
 use rsnap_overlay::bench_support::{
 	ScrollCaptureBenchHarness, ScrollCaptureBenchScenario, ScrollCaptureFingerprintMetrics,
 	ScrollCaptureOverlapMetrics, ScrollCaptureSessionMetrics,
 };
-use rsnap_overlay::frozen_edit::{
-	FrozenOverlayEditColor, FrozenOverlayEditPoint, FrozenOverlayEditRect,
-	FrozenOverlayEditSession, FrozenOverlayEditSpotlightStyle, FrozenOverlayEditStrokeStyle,
-	FrozenOverlayEditStyle, FrozenOverlayEditTextStyle,
-};
-use rsnap_overlay::frozen_export::{
-	self, FrozenOverlayExportArrow, FrozenOverlayExportElement, FrozenOverlayExportMosaic,
-	FrozenOverlayExportPen, FrozenOverlayExportPoint, FrozenOverlayExportSpotlight,
-	FrozenOverlayExportSpotlightStyle, FrozenOverlayExportStrokeStyle, FrozenOverlayExportText,
-	FrozenOverlayExportTextStyle,
-};
-
-struct PerfCaseResult {
-	name: String,
-	iterations: u32,
-	elapsed: Duration,
-	budget: Duration,
-	checksum: u64,
-}
-impl PerfCaseResult {
-	fn print(&self) {
-		println!(
-			"[perf] {} iterations={} elapsed={} budget={} checksum={:#018x}",
-			self.name,
-			self.iterations,
-			format_duration(self.elapsed),
-			format_duration(self.budget),
-			self.checksum
-		);
-	}
-
-	fn require_budget(&self) -> Result<()> {
-		eyre::ensure!(
-			self.elapsed <= self.budget,
-			"performance case {} exceeded budget: elapsed={} budget={}",
-			self.name,
-			format_duration(self.elapsed),
-			format_duration(self.budget)
-		);
-
-		Ok(())
-	}
-}
+use rsnap_overlay::frozen_export;
 
 fn main() -> Result<()> {
 	color_eyre::install()?;
@@ -85,11 +39,11 @@ fn main() -> Result<()> {
 }
 
 fn run_export_cases(results: &mut Vec<PerfCaseResult>) -> Result<()> {
-	let image = build_export_fixture(1_440, 900);
+	let image = fixtures::build_export_fixture(1_440, 900);
 	let auto_center_image =
-		build_auto_center_fixture(1_440, 900, RectPoints::new(420, 240, 360, 220));
+		fixtures::build_auto_center_fixture(1_440, 900, RectPoints::new(420, 240, 360, 220));
 	let bgra_bytes_per_row = 640 * 4 + 16;
-	let bgra_frame = build_bgra_fixture(640, 480, bgra_bytes_per_row);
+	let bgra_frame = fixtures::build_bgra_fixture(640, 480, bgra_bytes_per_row);
 
 	verify_export_round_trip(&image)?;
 	verify_crop_exactness(&image)?;
@@ -102,7 +56,7 @@ fn run_export_cases(results: &mut Vec<PerfCaseResult>) -> Result<()> {
 	verify_frozen_overlay_edit_session()?;
 	verify_auto_center_content_bounds(&auto_center_image)?;
 
-	let wallpaper_fixture = write_wallpaper_fixture_png()?;
+	let wallpaper_fixture = fixtures::write_wallpaper_fixture_png()?;
 
 	verify_wallpaper_png_thumbnail(&wallpaper_fixture)?;
 	run_core_export_perf_cases(results, &image)?;
@@ -114,29 +68,35 @@ fn run_export_cases(results: &mut Vec<PerfCaseResult>) -> Result<()> {
 	run_auto_center_perf_case(results, &auto_center_image)?;
 	run_wallpaper_thumbnail_perf_case(results, &wallpaper_fixture)?;
 
-	let _ = fs::remove_file(wallpaper_fixture);
+	fixtures::remove_wallpaper_fixture(wallpaper_fixture);
 
 	Ok(())
 }
 
 fn run_core_export_perf_cases(results: &mut Vec<PerfCaseResult>, image: &RgbaImage) -> Result<()> {
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"export_png_lossless_fast_1440x900",
 		4,
 		Duration::from_millis(900),
 		|| {
 			let png = rsnap_capture_core::encode_png_lossless_fast(image)?;
 
-			Ok(checksum_bytes(&png))
+			Ok(fixtures::checksum_bytes(&png))
 		},
 	)?);
-	results.push(time_case("crop_rgba_960x540", 200, Duration::from_millis(900), || {
-		let crop = rsnap_capture_core::crop_rgba_image(image, RectPoints::new(240, 160, 960, 540))
-			.ok_or_else(|| eyre::eyre!("export crop performance fixture is invalid"))?;
+	results.push(measurement::time_case(
+		"crop_rgba_960x540",
+		200,
+		Duration::from_millis(900),
+		|| {
+			let crop =
+				rsnap_capture_core::crop_rgba_image(image, RectPoints::new(240, 160, 960, 540))
+					.ok_or_else(|| eyre::eyre!("export crop performance fixture is invalid"))?;
 
-		Ok(checksum_bytes(crop.as_raw()))
-	})?);
-	results.push(time_case(
+			Ok(fixtures::checksum_bytes(crop.as_raw()))
+		},
+	)?);
+	results.push(measurement::time_case(
 		"frozen_mosaic_light_privacy_patch_960x540",
 		1_000,
 		Duration::from_millis(120),
@@ -148,10 +108,10 @@ fn run_core_export_perf_cases(results: &mut Vec<PerfCaseResult>, image: &RgbaIma
 			)
 			.ok_or_else(|| eyre::eyre!("mosaic patch performance fixture is invalid"))?;
 
-			Ok(checksum_bytes(patch.as_raw()))
+			Ok(fixtures::checksum_bytes(patch.as_raw()))
 		},
 	)?);
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"frozen_overlay_export_rgba_1440x900",
 		10,
 		Duration::from_millis(900),
@@ -161,10 +121,10 @@ fn run_core_export_perf_cases(results: &mut Vec<PerfCaseResult>, image: &RgbaIma
 				image.height(),
 				image.as_raw(),
 				DisplayPointRect::new(0.0, 0.0, 1_440.0, 900.0),
-				&frozen_overlay_export_fixture(),
+				&fixtures::frozen_overlay_export_fixture(),
 			)?;
 
-			Ok(checksum_bytes(rendered.as_raw()))
+			Ok(fixtures::checksum_bytes(rendered.as_raw()))
 		},
 	)?);
 
@@ -175,7 +135,7 @@ fn run_auto_center_perf_case(
 	results: &mut Vec<PerfCaseResult>,
 	auto_center_image: &RgbaImage,
 ) -> Result<()> {
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"auto_center_content_bounds_rgba_1440x900",
 		50,
 		Duration::from_millis(900),
@@ -200,7 +160,7 @@ fn run_auto_center_perf_case(
 				450.0,
 			);
 
-			Ok(checksum_f64s(&[
+			Ok(fixtures::checksum_f64s(&[
 				f64::from(bounds.x),
 				f64::from(bounds.y),
 				f64::from(bounds.width),
@@ -218,7 +178,7 @@ fn run_wallpaper_thumbnail_perf_case(
 	results: &mut Vec<PerfCaseResult>,
 	wallpaper_fixture: &Path,
 ) -> Result<()> {
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"wallpaper_png_thumbnail_stream_lanczos_512x288_to_128",
 		20,
 		Duration::from_millis(500),
@@ -229,7 +189,7 @@ fn run_wallpaper_thumbnail_perf_case(
 						eyre::eyre!("wallpaper thumbnail performance fixture is invalid")
 					})?;
 
-			Ok(checksum_bytes(thumbnail.as_raw()))
+			Ok(fixtures::checksum_bytes(thumbnail.as_raw()))
 		},
 	)?);
 
@@ -237,15 +197,15 @@ fn run_wallpaper_thumbnail_perf_case(
 }
 
 fn run_scroll_minimap_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()> {
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"scroll_minimap_plan_100x200",
 		10_000,
 		Duration::from_millis(60),
 		|| {
-			let plan = rsnap_capture_core::scroll_minimap_plan(scroll_minimap_fixture())
+			let plan = rsnap_capture_core::scroll_minimap_plan(fixtures::scroll_minimap_fixture())
 				.ok_or_else(|| eyre::eyre!("scroll minimap plan performance fixture is invalid"))?;
 
-			Ok(checksum_f64s(&[
+			Ok(fixtures::checksum_f64s(&[
 				plan.frame.x,
 				plan.frame.y,
 				plan.frame.width,
@@ -264,14 +224,14 @@ fn run_scroll_minimap_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()>
 }
 
 fn run_capture_frame_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()> {
-	let source_image = build_export_fixture(1_440, 900);
+	let source_image = fixtures::build_export_fixture(1_440, 900);
 	let source = CaptureFrameRenderImageRef::new(
 		source_image.width(),
 		source_image.height(),
 		source_image.as_raw(),
 	)?;
 
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"capture_frame_plan_and_background_1440x900",
 		10_000,
 		Duration::from_millis(60),
@@ -304,7 +264,7 @@ fn run_capture_frame_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()> 
 				eyre::eyre!("capture frame wallpaper request performance fixture is invalid")
 			})?;
 
-			Ok(checksum_f64s(&[
+			Ok(fixtures::checksum_f64s(&[
 				plan.canvas_width,
 				plan.canvas_height,
 				plan.image_rect.x,
@@ -324,7 +284,7 @@ fn run_capture_frame_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()> 
 			]))
 		},
 	)?);
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"capture_frame_render_rgba_1440x900",
 		4,
 		Duration::from_millis(1_200),
@@ -339,7 +299,7 @@ fn run_capture_frame_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()> 
 			)?
 			.ok_or_else(|| eyre::eyre!("capture frame render performance fixture is invalid"))?;
 
-			Ok(checksum_bytes(rendered.as_raw()))
+			Ok(fixtures::checksum_bytes(rendered.as_raw()))
 		},
 	)?);
 
@@ -351,7 +311,7 @@ fn run_bgra_frame_perf_case(
 	bgra_frame: &[u8],
 	bgra_bytes_per_row: usize,
 ) -> Result<()> {
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"bgra_loupe_patch_rgba_64x64",
 		4_000,
 		Duration::from_millis(120),
@@ -370,7 +330,7 @@ fn run_bgra_frame_perf_case(
 			)
 			.ok_or_else(|| eyre::eyre!("BGRA loupe patch performance fixture is invalid"))?;
 
-			Ok(checksum_bytes(patch.as_raw()))
+			Ok(fixtures::checksum_bytes(patch.as_raw()))
 		},
 	)?);
 
@@ -378,18 +338,17 @@ fn run_bgra_frame_perf_case(
 }
 
 fn run_frozen_selection_transform_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()> {
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"frozen_selection_transform_rect",
 		10_000,
 		Duration::from_millis(60),
 		|| {
-			let rect =
-				rsnap_capture_core::frozen_selection_transform_rect(selection_transform_fixture())
-					.ok_or_else(|| {
-						eyre::eyre!("selection transform performance fixture is invalid")
-					})?;
+			let rect = rsnap_capture_core::frozen_selection_transform_rect(
+				fixtures::selection_transform_fixture(),
+			)
+			.ok_or_else(|| eyre::eyre!("selection transform performance fixture is invalid"))?;
 
-			Ok(checksum_f64s(&[rect.x, rect.y, rect.width, rect.height]))
+			Ok(fixtures::checksum_f64s(&[rect.x, rect.y, rect.width, rect.height]))
 		},
 	)?);
 
@@ -397,11 +356,11 @@ fn run_frozen_selection_transform_perf_case(results: &mut Vec<PerfCaseResult>) -
 }
 
 fn run_frozen_overlay_edit_perf_case(results: &mut Vec<PerfCaseResult>) -> Result<()> {
-	results.push(time_case(
+	results.push(measurement::time_case(
 		"frozen_overlay_edit_session_lifecycle",
 		2_000,
 		Duration::from_millis(120),
-		|| Ok(run_frozen_overlay_edit_lifecycle()),
+		|| Ok(fixtures::run_frozen_overlay_edit_lifecycle()),
 	)?);
 
 	Ok(())
@@ -414,7 +373,7 @@ fn run_scroll_capture_cases(results: &mut Vec<PerfCaseResult>) -> Result<()> {
 
 		verify_scroll_fingerprint(scenario, harness.run_fingerprint())?;
 
-		results.push(time_case(
+		results.push(measurement::time_case(
 			format!("scroll_capture_fingerprint_{name}"),
 			500,
 			Duration::from_millis(250),
@@ -427,27 +386,27 @@ fn run_scroll_capture_cases(results: &mut Vec<PerfCaseResult>) -> Result<()> {
 
 		verify_scroll_overlap(scenario, harness.run_overlap_match())?;
 
-		results.push(time_case(
+		results.push(measurement::time_case(
 			format!("scroll_capture_overlap_match_{name}"),
 			120,
 			Duration::from_millis(900),
 			|| {
 				let metrics = harness.run_overlap_match();
 
-				Ok(scroll_overlap_checksum(metrics))
+				Ok(fixtures::scroll_overlap_checksum(metrics))
 			},
 		)?);
 
 		verify_scroll_session(scenario, harness.run_session_commit())?;
 
-		results.push(time_case(
+		results.push(measurement::time_case(
 			format!("scroll_capture_session_commit_{name}"),
 			80,
 			Duration::from_millis(1_800),
 			|| {
 				let metrics = harness.run_session_commit();
 
-				Ok(scroll_session_checksum(metrics))
+				Ok(fixtures::scroll_session_checksum(metrics))
 			},
 		)?);
 	}
@@ -509,7 +468,7 @@ fn verify_frozen_overlay_export(image: &RgbaImage) -> Result<()> {
 		image.height(),
 		image.as_raw(),
 		DisplayPointRect::new(0.0, 0.0, 1_440.0, 900.0),
-		&frozen_overlay_export_fixture(),
+		&fixtures::frozen_overlay_export_fixture(),
 	)?;
 
 	eyre::ensure!(rendered.dimensions() == image.dimensions(), "frozen overlay dimensions changed");
@@ -623,7 +582,7 @@ fn verify_capture_frame_plan() -> Result<()> {
 }
 
 fn verify_scroll_minimap_plan() -> Result<()> {
-	let plan = rsnap_capture_core::scroll_minimap_plan(scroll_minimap_fixture())
+	let plan = rsnap_capture_core::scroll_minimap_plan(fixtures::scroll_minimap_fixture())
 		.ok_or_else(|| eyre::eyre!("scroll minimap plan fixture is invalid"))?;
 
 	eyre::ensure!(
@@ -650,8 +609,10 @@ fn verify_frozen_selection_transform() -> Result<()> {
 
 	eyre::ensure!(hit == FrozenSelectionTransformKind::ResizeTopLeft, "selection hit changed");
 
-	let rect = rsnap_capture_core::frozen_selection_transform_rect(selection_transform_fixture())
-		.ok_or_else(|| eyre::eyre!("selection transform fixture is invalid"))?;
+	let rect = rsnap_capture_core::frozen_selection_transform_rect(
+		fixtures::selection_transform_fixture(),
+	)
+	.ok_or_else(|| eyre::eyre!("selection transform fixture is invalid"))?;
 
 	eyre::ensure!(
 		rect == DisplayPointRect::new(100.0, 228.0, 12.0, 12.0),
@@ -662,7 +623,7 @@ fn verify_frozen_selection_transform() -> Result<()> {
 }
 
 fn verify_frozen_overlay_edit_session() -> Result<()> {
-	let checksum = run_frozen_overlay_edit_lifecycle();
+	let checksum = fixtures::run_frozen_overlay_edit_lifecycle();
 
 	eyre::ensure!(checksum != 0, "frozen overlay edit lifecycle checksum is empty");
 
@@ -714,10 +675,10 @@ fn verify_scroll_fingerprint(
 	eyre::ensure!(metrics.byte_len == 768, "scroll fingerprint byte length changed");
 	eyre::ensure!(metrics.checksum != 0, "scroll fingerprint checksum is empty");
 	eyre::ensure!(
-		metrics.checksum == expected_scroll_fingerprint_checksum(scenario),
+		metrics.checksum == fixtures::expected_scroll_fingerprint_checksum(scenario),
 		"scroll fingerprint checksum changed for {}: expected={} actual={}",
 		scenario.as_str(),
-		expected_scroll_fingerprint_checksum(scenario),
+		fixtures::expected_scroll_fingerprint_checksum(scenario),
 		metrics.checksum
 	);
 
@@ -730,12 +691,12 @@ fn verify_scroll_overlap(
 ) -> Result<()> {
 	eyre::ensure!(metrics.matched, "scroll overlap did not match for {}", scenario.as_str());
 	eyre::ensure!(
-		metrics.motion_rows == expected_scroll_motion_rows(scenario),
+		metrics.motion_rows == fixtures::expected_scroll_motion_rows(scenario),
 		"scroll overlap motion changed for {}",
 		scenario.as_str()
 	);
 	eyre::ensure!(
-		metrics.overlap_rows == expected_scroll_overlap_rows(scenario),
+		metrics.overlap_rows == fixtures::expected_scroll_overlap_rows(scenario),
 		"scroll overlap rows changed for {}",
 		scenario.as_str()
 	);
@@ -754,333 +715,20 @@ fn verify_scroll_session(
 ) -> Result<()> {
 	eyre::ensure!(metrics.committed, "scroll session did not commit for {}", scenario.as_str());
 	eyre::ensure!(
-		metrics.growth_rows == expected_scroll_motion_rows(scenario),
+		metrics.growth_rows == fixtures::expected_scroll_motion_rows(scenario),
 		"scroll session growth changed for {}",
 		scenario.as_str()
 	);
 	eyre::ensure!(
-		metrics.export_height == expected_scroll_export_height(scenario),
+		metrics.export_height == fixtures::expected_scroll_export_height(scenario),
 		"scroll session export height changed for {}",
 		scenario.as_str()
 	);
 	eyre::ensure!(
-		metrics.preview_height == expected_scroll_preview_height(scenario),
+		metrics.preview_height == fixtures::expected_scroll_preview_height(scenario),
 		"scroll session preview height changed for {}",
 		scenario.as_str()
 	);
 
 	Ok(())
-}
-
-fn time_case(
-	name: impl Into<String>,
-	iterations: u32,
-	budget: Duration,
-	mut run_once: impl FnMut() -> Result<u64>,
-) -> Result<PerfCaseResult> {
-	let started_at = Instant::now();
-	let mut checksum = 0_u64;
-
-	for _ in 0..iterations {
-		checksum = checksum.wrapping_add(hint::black_box(run_once()?));
-	}
-
-	Ok(PerfCaseResult {
-		name: name.into(),
-		iterations,
-		elapsed: started_at.elapsed(),
-		budget,
-		checksum,
-	})
-}
-
-fn build_export_fixture(width: u32, height: u32) -> RgbaImage {
-	RgbaImage::from_fn(width, height, |x, y| {
-		let diagonal = x.wrapping_add(y);
-		let r = pattern_byte(x.wrapping_mul(13).wrapping_add(y.wrapping_mul(7)));
-		let g = pattern_byte(x.wrapping_mul(3).wrapping_add(y.wrapping_mul(17)));
-		let b = pattern_byte(diagonal.wrapping_mul(11).wrapping_add((x / 5) * 19));
-		let a = if (x / 32 + y / 32).is_multiple_of(7) { 220 } else { 255 };
-
-		Rgba([r, g, b, a])
-	})
-}
-
-fn frozen_overlay_export_fixture() -> Vec<FrozenOverlayExportElement> {
-	vec![
-		FrozenOverlayExportElement::Mosaic(FrozenOverlayExportMosaic {
-			rect: DisplayPointRect::new(180.0, 160.0, 320.0, 180.0),
-		}),
-		FrozenOverlayExportElement::Spotlight(FrozenOverlayExportSpotlight {
-			rect: DisplayPointRect::new(760.0, 180.0, 360.0, 240.0),
-			style: FrozenOverlayExportSpotlightStyle {
-				border_width_points: 1.5,
-				border_rgba: [255, 255, 255, 255],
-			},
-		}),
-		FrozenOverlayExportElement::Pen(FrozenOverlayExportPen {
-			points: vec![
-				FrozenOverlayExportPoint::new(120.0, 120.0),
-				FrozenOverlayExportPoint::new(360.0, 260.0),
-				FrozenOverlayExportPoint::new(520.0, 220.0),
-			],
-			style: FrozenOverlayExportStrokeStyle {
-				stroke_width_points: 3.0,
-				rgba: [102, 178, 255, 255],
-			},
-		}),
-		FrozenOverlayExportElement::Arrow(FrozenOverlayExportArrow {
-			start: FrozenOverlayExportPoint::new(520.0, 650.0),
-			end: FrozenOverlayExportPoint::new(980.0, 520.0),
-			style: FrozenOverlayExportStrokeStyle {
-				stroke_width_points: 4.0,
-				rgba: [255, 107, 107, 255],
-			},
-		}),
-		FrozenOverlayExportElement::Text(FrozenOverlayExportText {
-			anchor: FrozenOverlayExportPoint::new(120.0, 720.0),
-			text: "Rsnap".to_owned(),
-			style: FrozenOverlayExportTextStyle {
-				font_size_points: 20.0,
-				rgba: [255, 255, 255, 255],
-			},
-		}),
-	]
-}
-
-fn write_wallpaper_fixture_png() -> Result<PathBuf> {
-	let image = build_export_fixture(512, 288);
-	let png = rsnap_capture_core::encode_png_lossless_fast(&image)?;
-	let path = env::temp_dir().join(format!("rsnap-perf-wallpaper-fixture-{}.png", process::id()));
-
-	fs::write(&path, png).map_err(|error| {
-		eyre::eyre!("failed to write wallpaper performance fixture {}: {error}", path.display())
-	})?;
-
-	Ok(path)
-}
-
-fn build_auto_center_fixture(width: u32, height: u32, content: RectPoints) -> RgbaImage {
-	RgbaImage::from_fn(width, height, |x, y| {
-		if x >= content.x
-			&& x < content.x + content.width
-			&& y >= content.y
-			&& y < content.y + content.height
-		{
-			return Rgba([24, 32, 40, 255]);
-		}
-
-		Rgba([180, 180, 180, 255])
-	})
-}
-
-fn build_bgra_fixture(width: u32, height: u32, bytes_per_row: usize) -> Vec<u8> {
-	let mut bytes = vec![0xEE; bytes_per_row * height as usize];
-
-	for y in 0..height {
-		for x in 0..width {
-			let offset = y as usize * bytes_per_row + x as usize * 4;
-
-			bytes[offset] = pattern_byte(30 + y * 15 + x);
-			bytes[offset + 1] = pattern_byte(20 + y * 10 + x);
-			bytes[offset + 2] = pattern_byte(10 + y * 5 + x);
-			bytes[offset + 3] = 200 + pattern_byte((x + y) % 55);
-		}
-	}
-
-	bytes
-}
-
-fn scroll_minimap_fixture() -> ScrollMinimapInput {
-	ScrollMinimapInput {
-		selection: DisplayPointRect::new(100.0, 100.0, 100.0, 100.0),
-		export_width: 100.0,
-		export_height: 200.0,
-		bounds: DisplayPointRect::new(0.0, 0.0, 500.0, 500.0),
-		preferred_width: 96.0,
-		minimum_width: 44.0,
-		gap: 10.0,
-		margin: 10.0,
-		image_inset: 3.0,
-		viewport_top_pixels: 20.0,
-		viewport_height_pixels: 100.0,
-	}
-}
-
-fn selection_transform_fixture() -> FrozenSelectionTransformInput {
-	FrozenSelectionTransformInput {
-		kind: FrozenSelectionTransformKind::ResizeBottomRight,
-		initial_selection: DisplayPointRect::new(100.0, 80.0, 240.0, 160.0),
-		monitor_frame: DisplayPointRect::new(0.0, 0.0, 500.0, 400.0),
-		initial_pointer_x: 340.0,
-		initial_pointer_y: 80.0,
-		point_x: 50.0,
-		point_y: 300.0,
-		minimum_size: 12.0,
-	}
-}
-
-fn frozen_overlay_edit_selection() -> FrozenOverlayEditRect {
-	FrozenOverlayEditRect::new(10.0, 20.0, 420.0, 260.0)
-}
-
-fn frozen_overlay_edit_style() -> FrozenOverlayEditStyle {
-	FrozenOverlayEditStyle {
-		stroke: FrozenOverlayEditStrokeStyle {
-			stroke_width_points: 3.0,
-			color: FrozenOverlayEditColor::Blue,
-		},
-		spotlight: FrozenOverlayEditSpotlightStyle {
-			border_width_points: 1.5,
-			border_color: FrozenOverlayEditColor::White,
-		},
-		text: FrozenOverlayEditTextStyle {
-			font_size_points: 16.0,
-			color: FrozenOverlayEditColor::White,
-		},
-	}
-}
-
-fn run_frozen_overlay_edit_lifecycle() -> u64 {
-	let selection = frozen_overlay_edit_selection();
-	let style = frozen_overlay_edit_style();
-	let mut session = FrozenOverlayEditSession::default();
-	let mut checksum = bool_bit(session.begin(
-		ToolbarItemKind::Pen,
-		FrozenOverlayEditPoint::new(20.0, 30.0),
-		selection,
-		style,
-	));
-
-	for offset in 1..=12 {
-		checksum = checksum.wrapping_add(bool_bit(session.update(
-			FrozenOverlayEditPoint::new(20.0 + f64::from(offset * 4), 30.0 + f64::from(offset * 3)),
-			selection,
-		)));
-	}
-
-	checksum = checksum.wrapping_add(bool_bit(session.finish(selection)));
-	checksum = checksum.wrapping_add(bool_bit(session.begin(
-		ToolbarItemKind::Mosaic,
-		FrozenOverlayEditPoint::new(90.0, 80.0),
-		selection,
-		style,
-	)));
-	checksum = checksum.wrapping_add(bool_bit(
-		session.update(FrozenOverlayEditPoint::new(180.0, 150.0), selection),
-	));
-	checksum = checksum.wrapping_add(bool_bit(session.finish(selection)));
-	checksum = checksum.wrapping_add(bool_bit(session.begin(
-		ToolbarItemKind::Text,
-		FrozenOverlayEditPoint::new(210.0, 110.0),
-		selection,
-		style,
-	)));
-	checksum = checksum.wrapping_add(bool_bit(session.append_text("Rsnap")));
-	checksum = checksum.wrapping_add(bool_bit(session.commit_text_edit(style.text)));
-	checksum = checksum.wrapping_add(bool_bit(
-		session.contains_movable_annotation(FrozenOverlayEditPoint::new(212.0, 112.0)),
-	));
-	checksum = checksum.wrapping_add(bool_bit(session.begin(
-		ToolbarItemKind::Pointer,
-		FrozenOverlayEditPoint::new(212.0, 112.0),
-		selection,
-		style,
-	)));
-	checksum = checksum.wrapping_add(bool_bit(
-		session.update(FrozenOverlayEditPoint::new(260.0, 160.0), selection),
-	));
-
-	let moving_snapshot = session.snapshot();
-
-	checksum = checksum
-		.wrapping_add(bool_bit(moving_snapshot.is_moving_movable_annotation))
-		.wrapping_add(moving_snapshot.elements.len() as u64)
-		.wrapping_add(bool_bit(moving_snapshot.preview_text.is_some()) << 8);
-	checksum = checksum.wrapping_add(bool_bit(session.finish(selection)));
-	checksum = checksum.wrapping_add(bool_bit(session.undo()) << 16);
-	checksum = checksum.wrapping_add(bool_bit(session.redo()) << 24);
-
-	let snapshot = session.snapshot();
-
-	checksum
-		.wrapping_add(snapshot.elements.len() as u64)
-		.wrapping_add(bool_bit(snapshot.can_undo) << 32)
-		.wrapping_add(bool_bit(snapshot.can_redo) << 40)
-}
-
-fn pattern_byte(value: u32) -> u8 {
-	let reduced = value % 251;
-
-	reduced.to_le_bytes()[0]
-}
-
-fn checksum_bytes(bytes: &[u8]) -> u64 {
-	bytes.iter().fold(0xcbf2_9ce4_8422_2325_u64, |acc, byte| {
-		acc.wrapping_mul(0x0000_0001_0000_01b3).wrapping_add(u64::from(*byte) + 1)
-	})
-}
-
-fn checksum_f64s(values: &[f64]) -> u64 {
-	values.iter().fold(0xcbf2_9ce4_8422_2325_u64, |acc, value| {
-		acc.wrapping_mul(0x0000_0001_0000_01b3).wrapping_add(value.to_bits())
-	})
-}
-
-fn scroll_overlap_checksum(metrics: ScrollCaptureOverlapMetrics) -> u64 {
-	bool_bit(metrics.matched)
-		.wrapping_add(u64::from(metrics.motion_rows) << 8)
-		.wrapping_add(u64::from(metrics.overlap_rows) << 24)
-		.wrapping_add(u64::from(metrics.mean_abs_diff_x100) << 40)
-}
-
-fn scroll_session_checksum(metrics: ScrollCaptureSessionMetrics) -> u64 {
-	bool_bit(metrics.committed)
-		.wrapping_add(u64::from(metrics.growth_rows) << 8)
-		.wrapping_add(u64::from(metrics.export_height) << 24)
-		.wrapping_add(u64::from(metrics.preview_height) << 40)
-}
-
-fn bool_bit(value: bool) -> u64 {
-	u64::from(u8::from(value))
-}
-
-fn expected_scroll_fingerprint_checksum(scenario: ScrollCaptureBenchScenario) -> u32 {
-	match scenario {
-		ScrollCaptureBenchScenario::Baseline => 1_186_711_576,
-		ScrollCaptureBenchScenario::Wide => 996_223_489,
-	}
-}
-
-fn expected_scroll_motion_rows(scenario: ScrollCaptureBenchScenario) -> u32 {
-	match scenario {
-		ScrollCaptureBenchScenario::Baseline => 12,
-		ScrollCaptureBenchScenario::Wide => 20,
-	}
-}
-
-fn expected_scroll_overlap_rows(scenario: ScrollCaptureBenchScenario) -> u32 {
-	match scenario {
-		ScrollCaptureBenchScenario::Baseline => 116,
-		ScrollCaptureBenchScenario::Wide => 140,
-	}
-}
-
-fn expected_scroll_export_height(scenario: ScrollCaptureBenchScenario) -> u32 {
-	match scenario {
-		ScrollCaptureBenchScenario::Baseline => 140,
-		ScrollCaptureBenchScenario::Wide => 180,
-	}
-}
-
-fn expected_scroll_preview_height(scenario: ScrollCaptureBenchScenario) -> u32 {
-	expected_scroll_export_height(scenario)
-}
-
-fn format_duration(duration: Duration) -> String {
-	let micros = duration.as_micros();
-	let millis = micros / 1_000;
-	let fractional = micros % 1_000;
-
-	format!("{millis}.{fractional:03}ms")
 }

--- a/apps/rsnap-perf/src/measurement.rs
+++ b/apps/rsnap-perf/src/measurement.rs
@@ -1,0 +1,68 @@
+#![allow(missing_docs)]
+
+use std::hint;
+use std::time::{Duration, Instant};
+
+use color_eyre::eyre::{self, Result};
+
+pub(crate) struct PerfCaseResult {
+	name: String,
+	iterations: u32,
+	elapsed: Duration,
+	budget: Duration,
+	checksum: u64,
+}
+impl PerfCaseResult {
+	pub(crate) fn print(&self) {
+		println!(
+			"[perf] {} iterations={} elapsed={} budget={} checksum={:#018x}",
+			self.name,
+			self.iterations,
+			format_duration(self.elapsed),
+			format_duration(self.budget),
+			self.checksum
+		);
+	}
+
+	pub(crate) fn require_budget(&self) -> Result<()> {
+		eyre::ensure!(
+			self.elapsed <= self.budget,
+			"performance case {} exceeded budget: elapsed={} budget={}",
+			self.name,
+			format_duration(self.elapsed),
+			format_duration(self.budget)
+		);
+
+		Ok(())
+	}
+}
+
+pub(crate) fn time_case(
+	name: impl Into<String>,
+	iterations: u32,
+	budget: Duration,
+	mut run_once: impl FnMut() -> Result<u64>,
+) -> Result<PerfCaseResult> {
+	let started_at = Instant::now();
+	let mut checksum = 0_u64;
+
+	for _ in 0..iterations {
+		checksum = checksum.wrapping_add(hint::black_box(run_once()?));
+	}
+
+	Ok(PerfCaseResult {
+		name: name.into(),
+		iterations,
+		elapsed: started_at.elapsed(),
+		budget,
+		checksum,
+	})
+}
+
+fn format_duration(duration: Duration) -> String {
+	let micros = duration.as_micros();
+	let millis = micros / 1_000;
+	let fractional = micros % 1_000;
+
+	format!("{millis}.{fractional:03}ms")
+}

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -32,6 +32,7 @@ For the active target architecture and migration direction, read:
 | --- | --- |
 | `native/macos-host/` | SwiftPM AppKit-first macOS host shell: menu bar entry, full-screen capture windows, in-window HUD/toolbar, and native bridging into `rsnap-host-ffi` |
 | `apps/rsnap/` | Thin launcher/bootstrap crate: startup logging, build metadata, stable-bundle resolution, and `cargo run -p rsnap` handoff into the staged native macOS host |
+| `apps/rsnap-perf/` | Deterministic local performance sweep: fixed fixture construction, checksum-backed correctness checks, case timing, and budget assertions |
 | `packages/rsnap-overlay/` | Transitional Rust runtime and implementation reservoir: legacy overlay runtime, retained scroll-capture logic, frozen edit/export logic, and macOS adapters that have not yet moved into `rsnap-capture-core` |
 | `packages/rsnap-capture-core/` | Durable Rust product-semantics and image-algorithm crate: shared geometry, semantic scene model, host/core protocol enums, reset-native session core, export/crop/PNG encoding, capture-frame rendering, wallpaper thumbnail, minimap, mosaic, selection transform, auto-center, and live-sample helpers |
 | `packages/rsnap-host-ffi/` | Thin C ABI bridge crate used by the native macOS host to call the Rust product core and retained Rust transition modules |
@@ -63,6 +64,24 @@ Key paths:
 - `apps/rsnap/src/native_launcher_macos.rs`: staged native-bundle lookup and launch handoff
 - `apps/rsnap/src/startup.rs`: startup logging/bootstrap helpers
 - `apps/rsnap/src/unsupported_platform.rs`: explicit non-macOS error path
+
+### `apps/rsnap-perf/`
+
+Treat `apps/rsnap-perf/` as the deterministic local performance sweep.
+
+It owns:
+
+- fixed export, capture-frame, frozen-edit, and scroll-capture performance cases
+- checksum-backed correctness checks that guard benchmark fixture drift
+- deterministic fixture construction under `apps/rsnap-perf/src/fixtures.rs`
+- timing and budget result reporting under `apps/rsnap-perf/src/measurement.rs`
+
+Key paths:
+
+- `apps/rsnap-perf/src/main.rs`: perf sweep orchestration plus semantic verification for each
+  case family
+- `apps/rsnap-perf/src/fixtures.rs`: deterministic fixture, checksum, and expected-value support
+- `apps/rsnap-perf/src/measurement.rs`: per-case timing, formatting, and budget enforcement
 
 ### `packages/rsnap-overlay/`
 


### PR DESCRIPTION
## Summary
- move deterministic perf fixtures, checksum helpers, and expected scroll metrics into `apps/rsnap-perf/src/fixtures.rs`
- move perf case timing, budget reporting, and duration formatting into `apps/rsnap-perf/src/measurement.rs`
- keep `apps/rsnap-perf/src/main.rs` focused on sweep orchestration and semantic verification
- update workspace layout docs for the `rsnap-perf` ownership boundary

## Validation
- `cargo make fmt-rust`
- `git diff --check`
- `rg -n "include!|#\\[path" packages apps native scripts || true`
- `cargo check -p rsnap-perf`
- `cargo make check-rust`
- `cargo make check-vstyle-rust`
- `scripts/perf/local.sh` (first run had a local timing spike in one case; immediate rerun passed)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`
