### PR TITLE
Extract overlay worker protocol owner

### DIFF
--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -118,6 +118,8 @@ Key paths:
 - `packages/rsnap-overlay/src/overlay/macos_native_capture_shell_runtime.rs`: retained macOS
   native capture-shell host sync; AppKit shell window lifecycle and creation live under
   `overlay/macos_native_capture_shell_runtime/shell_windows.rs`
+- `packages/rsnap-overlay/src/worker.rs`: overlay worker thread and backend request handlers;
+  worker message protocol and pending-request coalescing live under `worker/`
 - `packages/rsnap-overlay/src/live_frame_stream_macos.rs`: current macOS live-stream support
 - `packages/rsnap-overlay/src/scroll_capture.rs`: current scroll-capture session entry with
   focused support modules under `scroll_capture/`

--- a/packages/rsnap-overlay/src/worker.rs
+++ b/packages/rsnap-overlay/src/worker.rs
@@ -1,3 +1,11 @@
+mod pending_requests;
+mod protocol;
+
+pub(crate) use self::protocol::{
+	CapturedMonitorRegionResponse, CapturedMonitorRegionResult, FreezeCaptureTarget,
+	WorkerErrorSource, WorkerRequest, WorkerRequestSendError, WorkerResponse,
+};
+
 #[cfg(all(test, target_os = "macos"))]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{
@@ -10,110 +18,13 @@ use std::time::{Duration, Instant};
 
 use image::RgbaImage;
 
+use self::pending_requests::PendingWorkerRequests;
 use crate::backend::CaptureBackend;
 use crate::png;
 #[cfg(not(target_os = "macos"))]
 use crate::state::LiveCursorSample;
 use crate::state::RectPoints;
-use crate::state::{GlobalPoint, MonitorRect, WindowHit, WindowListSnapshot};
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum FreezeCaptureTarget {
-	Monitor,
-	Window { window_id: u32 },
-}
-
-#[derive(Debug)]
-pub(crate) enum WorkerRequest {
-	HitTestWindow {
-		monitor: MonitorRect,
-		point: GlobalPoint,
-		request_id: u64,
-	},
-	#[cfg(not(target_os = "macos"))]
-	SampleLiveCursor {
-		monitor: MonitorRect,
-		point: GlobalPoint,
-		request_id: u64,
-		want_patch: bool,
-		patch_width_px: u32,
-		patch_height_px: u32,
-	},
-	RefreshWindowList,
-	FreezeCapture {
-		monitor: MonitorRect,
-		target: FreezeCaptureTarget,
-	},
-	CaptureMonitorRegion {
-		monitor: MonitorRect,
-		rect_px: RectPoints,
-		request_id: u64,
-	},
-	EncodePng {
-		image: RgbaImage,
-	},
-}
-
-#[derive(Debug)]
-pub(crate) enum WorkerResponse {
-	#[cfg(not(target_os = "macos"))]
-	SampledLiveCursor {
-		monitor: MonitorRect,
-		point: GlobalPoint,
-		request_id: u64,
-		sample: LiveCursorSample,
-	},
-	HitTestWindow {
-		monitor: MonitorRect,
-		point: GlobalPoint,
-		request_id: u64,
-		hit: Option<WindowHit>,
-	},
-	RefreshedWindowList {
-		snapshot: Arc<WindowListSnapshot>,
-	},
-	CapturedFreeze {
-		monitor: MonitorRect,
-		image: RgbaImage,
-		window_image: Option<RgbaImage>,
-		captured_window_id: Option<u32>,
-	},
-	EncodedPng {
-		png_bytes: Vec<u8>,
-	},
-	Error {
-		source: WorkerErrorSource,
-		message: String,
-	},
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum WorkerErrorSource {
-	EncodePng,
-	FreezeCapture,
-	RefreshWindowList,
-	CaptureMonitorRegion,
-}
-
-#[derive(Debug)]
-pub(crate) enum CapturedMonitorRegionResult {
-	Image(RgbaImage),
-	NoNewFrame,
-}
-
-#[derive(Debug)]
-pub(crate) enum WorkerRequestSendError {
-	Full,
-	Disconnected,
-}
-
-#[derive(Debug)]
-pub(crate) struct CapturedMonitorRegionResponse {
-	pub(crate) monitor: MonitorRect,
-	pub(crate) rect_px: RectPoints,
-	pub(crate) request_id: u64,
-	pub(crate) result: CapturedMonitorRegionResult,
-}
+use crate::state::{GlobalPoint, MonitorRect};
 
 pub(crate) struct OverlayWorker {
 	req_tx: SyncSender<WorkerRequest>,
@@ -478,112 +389,6 @@ impl OverlayWorker {
 			Ok(msg) => Some(msg),
 			Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => None,
 		}
-	}
-}
-
-#[derive(Default)]
-struct PendingWorkerRequests {
-	last_hit_test: Option<(MonitorRect, GlobalPoint, u64)>,
-	#[cfg(not(target_os = "macos"))]
-	last_sample_cursor: Option<(MonitorRect, GlobalPoint, u64, bool, u32, u32)>,
-	last_refresh_window_list: bool,
-	last_freeze: Option<(MonitorRect, FreezeCaptureTarget)>,
-	last_capture_region: Option<(MonitorRect, RectPoints, u64)>,
-	last_encode: Option<RgbaImage>,
-}
-impl PendingWorkerRequests {
-	fn record(&mut self, request: WorkerRequest) {
-		match request {
-			WorkerRequest::HitTestWindow { monitor, point, request_id } => {
-				self.last_hit_test = Some((monitor, point, request_id));
-			},
-			#[cfg(not(target_os = "macos"))]
-			WorkerRequest::SampleLiveCursor {
-				monitor,
-				point,
-				request_id,
-				want_patch,
-				patch_width_px,
-				patch_height_px,
-			} => {
-				self.last_sample_cursor =
-					Some((monitor, point, request_id, want_patch, patch_width_px, patch_height_px));
-			},
-			WorkerRequest::RefreshWindowList => {
-				self.last_refresh_window_list = true;
-			},
-			WorkerRequest::FreezeCapture { monitor, target } => {
-				self.last_freeze = Some((monitor, target));
-			},
-			WorkerRequest::CaptureMonitorRegion { monitor, rect_px, request_id } => {
-				self.last_capture_region = Some((monitor, rect_px, request_id));
-			},
-			WorkerRequest::EncodePng { image } => {
-				self.last_encode = Some(image);
-			},
-		}
-	}
-
-	fn dispatch(
-		self,
-		backend: &mut dyn CaptureBackend,
-		resp_tx: &Sender<WorkerResponse>,
-		_region_capture_resp_tx: &Sender<CapturedMonitorRegionResponse>,
-		response_waker: Option<&(dyn Fn() + Send + Sync)>,
-	) {
-		let mut handled_high_priority = false;
-
-		if let Some(image) = self.last_encode {
-			OverlayWorker::handle_encode_request(resp_tx, response_waker, image);
-
-			handled_high_priority = true;
-		}
-
-		if handled_high_priority {
-			return;
-		}
-
-		if let Some((monitor, target)) = self.last_freeze {
-			OverlayWorker::handle_freeze_request(backend, resp_tx, response_waker, monitor, target);
-
-			return;
-		}
-		if let Some((monitor, rect_px, request_id)) = self.last_capture_region {
-			OverlayWorker::handle_capture_monitor_region_request(
-				backend,
-				resp_tx,
-				_region_capture_resp_tx,
-				response_waker,
-				monitor,
-				rect_px,
-				request_id,
-			);
-
-			return;
-		}
-
-		if self.last_refresh_window_list {
-			OverlayWorker::handle_refresh_window_list_request(backend, resp_tx, response_waker);
-		}
-
-		#[cfg(not(target_os = "macos"))]
-		if let Some((monitor, point, request_id, want_patch, patch_width_px, patch_height_px)) =
-			self.last_sample_cursor
-		{
-			OverlayWorker::handle_sample_cursor_request(
-				backend,
-				resp_tx,
-				response_waker,
-				(monitor, point, request_id, want_patch, patch_width_px, patch_height_px),
-			);
-		}
-
-		OverlayWorker::handle_hit_test_request(
-			backend,
-			resp_tx,
-			response_waker,
-			self.last_hit_test,
-		);
 	}
 }
 

--- a/packages/rsnap-overlay/src/worker/pending_requests.rs
+++ b/packages/rsnap-overlay/src/worker/pending_requests.rs
@@ -1,0 +1,116 @@
+use std::sync::mpsc::Sender;
+
+use image::RgbaImage;
+
+use crate::backend::CaptureBackend;
+use crate::state::{GlobalPoint, MonitorRect, RectPoints};
+use crate::worker::{
+	CapturedMonitorRegionResponse, FreezeCaptureTarget, OverlayWorker, WorkerRequest,
+	WorkerResponse,
+};
+
+#[derive(Default)]
+pub(super) struct PendingWorkerRequests {
+	last_hit_test: Option<(MonitorRect, GlobalPoint, u64)>,
+	#[cfg(not(target_os = "macos"))]
+	last_sample_cursor: Option<(MonitorRect, GlobalPoint, u64, bool, u32, u32)>,
+	last_refresh_window_list: bool,
+	last_freeze: Option<(MonitorRect, FreezeCaptureTarget)>,
+	last_capture_region: Option<(MonitorRect, RectPoints, u64)>,
+	last_encode: Option<RgbaImage>,
+}
+impl PendingWorkerRequests {
+	pub(super) fn record(&mut self, request: WorkerRequest) {
+		match request {
+			WorkerRequest::HitTestWindow { monitor, point, request_id } => {
+				self.last_hit_test = Some((monitor, point, request_id));
+			},
+			#[cfg(not(target_os = "macos"))]
+			WorkerRequest::SampleLiveCursor {
+				monitor,
+				point,
+				request_id,
+				want_patch,
+				patch_width_px,
+				patch_height_px,
+			} => {
+				self.last_sample_cursor =
+					Some((monitor, point, request_id, want_patch, patch_width_px, patch_height_px));
+			},
+			WorkerRequest::RefreshWindowList => {
+				self.last_refresh_window_list = true;
+			},
+			WorkerRequest::FreezeCapture { monitor, target } => {
+				self.last_freeze = Some((monitor, target));
+			},
+			WorkerRequest::CaptureMonitorRegion { monitor, rect_px, request_id } => {
+				self.last_capture_region = Some((monitor, rect_px, request_id));
+			},
+			WorkerRequest::EncodePng { image } => {
+				self.last_encode = Some(image);
+			},
+		}
+	}
+
+	pub(super) fn dispatch(
+		self,
+		backend: &mut dyn CaptureBackend,
+		resp_tx: &Sender<WorkerResponse>,
+		region_capture_resp_tx: &Sender<CapturedMonitorRegionResponse>,
+		response_waker: Option<&(dyn Fn() + Send + Sync)>,
+	) {
+		let mut handled_high_priority = false;
+
+		if let Some(image) = self.last_encode {
+			OverlayWorker::handle_encode_request(resp_tx, response_waker, image);
+
+			handled_high_priority = true;
+		}
+
+		if handled_high_priority {
+			return;
+		}
+
+		if let Some((monitor, target)) = self.last_freeze {
+			OverlayWorker::handle_freeze_request(backend, resp_tx, response_waker, monitor, target);
+
+			return;
+		}
+		if let Some((monitor, rect_px, request_id)) = self.last_capture_region {
+			OverlayWorker::handle_capture_monitor_region_request(
+				backend,
+				resp_tx,
+				region_capture_resp_tx,
+				response_waker,
+				monitor,
+				rect_px,
+				request_id,
+			);
+
+			return;
+		}
+
+		if self.last_refresh_window_list {
+			OverlayWorker::handle_refresh_window_list_request(backend, resp_tx, response_waker);
+		}
+
+		#[cfg(not(target_os = "macos"))]
+		if let Some((monitor, point, request_id, want_patch, patch_width_px, patch_height_px)) =
+			self.last_sample_cursor
+		{
+			OverlayWorker::handle_sample_cursor_request(
+				backend,
+				resp_tx,
+				response_waker,
+				(monitor, point, request_id, want_patch, patch_width_px, patch_height_px),
+			);
+		}
+
+		OverlayWorker::handle_hit_test_request(
+			backend,
+			resp_tx,
+			response_waker,
+			self.last_hit_test,
+		);
+	}
+}

--- a/packages/rsnap-overlay/src/worker/protocol.rs
+++ b/packages/rsnap-overlay/src/worker/protocol.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use image::RgbaImage;
+
+#[cfg(not(target_os = "macos"))]
+use crate::state::LiveCursorSample;
+use crate::state::{GlobalPoint, MonitorRect, RectPoints, WindowHit, WindowListSnapshot};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FreezeCaptureTarget {
+	Monitor,
+	Window { window_id: u32 },
+}
+
+#[derive(Debug)]
+pub(crate) enum WorkerRequest {
+	HitTestWindow {
+		monitor: MonitorRect,
+		point: GlobalPoint,
+		request_id: u64,
+	},
+	#[cfg(not(target_os = "macos"))]
+	SampleLiveCursor {
+		monitor: MonitorRect,
+		point: GlobalPoint,
+		request_id: u64,
+		want_patch: bool,
+		patch_width_px: u32,
+		patch_height_px: u32,
+	},
+	RefreshWindowList,
+	FreezeCapture {
+		monitor: MonitorRect,
+		target: FreezeCaptureTarget,
+	},
+	CaptureMonitorRegion {
+		monitor: MonitorRect,
+		rect_px: RectPoints,
+		request_id: u64,
+	},
+	EncodePng {
+		image: RgbaImage,
+	},
+}
+
+#[derive(Debug)]
+pub(crate) enum WorkerResponse {
+	#[cfg(not(target_os = "macos"))]
+	SampledLiveCursor {
+		monitor: MonitorRect,
+		point: GlobalPoint,
+		request_id: u64,
+		sample: LiveCursorSample,
+	},
+	HitTestWindow {
+		monitor: MonitorRect,
+		point: GlobalPoint,
+		request_id: u64,
+		hit: Option<WindowHit>,
+	},
+	RefreshedWindowList {
+		snapshot: Arc<WindowListSnapshot>,
+	},
+	CapturedFreeze {
+		monitor: MonitorRect,
+		image: RgbaImage,
+		window_image: Option<RgbaImage>,
+		captured_window_id: Option<u32>,
+	},
+	EncodedPng {
+		png_bytes: Vec<u8>,
+	},
+	Error {
+		source: WorkerErrorSource,
+		message: String,
+	},
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WorkerErrorSource {
+	EncodePng,
+	FreezeCapture,
+	RefreshWindowList,
+	CaptureMonitorRegion,
+}
+
+#[derive(Debug)]
+pub(crate) enum CapturedMonitorRegionResult {
+	Image(RgbaImage),
+	NoNewFrame,
+}
+
+#[derive(Debug)]
+pub(crate) enum WorkerRequestSendError {
+	Full,
+	Disconnected,
+}
+
+#[derive(Debug)]
+pub(crate) struct CapturedMonitorRegionResponse {
+	pub(crate) monitor: MonitorRect,
+	pub(crate) rect_px: RectPoints,
+	pub(crate) request_id: u64,
+	pub(crate) result: CapturedMonitorRegionResult,
+}


### PR DESCRIPTION
## Summary
- move overlay worker message/request/response protocol into `worker/protocol.rs`
- move pending worker request coalescing and dispatch priority policy into `worker/pending_requests.rs`
- keep `worker.rs` focused on `OverlayWorker`, thread lifecycle, backend handlers, and public request/receive methods
- update workspace layout docs with the new worker owner boundary

## Validation
- `cargo make fmt-rust`
- `cargo check -p rsnap-overlay`
- `cargo test -p rsnap-overlay worker --lib` (54 passed)
- `cargo make check-vstyle-rust`
- `git diff --check`
- `rg -n "include!|#\\[path" packages apps native scripts || true` (no matches)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check` (clippy, Swift lint/build, Rust/Swift vstyle, nextest 689 passed, native host probes)
