### PR TITLE
Extract frozen capture session state owner

### DIFF
--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -113,6 +113,9 @@ Key paths:
   under `backend/xcap_capture_backend.rs`
 - `packages/rsnap-overlay/src/overlay.rs`: current overlay root plus its focused
   runtime/rendering support modules
+- `packages/rsnap-overlay/src/overlay/session_state.rs`: shared transitional overlay session
+  state; frozen capture/export lifecycle state lives under
+  `overlay/session_state/frozen_capture.rs`
 - `packages/rsnap-overlay/src/overlay/rendering.rs`: overlay window renderer orchestration; shared
   selection geometry/cache structs live under `overlay/rendering/selection_geometry.rs`, and
   renderer phase timing telemetry lives under `overlay/rendering/timing.rs`

--- a/packages/rsnap-overlay/src/overlay/session_state.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state.rs
@@ -1,3 +1,10 @@
+mod frozen_capture;
+
+pub(super) use self::frozen_capture::{
+	FrozenCaptureSessionState, FrozenCaptureWorkerState, FrozenExportSessionState,
+	WindowFreezeCaptureTarget,
+};
+
 #[cfg(target_os = "macos")]
 use std::collections::VecDeque;
 use std::{
@@ -24,49 +31,6 @@ pub(in crate::overlay) const FROZEN_BRUSH_STROKE_WIDTH_MAX_POINTS: f32 = 24.0;
 pub(in crate::overlay) const FROZEN_TEXT_FONT_SIZE_POINTS: f32 = 16.0;
 pub(in crate::overlay) const FROZEN_TEXT_FONT_SIZE_MIN_POINTS: f32 = 12.0;
 pub(in crate::overlay) const FROZEN_TEXT_FONT_SIZE_MAX_POINTS: f32 = 72.0;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct WindowFreezeCaptureTarget {
-	pub(super) monitor: MonitorRect,
-	pub(super) window_id: u32,
-	pub(super) rect: RectPoints,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) enum FrozenCaptureWorkerState {
-	#[default]
-	Idle,
-	Armed,
-	Inflight,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum FrozenExportSessionState {
-	Pending {
-		worker_state: FrozenCaptureWorkerState,
-		window_target: Option<WindowFreezeCaptureTarget>,
-	},
-	Ready,
-	Failed,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) enum FrozenCaptureSessionState {
-	#[default]
-	Inactive,
-	DisplayPending {
-		monitor: MonitorRect,
-		worker_state: FrozenCaptureWorkerState,
-		window_target: Option<WindowFreezeCaptureTarget>,
-	},
-	DisplayFailed {
-		monitor: MonitorRect,
-	},
-	DisplayReady {
-		monitor: MonitorRect,
-		export: FrozenExportSessionState,
-	},
-}
 
 #[derive(Default)]
 pub(super) struct SlowOperationLogger {

--- a/packages/rsnap-overlay/src/overlay/session_state/frozen_capture.rs
+++ b/packages/rsnap-overlay/src/overlay/session_state/frozen_capture.rs
@@ -1,0 +1,44 @@
+use crate::overlay::{MonitorRect, RectPoints};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::overlay) struct WindowFreezeCaptureTarget {
+	pub(in crate::overlay) monitor: MonitorRect,
+	pub(in crate::overlay) window_id: u32,
+	pub(in crate::overlay) rect: RectPoints,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(in crate::overlay) enum FrozenCaptureWorkerState {
+	#[default]
+	Idle,
+	Armed,
+	Inflight,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::overlay) enum FrozenExportSessionState {
+	Pending {
+		worker_state: FrozenCaptureWorkerState,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	},
+	Ready,
+	Failed,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(in crate::overlay) enum FrozenCaptureSessionState {
+	#[default]
+	Inactive,
+	DisplayPending {
+		monitor: MonitorRect,
+		worker_state: FrozenCaptureWorkerState,
+		window_target: Option<WindowFreezeCaptureTarget>,
+	},
+	DisplayFailed {
+		monitor: MonitorRect,
+	},
+	DisplayReady {
+		monitor: MonitorRect,
+		export: FrozenExportSessionState,
+	},
+}


### PR DESCRIPTION
## Summary
- Move frozen capture/export session state into overlay/session_state/frozen_capture.rs
- Keep session_state.rs as the stable re-export surface for existing overlay callers
- Document the new session-state owner boundary in workspace layout

## Validation
- cargo make fmt-rust
- cargo check -p rsnap-overlay
- cargo test -p rsnap-overlay frozen_capture --lib
- cargo make check-vstyle-rust
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check