### PR TITLE
Extract frozen export model owner

### DIFF
--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -120,6 +120,9 @@ Key paths:
   `overlay/session_state/scroll_capture.rs`
 - `packages/rsnap-overlay/src/frozen_edit.rs`: Rust-owned frozen overlay edit session state machine;
   edit geometry, text hit bounds, and movement clamping live under `frozen_edit/geometry.rs`
+- `packages/rsnap-overlay/src/frozen_export.rs`: Rust-owned frozen-overlay export compositor;
+  export element schema lives under `frozen_export/model.rs`, and stroke rasterization lives under
+  `frozen_export/stroke_raster.rs`
 - `packages/rsnap-overlay/src/overlay/frozen_brush_runtime.rs`: Frozen pen interaction routing
   for `OverlaySession`; the brush sampling, response, smoothing, preview, and rendered point model
   lives under `overlay/frozen_brush_model.rs`

--- a/packages/rsnap-overlay/src/frozen_export.rs
+++ b/packages/rsnap-overlay/src/frozen_export.rs
@@ -1,6 +1,14 @@
 //! Portable frozen-overlay export compositing used by native hosts.
 
+mod model;
 mod stroke_raster;
+
+pub use model::{
+	FrozenOverlayExportArrow, FrozenOverlayExportElement, FrozenOverlayExportMosaic,
+	FrozenOverlayExportPen, FrozenOverlayExportPoint, FrozenOverlayExportSpotlight,
+	FrozenOverlayExportSpotlightStyle, FrozenOverlayExportStrokeStyle, FrozenOverlayExportText,
+	FrozenOverlayExportTextStyle,
+};
 
 use std::f32::consts::PI;
 
@@ -18,96 +26,6 @@ const SPOTLIGHT_VISIBLE_NUMERATOR: u16 = 173;
 const STROKE_EXPORT_ALPHA: f32 = 0.96;
 const DARK_TEXT_SHADOW_RGBA: [u8; 4] = [0, 0, 0, 115];
 const LIGHT_TEXT_SHADOW_RGBA: [u8; 4] = [255, 255, 255, 122];
-
-/// Point-space coordinate used by frozen-overlay export annotations.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FrozenOverlayExportPoint {
-	/// X coordinate in frozen capture point-space.
-	pub x: f64,
-	/// Y coordinate in frozen capture point-space.
-	pub y: f64,
-}
-impl FrozenOverlayExportPoint {
-	/// Creates a frozen-overlay export point.
-	#[must_use]
-	pub const fn new(x: f64, y: f64) -> Self {
-		Self { x, y }
-	}
-}
-
-/// Stroke style used by pen and arrow export annotations.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FrozenOverlayExportStrokeStyle {
-	/// Stroke width in frozen capture points.
-	pub stroke_width_points: f32,
-	/// Source color as non-premultiplied RGBA bytes.
-	pub rgba: [u8; 4],
-}
-
-/// Spotlight border style used by export annotations.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FrozenOverlayExportSpotlightStyle {
-	/// Border width in frozen capture points.
-	pub border_width_points: f32,
-	/// Border color as non-premultiplied RGBA bytes.
-	pub border_rgba: [u8; 4],
-}
-
-/// Text style used by export annotations.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FrozenOverlayExportTextStyle {
-	/// Font size in frozen capture points.
-	pub font_size_points: f32,
-	/// Text fill color as non-premultiplied RGBA bytes.
-	pub rgba: [u8; 4],
-}
-
-/// Pen stroke export annotation.
-#[derive(Clone, Debug, PartialEq)]
-pub struct FrozenOverlayExportPen {
-	/// Stroke points in frozen capture point-space.
-	pub points: Vec<FrozenOverlayExportPoint>,
-	/// Stroke style.
-	pub style: FrozenOverlayExportStrokeStyle,
-}
-
-/// Arrow export annotation.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FrozenOverlayExportArrow {
-	/// Arrow tail in frozen capture point-space.
-	pub start: FrozenOverlayExportPoint,
-	/// Arrow tip in frozen capture point-space.
-	pub end: FrozenOverlayExportPoint,
-	/// Stroke style.
-	pub style: FrozenOverlayExportStrokeStyle,
-}
-
-/// Mosaic privacy export annotation.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FrozenOverlayExportMosaic {
-	/// Mosaic rectangle in frozen capture point-space.
-	pub rect: DisplayPointRect,
-}
-
-/// Spotlight export annotation.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FrozenOverlayExportSpotlight {
-	/// Spotlight rectangle in frozen capture point-space.
-	pub rect: DisplayPointRect,
-	/// Spotlight border style.
-	pub style: FrozenOverlayExportSpotlightStyle,
-}
-
-/// Text export annotation.
-#[derive(Clone, Debug, PartialEq)]
-pub struct FrozenOverlayExportText {
-	/// Text anchor in frozen capture point-space.
-	pub anchor: FrozenOverlayExportPoint,
-	/// Text payload.
-	pub text: String,
-	/// Text style.
-	pub style: FrozenOverlayExportTextStyle,
-}
 
 #[derive(Clone, Copy, Debug)]
 struct ArrowGeometry {
@@ -225,21 +143,6 @@ impl ExportTransform {
 			(bottom - rect.y) * self.scale_y,
 		))
 	}
-}
-
-/// One committed frozen-overlay edit to composite into an exported image.
-#[derive(Clone, Debug, PartialEq)]
-pub enum FrozenOverlayExportElement {
-	/// Pen stroke annotation.
-	Pen(FrozenOverlayExportPen),
-	/// Arrow annotation.
-	Arrow(FrozenOverlayExportArrow),
-	/// Mosaic privacy rectangle.
-	Mosaic(FrozenOverlayExportMosaic),
-	/// Spotlight annotation.
-	Spotlight(FrozenOverlayExportSpotlight),
-	/// Text annotation.
-	Text(FrozenOverlayExportText),
 }
 
 /// Composites committed frozen-overlay annotations into a row-major RGBA export image.

--- a/packages/rsnap-overlay/src/frozen_export/model.rs
+++ b/packages/rsnap-overlay/src/frozen_export/model.rs
@@ -1,0 +1,106 @@
+use rsnap_capture_core::DisplayPointRect;
+
+/// Point-space coordinate used by frozen-overlay export annotations.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrozenOverlayExportPoint {
+	/// X coordinate in frozen capture point-space.
+	pub x: f64,
+	/// Y coordinate in frozen capture point-space.
+	pub y: f64,
+}
+impl FrozenOverlayExportPoint {
+	/// Creates a frozen-overlay export point.
+	#[must_use]
+	pub const fn new(x: f64, y: f64) -> Self {
+		Self { x, y }
+	}
+}
+
+/// Stroke style used by pen and arrow export annotations.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrozenOverlayExportStrokeStyle {
+	/// Stroke width in frozen capture points.
+	pub stroke_width_points: f32,
+	/// Source color as non-premultiplied RGBA bytes.
+	pub rgba: [u8; 4],
+}
+
+/// Spotlight border style used by export annotations.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrozenOverlayExportSpotlightStyle {
+	/// Border width in frozen capture points.
+	pub border_width_points: f32,
+	/// Border color as non-premultiplied RGBA bytes.
+	pub border_rgba: [u8; 4],
+}
+
+/// Text style used by export annotations.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrozenOverlayExportTextStyle {
+	/// Font size in frozen capture points.
+	pub font_size_points: f32,
+	/// Text fill color as non-premultiplied RGBA bytes.
+	pub rgba: [u8; 4],
+}
+
+/// Pen stroke export annotation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrozenOverlayExportPen {
+	/// Stroke points in frozen capture point-space.
+	pub points: Vec<FrozenOverlayExportPoint>,
+	/// Stroke style.
+	pub style: FrozenOverlayExportStrokeStyle,
+}
+
+/// Arrow export annotation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrozenOverlayExportArrow {
+	/// Arrow tail in frozen capture point-space.
+	pub start: FrozenOverlayExportPoint,
+	/// Arrow tip in frozen capture point-space.
+	pub end: FrozenOverlayExportPoint,
+	/// Stroke style.
+	pub style: FrozenOverlayExportStrokeStyle,
+}
+
+/// Mosaic privacy export annotation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrozenOverlayExportMosaic {
+	/// Mosaic rectangle in frozen capture point-space.
+	pub rect: DisplayPointRect,
+}
+
+/// Spotlight export annotation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrozenOverlayExportSpotlight {
+	/// Spotlight rectangle in frozen capture point-space.
+	pub rect: DisplayPointRect,
+	/// Spotlight border style.
+	pub style: FrozenOverlayExportSpotlightStyle,
+}
+
+/// Text export annotation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrozenOverlayExportText {
+	/// Text anchor in frozen capture point-space.
+	pub anchor: FrozenOverlayExportPoint,
+	/// Text payload.
+	pub text: String,
+	/// Text style.
+	pub style: FrozenOverlayExportTextStyle,
+}
+
+/// One committed frozen-overlay edit to composite into an exported image.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FrozenOverlayExportElement {
+	/// Pen stroke annotation.
+	Pen(FrozenOverlayExportPen),
+	/// Arrow annotation.
+	Arrow(FrozenOverlayExportArrow),
+	/// Mosaic privacy rectangle.
+	Mosaic(FrozenOverlayExportMosaic),
+	/// Spotlight annotation.
+	Spotlight(FrozenOverlayExportSpotlight),
+	/// Text annotation.
+	Text(FrozenOverlayExportText),
+}


### PR DESCRIPTION
## Summary
- move frozen-overlay export element schema into `frozen_export/model.rs`
- keep the compositor pipeline in `frozen_export.rs` with the same public re-export surface
- document the export model/compositor ownership split

## Validation
- cargo make fmt-rust
- cargo make check-vstyle-rust
- cargo check -p rsnap-overlay
- cargo test -p rsnap-overlay frozen_export --lib
- cargo clippy -p rsnap-overlay --all-features --all-targets -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D warnings
- git diff --check
- rg -n "include!|#\[path" packages apps native scripts
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check