### PR TITLE
Move frozen edit into capture core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,6 @@ dependencies = [
  "color-eyre",
  "image",
  "rsnap-capture-core",
- "rsnap-overlay",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -53,12 +53,11 @@ Prototype / in active development.
   - `native/macos-host/` is the SwiftPM AppKit host shell and the default local Run path.
   - `apps/rsnap/` is now a thin launcher/bootstrap crate that stages or opens the native host
     bundle and records startup logging.
-  - `packages/rsnap-overlay/` is now a narrowed Rust transition crate for retained frozen edit
-    state and macOS live-sampling adapters that have not yet moved into `rsnap-capture-core` / the
-    native host.
+  - `packages/rsnap-overlay/` is now a narrowed Rust transition crate for macOS live-sampling
+    adapters that have not yet moved into the native host.
 - The active reset target is no longer a pure-Rust UI stack. New boundary crates now live in:
   - `packages/rsnap-capture-core/` for platform-neutral session semantics and host/core protocol
-    models, plus Rust-owned export, frozen-overlay export, capture-frame rendering, wallpaper
+    models, plus Rust-owned export, frozen-overlay edit/export, capture-frame rendering, wallpaper
     thumbnail, minimap, scroll stitching, selection-transform, and image-analysis algorithms
   - `packages/rsnap-host-ffi/` for the thin C ABI that the native macOS host calls
     through `packages/rsnap-host-ffi/include/rsnap_host_ffi.h`

--- a/apps/rsnap-perf/Cargo.toml
+++ b/apps/rsnap-perf/Cargo.toml
@@ -17,4 +17,3 @@ path = "src/main.rs"
 color-eyre         = { workspace = true }
 image              = { workspace = true }
 rsnap-capture-core = { workspace = true }
-rsnap-overlay      = { workspace = true }

--- a/apps/rsnap-perf/src/fixtures.rs
+++ b/apps/rsnap-perf/src/fixtures.rs
@@ -13,16 +13,16 @@ use rsnap_capture_core::{
 	ScrollMinimapInput, ToolbarItemKind,
 };
 use rsnap_capture_core::{
+	FrozenOverlayEditColor, FrozenOverlayEditPoint, FrozenOverlayEditRect,
+	FrozenOverlayEditSession, FrozenOverlayEditSpotlightStyle, FrozenOverlayEditStrokeStyle,
+	FrozenOverlayEditStyle, FrozenOverlayEditTextStyle,
+};
+use rsnap_capture_core::{
 	FrozenOverlayExportArrow, FrozenOverlayExportElement, FrozenOverlayExportMosaic,
 	FrozenOverlayExportPen, FrozenOverlayExportPoint, FrozenOverlayExportSpotlight,
 	FrozenOverlayExportSpotlightStyle, FrozenOverlayExportStrokeStyle, FrozenOverlayExportText,
 	FrozenOverlayExportTextStyle, ScrollCaptureBenchScenario, ScrollCaptureOverlapMetrics,
 	ScrollCaptureSessionMetrics,
-};
-use rsnap_overlay::frozen_edit::{
-	FrozenOverlayEditColor, FrozenOverlayEditPoint, FrozenOverlayEditRect,
-	FrozenOverlayEditSession, FrozenOverlayEditSpotlightStyle, FrozenOverlayEditStrokeStyle,
-	FrozenOverlayEditStyle, FrozenOverlayEditTextStyle,
 };
 
 pub(crate) fn build_export_fixture(width: u32, height: u32) -> RgbaImage {

--- a/docs/evidence/legacy-overlay-cleanup-drift-2026-07-06.md
+++ b/docs/evidence/legacy-overlay-cleanup-drift-2026-07-06.md
@@ -25,9 +25,8 @@ last_verified: 2026-07-06
 
 - `Cargo.toml` and `packages/rsnap-overlay/Cargo.toml` remove the `egui*` workspace dependencies
   and crate dependencies.
-- `packages/rsnap-overlay/src/lib.rs` exposes only frozen edit and macOS live sampling transition
-  helpers; scroll stitching and frozen-overlay export have since moved to
-  `packages/rsnap-capture-core/`.
+- `packages/rsnap-overlay/src/lib.rs` exposes only macOS live sampling transition helpers; scroll
+  stitching and frozen-overlay edit/export have since moved to `packages/rsnap-capture-core/`.
 - `packages/rsnap-capture-core/src/point.rs`,
   `packages/rsnap-capture-core/src/frozen_overlay_export.rs`,
   `packages/rsnap-capture-core/src/frozen_overlay_export/stroke_raster.rs`, and

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,8 @@
 
 ## 2026-07-06
 
+- Moved frozen-overlay edit state references from `rsnap-overlay` to `rsnap-capture-core` after the
+  edit session migrated into the durable core crate.
 - Moved frozen-overlay export composition, text rendering, and font fallback references from
   `rsnap-overlay` to `rsnap-capture-core` after the compositor migrated into the durable core
   crate.

--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -50,15 +50,15 @@ The checked-in repository does not yet fully match the target design.
 Today:
 
 - `apps/rsnap/` is now the thin launcher/bootstrap layer for the staged native host bundle
-- `packages/rsnap-overlay/` is now a narrowed transition crate for retained frozen edit state and
-  macOS live-sampling adapters; the legacy Rust overlay UI/runtime, replay harness, trace
-  recorder, shaders, backend worker tree, scroll-capture stitching engine, and frozen-overlay
-  export compositor are no longer part of this crate
+- `packages/rsnap-overlay/` is now a narrowed transition crate for macOS live-sampling adapters;
+  the legacy Rust overlay UI/runtime, replay harness, trace recorder, shaders, backend worker
+  tree, scroll-capture stitching engine, frozen-overlay edit state, and frozen-overlay export
+  compositor are no longer part of this crate
 - `packages/rsnap-capture-core/` is now the checked-in landing zone for portable geometry,
-  semantic scene models, host/core protocol types, export/crop/PNG encoding, frozen-overlay export
-  composition, capture-frame planning/rendering, wallpaper thumbnail decode/cache, minimap
-  planning, scroll stitching, mosaic generation, frozen-selection transforms, auto-centering, and
-  live-sample pixel helpers
+  semantic scene models, host/core protocol types, export/crop/PNG encoding, frozen-overlay edit
+  state and export composition, capture-frame planning/rendering, wallpaper thumbnail
+  decode/cache, minimap planning, scroll stitching, mosaic generation, frozen-selection
+  transforms, auto-centering, and live-sample pixel helpers
 - `packages/rsnap-host-ffi/` is now the checked-in thin C ABI bridge for the native macOS host and
   ships the checked-in header at `packages/rsnap-host-ffi/include/rsnap_host_ffi.h`
 - `native/macos-host/` is now the visible app shell and owns clipboard, save, and deferred OCR

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -42,8 +42,8 @@ For the active target architecture and migration direction, read:
 | `native/macos-host/` | SwiftPM AppKit-first macOS host shell: menu bar entry, full-screen capture windows, in-window HUD/toolbar, and native bridging into `rsnap-host-ffi` |
 | `apps/rsnap/` | Thin launcher/bootstrap crate: startup logging, build metadata, stable-bundle resolution, and `cargo run -p rsnap` handoff into the staged native macOS host |
 | `apps/rsnap-perf/` | Deterministic local performance sweep: fixed fixture construction, checksum-backed correctness checks, case timing, and budget assertions |
-| `packages/rsnap-overlay/` | Narrow Rust transition crate: retained frozen edit state and macOS live-sampling adapters that have not yet moved into durable owners |
-| `packages/rsnap-capture-core/` | Durable Rust product-semantics and image-algorithm crate: shared geometry, semantic scene model, host/core protocol enums, reset-native session core, export/crop/PNG encoding, frozen-overlay export composition, capture-frame rendering, wallpaper thumbnail, minimap, mosaic, selection transform, auto-center, scroll stitching, and live-sample helpers |
+| `packages/rsnap-overlay/` | Narrow Rust transition crate: macOS live-sampling adapters that have not yet moved into the native host |
+| `packages/rsnap-capture-core/` | Durable Rust product-semantics and image-algorithm crate: shared geometry, semantic scene model, host/core protocol enums, reset-native session core, export/crop/PNG encoding, frozen-overlay edit/export, capture-frame rendering, wallpaper thumbnail, minimap, mosaic, selection transform, auto-center, scroll stitching, and live-sample helpers |
 | `packages/rsnap-host-ffi/` | Thin C ABI bridge crate used by the native macOS host to call the Rust product core and retained Rust transition modules |
 | `docs/` | Agent-facing repository docs split into `spec`, `runbook`, `reference`, and `decisions` |
 | `assets/` | Shared app-icon source plus generated bundle/runtime assets |
@@ -100,7 +100,6 @@ has native-host callers or deterministic validation surfaces but has not yet mov
 
 Today it owns:
 
-- frozen edit state that is still Rust-owned but has not yet moved into `rsnap-capture-core`
 - macOS live-frame and live-sampling adapters used through `rsnap-host-ffi`
 
 Important:
@@ -115,10 +114,7 @@ Important:
 Key paths:
 
 - `packages/rsnap-overlay/src/lib.rs`: explicit public surface for the remaining transition
-  helpers: frozen edit and macOS live sampling
-- `packages/rsnap-overlay/src/frozen_edit.rs`: Rust-owned frozen overlay edit session state
-  machine, including edit geometry, text hit bounds, and movement clamping policy; element models
-  live under `frozen_edit/elements.rs`
+  helper: macOS live sampling
 - `packages/rsnap-overlay/src/host_live_sampling_macos.rs`: macOS live sampler adapter exposed
   through `rsnap-host-ffi`
 - `packages/rsnap-overlay/src/live_frame_stream_macos.rs`: macOS ScreenCaptureKit live-frame stream
@@ -140,7 +136,7 @@ It owns:
 - the first reset-native reference session core
 - RGBA/BGRA pixel helpers used by host bridge code
 - export crop mapping and lossless PNG encoding
-- frozen-overlay export composition, text rendering, and system font fallback selection
+- frozen-overlay edit state, export composition, text rendering, and system font fallback selection
 - capture-frame layout, background planning, shadowing, wallpaper thumbnail decode/cache, and final
   RGBA composition
 - scroll minimap planning
@@ -158,6 +154,9 @@ This crate must stay free of:
 
 Key frozen-overlay export paths:
 
+- `packages/rsnap-capture-core/src/frozen_edit.rs`: frozen-overlay edit session state machine,
+  including edit geometry, text hit bounds, movement clamping policy, and element models under
+  `frozen_edit/elements.rs`
 - `packages/rsnap-capture-core/src/frozen_overlay_export.rs`: public frozen-overlay export
   compositor used by `rsnap-host-ffi` and `rsnap-perf`
 - `packages/rsnap-capture-core/src/frozen_overlay_export/model.rs`: export element schema shared

--- a/packages/rsnap-capture-core/src/frozen_edit.rs
+++ b/packages/rsnap-capture-core/src/frozen_edit.rs
@@ -10,7 +10,7 @@ pub use self::elements::{
 	FrozenOverlayEditTextStyle, FrozenOverlayTextEdit,
 };
 
-use rsnap_capture_core::{FrozenOverlayTextBounds, ToolbarItemKind};
+use crate::{FrozenOverlayTextBounds, ToolbarItemKind};
 
 const PEN_SAMPLE_MIN_DISTANCE_POINTS: f64 = 1.5;
 const ARROW_MIN_DISTANCE_POINTS: f64 = 6.0;
@@ -706,13 +706,12 @@ fn text_hit_bounds(annotation: &FrozenOverlayEditText) -> FrozenOverlayEditRect 
 
 fn text_bounds(annotation: &FrozenOverlayEditText) -> FrozenOverlayEditRect {
 	let font_size = annotation.style.font_size_points.max(1.0) as f32;
-	let bounds =
-		rsnap_capture_core::measure_frozen_overlay_text_bounds(&annotation.text, font_size)
-			.unwrap_or_else(|| {
-				let width = annotation.text.chars().count().max(1) as f32 * font_size * 0.6;
+	let bounds = crate::measure_frozen_overlay_text_bounds(&annotation.text, font_size)
+		.unwrap_or_else(|| {
+			let width = annotation.text.chars().count().max(1) as f32 * font_size * 0.6;
 
-				FrozenOverlayTextBounds { width, height: font_size * 1.2 }
-			});
+			FrozenOverlayTextBounds { width, height: font_size * 1.2 }
+		});
 
 	FrozenOverlayEditRect::new(
 		annotation.anchor.x,
@@ -724,12 +723,12 @@ fn text_bounds(annotation: &FrozenOverlayEditText) -> FrozenOverlayEditRect {
 
 #[cfg(test)]
 mod tests {
+	use crate::ToolbarItemKind;
 	use crate::frozen_edit::{
 		FrozenOverlayEditColor, FrozenOverlayEditElement, FrozenOverlayEditPoint,
 		FrozenOverlayEditRect, FrozenOverlayEditSession, FrozenOverlayEditStyle,
 		FrozenOverlayEditTextStyle, FrozenOverlayTextEdit,
 	};
-	use rsnap_capture_core::ToolbarItemKind;
 
 	fn selection() -> FrozenOverlayEditRect {
 		FrozenOverlayEditRect::new(10.0, 20.0, 400.0, 240.0)

--- a/packages/rsnap-capture-core/src/frozen_edit/elements.rs
+++ b/packages/rsnap-capture-core/src/frozen_edit/elements.rs
@@ -1,4 +1,4 @@
-use rsnap_capture_core::{
+use crate::{
 	DisplayPointRect, FrozenOverlayExportArrow, FrozenOverlayExportElement,
 	FrozenOverlayExportMosaic, FrozenOverlayExportPen, FrozenOverlayExportPoint,
 	FrozenOverlayExportSpotlight, FrozenOverlayExportSpotlightStyle,

--- a/packages/rsnap-capture-core/src/lib.rs
+++ b/packages/rsnap-capture-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod auto_center;
 pub mod bgra_frame;
 pub mod capture_frame;
 pub mod export;
+pub mod frozen_edit;
 pub mod frozen_overlay_export;
 pub mod geometry;
 pub mod minimap;
@@ -40,6 +41,14 @@ pub use self::{
 	export::{
 		RgbaExportImage, crop_export_image, crop_rgba_image, encode_png_lossless_fast,
 		encode_png_lossless_fast_with_screen_scale,
+	},
+	frozen_edit::{
+		FrozenOverlayEditArrow, FrozenOverlayEditColor, FrozenOverlayEditElement,
+		FrozenOverlayEditMosaic, FrozenOverlayEditPen, FrozenOverlayEditPoint,
+		FrozenOverlayEditRect, FrozenOverlayEditSession, FrozenOverlayEditSnapshot,
+		FrozenOverlayEditSpotlight, FrozenOverlayEditSpotlightStyle, FrozenOverlayEditStrokeStyle,
+		FrozenOverlayEditStyle, FrozenOverlayEditText, FrozenOverlayEditTextStyle,
+		FrozenOverlayTextEdit,
 	},
 	frozen_overlay_export::{
 		FrozenOverlayExportArrow, FrozenOverlayExportElement, FrozenOverlayExportMosaic,

--- a/packages/rsnap-host-ffi/src/abi/handles.rs
+++ b/packages/rsnap-host-ffi/src/abi/handles.rs
@@ -1,6 +1,4 @@
-use rsnap_capture_core::CaptureSessionCore;
-use rsnap_capture_core::ScrollStitchSession;
-use rsnap_overlay::frozen_edit::FrozenOverlayEditSession;
+use rsnap_capture_core::{CaptureSessionCore, FrozenOverlayEditSession, ScrollStitchSession};
 #[cfg(target_os = "macos")]
 use rsnap_overlay::host_live_sampling_macos::HostMacLiveSampler;
 

--- a/packages/rsnap-host-ffi/src/frozen_overlay.rs
+++ b/packages/rsnap-host-ffi/src/frozen_overlay.rs
@@ -12,7 +12,7 @@ use crate::{
 	RsnapFrozenOverlayEditStyle, RsnapFrozenOverlayExportElement,
 	RsnapFrozenOverlayExportElementKind, RsnapStatus, RsnapToolbarItemKind,
 };
-use rsnap_overlay::frozen_edit::{
+use rsnap_capture_core::{
 	FrozenOverlayEditArrow, FrozenOverlayEditColor, FrozenOverlayEditElement,
 	FrozenOverlayEditMosaic, FrozenOverlayEditPen, FrozenOverlayEditPoint, FrozenOverlayEditRect,
 	FrozenOverlayEditSession, FrozenOverlayEditSnapshot, FrozenOverlayEditSpotlight,

--- a/packages/rsnap-overlay/src/lib.rs
+++ b/packages/rsnap-overlay/src/lib.rs
@@ -4,7 +4,6 @@
 //! used by native-host FFI and deterministic performance checks. The retired Rust UI
 //! overlay runtime is no longer part of the public or compiled crate surface.
 
-pub mod frozen_edit;
 #[cfg(target_os = "macos")]
 pub mod host_live_sampling_macos;
 


### PR DESCRIPTION
## Summary
- move frozen-overlay edit session and edit model from rsnap-overlay to rsnap-capture-core
- switch rsnap-host-ffi and rsnap-perf edit callers to core-owned APIs
- narrow rsnap-overlay to macOS live sampling transition helpers

## Validation
- cargo check -p rsnap-capture-core -p rsnap-overlay -p rsnap-host-ffi -p rsnap-perf --all-targets
- cargo test -p rsnap-capture-core frozen_edit --lib
- cargo test -p rsnap-overlay -p rsnap-host-ffi
- cargo clippy -p rsnap-overlay --all-targets --target x86_64-unknown-linux-gnu -- -D unused-crate-dependencies -D warnings
- cargo clippy --all-features --all-targets --workspace -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D unused-crate-dependencies -D warnings
- cargo vstyle curate --language rust --workspace --all-features
- scripts/perf/local.sh (first run had transient bgra_loupe budget miss; immediate rerun passed with unchanged code)
- cargo +nightly fmt --all -- --check
- git diff --check
- decodex docs check

## Review
- read-only skeptic subagent found no blockers