### PR TITLE
Fix live to frozen capture handoff

### DIFF
--- a/docs/reference/live-sampling.md
+++ b/docs/reference/live-sampling.md
@@ -133,6 +133,10 @@ Frozen commit must use `FrozenFrameAuthority` or another source with equivalent 
 - `post_token` is preferred: the frame sequence advanced after the frozen latch.
 - `latest_unchanged` is allowed only for a fresh same-sequence frame on an unchanged/static
   desktop.
+- `screenshot_manager` is allowed when the frozen authority has an active self-capture-safe
+  ScreenCaptureKit stream/filter but the display stream has stopped emitting frames because the
+  desktop is static. This path captures a current image through `SCScreenshotManager` with the same
+  content filter; it is not a cache-only latest-frame shortcut.
 - Cache-only wrappers that synthesize `capturedAt` at call time must not feed the frozen first
   frame.
 - A frozen-authority stream warmed before overlay windows became visible must be replaced after
@@ -142,8 +146,8 @@ Frozen commit must use `FrozenFrameAuthority` or another source with equivalent 
   running. Once the replacement stream is ready, the first Frozen display frame must come from a
   self-capture-excluding filter, not from a pre-overlay filter that can see Rsnap's own live mask,
   border, badge, or toolbar.
-- If no freshness-proven frame is available, fail the freeze with `no_fresh_frame` instead of
-  showing a screenshot from seconds earlier.
+- If no self-capture-safe stream/filter or freshness-proven capture source is available, fail the
+  freeze with `no_fresh_frame` instead of showing a screenshot from seconds earlier.
 
 This is the guard against the old regression where a quick drag could freeze a frame that came from
 seconds-old live-stream cache data while telemetry incorrectly reported it as current.

--- a/docs/runbook/telemetry-debugging.md
+++ b/docs/runbook/telemetry-debugging.md
@@ -130,9 +130,12 @@ If the chain stops at `capture_timing.freeze_commit_failed`, inspect
 frame timing. On static desktops, successful freezes may report `snapshotSource=latest_unchanged`;
 that is expected when no post-latch ScreenCaptureKit frame was emitted because the excluded overlay
 was the only thing moving.
-Fast freezes should usually report `snapshotSource=post_token`; fresh static handoffs may report
-`snapshotSource=latest_unchanged`. In both cases, check `frameAgeMs`: it must reflect the actual
-source frame age and should stay within the frozen authority freshness guard. If
+Fast freezes should usually report `snapshotSource=post_token`; static handoffs may report
+`snapshotSource=latest_unchanged` when a fresh same-sequence frame exists, or
+`snapshotSource=screenshot_manager` when the authority uses the active self-capture-safe
+ScreenCaptureKit filter to capture the current static display. In all cases, check `frameAgeMs`: it
+must reflect the actual source frame age and should stay within the frozen authority freshness
+guard for stream-derived frames. If
 `snapshotSource=live_sampler_latest`, `authority_latest`, or `window_list_below_overlay` appears in
 release-handoff telemetry, treat it as a regression. The first two sources mean the frozen handoff
 has fallen back to an obsolete cache-only/latest-frame shortcut; the last means full-monitor

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -102,8 +102,9 @@ Mode transitions are not continuous cadence loops, but they are user-visible. Th
 release handoff must avoid waiting for a future ScreenCaptureKit frame when a freshness-proven
 frozen authority frame is already available. The intended path is:
 
-1. use a `post_token` frozen authority frame, or a fresh `latest_unchanged` authority frame for an
-   unchanged/static desktop,
+1. use a `post_token` frozen authority frame, a fresh `latest_unchanged` authority frame, or a
+   current `screenshot_manager` capture through the active self-capture-safe ScreenCaptureKit
+   filter for an unchanged/static desktop,
 2. present the frozen frame, toolbar, and scrim in one continuous handoff,
 3. perform cleanup such as secondary-window collapse after the first frozen frame is installed.
 

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -112,6 +112,9 @@ Do not encode values into the event name; emit values as fields.
 - Frozen capture frame provenance uses `snapshotSource`; `post_token` means ScreenCaptureKit
   produced a frame after the frozen latch, and `latest_unchanged` means no newer frame arrived
   but the frozen authority still had a fresh same-sequence frame for an unchanged/static desktop.
+  `screenshot_manager` means no fresh stream frame was available, so the frozen authority captured
+  a current image through `SCScreenshotManager` using the active self-capture-safe
+  ScreenCaptureKit content filter.
   `frameAgeMs` must be derived from the source frame's real capture timestamp, not from the time a
   wrapper copied cached pixels. The release handoff must not use cache-only live-sampler
   latest-monitor snapshots; those FFI wrappers were removed because they lacked

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+SnapshotResolution.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+SnapshotResolution.swift
@@ -1,8 +1,49 @@
 import CoreGraphics
 import Foundation
 import RsnapHostBridge
+import ScreenCaptureKit
 
 extension FrozenFrameAuthority {
+	private struct ScreenshotSnapshotRequest: @unchecked Sendable {
+		let displayID: CGDirectDisplayID
+		let displayFrame: CGRect
+		let generation: UInt64
+		let selfCaptureFilterComplete: Bool
+		let filter: SCContentFilter
+		let configuration: SCStreamConfiguration
+	}
+
+	private final class ScreenshotSnapshotResult: @unchecked Sendable {
+		private let condition = NSCondition()
+		private var completed = false
+		private var image: CGImage?
+		private var error: Error?
+		private var capturedAtUptime = ProcessInfo.processInfo.systemUptime
+
+		func complete(image: CGImage?, error: Error?) {
+			condition.lock()
+			self.image = image
+			self.error = error
+			capturedAtUptime = ProcessInfo.processInfo.systemUptime
+			completed = true
+			condition.signal()
+			condition.unlock()
+		}
+
+		func wait(until deadline: Date) -> (
+			image: CGImage?, error: Error?, capturedAtUptime: TimeInterval
+		) {
+			condition.lock()
+			while completed == false, Date() < deadline {
+				condition.wait(until: deadline)
+			}
+			let snapshot =
+				completed ? (image, error, capturedAtUptime) : (nil, nil, capturedAtUptime)
+			condition.unlock()
+			return snapshot
+		}
+	}
+
 	func latchToken(containing point: CGPoint) -> FrozenFrameLatchToken? {
 		stateLock.lock()
 		defer {
@@ -273,13 +314,140 @@ extension FrozenFrameAuthority {
 		after token: FrozenFrameLatchToken?,
 		maxWait: TimeInterval
 	) -> SnapshotResolution {
+		if hasStaleUnchangedRecord(containing: point, token: token),
+			let snapshot = screenshotManagerSnapshot(
+				containing: point,
+				maxWait: Self.screenshotManagerSnapshotWait
+			)
+		{
+			return .resolved(snapshot)
+		}
 		if let snapshot = snapshot(containing: point, after: token, maxWait: maxWait) {
+			return .resolved(snapshot)
+		}
+		if let snapshot = screenshotManagerSnapshot(
+			containing: point,
+			maxWait: Self.screenshotManagerSnapshotWait
+		) {
 			return .resolved(snapshot)
 		}
 		if needsSelfCaptureCompleteFrame(containing: point) {
 			return .pendingSelfCaptureFrame
 		}
 		return .noFreshFrame
+	}
+
+	private func hasStaleUnchangedRecord(
+		containing point: CGPoint,
+		token: FrozenFrameLatchToken?
+	) -> Bool {
+		stateLock.lock()
+		defer {
+			stateLock.unlock()
+		}
+		let displayID =
+			token?.displayID
+			?? displayTargets.first(where: { $0.value.frame.inclusivelyContains(point) })?.key
+		guard
+			let displayID,
+			let token,
+			token.minSequence > 0,
+			let record = latestFrames[displayID],
+			let eligibleRecord = snapshotEligibleRecordLocked(record),
+			eligibleRecord.generation == token.generation,
+			eligibleRecord.sequence == token.minSequence
+		else {
+			return false
+		}
+		return Self.isFreshForSnapshot(eligibleRecord) == false
+	}
+
+	private func screenshotManagerSnapshot(
+		containing point: CGPoint,
+		maxWait: TimeInterval
+	) -> FrozenFrameSnapshot? {
+		guard let request = screenshotSnapshotRequest(containing: point) else {
+			return nil
+		}
+		let deadline = Date(timeIntervalSinceNow: max(0, maxWait))
+		let result = ScreenshotSnapshotResult()
+
+		SCScreenshotManager.captureImage(
+			contentFilter: request.filter,
+			configuration: request.configuration
+		) { image, error in
+			result.complete(image: image, error: error)
+		}
+
+		let snapshotResult = result.wait(until: deadline)
+		let image = snapshotResult.image
+		let error = snapshotResult.error
+
+		if let error {
+			let telemetry = currentTelemetrySnapshot()
+			NativeHostTelemetry.frozenAuthorityWarning(
+				"frozen_authority.screenshot_snapshot_failed",
+				captureID: telemetry.captureID,
+				source: telemetry.source,
+				displayID: request.displayID,
+				error: String(describing: error)
+			)
+		}
+		guard let image else {
+			return nil
+		}
+
+		stateLock.lock()
+		guard
+			generation == request.generation,
+			activeDisplayIDs.contains(request.displayID)
+		else {
+			stateLock.unlock()
+			return nil
+		}
+		orderedFrameSequence &+= 1
+		let sequence = orderedFrameSequence
+		stateLock.unlock()
+
+		return FrozenFrameSnapshot(
+			displayID: request.displayID,
+			displayFrame: request.displayFrame,
+			image: image,
+			generation: request.generation,
+			sequence: sequence,
+			capturedAtUptime: snapshotResult.capturedAtUptime,
+			source: "screenshot_manager",
+			selfCaptureSafe: true,
+			selfCaptureFilterComplete: request.selfCaptureFilterComplete
+		)
+	}
+
+	private func screenshotSnapshotRequest(containing point: CGPoint)
+		-> ScreenshotSnapshotRequest?
+	{
+		stateLock.lock()
+		defer {
+			stateLock.unlock()
+		}
+		guard
+			let displayID = displayTargets.first(where: {
+				$0.value.frame.inclusivelyContains(point)
+			})?.key,
+			let displayStream = streams[displayID]
+		else {
+			return nil
+		}
+		if selfCaptureFilterRequired, displayStream.selfCaptureFilterComplete == false {
+			return nil
+		}
+		return ScreenshotSnapshotRequest(
+			displayID: displayID,
+			displayFrame: displayStream.displayFrame,
+			generation: generation,
+			selfCaptureFilterComplete: displayStream.selfCaptureFilterComplete,
+			filter: displayStream.filter,
+			configuration: displayStream.configuration
+		)
 	}
 
 	private func freshRecordLocked(displayID: CGDirectDisplayID, token: FrozenFrameLatchToken?)

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+StreamSetup.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority+StreamSetup.swift
@@ -271,9 +271,10 @@ extension FrozenFrameAuthority {
 			} telemetrySnapshot: { [weak self] in
 				self?.currentTelemetrySnapshot() ?? (captureID: captureID, source: source)
 			}
+			let configuration = FrozenFrameContentFilterPlanner.streamConfiguration(for: target)
 			let stream = SCStream(
 				filter: preparedFilter.filter,
-				configuration: FrozenFrameContentFilterPlanner.streamConfiguration(for: target),
+				configuration: configuration,
 				delegate: output)
 			do {
 				try stream.addStreamOutput(
@@ -297,7 +298,10 @@ extension FrozenFrameAuthority {
 				streams[target.displayID] = DisplayStream(
 					stream: stream,
 					output: output,
-					selfCaptureFilterComplete: preparedFilter.selfCaptureFilterComplete
+					selfCaptureFilterComplete: preparedFilter.selfCaptureFilterComplete,
+					displayFrame: target.frame,
+					filter: preparedFilter.filter,
+					configuration: configuration
 				)
 			}
 			stateLock.unlock()

--- a/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/FrozenFrameAuthority.swift
@@ -42,6 +42,7 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 	static let maximumOrderedRegionAgeMicroseconds: UInt64 = 90_000
 	static let orderedRegionAheadWaitTimeout: TimeInterval = 0.024
 	static let orderedRegionFrameHistoryCapacity = 32
+	static let screenshotManagerSnapshotWait: TimeInterval = 0.35
 	static let selfCaptureFilterRetryInterval: TimeInterval = 0.035
 	static let selfCaptureFilterRetryWindow: TimeInterval = 2.5
 
@@ -69,15 +70,24 @@ final class FrozenFrameAuthority: @unchecked Sendable {
 		let stream: SCStream
 		let output: FrozenFrameStreamOutput
 		let selfCaptureFilterComplete: Bool
+		let displayFrame: CGRect
+		let filter: SCContentFilter
+		let configuration: SCStreamConfiguration
 
 		init(
 			stream: SCStream,
 			output: FrozenFrameStreamOutput,
-			selfCaptureFilterComplete: Bool
+			selfCaptureFilterComplete: Bool,
+			displayFrame: CGRect,
+			filter: SCContentFilter,
+			configuration: SCStreamConfiguration
 		) {
 			self.stream = stream
 			self.output = output
 			self.selfCaptureFilterComplete = selfCaptureFilterComplete
+			self.displayFrame = displayFrame
+			self.filter = filter
+			self.configuration = configuration
 		}
 
 		func stop() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostAppearanceSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostAppearanceSettings.swift
@@ -29,7 +29,7 @@ struct AppearanceSettingsPanel: View {
 					subtitle: materialSubtitle
 				) {
 					HudGlassModePicker(
-						selection: model.settings.resolvedHudGlassMode,
+						selection: model.settings.hudGlassMode,
 						isEnabled: model.settings.hudGlassEnabled,
 						onSelect: updateGlassMode
 					)
@@ -106,7 +106,7 @@ struct AppearanceSettingsPanel: View {
 		}
 		.animation(
 			.spring(response: 0.26, dampingFraction: 0.86),
-			value: model.settings.resolvedHudGlassMode
+			value: model.settings.hudGlassMode
 		)
 	}
 
@@ -140,10 +140,6 @@ struct AppearanceSettingsPanel: View {
 	}
 
 	private func updateGlassMode(_ mode: HudGlassModePreference) {
-		if mode == .liquidGlass, !LiveChromeGlassMaterialSupport.isLiquidGlassAvailable {
-			model.refresh()
-			return
-		}
 		model.update { $0.hudGlassMode = mode }
 	}
 }
@@ -173,21 +169,26 @@ private struct HudGlassModePicker: View {
 	var body: some View {
 		HStack(spacing: 8) {
 			ForEach(HudGlassModePreference.allCases, id: \.rawValue) { mode in
-				let available =
-					mode != .liquidGlass || LiveChromeGlassMaterialSupport.isLiquidGlassAvailable
 				ModernSegmentButton(
 					title: mode.title,
 					isSelected: selection == mode,
-					isEnabled: isEnabled && available
+					isEnabled: isEnabled
 				) {
 					onSelect(mode)
 				}
-				.help(available ? mode.title : LiveChromeGlassMaterialSupport.unavailableHelpText)
+				.help(helpText(for: mode))
 			}
 		}
 		.padding(.horizontal, 1)
 		.frame(width: SettingsControlLayout.controlColumnWidth)
 		.segmentedGlassBackground()
+	}
+
+	private func helpText(for mode: HudGlassModePreference) -> String {
+		if mode == .liquidGlass, !LiveChromeGlassMaterialSupport.isLiquidGlassAvailable {
+			return LiveChromeGlassMaterialSupport.unavailableHelpText
+		}
+		return mode.title
 	}
 }
 

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -37,19 +37,8 @@ RUST_BUILD_ARGS=(-p rsnap-host-ffi)
 RESOLVED_SIGN_IDENTITY=""
 STAGED_APP_DIRTY=0
 
-case "$MODE" in
-	run|logs|--logs|telemetry|--telemetry|verify|--verify)
-		default_rust_profile="final-release"
-		default_swift_configuration="release"
-		;;
-	*)
-		default_rust_profile="debug"
-		default_swift_configuration="debug"
-		;;
-esac
-
-RUST_PROFILE="${RSNAP_NATIVE_HOST_RUST_PROFILE:-$default_rust_profile}"
-SWIFT_CONFIGURATION="${RSNAP_NATIVE_HOST_SWIFT_CONFIGURATION:-$default_swift_configuration}"
+RUST_PROFILE="final-release"
+SWIFT_CONFIGURATION="release"
 if [[ -z "${RSNAP_NATIVE_HOST_SWIFT_CLEAN:-}" ]]; then
 	if [[ "$SWIFT_CONFIGURATION" == "release" ]]; then
 		# SwiftPM can reuse stale release objects across local worktree rebuilds. Prefer a
@@ -76,35 +65,6 @@ if [[ -z "$APP_VERSION" ]]; then
 	APP_VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -n 1)"
 fi
 APP_VERSION="${APP_VERSION:-0.2.5}"
-
-require_liquid_glass_capable_swift_for_release() {
-	[[ "$SWIFT_CONFIGURATION" == "release" ]] || return 0
-
-	local swift_version_output
-	swift_version_output="$(swift --version 2>/dev/null || true)"
-	if python3 - "$swift_version_output" <<'PY'
-import re
-import sys
-
-match = re.search(r"Apple Swift version\s+(\d+)\.(\d+)", sys.argv[1])
-if not match:
-    sys.exit(1)
-
-major, minor = (int(match.group(1)), int(match.group(2)))
-sys.exit(0 if (major, minor) >= (6, 2) else 1)
-PY
-	then
-		return 0
-	fi
-
-	echo "error: release Rsnap native host builds require Apple Swift 6.2 or newer for Liquid Glass support." >&2
-	while IFS= read -r line; do
-		[[ -n "$line" ]] || continue
-		echo "error: found $line" >&2
-	done <<<"$swift_version_output"
-	echo "error: select a newer Xcode or set RSNAP_NATIVE_HOST_SWIFT_CONFIGURATION=debug for a local non-release fallback build." >&2
-	exit 1
-}
 
 relink_native_host_if_missing() {
 	local product_dir link_file swift_frameworks sdk swiftc
@@ -559,7 +519,6 @@ if [[ "$MODE" != "stage" ]]; then
 	terminate_running_host
 fi
 
-require_liquid_glass_capable_swift_for_release
 canonicalize_app_bundle_name
 if [[ "${RSNAP_NATIVE_HOST_FORCE_REBUILD:-0}" != "1" ]] && staged_bundle_is_current; then
 	BUILD_ROOT=""


### PR DESCRIPTION
## Summary
- force native host build/run entrypoint to use release/final-release
- persist Liquid Glass as a preference while preserving runtime fallback
- fix live-to-frozen static desktop captures by using ScreenCaptureKit screenshot snapshots from the active self-capture-safe filter

## Validation
- swift format lint --strict targeted native files
- git diff --check
- cargo test -p rsnap-capture-core session -- --nocapture
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/build_and_run.sh run
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer VISUAL_CONTRACT_CASES=liquid REPEATED_DRAG_FREEZES=0 REPEATED_CLICK_FREEZES=1 VISUAL_PROBE_ALL_DRAGS=0 scripts/smoke/native-visual-contract-macos.sh
