### PR TITLE
Fix OCR first-use stall

### DIFF
--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -222,8 +222,10 @@ The main host-kit files are split by responsibility:
   capture-image export orchestration
 - `CaptureSessionController+PreparedExport.swift`: frozen export render request construction,
   prepared export invalidation, scroll/annotation quiet-delay scheduling, and OCR image prewarming
-- `CaptureSessionController+TextRecognition.swift`: Vision OCR request execution and recognized
+- `CaptureSessionController+TextRecognition.swift`: OCR host-effect orchestration and recognized
   text pasteboard publication
+- `NativeTextRecognitionEngine.swift`: Vision OCR prewarming, background request execution, and
+  OCR result extraction
 - `CaptureSessionController+Runtime.swift`: shared monitor/window lookup, overlay refresh,
   teardown, status message, and capture-stream release helpers
 - `CaptureChrome.swift`: shared native chrome metrics, palette, and drawing geometry

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -139,7 +139,10 @@ Expected capture-session chain:
 6. `capture.teardown`
 
 Optional host-effect timing events include `capture_timing.recognize_text` when the user requests
-OCR from a frozen capture.
+OCR from a frozen capture. OCR lifecycle diagnostics also include
+`capture.recognize_text_prewarm`, `capture.recognize_text_queued`, and
+`capture.recognize_text_discarded` so first-use Vision startup, request dispatch, and stale-job
+discarding can be distinguished without logging image or text contents.
 
 Screen-monitoring resource lifecycle events include `capture.stream_release_scheduled`,
 `capture.stream_release_canceled`, `capture.stream_release_requested`, and

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+TextRecognition.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+TextRecognition.swift
@@ -2,7 +2,6 @@ import AppKit
 import CoreGraphics
 import Foundation
 import RsnapHostBridge
-import Vision
 
 extension CaptureSessionController {
 	struct RecognizeTextRun {
@@ -13,20 +12,13 @@ extension CaptureSessionController {
 		let automaticallyDetectsLanguage: Bool
 	}
 
-	struct RecognizeTextResult {
-		let observations: [VNRecognizedTextObservation]
-		let recognizedLines: [String]
-		let text: String
-		let processingMilliseconds: Double
-	}
-
 	struct RecognizeTextPasteboardTiming {
 		let clearMilliseconds: Double
 		let writeMilliseconds: Double
 	}
 
 	func performRecognizeText() throws {
-		guard let session else {
+		guard session != nil else {
 			return
 		}
 		guard recognizeTextActionEnabled else {
@@ -52,24 +44,93 @@ extension CaptureSessionController {
 		}
 		let cgImage = captureImage.image
 		let captureImageMilliseconds = captureImage.captureImageMilliseconds
-		let request = recognizeTextRequest(run: run)
-		let visionRequestMilliseconds = try performRecognizeTextRequest(
-			request,
-			cgImage: cgImage,
-			run: run,
-			captureImageMilliseconds: captureImageMilliseconds,
-			cacheHit: captureImage.cacheHit
+		let cacheHit = captureImage.cacheHit
+		hostEffectJobGeneration &+= 1
+		let jobGeneration = hostEffectJobGeneration
+		try setHostStatusMessage("Recognizing text...")
+		refreshOverlay()
+		NativeHostTelemetry.captureEvent(
+			"capture.recognize_text_queued",
+			captureID: run.captureID,
+			detail:
+				"width=\(cgImage.width) height=\(cgImage.height) cacheHit=\(cacheHit) jobGeneration=\(jobGeneration)"
 		)
-		let result = recognizeTextResult(from: request)
+
+		textRecognitionEngine.recognize(
+			cgImage: cgImage,
+			configuration: NativeTextRecognitionConfiguration(
+				recognitionLevel: run.recognitionLevel,
+				usesLanguageCorrection: run.usesLanguageCorrection,
+				automaticallyDetectsLanguage: run.automaticallyDetectsLanguage
+			)
+		) { [weak self] result in
+			self?.finishRecognizeTextJob(
+				result,
+				run: run,
+				cgImage: cgImage,
+				captureImageMilliseconds: captureImageMilliseconds,
+				cacheHit: cacheHit,
+				jobGeneration: jobGeneration
+			)
+		}
+	}
+
+	func finishRecognizeTextJob(
+		_ result: NativeTextRecognitionResult,
+		run: RecognizeTextRun,
+		cgImage: CGImage,
+		captureImageMilliseconds: Double,
+		cacheHit: Bool,
+		jobGeneration: UInt64
+	) {
+		guard hostEffectJobGeneration == jobGeneration, session != nil else {
+			NativeHostTelemetry.captureEvent(
+				"capture.recognize_text_discarded",
+				captureID: run.captureID,
+				outcome: "stale_job",
+				detail:
+					"jobGeneration=\(jobGeneration) currentGeneration=\(hostEffectJobGeneration)"
+			)
+			return
+		}
+		if let failureDescription = result.failureDescription {
+			recordRecognizeTextTiming(
+				run: run,
+				captureImageMilliseconds: captureImageMilliseconds,
+				visionRequestMilliseconds: result.visionRequestMilliseconds,
+				resultProcessingMilliseconds: result.processingMilliseconds,
+				clearPasteboardMilliseconds: 0,
+				writePasteboardMilliseconds: 0,
+				success: false,
+				outcome: "recognize_error",
+				failureStage: "vision_request",
+				width: cgImage.width,
+				height: cgImage.height,
+				observationCount: 0,
+				recognizedLines: 0,
+				recognizedCharacters: 0,
+				cacheHit: cacheHit
+			)
+			NativeHostTelemetry.captureWarning(
+				"capture.recognize_text_failed",
+				captureID: run.captureID,
+				stage: "vision_request",
+				error: failureDescription
+			)
+			try? setHostStatusMessage("Could not recognize text.")
+			refreshOverlay()
+			return
+		}
+
 		guard
-			let pasteboardTiming = try writeRecognizedTextIfNeeded(
+			let pasteboardTiming = try? writeRecognizedTextIfNeeded(
 				result.text,
 				run: run,
 				cgImage: cgImage,
 				captureImageMilliseconds: captureImageMilliseconds,
-				visionRequestMilliseconds: visionRequestMilliseconds,
+				visionRequestMilliseconds: result.visionRequestMilliseconds,
 				result: result,
-				cacheHit: captureImage.cacheHit
+				cacheHit: cacheHit
 			)
 		else {
 			return
@@ -78,7 +139,7 @@ extension CaptureSessionController {
 		recordRecognizeTextTiming(
 			run: run,
 			captureImageMilliseconds: captureImageMilliseconds,
-			visionRequestMilliseconds: visionRequestMilliseconds,
+			visionRequestMilliseconds: result.visionRequestMilliseconds,
 			resultProcessingMilliseconds: result.processingMilliseconds,
 			clearPasteboardMilliseconds: pasteboardTiming.clearMilliseconds,
 			writePasteboardMilliseconds: pasteboardTiming.writeMilliseconds,
@@ -87,23 +148,35 @@ extension CaptureSessionController {
 			failureStage: "none",
 			width: cgImage.width,
 			height: cgImage.height,
-			observationCount: result.observations.count,
-			recognizedLines: result.recognizedLines.count,
-			recognizedCharacters: result.text.count,
-			cacheHit: captureImage.cacheHit
+			observationCount: result.observationCount,
+			recognizedLines: result.recognizedLines,
+			recognizedCharacters: result.recognizedCharacters,
+			cacheHit: cacheHit
 		)
 
 		if result.text.isEmpty == false {
 			ocrCompletionSound.play()
 		}
 
-		try session.send(report: .hostEffectCompleted(.recognizeText))
 		let message =
 			result.text.isEmpty
 			? "No text was recognized."
 			: "Recognized text copied to clipboard."
-		try session.send(report: .statusMessage(message))
-		completedHostEffect = .recognizeText
+		do {
+			try session?.send(report: .hostEffectCompleted(.recognizeText))
+			try session?.send(report: .statusMessage(message))
+			completedHostEffect = .recognizeText
+			tearDownCapture()
+		} catch {
+			NativeHostTelemetry.captureWarning(
+				"capture.host_effect_complete_failed",
+				captureID: run.captureID,
+				stage: String(describing: HostEffectKind.recognizeText),
+				error: String(describing: error)
+			)
+			try? setHostStatusMessage(message)
+			refreshOverlay()
+		}
 	}
 
 	func recognizeTextCaptureImage(
@@ -139,76 +212,13 @@ extension CaptureSessionController {
 		return captureImage
 	}
 
-	func recognizeTextRequest(run: RecognizeTextRun) -> VNRecognizeTextRequest {
-		let request = VNRecognizeTextRequest()
-		request.recognitionLevel = .accurate
-		request.usesLanguageCorrection = run.usesLanguageCorrection
-		request.automaticallyDetectsLanguage = run.automaticallyDetectsLanguage
-		return request
-	}
-
-	func performRecognizeTextRequest(
-		_ request: VNRecognizeTextRequest,
-		cgImage: CGImage,
-		run: RecognizeTextRun,
-		captureImageMilliseconds: Double,
-		cacheHit: Bool
-	) throws -> Double {
-		let handler = VNImageRequestHandler(cgImage: cgImage)
-		let visionStartedAt = ProcessInfo.processInfo.systemUptime
-		do {
-			try handler.perform([request])
-		} catch {
-			let visionRequestMilliseconds = NativeHostTelemetry.milliseconds(since: visionStartedAt)
-			recordRecognizeTextTiming(
-				run: run,
-				captureImageMilliseconds: captureImageMilliseconds,
-				visionRequestMilliseconds: visionRequestMilliseconds,
-				resultProcessingMilliseconds: 0,
-				clearPasteboardMilliseconds: 0,
-				writePasteboardMilliseconds: 0,
-				success: false,
-				outcome: "recognize_error",
-				failureStage: "vision_request",
-				width: cgImage.width,
-				height: cgImage.height,
-				observationCount: 0,
-				recognizedLines: 0,
-				recognizedCharacters: 0,
-				cacheHit: cacheHit
-			)
-			throw error
-		}
-		return NativeHostTelemetry.milliseconds(since: visionStartedAt)
-	}
-
-	func recognizeTextResult(from request: VNRecognizeTextRequest) -> RecognizeTextResult {
-		let resultProcessingStartedAt = ProcessInfo.processInfo.systemUptime
-		let observations = request.results ?? []
-		let recognizedLines = observations.compactMap { observation -> String? in
-			guard let line = observation.topCandidates(1).first?.string,
-				line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-			else {
-				return nil
-			}
-			return line
-		}
-		return RecognizeTextResult(
-			observations: observations,
-			recognizedLines: recognizedLines,
-			text: recognizedLines.joined(separator: "\n"),
-			processingMilliseconds: NativeHostTelemetry.milliseconds(
-				since: resultProcessingStartedAt)
-		)
-	}
-
 	func writeRecognizedTextIfNeeded(
 		_ text: String,
 		run: RecognizeTextRun,
 		cgImage: CGImage,
 		captureImageMilliseconds: Double,
 		visionRequestMilliseconds: Double,
-		result: RecognizeTextResult,
+		result: NativeTextRecognitionResult,
 		cacheHit: Bool
 	) throws -> RecognizeTextPasteboardTiming? {
 		guard text.isEmpty == false else {
@@ -235,8 +245,8 @@ extension CaptureSessionController {
 				failureStage: "pasteboard_write",
 				width: cgImage.width,
 				height: cgImage.height,
-				observationCount: result.observations.count,
-				recognizedLines: result.recognizedLines.count,
+				observationCount: result.observationCount,
+				recognizedLines: result.recognizedLines,
 				recognizedCharacters: text.count,
 				cacheHit: cacheHit
 			)

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController.swift
@@ -6,7 +6,6 @@ import Darwin
 import Foundation
 import QuartzCore
 import RsnapHostBridge
-import Vision
 
 @MainActor
 final class CaptureSessionController: NSObject {
@@ -75,6 +74,7 @@ final class CaptureSessionController: NSObject {
 		label: "ink.hack.rsnap.frozen-image-render",
 		qos: .userInitiated
 	)
+	let textRecognitionEngine = NativeTextRecognitionEngine()
 	let frozenPreparedExportStore = FrozenPreparedExportStore()
 	let frozenPreparedRecognizeTextImageStore = FrozenPreparedRecognizeTextImageStore()
 	let captureSuccessSound = CaptureSuccessSound.load()
@@ -121,6 +121,7 @@ final class CaptureSessionController: NSObject {
 			name: NativeHostSettingsStore.didChangeNotification,
 			object: settingsStore
 		)
+		textRecognitionEngine.prewarm(reason: "session_controller_init")
 	}
 
 	deinit {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -6,7 +6,6 @@ import Darwin
 import Foundation
 import QuartzCore
 import RsnapHostBridge
-import Vision
 
 package struct LiveRgbSample: Sendable {
 	// SCStream may stop emitting while the captured display is static; FrozenFrameAuthority

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeTextRecognitionEngine.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeTextRecognitionEngine.swift
@@ -1,0 +1,150 @@
+import CoreGraphics
+import Foundation
+import Vision
+
+struct NativeTextRecognitionConfiguration: Sendable {
+	let recognitionLevel: String
+	let usesLanguageCorrection: Bool
+	let automaticallyDetectsLanguage: Bool
+}
+
+struct NativeTextRecognitionResult: @unchecked Sendable {
+	let text: String
+	let observationCount: Int
+	let recognizedLines: Int
+	let recognizedCharacters: Int
+	let visionRequestMilliseconds: Double
+	let processingMilliseconds: Double
+	let failureDescription: String?
+}
+
+final class NativeTextRecognitionEngine: @unchecked Sendable {
+	private let queue = DispatchQueue(
+		label: "ink.hack.rsnap.recognize-text",
+		qos: .userInitiated
+	)
+	private let lock = NSLock()
+	private var prewarmStarted = false
+
+	func prewarm(reason: String, captureID: UInt64 = 0) {
+		lock.lock()
+		guard prewarmStarted == false else {
+			lock.unlock()
+			return
+		}
+		prewarmStarted = true
+		lock.unlock()
+
+		queue.async {
+			let startedAt = ProcessInfo.processInfo.systemUptime
+			let result = Self.perform(
+				cgImage: Self.prewarmImage(),
+				configuration: Self.defaultConfiguration
+			)
+			NativeHostTelemetry.captureEvent(
+				"capture.recognize_text_prewarm",
+				captureID: captureID,
+				outcome: result.failureDescription == nil ? "success" : "failed",
+				detail:
+					"reason=\(reason) totalMs=\(String(format: "%.2f", NativeHostTelemetry.milliseconds(since: startedAt))) visionRequestMs=\(String(format: "%.2f", result.visionRequestMilliseconds))"
+			)
+		}
+	}
+
+	func recognize(
+		cgImage: CGImage,
+		configuration: NativeTextRecognitionConfiguration,
+		completion: @escaping @MainActor @Sendable (NativeTextRecognitionResult) -> Void
+	) {
+		queue.async {
+			let result = Self.perform(
+				cgImage: cgImage,
+				configuration: configuration
+			)
+			Task { @MainActor in
+				completion(result)
+			}
+		}
+	}
+
+	private static let defaultConfiguration = NativeTextRecognitionConfiguration(
+		recognitionLevel: "accurate",
+		usesLanguageCorrection: true,
+		automaticallyDetectsLanguage: true
+	)
+
+	private static func perform(
+		cgImage: CGImage,
+		configuration: NativeTextRecognitionConfiguration
+	) -> NativeTextRecognitionResult {
+		let request = VNRecognizeTextRequest()
+		request.recognitionLevel = .accurate
+		request.usesLanguageCorrection = configuration.usesLanguageCorrection
+		request.automaticallyDetectsLanguage = configuration.automaticallyDetectsLanguage
+
+		let handler = VNImageRequestHandler(cgImage: cgImage)
+		let visionStartedAt = ProcessInfo.processInfo.systemUptime
+		do {
+			try handler.perform([request])
+		} catch {
+			return NativeTextRecognitionResult(
+				text: "",
+				observationCount: 0,
+				recognizedLines: 0,
+				recognizedCharacters: 0,
+				visionRequestMilliseconds: NativeHostTelemetry.milliseconds(
+					since: visionStartedAt),
+				processingMilliseconds: 0,
+				failureDescription: String(describing: error)
+			)
+		}
+
+		let visionRequestMilliseconds = NativeHostTelemetry.milliseconds(since: visionStartedAt)
+		let resultProcessingStartedAt = ProcessInfo.processInfo.systemUptime
+		let observations = request.results ?? []
+		let recognizedLines = observations.compactMap { observation -> String? in
+			guard let line = observation.topCandidates(1).first?.string,
+				line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+			else {
+				return nil
+			}
+			return line
+		}
+		let text = recognizedLines.joined(separator: "\n")
+		return NativeTextRecognitionResult(
+			text: text,
+			observationCount: observations.count,
+			recognizedLines: recognizedLines.count,
+			recognizedCharacters: text.count,
+			visionRequestMilliseconds: visionRequestMilliseconds,
+			processingMilliseconds: NativeHostTelemetry.milliseconds(
+				since: resultProcessingStartedAt),
+			failureDescription: nil
+		)
+	}
+
+	private static func prewarmImage() -> CGImage {
+		let width = 8
+		let height = 8
+		let colorSpace = CGColorSpaceCreateDeviceGray()
+		guard
+			let context = CGContext(
+				data: nil,
+				width: width,
+				height: height,
+				bitsPerComponent: 8,
+				bytesPerRow: width,
+				space: colorSpace,
+				bitmapInfo: CGImageAlphaInfo.none.rawValue
+			)
+		else {
+			fatalError("Failed to create OCR prewarm bitmap context.")
+		}
+		context.setFillColor(gray: 1, alpha: 1)
+		context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+		guard let image = context.makeImage() else {
+			fatalError("Failed to create OCR prewarm image.")
+		}
+		return image
+	}
+}


### PR DESCRIPTION
## Summary
- Move Vision text recognition into a dedicated native OCR engine that owns prewarming and background execution.
- Keep CaptureSessionController on orchestration, frozen-image capture, UI status, pasteboard publication, and stale-job gating.
- Add OCR lifecycle telemetry for prewarm, queueing, and stale-job discard diagnostics; update docs.

## Root Cause
The frozen OCR path synchronously executed `VNImageRequestHandler.perform` on the main actor. On cold systems, especially after macOS 27 Vision/runtime changes, the first request can lazily initialize OCR models and block AppKit input. Later OCR requests appear fine because Vision is already warm.

## Validation
- `swift format lint --strict native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController.swift native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+TextRecognition.swift native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift native/macos-host/Sources/RsnapNativeHostKit/NativeTextRecognitionEngine.swift`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/build_and_run.sh stage`
- `cargo test -p rsnap-capture-core recognize_text_requires_frozen_mode_and_text_support -- --nocapture`
- `POST_ACTION_SETTLE_S=6 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer PREPARED_EXPORT_CASES=plain-ocr scripts/smoke/native-prepared-export-macos.sh`

Smoke evidence: `capture.recognize_text_prewarm` succeeded in 51.12ms; plain OCR recorded `cacheHit=true`, `ocr_total_ms=194.21`, `ocr_vision_request_ms=193.65`.
