### PR TITLE
Use crosshair cursor in live capture mode

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,19 @@
 # Documentation Log
 
+## 2026-07-07
+
+- Documented the quick screenshot no-focus contract: quick screenshot must preserve transient target
+  UI such as context menus by avoiding overlay activation, key-window promotion, and
+  first-responder ownership while keeping acquisition overlays mouse-transparent.
+- Recorded the host-side split between ordinary capture cursor ownership through focused AppKit
+  overlay views and quick screenshot cursor/input ownership through non-activating acquisition.
+- Recorded that ordinary and quick screenshot paths keep the native cursor visible and use a
+  small Rsnap-owned cursor-hotspot accent overlay as screenshot-mode feedback.
+- Recorded `CapturePointerAccentLayer.swift` as the shared visual owner for ordinary and quick
+  screenshot pointer hotspot accent chrome.
+- Added `CaptureHostCursorOwner.swift` and `QuickScreenshotController.swift` ownership notes to the
+  workspace layout reference.
+
 ## 2026-07-06
 
 - Removed the final active `rsnap-overlay` ownership references after macOS ordered live sampling

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -5,7 +5,7 @@ type: "Reference"
 status: active
 authority: normative
 owner: hack-ink/rsnap
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 ---
 # Workspace Layout Reference
 
@@ -295,8 +295,16 @@ The main host-kit files are split by responsibility:
   release-watchdog scheduling for AppKit interactions whose mouse-up event can be missed
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
   with per-track throttling state, and AppKit-to-controller pointer delivery
+- `CaptureHostCursorOwner.swift`: shared native cursor-owner helper for applying and clearing the
+  current AppKit cursor across ordinary capture views without owning an `NSCursor` push stack
+- `CapturePointerAccentLayer.swift`: shared AppKit layer for ordinary and quick screenshot
+  native-cursor hotspot accent chrome
 - `CaptureHostView+InputRouting.swift`: capture-host AppKit mouse, wheel, key, cursor, toolbar
   shortcut, and pointer-dispatch routing into the session controller
+- `QuickScreenshotController.swift`: non-activating quick screenshot acquisition path. It owns
+  event-tap input interception and native-cursor companion halo feedback without making overlay
+  windows key, mouse-interactive, or activating the app, so transient target UI such as context
+  menus remains visible.
 - `CaptureHostView+LivePrimaryInteraction.swift`: capture-host live primary interaction release
   recovery, pointer-preview mutation, mouse-up monitor wiring, and release-watchdog orchestration
 - `CaptureHostView+LivePreview.swift`: capture-host live preview snapshots, HUD/loupe placement,
@@ -327,7 +335,9 @@ The main host-kit files are split by responsibility:
 - `CaptureGeometry.swift`, `CaptureHostAnnotationStyleWheelGate.swift`,
   `CaptureHostToolbarHoverState.swift`, `CaptureHostFrozenFirstDisplayHandoffState.swift`,
   `CaptureHostScrollToolbarBackdropState.swift`, `CaptureHostCursorSupport.swift`,
-  `CaptureHostScrollMinimapRenderer.swift`, `CaptureHostLiveSampleCache.swift`,
+  `CaptureHostCursorOwner.swift`, `CapturePointerAccentLayer.swift`,
+  `CaptureHostScrollMinimapRenderer.swift`,
+  `CaptureHostLiveSampleCache.swift`,
   `CaptureHostLiveSampleResolver.swift`, `CaptureHostLiveInputTelemetry.swift`,
   `CaptureHostLivePointerPreviewState.swift`, `CaptureHostLivePrimaryInteractionState.swift`,
   `CaptureHostMouseReleaseRecovery.swift`, `CaptureHostPointerDispatch.swift`,
@@ -336,8 +346,9 @@ The main host-kit files are split by responsibility:
   `LiveChromeRefreshTelemetryKey.swift`, and `NativeHostTextMetrics.swift`: focused support
   boundaries for shared capture geometry, frozen annotation-size wheel gating, frozen toolbar hover
   state, frozen first-display handoff state, scroll toolbar backdrop state, capture-host cursor
-  presentation and NSCursor adaptation, frozen minimap presentation, live sample reuse, live sample
-  resolution, live input telemetry, live pointer preview state, live primary interaction state,
+  presentation, AppKit cursor adaptation, shared screenshot pointer hotspot accent chrome, frozen minimap
+  presentation, live sample reuse, live sample resolution, live input telemetry, live pointer preview state,
+  live primary interaction state,
   AppKit mouse-release recovery, pointer dispatch queue throttling, Rust-backed frozen image
   effects, capture-host glass patch caching and blur/tint adaptation, frozen-frame pixel-buffer
   image/sampling adaptation, prepared export cache ownership, live-chrome telemetry identity, and

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -72,6 +72,8 @@ product level rather than binding itself to a particular window toolkit or shell
 ## Live mode
 
 - Live mode presents a capture surface for the monitor under the cursor.
+- Live mode uses a crosshair cursor immediately after capture activation so users can tell the
+  screenshot surface is active before they freeze a selection.
 - Live mode shows a HUD near the cursor with:
   - global cursor coordinates `x,y`
   - pixel color `rgb(r,g,b)` under the cursor

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -5,7 +5,7 @@ type: "Spec"
 status: active
 authority: normative
 owner: hack-ink/rsnap
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 ---
 # Rsnap Capture Session Contract
 
@@ -68,6 +68,11 @@ product level rather than binding itself to a particular window toolkit or shell
 8. The product contract does not require any specific platform window implementation. Focus,
    cursor, keyboard, and IME correctness are mandatory outcomes, regardless of how the native host
    achieves them.
+9. The quick screenshot shortcut (default macOS: Shift-Option-X) is a separate acquisition path for
+   capturing transient UI such as right-click menus and submenu stacks. Quick screenshot MUST NOT
+   activate Rsnap, make an overlay key/main, take first responder, or otherwise steal focus from the
+   target app while the quick selection is armed or dragged. Any quick screenshot cursor feedback
+   must be implemented without relying on overlay focus.
 
 ## Live mode
 
@@ -110,6 +115,28 @@ product level rather than binding itself to a particular window toolkit or shell
 - Secondary click cancels capture from live mode.
 - Capture scope is single-monitor only for now. Cross-monitor region selection and cross-monitor
   window capture remain out of scope.
+
+## Quick screenshot mode
+
+- Quick screenshot mode exists to capture UI that would disappear when focus changes, including
+  context menus and nested submenu surfaces.
+- Quick screenshot mode MUST preserve the current frontmost app and focus chain while armed,
+  selecting, canceling, or completing the quick selection.
+- On macOS, quick screenshot overlays MUST remain non-key and non-activating. They may present
+  captured pixels, selection chrome, and pointer guide chrome, but they MUST NOT take
+  first-responder state, key-window state, application activation, or AppKit mouse delivery.
+- The native host may use a platform event tap or equivalent host-owned input acquisition mechanism
+  to intercept quick screenshot mouse and keyboard input without activating Rsnap.
+- Quick screenshot mode should present the same selection chrome vocabulary as ordinary capture
+  where that does not conflict with the no-focus requirement, including crosshair cursor feedback,
+  scrim, dashed selection border, and size badge.
+- On macOS, ordinary and quick screenshot paths should keep the native system cursor visible and
+  render a small Rsnap-owned capture halo overlay from Rsnap-controlled layers. The halo should read
+  as screenshot-mode feedback that pairs with the native cursor, not as a second replacement cursor.
+- The small capture halo overlay should be shared between ordinary live capture and quick screenshot
+  so both entry paths present the same pointer chrome.
+- Quick screenshot selection rendering must keep drag updates localized to the active selection
+  display and must not perform focus or z-order promotion inside the drag hot path.
 
 ## Focus, activation, and session cleanup
 

--- a/docs/spec/host-core-protocol.md
+++ b/docs/spec/host-core-protocol.md
@@ -5,7 +5,7 @@ type: "Spec"
 status: active
 authority: normative
 owner: hack-ink/rsnap
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 ---
 # Host/Core Protocol
 
@@ -63,6 +63,12 @@ The live capture contract now also requires:
 - `SceneModel.active_monitor`, `SceneModel.highlighted_window`, and `SceneModel.cursor_intent` as
   the only semantic inputs the native host uses for live hover glow, live targeting cursor state,
   and frozen cursor mapping
+
+`SceneModel.cursor_intent` describes product cursor semantics for the ordinary capture session. It
+does not require the quick screenshot path to activate or focus an overlay just to receive cursor
+rect updates. A native host quick screenshot acquisition path may hold temporary host-local cursor
+ownership while armed or selecting, provided it preserves the product no-focus invariant in
+`docs/spec/capture-session.md` and does not create durable product state outside the core protocol.
 
 The host must not retain its own product-state copy of:
 

--- a/docs/spec/host-core-protocol.md
+++ b/docs/spec/host-core-protocol.md
@@ -61,7 +61,8 @@ The live capture contract now also requires:
 - `HostRequest::RequestFreezeSnapshot.selection_editable` for the core-owned decision about
   whether the committed Frozen selection may be moved or resized after commit
 - `SceneModel.active_monitor`, `SceneModel.highlighted_window`, and `SceneModel.cursor_intent` as
-  the only semantic inputs the native host uses for live hover glow and frozen cursor mapping
+  the only semantic inputs the native host uses for live hover glow, live targeting cursor state,
+  and frozen cursor mapping
 
 The host must not retain its own product-state copy of:
 

--- a/docs/spec/platform-host-boundary.md
+++ b/docs/spec/platform-host-boundary.md
@@ -5,7 +5,7 @@ type: "Spec"
 status: active
 authority: normative
 owner: hack-ink/rsnap
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 ---
 # Platform Host Boundary
 
@@ -53,6 +53,13 @@ The native platform host owns:
 - OS resource discovery that has no portable API, such as the current desktop wallpaper path
 - clipboard, save-panel, notification, sound, and similar host-side effects
 - presenting rendered pixels returned by the core inside native windows and controls
+
+Host-owned cursor and input acquisition may differ by capture entry path as long as the product
+contract is preserved. For example, the ordinary macOS capture path may let a focused AppKit
+overlay view own cursor rects and pointer delivery, while the quick screenshot path must keep its
+overlay non-key, non-activating, and mouse-transparent so transient target UI remains visible. In
+that quick path, the native host owns event interception through a session event tap and renders
+pointer feedback through overlay layers rather than mutating the system cursor.
 
 ## Rust core ownership
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorOwner.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorOwner.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+@MainActor
+final class CaptureHostCursorOwner {
+	private var appliedPresentation: CaptureHostCursorPresentation?
+
+	isolated deinit {
+		clear()
+	}
+
+	func set(_ presentation: CaptureHostCursorPresentation) {
+		CaptureHostCursorSupport.cursor(for: presentation).set()
+		appliedPresentation = presentation
+	}
+
+	func clear() {
+		guard appliedPresentation != nil else {
+			return
+		}
+		NSCursor.arrow.set()
+		appliedPresentation = nil
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
@@ -163,6 +163,11 @@ extension CaptureHostView {
 
 	func syncVisibleCursor() {
 		let cursorPresentation = currentCursorPresentation()
+		guard window?.isKeyWindow == true else {
+			clearVisibleCursorOverride()
+			lastCursorPresentation = cursorPresentation
+			return
+		}
 		guard cursorPresentation != lastCursorPresentation else {
 			return
 		}
@@ -315,8 +320,26 @@ extension CaptureHostView {
 		guard cursorPresentation != lastAppliedCursorPresentation else {
 			return
 		}
+		clearVisibleCursorOverride()
 		lastAppliedCursorPresentation = cursorPresentation
-		CaptureHostCursorSupport.cursor(for: cursorPresentation).set()
+		CaptureHostCursorSupport.cursor(for: cursorPresentation).push()
+		pushedCursorPresentation = cursorPresentation
+	}
+
+	func forceVisibleCursorRefresh() {
+		lastCursorPresentation = nil
+		lastAppliedCursorPresentation = nil
+		clearVisibleCursorOverride()
+		syncVisibleCursor()
+	}
+
+	func clearVisibleCursorOverride() {
+		guard pushedCursorPresentation != nil else {
+			return
+		}
+		NSCursor.pop()
+		pushedCursorPresentation = nil
+		lastAppliedCursorPresentation = nil
 	}
 
 	private func suppressLiveHoverChrome() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
@@ -8,7 +8,7 @@ extension CaptureHostView {
 		if scene.mode == .frozen {
 			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
 		}
-		applyVisibleCursorIfNeeded(currentCursorPresentation())
+		setVisibleCursor(currentCursorPresentation())
 	}
 
 	func routeMouseMoved(with event: NSEvent) {
@@ -25,10 +25,12 @@ extension CaptureHostView {
 			}
 			liveInputTelemetry.recordMouseEvent()
 			updateLivePointerPreview(to: point, rendersImmediately: true)
+			setVisibleCursor(currentCursorPresentation())
 			return
 		}
 		updateLivePointerPreview(to: point, rendersImmediately: false)
 		queuePointerEvent(.moved(point))
+		setVisibleCursor(currentCursorPresentation())
 	}
 
 	func routeMouseDragged(with event: NSEvent) {
@@ -50,6 +52,7 @@ extension CaptureHostView {
 			updateLivePointerPreview(to: point, rendersImmediately: false)
 			queuePointerEvent(
 				livePrimaryInteraction.dragExceededThreshold ? .liveDragged(point) : .moved(point))
+			setVisibleCursor(currentCursorPresentation())
 		} else {
 			let point = globalPoint(from: event)
 			if recoverReleasedFrozenInteractionIfNeeded(at: point) {
@@ -169,13 +172,12 @@ extension CaptureHostView {
 			return
 		}
 		guard cursorPresentation != lastCursorPresentation else {
+			setVisibleCursor(cursorPresentation)
 			return
 		}
 		lastCursorPresentation = cursorPresentation
 		window?.invalidateCursorRects(for: self)
-		if scene.mode == .frozen {
-			applyVisibleCursorIfNeeded(cursorPresentation)
-		}
+		setVisibleCursor(cursorPresentation)
 	}
 
 	func pointerDispatchInterval() -> TimeInterval {
@@ -277,6 +279,9 @@ extension CaptureHostView {
 		if toolbarHoverState.pointerOverToolbar || toolbarHoverState.toolbarAction != nil {
 			return .arrow
 		}
+		if scene.mode == .live {
+			return .arrow
+		}
 		if scene.mode == .frozen {
 			if let interaction = chrome.frozenSelectionInteraction {
 				return CaptureHostCursorSupport.presentation(
@@ -316,30 +321,18 @@ extension CaptureHostView {
 		return CaptureHostCursorSupport.presentation(for: scene.cursorIntent)
 	}
 
-	private func applyVisibleCursorIfNeeded(_ cursorPresentation: CaptureHostCursorPresentation) {
-		guard cursorPresentation != lastAppliedCursorPresentation else {
-			return
-		}
-		clearVisibleCursorOverride()
-		lastAppliedCursorPresentation = cursorPresentation
-		CaptureHostCursorSupport.cursor(for: cursorPresentation).push()
-		pushedCursorPresentation = cursorPresentation
+	private func setVisibleCursor(_ cursorPresentation: CaptureHostCursorPresentation) {
+		cursorOwner.set(cursorPresentation)
 	}
 
 	func forceVisibleCursorRefresh() {
 		lastCursorPresentation = nil
-		lastAppliedCursorPresentation = nil
 		clearVisibleCursorOverride()
 		syncVisibleCursor()
 	}
 
 	func clearVisibleCursorOverride() {
-		guard pushedCursorPresentation != nil else {
-			return
-		}
-		NSCursor.pop()
-		pushedCursorPresentation = nil
-		lastAppliedCursorPresentation = nil
+		cursorOwner.clear()
 	}
 
 	private func suppressLiveHoverChrome() {

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -28,8 +28,7 @@ final class CaptureHostView: NSView {
 	private var trackingAreaRef: NSTrackingArea?
 	var annotationStyleWheelGate = CaptureHostAnnotationStyleWheelGate()
 	var lastCursorPresentation: CaptureHostCursorPresentation?
-	var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
-	var pushedCursorPresentation: CaptureHostCursorPresentation?
+	let cursorOwner = CaptureHostCursorOwner()
 	var livePrimaryInteraction = CaptureHostLivePrimaryInteractionState()
 	let mouseReleaseRecovery = CaptureHostMouseReleaseRecovery()
 	let livePointerPreview = CaptureHostLivePointerPreviewState()

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -29,6 +29,7 @@ final class CaptureHostView: NSView {
 	var annotationStyleWheelGate = CaptureHostAnnotationStyleWheelGate()
 	var lastCursorPresentation: CaptureHostCursorPresentation?
 	var lastAppliedCursorPresentation: CaptureHostCursorPresentation?
+	var pushedCursorPresentation: CaptureHostCursorPresentation?
 	var livePrimaryInteraction = CaptureHostLivePrimaryInteractionState()
 	let mouseReleaseRecovery = CaptureHostMouseReleaseRecovery()
 	let livePointerPreview = CaptureHostLivePointerPreviewState()
@@ -86,6 +87,10 @@ final class CaptureHostView: NSView {
 	@available(*, unavailable)
 	required init?(coder: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
+	}
+
+	isolated deinit {
+		clearVisibleCursorOverride()
 	}
 
 	func update(

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureOverlayController.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureOverlayController.swift
@@ -109,6 +109,7 @@ final class CaptureOverlayController {
 		if let focusedWindow {
 			focusedWindow.hostView.refreshLivePresentationNow()
 			focusedWindow.displayIfNeeded()
+			focusedWindow.hostView.forceVisibleCursorRefresh()
 		}
 	}
 
@@ -267,9 +268,13 @@ final class CaptureOverlayController {
 		targetWindow.makeFirstResponder(targetWindow.hostView)
 		focusedWindowNumber = targetWindow.windowNumber
 		(NSApp.delegate as? NativeHostApplicationController)?.window = targetWindow
+		for window in windows where window !== targetWindow {
+			window.hostView.clearVisibleCursorOverride()
+		}
 		liveChromePipeline.hideBackdrops()
 		targetWindow.hostView.refreshLivePresentationNow()
 		targetWindow.displayIfNeeded()
+		targetWindow.hostView.forceVisibleCursorRefresh()
 	}
 
 	func withPrimaryMousePassthrough<T>(duration: TimeInterval, perform: () -> T) -> T {
@@ -381,6 +386,7 @@ final class CaptureOverlayController {
 		(NSApp.delegate as? NativeHostApplicationController)?.window = nil
 
 		for window in windowsToRetire {
+			window.hostView.clearVisibleCursorOverride()
 			window.hostView.clearLivePrimaryInteractionState(rendersImmediately: false)
 			window.hostView.finishLivePresentationTelemetry(reason: "close")
 			window.hostView.controller = nil
@@ -585,6 +591,7 @@ final class CaptureOverlayController {
 		primaryWindow.makeFirstResponder(primaryWindow.hostView)
 
 		for window in secondaryWindows {
+			window.hostView.clearVisibleCursorOverride()
 			window.hostView.controller = nil
 			window.ignoresMouseEvents = true
 			window.orderOut(nil)

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureOverlayController.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureOverlayController.swift
@@ -54,6 +54,7 @@ final class CaptureOverlayController {
 		prepareCaptureStreams: (() -> Void)? = nil
 	) {
 		close()
+		NSApp.activate(ignoringOtherApps: true)
 		var targetWindow: CaptureOverlayWindow?
 		for screen in NSScreen.screens {
 			let window = CaptureOverlayWindow(
@@ -120,6 +121,7 @@ final class CaptureOverlayController {
 		focusPoint: CGPoint
 	) {
 		close()
+		NSApp.activate(ignoringOtherApps: true)
 		var targetWindow: CaptureOverlayWindow?
 		for screen in NSScreen.screens {
 			let window = CaptureOverlayWindow(
@@ -264,6 +266,7 @@ final class CaptureOverlayController {
 		}
 
 		targetWindow.orderFrontRegardless()
+		NSApp.activate(ignoringOtherApps: true)
 		targetWindow.makeKey()
 		targetWindow.makeFirstResponder(targetWindow.hostView)
 		focusedWindowNumber = targetWindow.windowNumber

--- a/native/macos-host/Sources/RsnapNativeHostKit/CapturePointerAccentLayer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CapturePointerAccentLayer.swift
@@ -1,0 +1,109 @@
+import AppKit
+import QuartzCore
+
+final class CapturePointerAccentLayer: CALayer {
+	private static let diameter: CGFloat = 28
+
+	private let contrastLayer = CALayer()
+	private let glowLayer = CALayer()
+	private let coreLayer = CALayer()
+
+	override init() {
+		super.init()
+		masksToBounds = false
+		allowsEdgeAntialiasing = true
+		configureLayers()
+		hide()
+	}
+
+	override init(layer: Any) {
+		super.init(layer: layer)
+		configureLayers()
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	func update(pointer: CGPoint?, in bounds: CGRect, contentsScale scale: CGFloat) {
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		defer { CATransaction.commit() }
+
+		guard let pointer, bounds.contains(pointer) else {
+			hide()
+			return
+		}
+
+		let diameter = Self.diameter
+		let layerBounds = CGRect(origin: .zero, size: CGSize(width: diameter, height: diameter))
+		let center = CGPoint(x: diameter / 2, y: diameter / 2)
+		frame = layerBounds.offsetBy(dx: pointer.x - center.x, dy: pointer.y - center.y)
+		updateLayerScales(scale)
+		contrastLayer.isHidden = false
+		glowLayer.isHidden = false
+		coreLayer.isHidden = false
+		isHidden = false
+	}
+
+	func hide() {
+		isHidden = true
+		contrastLayer.isHidden = true
+		glowLayer.isHidden = true
+		coreLayer.isHidden = true
+	}
+
+	private func configureLayers() {
+		let contrastSize: CGFloat = 13
+		contrastLayer.frame = centeredRect(size: contrastSize)
+		contrastLayer.cornerRadius = contrastSize / 2
+		contrastLayer.backgroundColor = NSColor.black.withAlphaComponent(0.2).cgColor
+		contrastLayer.shadowColor = NSColor.black.cgColor
+		contrastLayer.shadowOpacity = 0.36
+		contrastLayer.shadowRadius = 3.5
+		contrastLayer.shadowOffset = .zero
+		contrastLayer.shadowPath = CGPath(ellipseIn: contrastLayer.bounds, transform: nil)
+		addSublayer(contrastLayer)
+
+		let glowSize: CGFloat = 10
+		glowLayer.frame = centeredRect(size: glowSize)
+		glowLayer.cornerRadius = glowSize / 2
+		glowLayer.backgroundColor =
+			NSColor(calibratedRed: 82 / 255, green: 226 / 255, blue: 1, alpha: 0.3).cgColor
+		glowLayer.shadowColor =
+			NSColor(calibratedRed: 82 / 255, green: 226 / 255, blue: 1, alpha: 1).cgColor
+		glowLayer.shadowOpacity = 0.88
+		glowLayer.shadowRadius = 7
+		glowLayer.shadowOffset = .zero
+		glowLayer.shadowPath = CGPath(ellipseIn: glowLayer.bounds, transform: nil)
+		addSublayer(glowLayer)
+
+		let coreSize: CGFloat = 3.2
+		coreLayer.frame = centeredRect(size: coreSize)
+		coreLayer.cornerRadius = coreSize / 2
+		coreLayer.backgroundColor =
+			NSColor(calibratedRed: 232 / 255, green: 253 / 255, blue: 1, alpha: 0.95).cgColor
+		addSublayer(coreLayer)
+
+		for layer in [contrastLayer, glowLayer, coreLayer] {
+			layer.allowsEdgeAntialiasing = true
+		}
+	}
+
+	private func updateLayerScales(_ scale: CGFloat) {
+		for layer in [contrastLayer, glowLayer, coreLayer] {
+			layer.contentsScale = scale
+			layer.rasterizationScale = scale
+		}
+	}
+
+	private func centeredRect(size: CGFloat) -> CGRect {
+		CGRect(
+			x: (Self.diameter - size) / 2,
+			y: (Self.diameter - size) / 2,
+			width: size,
+			height: size
+		)
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LiveOverlayRenderer.swift
@@ -63,6 +63,7 @@ final class LiveOverlayRenderer {
 	private let loupeStrokeLayer = CAShapeLayer()
 	private let loupePatchLayer = CALayer()
 	private let loupeCenterLayer = CAShapeLayer()
+	private let pointerLayer = CapturePointerAccentLayer()
 	private let frameClock = LiveFrameClockDriver()
 	private let layerRenderDurationMetric = NativeHostTelemetry.distribution(
 		"live_chrome.layer_render_duration",
@@ -93,6 +94,7 @@ final class LiveOverlayRenderer {
 		static let selectionChrome: CGFloat = 30
 		static let selectionSize: CGFloat = 40
 		static let hudChrome: CGFloat = 1_000
+		static let pointer: CGFloat = 1_200
 	}
 
 	private var snapshotProvider: (() -> LivePreviewSnapshot?)?
@@ -219,6 +221,8 @@ final class LiveOverlayRenderer {
 			chromeLayer.zPosition = LayerZ.hudChrome
 			chromeRootLayer.addSublayer(chromeLayer)
 		}
+		pointerLayer.zPosition = LayerZ.pointer
+		chromeRootLayer.addSublayer(pointerLayer)
 		for hudSublayer in [
 			hudGlassLayer, hudFillLayer, hudStrokeLayer, hudSwatchLayer, hudPositionLayer,
 			hudHexLayer, hudHexRollLayer, hudKeycapLayer, hudKeycapTextLayer,
@@ -280,6 +284,7 @@ final class LiveOverlayRenderer {
 		lastRenderedFocusFlowAnimates = shouldAnimateSelectionFlow(snapshot)
 		renderHud(snapshot)
 		renderLoupe(snapshot)
+		renderPointer(snapshot)
 		CATransaction.commit()
 	}
 
@@ -300,6 +305,7 @@ final class LiveOverlayRenderer {
 		lastActiveChromeRenderUptime = nil
 		hudColorRollCoordinator.reset()
 		hoverFlowLayer.hide()
+		pointerLayer.hide()
 	}
 
 	private func currentSnapshot() -> LivePreviewSnapshot? {
@@ -327,6 +333,7 @@ final class LiveOverlayRenderer {
 		updateLiveFlowExclusions(excluding: chromeExclusions)
 		renderHud(snapshot)
 		renderLoupe(snapshot)
+		renderPointer(snapshot)
 		CATransaction.commit()
 	}
 
@@ -484,6 +491,15 @@ final class LiveOverlayRenderer {
 		loupeCenterLayer.fillColor = NSColor.clear.cgColor
 		loupeCenterLayer.strokeColor = NSColor.white.withAlphaComponent(0.9).cgColor
 		loupeCenterLayer.lineWidth = 2
+	}
+
+	private func renderPointer(_ snapshot: LivePreviewSnapshot) {
+		let scale = hostView?.window?.backingScaleFactor ?? 2
+		pointerLayer.update(
+			pointer: snapshot.pointerLocal,
+			in: snapshot.bounds,
+			contentsScale: scale
+		)
 	}
 
 	private func applySurfaceStyle(

--- a/native/macos-host/Sources/RsnapNativeHostKit/QuickScreenshotController.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/QuickScreenshotController.swift
@@ -2,6 +2,7 @@ import AppKit
 @preconcurrency import CoreGraphics
 import Darwin
 import Foundation
+import QuartzCore
 
 struct QuickScreenshotDisplayFrame {
 	let displayID: CGDirectDisplayID
@@ -106,6 +107,7 @@ private final class QuickScreenshotAcquisitionController {
 	private static let eventMask =
 		(CGEventMask(1) << CGEventType.leftMouseDown.rawValue)
 		| (CGEventMask(1) << CGEventType.leftMouseDragged.rawValue)
+		| (CGEventMask(1) << CGEventType.mouseMoved.rawValue)
 		| (CGEventMask(1) << CGEventType.leftMouseUp.rawValue)
 		| (CGEventMask(1) << CGEventType.rightMouseDown.rawValue)
 		| (CGEventMask(1) << CGEventType.keyDown.rawValue)
@@ -200,11 +202,19 @@ private final class QuickScreenshotAcquisitionController {
 		case .rightMouseDown:
 			cancel(reason: "right_mouse")
 			return nil
+		case .mouseMoved:
+			let point = Self.appKitPoint(from: event)
+			overlayController?.updatePointer(point)
+			return Unmanaged.passUnretained(event)
 		case .leftMouseDown:
-			beginSelection(at: Self.appKitPoint(from: event))
+			let point = Self.appKitPoint(from: event)
+			overlayController?.updatePointer(point)
+			beginSelection(at: point)
 			return nil
 		case .leftMouseDragged:
-			updateSelection(to: Self.appKitPoint(from: event))
+			let point = Self.appKitPoint(from: event)
+			overlayController?.updatePointer(point)
+			updateSelection(to: point)
 			return nil
 		case .leftMouseUp:
 			finishSelection(at: Self.appKitPoint(from: event))
@@ -330,6 +340,7 @@ private final class QuickScreenshotAcquisitionController {
 				displayFrames: preparedDisplayFrames
 			)
 			overlayController.prepare()
+			overlayController.showArmed(pointer: NSEvent.mouseLocation)
 			self.overlayController = overlayController
 		}
 		let prepareMilliseconds = NativeHostTelemetry.milliseconds(since: prepareStartedAt)
@@ -462,6 +473,7 @@ private final class QuickScreenshotAcquisitionController {
 private final class QuickScreenshotSelectionOverlayController {
 	private let displayFrames: [QuickScreenshotDisplayFrame]
 	private var windows: [QuickScreenshotSelectionWindow] = []
+	private var activeSelectionWindow: QuickScreenshotSelectionWindow?
 
 	init(displayFrames: [QuickScreenshotDisplayFrame]) {
 		self.displayFrames = displayFrames
@@ -480,26 +492,54 @@ private final class QuickScreenshotSelectionOverlayController {
 
 	func show(initialSelection: CGRect?) {
 		prepare()
+		let focusedWindow =
+			initialSelection.flatMap { selection in
+				windows.first { $0.frame.intersects(selection) }
+			} ?? windows.first
+		activeSelectionWindow = focusedWindow
 		for window in windows {
-			window.selectionView.selection = initialSelection
-			window.selectionView.needsDisplay = true
+			window.selectionView.updateSelection(initialSelection)
 			window.orderFrontRegardless()
 			window.displayIfNeeded()
 		}
 	}
 
-	func update(selection: CGRect) {
+	func showArmed(pointer: CGPoint?) {
+		prepare()
+		activeSelectionWindow = nil
 		for window in windows {
-			window.selectionView.selection = selection
-			window.selectionView.needsDisplay = true
+			window.selectionView.updateSelection(nil)
+			window.selectionView.updatePointer(pointer)
+			window.orderFrontRegardless()
 			window.displayIfNeeded()
 		}
 	}
 
+	func updatePointer(_ pointer: CGPoint?) {
+		for window in windows {
+			window.selectionView.updatePointer(pointer)
+		}
+	}
+
+	func update(selection: CGRect) {
+		let targetWindow =
+			activeSelectionWindow
+			?? windows.first { $0.frame.intersects(selection) }
+			?? windows.first
+		activeSelectionWindow = targetWindow
+		guard let targetWindow else {
+			return
+		}
+		targetWindow.selectionView.updateSelection(selection)
+		targetWindow.displayIfNeeded()
+	}
+
 	func close() {
 		for window in windows {
+			window.selectionView.clearPresentation()
 			window.orderOut(nil)
 		}
+		activeSelectionWindow = nil
 		windows.removeAll()
 	}
 }
@@ -555,12 +595,21 @@ private final class QuickScreenshotSelectionWindow: NSPanel {
 @MainActor
 private final class QuickScreenshotSelectionView: NSView {
 	private let displayFrame: QuickScreenshotDisplayFrame
-	var selection: CGRect?
+	private let rootLayer = CALayer()
+	private let scrimLayer = LiveScrimLayer()
+	private let dragBorderOutlineLayer = CAShapeLayer()
+	private let dragBorderLayer = CAShapeLayer()
+	private let selectionSizeLayer = CATextLayer()
+	private let pointerLayer = CapturePointerAccentLayer()
+	private var selection: CGRect?
+	private var pointer: CGPoint?
 
 	init(displayFrame: QuickScreenshotDisplayFrame) {
 		self.displayFrame = displayFrame
 		super.init(frame: CGRect(origin: .zero, size: displayFrame.frame.size))
 		wantsLayer = true
+		layer = rootLayer
+		configureLayers()
 	}
 
 	@available(*, unavailable)
@@ -571,33 +620,167 @@ private final class QuickScreenshotSelectionView: NSView {
 	override var isFlipped: Bool { false }
 	override var isOpaque: Bool { false }
 
-	override func draw(_ dirtyRect: NSRect) {
-		super.draw(dirtyRect)
-		NSGraphicsContext.current?.cgContext.clear(dirtyRect)
-		drawDimmedMask()
+	override func layout() {
+		super.layout()
+		rootLayer.frame = bounds
+		if let selection {
+			updateSelectionLayers(selection)
+		}
+		updateCrosshairLayers(pointer)
 	}
 
-	private func drawDimmedMask() {
-		let maskPath = NSBezierPath(rect: bounds)
+	func updateSelection(_ selection: CGRect?) {
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		self.selection = selection
 		if let selection {
-			maskPath.append(NSBezierPath(rect: localRect(from: selection)))
-			maskPath.windingRule = .evenOdd
+			updateSelectionLayers(selection)
+		} else {
+			hideSelectionLayers()
 		}
-		NSColor(calibratedWhite: 0, alpha: CaptureChrome.liveScrimAlpha).setFill()
-		maskPath.fill()
+		CATransaction.commit()
+	}
 
-		guard let selection else {
+	func updatePointer(_ pointer: CGPoint?) {
+		CATransaction.begin()
+		CATransaction.setDisableActions(true)
+		defer { CATransaction.commit() }
+
+		self.pointer = pointer
+		updateCrosshairLayers(pointer)
+	}
+
+	func clearPresentation() {
+		updateSelection(nil)
+		updatePointer(nil)
+	}
+
+	private func updateCrosshairLayers(_ pointer: CGPoint?) {
+		guard let pointer else {
+			hideCrosshairLayers()
 			return
 		}
-		let selectionRect = localRect(from: selection)
-		NSColor.white.withAlphaComponent(0.96).setStroke()
-		let stroke = NSBezierPath(rect: selectionRect)
-		stroke.lineWidth = 1.5
-		stroke.stroke()
-		NSColor.systemBlue.withAlphaComponent(0.95).setStroke()
-		let innerStroke = NSBezierPath(rect: selectionRect.insetBy(dx: 1.5, dy: 1.5))
-		innerStroke.lineWidth = 1
-		innerStroke.stroke()
+		let localPoint = CGPoint(
+			x: pointer.x - displayFrame.frame.minX,
+			y: pointer.y - displayFrame.frame.minY
+		)
+		guard bounds.contains(localPoint) else {
+			hideCrosshairLayers()
+			return
+		}
+		let scale = window?.screen?.backingScaleFactor ?? 1
+		pointerLayer.update(pointer: localPoint, in: bounds, contentsScale: scale)
+	}
+
+	private func configureLayers() {
+		rootLayer.masksToBounds = true
+		rootLayer.isOpaque = false
+		rootLayer.backgroundColor = NSColor.clear.cgColor
+
+		scrimLayer.isHidden = true
+		rootLayer.addSublayer(scrimLayer)
+
+		for layer in [dragBorderOutlineLayer, dragBorderLayer] {
+			layer.fillColor = NSColor.clear.cgColor
+			layer.lineCap = .butt
+			layer.lineJoin = .miter
+			layer.isHidden = true
+			rootLayer.addSublayer(layer)
+		}
+		dragBorderOutlineLayer.strokeColor =
+			NSColor(calibratedRed: 229 / 255, green: 247 / 255, blue: 1, alpha: 116 / 255)
+			.cgColor
+		dragBorderOutlineLayer.lineWidth = CaptureChrome.liveDashedBorderWidth + 0.75
+		dragBorderLayer.strokeColor =
+			NSColor(calibratedRed: 167 / 255, green: 223 / 255, blue: 1, alpha: 0.96).cgColor
+		dragBorderLayer.lineWidth = CaptureChrome.liveDashedBorderWidth
+
+		selectionSizeLayer.isHidden = true
+		selectionSizeLayer.alignmentMode = .left
+		selectionSizeLayer.foregroundColor = NSColor.white.withAlphaComponent(0.98).cgColor
+		selectionSizeLayer.font = LiveOverlayTypography.font
+		selectionSizeLayer.fontSize = LiveOverlayTypography.font.pointSize
+		rootLayer.addSublayer(selectionSizeLayer)
+
+		rootLayer.addSublayer(pointerLayer)
+	}
+
+	private func updateSelectionLayers(_ globalSelection: CGRect) {
+		let selectionRect = localRect(from: globalSelection)
+		let scale = window?.screen?.backingScaleFactor ?? 1
+		scrimLayer.frame = bounds
+		scrimLayer.contentsScale = scale
+		scrimLayer.update(
+			focusRect: selectionRect,
+			color: NSColor(calibratedWhite: 0, alpha: CaptureChrome.liveScrimAlpha).cgColor,
+			roundedExclusions: []
+		)
+		scrimLayer.isHidden = false
+
+		let borderOutset = CaptureChrome.dashedBorderOutset(
+			strokeWidth: CaptureChrome.liveDashedBorderWidth,
+			pixelsPerPoint: scale
+		)
+		let borderRect = selectionRect.insetBy(dx: -borderOutset, dy: -borderOutset)
+		let layerFrame = dashedBorderLayerFrame(
+			for: borderRect,
+			lineWidth: CaptureChrome.liveDashedBorderWidth + 0.75
+		)
+		let localBorderRect = borderRect.offsetBy(dx: -layerFrame.minX, dy: -layerFrame.minY)
+		let path = CaptureChrome.dashedBorderPath(for: localBorderRect)
+		for layer in [dragBorderOutlineLayer, dragBorderLayer] {
+			layer.frame = layerFrame
+			layer.contentsScale = scale
+			layer.path = path
+			layer.isHidden = selectionRect.intersects(bounds) == false
+		}
+
+		renderSelectionSizeBadge(selectionRect, scale: scale)
+	}
+
+	private func hideSelectionLayers() {
+		scrimLayer.isHidden = true
+		dragBorderOutlineLayer.isHidden = true
+		dragBorderLayer.isHidden = true
+		selectionSizeLayer.isHidden = true
+	}
+
+	private func hideCrosshairLayers() {
+		pointerLayer.hide()
+	}
+
+	private func renderSelectionSizeBadge(_ selectionRect: CGRect, scale: CGFloat) {
+		guard selectionRect.intersects(bounds) else {
+			selectionSizeLayer.isHidden = true
+			return
+		}
+		let text = selectionSizeText(for: selectionRect)
+		let font = LiveOverlayTypography.font
+		let textSize = text.size(using: font)
+		selectionSizeLayer.contentsScale = scale
+		selectionSizeLayer.string = text
+		selectionSizeLayer.frame = CaptureChrome.selectionSizeBadgeFrame(
+			for: selectionRect,
+			textSize: textSize,
+			in: bounds
+		)
+		selectionSizeLayer.isHidden = false
+	}
+
+	private func dashedBorderLayerFrame(for borderRect: CGRect, lineWidth: CGFloat) -> CGRect {
+		let padding = max(lineWidth + 2, 4)
+		return borderRect.insetBy(dx: -padding, dy: -padding)
+	}
+
+	private func selectionSizeText(for rect: CGRect) -> String {
+		let scale = window?.screen?.backingScaleFactor ?? 1
+		let sizeText = "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))px"
+
+		if abs(scale - 1) <= 0.005 {
+			return sizeText
+		}
+
+		return "\(sizeText) @\(String(format: "%g", Double(scale)))x"
 	}
 
 	private func localRect(from globalRect: CGRect) -> CGRect {

--- a/packages/rsnap-capture-core/src/session.rs
+++ b/packages/rsnap-capture-core/src/session.rs
@@ -53,7 +53,7 @@ impl CaptureSessionCore {
 	/// Enters live mode and requests native live capture.
 	pub fn enter_live(&mut self) {
 		self.scene.mode = CaptureMode::Live;
-		self.scene.cursor_intent = CursorIntent::Default;
+		self.scene.cursor_intent = CursorIntent::Crosshair;
 		self.scene.pointer = None;
 		self.scene.active_monitor = None;
 		self.scene.highlighted_window = None;
@@ -338,7 +338,7 @@ impl CaptureSessionCore {
 	fn update_cursor_intent(&mut self, point: GlobalPoint) {
 		self.scene.cursor_intent = match self.scene.mode {
 			CaptureMode::Hidden => CursorIntent::Default,
-			CaptureMode::Live => CursorIntent::Default,
+			CaptureMode::Live => CursorIntent::Crosshair,
 			CaptureMode::Frozen => {
 				if !self.frozen_selection_editable {
 					CursorIntent::Default
@@ -409,13 +409,13 @@ mod tests {
 	}
 
 	#[test]
-	fn enter_live_requests_capture_and_default_cursor() {
+	fn enter_live_requests_capture_and_crosshair_cursor() {
 		let mut session = CaptureSessionCore::with_config(SessionConfig::default());
 
 		session.enter_live();
 
 		assert_eq!(session.scene_model().mode, CaptureMode::Live);
-		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Default);
+		assert_eq!(session.scene_model().cursor_intent, CursorIntent::Crosshair);
 		assert_eq!(session.pop_host_request(), Some(HostRequest::StartLiveCapture));
 	}
 

--- a/packages/rsnap-host-ffi/src/tests.rs
+++ b/packages/rsnap-host-ffi/src/tests.rs
@@ -108,7 +108,7 @@ fn ffi_session_enters_live_and_emits_request() {
 		RsnapStatus::Ok
 	);
 	assert_eq!(scene.scene_kind, RsnapSceneKind::Live as u32);
-	assert_eq!(scene.cursor_intent, RsnapCursorIntent::Default as u32);
+	assert_eq!(scene.cursor_intent, RsnapCursorIntent::Crosshair as u32);
 
 	unsafe { crate::rsnap_session_destroy(handle) };
 }


### PR DESCRIPTION
## Summary
- Change live capture mode cursor intent from default to crosshair immediately on activation.
- Keep live pointer updates pinned to crosshair until the session leaves live mode.
- Update FFI/core tests and specs so the cursor affordance is part of the product contract.

## Root Cause
The native host already maps `CursorIntent.crosshair` to `NSCursor.crosshair`, but the core always emitted `CursorIntent::Default` in `enter_live()` and for live pointer updates. That meant the host was correctly rendering the wrong semantic intent.

## Validation
- `cargo fmt --all --check`
- `cargo test -p rsnap-capture-core session -- --nocapture`
- `cargo test -p rsnap-host-ffi ffi_session_enters_live_and_emits_request -- --nocapture`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/build_and_run.sh stage`
