### PR TITLE
Optimize frozen selection drag responsiveness

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -13,6 +13,9 @@
   screenshot pointer hotspot accent chrome.
 - Added `CaptureHostCursorOwner.swift` and `QuickScreenshotController.swift` ownership notes to the
   workspace layout reference.
+- Recorded frozen selection-transform performance ownership: drag updates are coalesced through
+  the capture-host pointer dispatch queue and active transform redraws are narrowed to dirty
+  regions.
 
 ## 2026-07-06
 

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -262,8 +262,8 @@ The main host-kit files are split by responsibility:
   seed-patch cache, active frame, refresh cadence, and change-count state
 - `CaptureHostScrollToolbarBackdropWorker.swift`: scroll toolbar backdrop live-frame freshness,
   signature hashing, fallback capture selection, and capture result shaping
-- `CaptureHostView.swift`: AppKit view orchestration, hit testing, and frozen presentation
-  rendering
+- `CaptureHostView.swift`: AppKit view orchestration, hit testing, frozen presentation rendering,
+  and dirty-region redraw narrowing for active frozen selection transforms
 - `CaptureHostMaterialViewCoordinator.swift`: Liquid Glass/material subview ownership, classic glass
   patch resolution, and scroll-toolbar backdrop refresh scheduling plus view installation
 - `CaptureHostGlassPatchResolver.swift`: classic glass patch cache lookup, frozen display crop
@@ -294,7 +294,8 @@ The main host-kit files are split by responsibility:
 - `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
   release-watchdog scheduling for AppKit interactions whose mouse-up event can be missed
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
-  with per-track throttling state, and AppKit-to-controller pointer delivery
+  with per-track throttling state, and AppKit-to-controller pointer delivery for live drag and
+  frozen selection-transform drag
 - `CaptureHostCursorOwner.swift`: shared native cursor-owner helper for applying and clearing the
   current AppKit cursor across ordinary capture views without owning an `NSCursor` push stack
 - `CapturePointerAccentLayer.swift`: shared AppKit layer for ordinary and quick screenshot

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostPointerDispatch.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostPointerDispatch.swift
@@ -9,12 +9,13 @@ package enum CaptureHostPointerDispatchTrack: Equatable {
 package enum CaptureHostPointerDispatchEvent: Equatable {
 	case moved(CGPoint)
 	case liveDragged(CGPoint)
+	case frozenSelectionDragged(CGPoint)
 
 	package var track: CaptureHostPointerDispatchTrack {
 		switch self {
 		case .moved:
 			return .hover
-		case .liveDragged:
+		case .liveDragged, .frozenSelectionDragged:
 			return .drag
 		}
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift
@@ -34,7 +34,7 @@ extension CaptureHostView {
 	}
 
 	func routeMouseDragged(with event: NSEvent) {
-		if scene.mode == .frozen {
+		if scene.mode == .frozen, chrome.frozenSelectionInteraction == nil {
 			frozenToolbar.refreshHoveredAction(for: event.locationInWindow)
 		}
 
@@ -56,6 +56,11 @@ extension CaptureHostView {
 		} else {
 			let point = globalPoint(from: event)
 			if recoverReleasedFrozenInteractionIfNeeded(at: point) {
+				return
+			}
+			if chrome.frozenSelectionInteraction != nil {
+				queuePointerEvent(.frozenSelectionDragged(point))
+				syncVisibleCursor()
 				return
 			}
 			controller?.continueFrozenInteraction(to: point)
@@ -129,6 +134,7 @@ extension CaptureHostView {
 			controller?.completeLivePrimaryInteraction(from: self, at: point)
 		} else if scene.mode == .frozen {
 			cancelFrozenMouseReleaseWatchdog()
+			cancelQueuedPointerDispatch()
 			controller?.completeFrozenInteraction(at: point)
 			syncVisibleCursor()
 		}
@@ -356,6 +362,11 @@ extension CaptureHostView {
 				return
 			}
 			controller?.continuePrimaryInteraction(to: point)
+		case .frozenSelectionDragged(let point):
+			if recoverReleasedFrozenInteractionIfNeeded(at: point) {
+				return
+			}
+			controller?.continueFrozenInteraction(to: point)
 		}
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+LivePrimaryInteraction.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+LivePrimaryInteraction.swift
@@ -95,6 +95,7 @@ extension CaptureHostView {
 			return false
 		}
 		cancelFrozenMouseReleaseWatchdog()
+		cancelQueuedPointerDispatch()
 		controller?.completeFrozenInteraction(at: point)
 		syncVisibleCursor()
 		return true
@@ -231,6 +232,7 @@ extension CaptureHostView {
 				captureID: controller?.activeTelemetryCaptureID ?? 0,
 				detail: "x=\(Int(point.x.rounded())) y=\(Int(point.y.rounded()))"
 			)
+			cancelQueuedPointerDispatch()
 			controller?.completeFrozenInteraction(at: point)
 			syncVisibleCursor()
 			return false
@@ -251,7 +253,7 @@ extension CaptureHostView {
 		)
 	}
 
-	private func cancelQueuedPointerDispatch() {
+	func cancelQueuedPointerDispatch() {
 		pointerDispatchQueue.cancel()
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -102,6 +102,14 @@ final class CaptureHostView: NSView {
 		let previousSettings = self.settings
 		let previousMode = self.scene.mode
 		let transitioningToFrozen = previousMode == .live && scene.mode == .frozen
+		let frozenTransformDirtyRect = frozenSelectionTransformDirtyRect(
+			previousScene: previousScene,
+			previousChrome: previousChrome,
+			previousSettings: previousSettings,
+			nextScene: scene,
+			nextChrome: chrome,
+			nextSettings: settings
+		)
 		let hostLocalFrozenSelectingEnded =
 			previousChrome.hostLocalFrozenSelecting && !chrome.hostLocalFrozenSelecting
 		if scene.mode != .frozen {
@@ -153,7 +161,9 @@ final class CaptureHostView: NSView {
 					now: ProcessInfo.processInfo.systemUptime)
 			}
 		}
-		frozenToolbar.refreshHoveredAction()
+		if chrome.frozenSelectionInteraction == nil {
+			frozenToolbar.refreshHoveredAction()
+		}
 		syncVisibleCursor()
 		updateChromeMaterialViews()
 		updateLiveRendererState()
@@ -178,9 +188,93 @@ final class CaptureHostView: NSView {
 				if previousMode == .live {
 					stopLivePresentationNow()
 				}
-				needsDisplay = true
+				if let frozenTransformDirtyRect {
+					setNeedsDisplay(frozenTransformDirtyRect)
+				} else {
+					needsDisplay = true
+				}
 			}
 		}
+	}
+
+	private func frozenSelectionTransformDirtyRect(
+		previousScene: SceneSnapshot,
+		previousChrome: CaptureChromeState,
+		previousSettings: NativeHostSettings,
+		nextScene: SceneSnapshot,
+		nextChrome: CaptureChromeState,
+		nextSettings: NativeHostSettings
+	) -> CGRect? {
+		guard previousScene.mode == .frozen, nextScene.mode == .frozen else {
+			return nil
+		}
+		guard previousSettings == nextSettings else {
+			return nil
+		}
+		guard
+			previousChrome.frozenSelectionInteraction != nil
+				|| nextChrome.frozenSelectionInteraction != nil
+		else {
+			return nil
+		}
+		guard previousChrome.frozenDisplayFrame == nextChrome.frozenDisplayFrame else {
+			return nil
+		}
+		guard
+			let previousSelection = localRect(
+				from: previousChrome.frozenSelectionSnapshot ?? previousScene.frozenSelection),
+			let nextSelection = localRect(
+				from: nextChrome.frozenSelectionSnapshot ?? nextScene.frozenSelection)
+		else {
+			return nil
+		}
+
+		var dirtyRect = previousSelection.union(nextSelection)
+		if let previousToolbarFrame = frozenToolbarFrame(
+			for: previousSelection,
+			scene: previousScene,
+			chrome: previousChrome,
+			settings: previousSettings
+		) {
+			dirtyRect = dirtyRect.union(previousToolbarFrame)
+		}
+		if let nextToolbarFrame = frozenToolbarFrame(
+			for: nextSelection,
+			scene: nextScene,
+			chrome: nextChrome,
+			settings: nextSettings
+		) {
+			dirtyRect = dirtyRect.union(nextToolbarFrame)
+		}
+		let clippedDirtyRect = dirtyRect.insetBy(dx: -96, dy: -96).intersection(bounds)
+		return clippedDirtyRect.isNull ? nil : clippedDirtyRect
+	}
+
+	private func frozenToolbarFrame(
+		for selection: CGRect,
+		scene: SceneSnapshot,
+		chrome: CaptureChromeState,
+		settings: NativeHostSettings
+	) -> CGRect? {
+		FrozenToolbarLayoutPlanner.layout(
+			selection: selection,
+			bounds: bounds,
+			prefersTopPlacement: settings.toolbarPlacement == .top,
+			items: FrozenToolbarLayoutPlanner.visibleItems(
+				from: scene.toolbarItems,
+				availability: FrozenToolbarAvailability(
+					scrollCaptureActive: chrome.scrollMinimapPreview != nil,
+					canUndo: chrome.frozenOverlay.canUndo,
+					canRedo: chrome.frozenOverlay.canRedo,
+					frozenSelectionAvailable: scene.frozenSelection != nil,
+					keepsFrozenSelectionFixed: chrome.frozenOverlay.keepsFrozenSelectionFixed,
+					scrollToolbarEnabled: controller?.scrollCaptureToolbarEnabled ?? false,
+					hasRecognizeTextBlockingEdits: chrome.frozenOverlay
+						.hasRecognizeTextBlockingEdits
+				)
+			),
+			annotationStyle: chrome.annotationStyle
+		)?.frame
 	}
 
 	private func shouldRenderFullLiveOverlay(

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+FrozenInteraction.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+FrozenInteraction.swift
@@ -201,7 +201,9 @@ extension CaptureSessionController {
 	}
 
 	var hasFrozenOverlayActiveInteraction: Bool {
-		scene.mode == .frozen && chromeState.frozenOverlay.hasActiveInteraction
+		scene.mode == .frozen
+			&& (chromeState.frozenOverlay.hasActiveInteraction
+				|| chromeState.frozenSelectionInteraction != nil)
 	}
 
 	func completeFrozenInteraction(at point: CGPoint) {

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -182,6 +182,7 @@ enum RsnapNativeHostKitProbe {
 		guard
 			CaptureHostPointerDispatchEvent.moved(.zero).track == .hover,
 			CaptureHostPointerDispatchEvent.liveDragged(.zero).track == .drag,
+			CaptureHostPointerDispatchEvent.frozenSelectionDragged(.zero).track == .drag,
 			approximatelyEqual(
 				CaptureHostPointerDispatchTiming.delay(
 					now: 10,


### PR DESCRIPTION
## Summary
- coalesce frozen selection transform drag updates through the pointer dispatch queue
- narrow active transform redraws to selection/toolbar dirty regions
- keep final mouse-up commit exact and cover frozen transform release recovery

## Validation
- swift format lint --strict native/macos-host/Sources/RsnapNativeHostKit/CaptureHostPointerDispatch.swift native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+InputRouting.swift native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView+LivePrimaryInteraction.swift native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+FrozenInteraction.swift native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
- cargo test -p rsnap-capture-core session -- --nocapture
- cargo test -p rsnap-capture-core selection_transform -- --nocapture
- decodex docs check
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift run --package-path native/macos-host RsnapNativeHostKitProbe
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/build_and_run.sh run