### PR TITLE
Document quick screenshot shortcut guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ https://github.com/user-attachments/assets/ff2fe84f-f551-40e8-919c-66ae8a61f8e7
 ## Feature Highlights
 
 - Menubar-only app (no Dock icon) on macOS.
-- Global hotkey: `Alt+X` (macOS: Option+X).
+- Global hotkey: `Alt+X` (macOS: Option-X).
+- Quick screenshot hotkey: `Alt+Shift+X` (macOS: Option-Shift-X) for transient UI
+  such as context menus and submenu stacks.
 - Transparent capture-session overlay that blocks desktop interaction.
 - HUD near the cursor showing global `x,y` and `rgb(r,g,b)`.
 - Left click + drag freezes a selected region; a single left click freezes the hovered window or falls back to the active monitor fullscreen.
@@ -131,6 +133,10 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
   wheel forwarding; it does not require Accessibility, Input Monitoring, Accessibility target
   acquisition, app scripting, or browser/DOM access. The v0.2.5 native-host release exposes Scroll
   Capture from dragged-region Frozen captures only.
+- Quick Screenshot uses a temporary macOS event tap to keep transient target UI focused while Rsnap
+  captures the selected region. If macOS refuses the event tap, Quick Screenshot fails closed and
+  records native-host telemetry; Screen Recording remains the required permission for captured
+  pixels.
 - macOS may describe Screen Recording as `Screen & System Audio Recording` or as direct screen/audio access when Rsnap bypasses the system picker.
 - Settings -> Permissions shows Screen Recording as the required capture permission.
 - Normal native capture depends on Screen Recording; if access is missing, Rsnap opens the Screen Recording page in System Settings and shows a floating drag-to-grant guide.
@@ -138,9 +144,21 @@ Rsnap requires **Screen Recording** permission to capture other apps/windows.
 - Base capture path: `System Settings` -> `Privacy & Security` -> `Screen Recording`.
 - Enable `Rsnap.app`, then retry capture. If macOS still keeps capture blocked after changing a permission, relaunch the app.
 
+### Screenshot shortcuts
+
+- New Screenshot: `Alt+X` (macOS: Option-X). Use this for the normal live capture overlay.
+- Quick Screenshot: `Alt+Shift+X` (macOS: Option-Shift-X). Use this for transient UI that
+  would disappear when another app activates, such as context menus and submenu stacks.
+- In live capture, `Tab` toggles the loupe sample.
+- In Frozen mode, `Space` copies the current frozen PNG to the clipboard and exits.
+- In Frozen mode, Cmd+S (macOS) / Ctrl+S saves the current PNG to disk and exits.
+- `Esc` cancels capture.
+
 ### HUD settings behavior
 
 - The native `Settings…` window currently owns:
+  - New Screenshot shortcut
+  - Quick Screenshot shortcut
   - HUD glass enable/disable
   - HUD glass style (`Classic Glass` / `Liquid Glass`)
   - Liquid Glass style (`Regular` / `Clear`) when supported by macOS and the current build

--- a/docs/log.md
+++ b/docs/log.md
@@ -16,6 +16,10 @@
 - Recorded frozen selection-transform performance ownership: drag updates are coalesced through
   the capture-host pointer dispatch queue and active transform redraws are narrowed to dirty
   regions.
+- Added user-facing and release-validation documentation for the default quick screenshot shortcut:
+  `Alt+Shift+X` / macOS `Option-Shift-X`.
+- Recorded quick screenshot Settings ownership, status-menu validation, and event-tap failure
+  expectations.
 
 ## 2026-07-06
 

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -5,7 +5,7 @@ type: "Runbook"
 status: active
 authority: normative
 owner: hack-ink/rsnap
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 ---
 # Validate Release
 
@@ -63,6 +63,13 @@ Validate these user-visible flows:
 - First launch and missing Screen Recording recovery.
 - Menubar app identity, no Dock icon during capture, Settings open/close behavior.
 - Option-X capture start, cancel, and frontmost-app restoration.
+- Option-Shift-X quick screenshot start, transient-menu preservation, dragged-region freeze,
+  cancel, and frontmost-app restoration.
+- Status menu exposes Quick Screenshot and shows the configured quick screenshot shortcut. Settings
+  -> Capture shows canonical `Option-X` and `Option-Shift-X` shortcut values; changing the Quick
+  Screenshot shortcut persists, updates the status-menu item, and still starts quick screenshot
+  without activating Rsnap. If event-tap setup fails, collect native-host telemetry and treat it as
+  a quick screenshot blocker.
 - Live HUD, Tab loupe sampling, window outline, dragged-region freeze, click-window freeze, and
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -48,7 +48,7 @@ product level rather than binding itself to a particular window toolkit or shell
 1. Background app shell on macOS: no Dock icon while Settings is closed and no other ordinary app
    window is visible. Opening Settings may temporarily use a normal app/window activation policy;
    closing Settings must return Rsnap to the background menubar shell.
-2. Global hotkey starts capture session (default `Alt+X`, macOS: Option+X) and can be customized
+2. Global hotkey starts capture session (default `Alt+X`, macOS: Option-X) and can be customized
    from Settings.
 3. The status menu's New Screenshot item must use the configured capture shortcut. Shortcut display
    strings must use platform-native names such as `Option-X`, not raw event names such as
@@ -68,7 +68,7 @@ product level rather than binding itself to a particular window toolkit or shell
 8. The product contract does not require any specific platform window implementation. Focus,
    cursor, keyboard, and IME correctness are mandatory outcomes, regardless of how the native host
    achieves them.
-9. The quick screenshot shortcut (default macOS: Shift-Option-X) is a separate acquisition path for
+9. The quick screenshot shortcut (default macOS: Option-Shift-X) is a separate acquisition path for
    capturing transient UI such as right-click menus and submenu stacks. Quick screenshot MUST NOT
    activate Rsnap, make an overlay key/main, take first responder, or otherwise steal focus from the
    target app while the quick selection is armed or dragged. Any quick screenshot cursor feedback

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -5,7 +5,7 @@ type: "Spec"
 status: active
 authority: normative
 owner: hack-ink/rsnap
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 ---
 # Settings and App Shell Contract
 
@@ -47,8 +47,8 @@ Defines:
 
 ## Status Menu
 
-- The status menu must expose New Screenshot, Open Screenshots Folder, Check for Updates, Settings,
-  and Quit.
+- The status menu must expose New Screenshot, Quick Screenshot, Open Screenshots Folder,
+  Check for Updates, Settings, and Quit.
 - Open Screenshots Folder must open the configured output directory, creating it first when needed.
 - Check for Updates must invoke the same Sparkle-backed update check flow as the About section.
 - The status menu must not expose Cancel Capture. Capture cancellation is handled in-session by
@@ -56,6 +56,7 @@ Defines:
 - The status menu must not expose Permissions as a separate menu item. Permission status and
   recovery live in Settings.
 - New Screenshot must use the same configured shortcut as the global capture hotkey.
+- Quick Screenshot must use the same configured shortcut as the quick screenshot hotkey.
 
 ## Settings Window
 
@@ -69,17 +70,20 @@ Defines:
 
 ## Shortcut Settings
 
-- The capture shortcut configuration must be present in Settings.
-- Shortcut display strings must use canonical platform names such as `Option-X`.
+- The capture shortcut and quick screenshot shortcut configuration must be present in Settings.
+- Shortcut display strings must use canonical platform names such as `Option-X` and
+  `Option-Shift-X`.
 - Raw event spellings such as `alt+KeyX` must not appear in user-facing shortcut fields,
   summaries, or menu shortcut labels.
 - The default capture shortcut is `Option-X`.
+- The default quick screenshot shortcut is `Option-Shift-X`.
 - In live capture, plain `Tab` toggles the loupe on and off. Hold-to-show Tab behavior is not a
   supported setting.
 
 ## Default Configuration
 
 - Capture shortcut: `Option-X`.
+- Quick screenshot shortcut: `Option-Shift-X`.
 - Open at Login: off, until the user enables the macOS Login Items registration.
 - Output directory: `~/Desktop`.
 - Output filename prefix: `Rsnap`.
@@ -127,6 +131,10 @@ Defines:
 - Settings must not present Accessibility or Input Monitoring as required for Scroll Capture; the
   current product path uses overlay-local wheel forwarding rather than Accessibility target control
   or a CGEvent tap.
+- Quick Screenshot may use a platform event tap for no-focus shortcut and selection input. If the
+  platform refuses that event tap, Quick Screenshot must fail closed and emit diagnostic telemetry;
+  Settings must not present event-tap access as a required capture permission unless a dedicated
+  recovery flow exists.
 - The Open at Login control must live at the bottom of the Permissions section so OS-owned app
   access controls remain first.
 - When Screen Recording is missing at launch or at capture start, Rsnap must open the macOS Screen


### PR DESCRIPTION
## Summary
- document Quick Screenshot default shortcut in README and specs
- add Settings/status-menu shortcut contract and RC validation coverage
- record event-tap fail-closed telemetry expectations

## Validation
- git diff --check
- decodex docs check
- docs path-reference resolver
- skeptic subagent re-review: pass