### PR TITLE
Optimize frozen selection transform drag

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -20,6 +20,11 @@
   `Alt+Shift+X` / macOS `Option-Shift-X`.
 - Recorded quick screenshot Settings ownership, status-menu validation, and event-tap failure
   expectations.
+- Recorded the follow-up frozen selection-transform performance constraints: drag delivery keeps
+  hover and drag queues separate, drag cancels queued hover work, unchanged transform samples do not
+  refresh the overlay, active toolbar translation reuses existing Liquid Glass/content views without
+  synchronous redraw, and transform invalidation remains window-local without adding cross-screen
+  selection movement.
 
 ## 2026-07-06
 

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -294,8 +294,8 @@ The main host-kit files are split by responsibility:
 - `CaptureHostMouseReleaseRecovery.swift`: capture-host local mouse-up monitor and live/frozen
   release-watchdog scheduling for AppKit interactions whose mouse-up event can be missed
 - `CaptureHostPointerDispatch.swift`: capture-host pointer dispatch events, a shared delivery queue
-  with per-track throttling state, and AppKit-to-controller pointer delivery for live drag and
-  frozen selection-transform drag
+  with separate hover/drag queue state, drag-side queued-hover cancellation, and
+  AppKit-to-controller pointer delivery for live drag and frozen selection-transform drag
 - `CaptureHostCursorOwner.swift`: shared native cursor-owner helper for applying and clearing the
   current AppKit cursor across ordinary capture views without owning an `NSCursor` push stack
 - `CapturePointerAccentLayer.swift`: shared AppKit layer for ordinary and quick screenshot

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -188,6 +188,23 @@ Current coarse smoke surfaces:
   and content draw, self-screenshot readiness, no pending-frame/no-scrim-drop flash, and Liquid
   Glass versus Classic Glass material contract
 
+### Scenario 2a: frozen selection transform drag
+
+Surface:
+- frozen selection chrome while moving or resizing an editable frozen selection
+- the frozen toolbar and its material/content views while they follow the active selection
+
+Required behavior:
+- repeated transform samples that clamp to the same selection rectangle must not refresh the overlay
+- pointer dispatch must keep drag delivery independent from hover delivery and must drop stale
+  queued hover work when active drag input arrives
+- toolbar movement caused by pure frame translation should move existing AppKit views/layers; it
+  should not synchronously redraw toolbar content, relayout Liquid Glass, or resample scroll toolbar
+  backdrops unless content, size, material settings, or first-visible state changed
+- the active overlay window invalidates only its local dirty region during a transform; selection
+  movement outside a given window must not force that window to perform a full redraw or imply
+  cross-screen selection transform support
+
 ### Scenario 3: scroll-capture and image-processing hot paths
 
 Surface:

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorOwner.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostCursorOwner.swift
@@ -9,6 +9,9 @@ final class CaptureHostCursorOwner {
 	}
 
 	func set(_ presentation: CaptureHostCursorPresentation) {
+		guard appliedPresentation != presentation else {
+			return
+		}
 		CaptureHostCursorSupport.cursor(for: presentation).set()
 		appliedPresentation = presentation
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostMaterialViewCoordinator.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostMaterialViewCoordinator.swift
@@ -19,6 +19,7 @@ final class CaptureHostMaterialViewCoordinator {
 	private var toolbarLiquidGlassBackdropView: NSImageView?
 	private var toolbarLiquidGlassView: NSView?
 	private var toolbarLiquidGlassContentView: FrozenToolbarRenderView?
+	private var frozenToolbarLiquidGlassSettings: NativeHostSettings?
 	private var frozenToolbarLiquidGlassVisible = false
 	private var frozenToolbarLiquidGlassContentDrawn = false
 	private let scrollToolbarBackdropRefreshGapMetric = NativeHostTelemetry.distribution(
@@ -298,6 +299,7 @@ final class CaptureHostMaterialViewCoordinator {
 	private func prewarmFrozenToolbarLiquidGlassViewIfNeeded() {
 		if let toolbarLiquidGlassView {
 			LiveChromeLiquidGlassBridge.update(toolbarLiquidGlassView, settings: settings)
+			frozenToolbarLiquidGlassSettings = settings
 			ensureFrozenToolbarContentView(above: toolbarLiquidGlassView)
 			return
 		}
@@ -309,6 +311,7 @@ final class CaptureHostMaterialViewCoordinator {
 			zPosition: Self.frozenToolbarLiquidGlassZ
 		)
 		LiveChromeLiquidGlassBridge.update(createdView, settings: settings)
+		frozenToolbarLiquidGlassSettings = settings
 		createdView.frame = .zero
 		createdView.isHidden = true
 		hostView.addSubview(createdView, positioned: .below, relativeTo: nil)
@@ -356,7 +359,8 @@ final class CaptureHostMaterialViewCoordinator {
 
 	private func updateFrozenToolbarBackdrop(
 		for toolbarFrame: CGRect,
-		preparingFirstVisibleToolbar: Bool
+		preparingFirstVisibleToolbar: Bool,
+		capturesUpdates: Bool = true
 	) {
 		guard chrome.scrollMinimapPreview != nil,
 			let globalFrame = globalRect(from: toolbarFrame)
@@ -389,10 +393,12 @@ final class CaptureHostMaterialViewCoordinator {
 			backdropView.image = NSImage(cgImage: seedPatch, size: toolbarFrame.size)
 			backdropView.isHidden = preparingFirstVisibleToolbar
 		}
-		scheduleScrollToolbarBackdropCapture(
-			toolbarFrame: toolbarFrame,
-			globalFrame: globalFrame
-		)
+		if capturesUpdates {
+			scheduleScrollToolbarBackdropCapture(
+				toolbarFrame: toolbarFrame,
+				globalFrame: globalFrame
+			)
+		}
 	}
 
 	private func scheduleScrollToolbarBackdropCapture(
@@ -504,7 +510,9 @@ final class CaptureHostMaterialViewCoordinator {
 	}
 
 	func refreshScrollCaptureToolbarBackdropNow() {
-		guard settings.usesLiquidHudGlass, chrome.scrollMinimapPreview != nil else {
+		guard settings.usesLiquidHudGlass, chrome.scrollMinimapPreview != nil,
+			chrome.frozenSelectionInteraction == nil
+		else {
 			return
 		}
 		guard let state = controller?.scrollCaptureState,
@@ -538,6 +546,7 @@ final class CaptureHostMaterialViewCoordinator {
 		guard
 			scene.mode == .frozen,
 			settings.usesLiquidHudGlass,
+			chrome.frozenSelectionInteraction == nil,
 			frozenToolbarLiquidGlassVisible,
 			frozenToolbarLiquidGlassContentDrawn,
 			let toolbarLiquidGlassView,
@@ -578,14 +587,26 @@ final class CaptureHostMaterialViewCoordinator {
 			hideFrozenToolbarLiquidGlassView()
 			return
 		}
-		updateLiveLiquidGlassView(
-			&toolbarLiquidGlassView,
-			frame: layout.frame,
-			zPosition: Self.frozenToolbarLiquidGlassZ
-		)
+		let activelyTransformingSelection = chrome.frozenSelectionInteraction != nil
+		if activelyTransformingSelection,
+			toolbarLiquidGlassView != nil,
+			frozenToolbarLiquidGlassVisible,
+			frozenToolbarLiquidGlassContentDrawn,
+			frozenToolbarLiquidGlassSettings == settings
+		{
+			moveExistingLiveLiquidGlassView(toolbarLiquidGlassView, frame: layout.frame)
+		} else {
+			updateLiveLiquidGlassView(
+				&toolbarLiquidGlassView,
+				frame: layout.frame,
+				zPosition: Self.frozenToolbarLiquidGlassZ
+			)
+			frozenToolbarLiquidGlassSettings = settings
+		}
 		guard let toolbarLiquidGlassView else {
 			frozenToolbarLiquidGlassVisible = false
 			frozenToolbarLiquidGlassContentDrawn = false
+			frozenToolbarLiquidGlassSettings = nil
 			toolbarLiquidGlassContentView?.isHidden = true
 			if wasVisible {
 				hostView.needsDisplay = true
@@ -600,13 +621,18 @@ final class CaptureHostMaterialViewCoordinator {
 		}
 		updateFrozenToolbarBackdrop(
 			for: layout.frame,
-			preparingFirstVisibleToolbar: preparingFirstVisibleToolbar
+			preparingFirstVisibleToolbar: preparingFirstVisibleToolbar,
+			capturesUpdates: !activelyTransformingSelection || preparingFirstVisibleToolbar
 		)
 		let contentView = ensureFrozenToolbarContentView(above: toolbarLiquidGlassView)
-		let frameChanged = contentView.frame != layout.frame
-		if contentView.frame != layout.frame {
+		let previousContentFrame = contentView.frame
+		let frameChanged = previousContentFrame != layout.frame
+		let sizeChanged = previousContentFrame.size != layout.frame.size
+		if frameChanged {
 			contentView.frame = layout.frame
-			contentView.needsDisplay = true
+			if sizeChanged {
+				contentView.needsDisplay = true
+			}
 		}
 		contentView.isHidden = preparingFirstVisibleToolbar
 		let changed = contentView.update(
@@ -634,7 +660,7 @@ final class CaptureHostMaterialViewCoordinator {
 		if changed {
 			contentView.needsDisplay = true
 		}
-		if frameChanged || changed || !wasVisible || !frozenToolbarLiquidGlassContentDrawn {
+		if sizeChanged || changed || !wasVisible || !frozenToolbarLiquidGlassContentDrawn {
 			contentView.display()
 		}
 		if preparingFirstVisibleToolbar {
@@ -658,6 +684,7 @@ final class CaptureHostMaterialViewCoordinator {
 		let wasVisible = frozenToolbarLiquidGlassVisible
 		frozenToolbarLiquidGlassVisible = false
 		frozenToolbarLiquidGlassContentDrawn = false
+		frozenToolbarLiquidGlassSettings = nil
 		scrollToolbarBackdropState.resetAndInvalidateCaptures()
 		toolbarLiquidGlassBackdropView?.isHidden = true
 		toolbarLiquidGlassBackdropView?.image = nil

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostPointerDispatch.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostPointerDispatch.swift
@@ -32,79 +32,93 @@ package enum CaptureHostPointerDispatchTiming {
 }
 
 @MainActor
-final class CaptureHostPointerDispatchQueue {
-	private var queuedEvent: CaptureHostPointerDispatchEvent?
-	private var queuedWorkItem: DispatchWorkItem?
-	private var lastHoverDispatchUptime: TimeInterval = 0
-	private var lastDragDispatchUptime: TimeInterval = 0
+package final class CaptureHostPointerDispatchQueue {
+	private final class TrackState {
+		var queuedEvent: CaptureHostPointerDispatchEvent?
+		var queuedWorkItem: DispatchWorkItem?
+		var lastDispatchUptime: TimeInterval = 0
+	}
+
+	private let hoverState = TrackState()
+	private let dragState = TrackState()
 	private let targetInterval: () -> TimeInterval
 	private let dispatchEvent: (CaptureHostPointerDispatchEvent) -> Void
+	private let schedule: (TimeInterval, DispatchWorkItem) -> Void
 
-	init(
+	package init(
 		targetInterval: @escaping () -> TimeInterval,
-		dispatchEvent: @escaping (CaptureHostPointerDispatchEvent) -> Void
+		dispatchEvent: @escaping (CaptureHostPointerDispatchEvent) -> Void,
+		schedule: @escaping (TimeInterval, DispatchWorkItem) -> Void = { delay, workItem in
+			if delay <= 0 {
+				DispatchQueue.main.async(execute: workItem)
+			} else {
+				DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+			}
+		}
 	) {
 		self.targetInterval = targetInterval
 		self.dispatchEvent = dispatchEvent
+		self.schedule = schedule
 	}
 
-	func enqueue(_ event: CaptureHostPointerDispatchEvent) {
+	package func enqueue(_ event: CaptureHostPointerDispatchEvent) {
+		if event.track == .drag {
+			cancel(hoverState)
+		}
+		let state = state(for: event.track)
 		let now = ProcessInfo.processInfo.systemUptime
 		let delay = CaptureHostPointerDispatchTiming.delay(
 			now: now,
 			targetInterval: targetInterval(),
-			lastDispatchUptime: lastDispatchUptime(for: event)
+			lastDispatchUptime: state.lastDispatchUptime
 		)
 
-		queuedEvent = event
-		guard queuedWorkItem == nil else {
+		state.queuedEvent = event
+		guard state.queuedWorkItem == nil else {
 			return
 		}
 
-		let workItem = DispatchWorkItem { [weak self] in
+		var scheduledWorkItem: DispatchWorkItem?
+		let workItem = DispatchWorkItem { [weak self, weak state] in
 			guard let self else {
 				return
 			}
-			self.queuedWorkItem = nil
-			guard let event = self.queuedEvent else {
+			guard let state else {
 				return
 			}
-			self.queuedEvent = nil
-			self.setLastDispatchUptime(ProcessInfo.processInfo.systemUptime, for: event)
+			guard state.queuedWorkItem === scheduledWorkItem else {
+				return
+			}
+			state.queuedWorkItem = nil
+			guard let event = state.queuedEvent else {
+				return
+			}
+			state.queuedEvent = nil
 			self.dispatchEvent(event)
+			state.lastDispatchUptime = ProcessInfo.processInfo.systemUptime
 		}
-		queuedWorkItem = workItem
-		if delay <= 0 {
-			DispatchQueue.main.async(execute: workItem)
-		} else {
-			DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
-		}
+		scheduledWorkItem = workItem
+		state.queuedWorkItem = workItem
+		schedule(delay, workItem)
 	}
 
-	func cancel() {
-		queuedWorkItem?.cancel()
-		queuedWorkItem = nil
-		queuedEvent = nil
+	package func cancel() {
+		cancel(hoverState)
+		cancel(dragState)
 	}
 
-	private func lastDispatchUptime(for event: CaptureHostPointerDispatchEvent) -> TimeInterval {
-		switch event.track {
+	private func state(for track: CaptureHostPointerDispatchTrack) -> TrackState {
+		switch track {
 		case .hover:
-			return lastHoverDispatchUptime
+			return hoverState
 		case .drag:
-			return lastDragDispatchUptime
+			return dragState
 		}
 	}
 
-	private func setLastDispatchUptime(
-		_ uptime: TimeInterval,
-		for event: CaptureHostPointerDispatchEvent
-	) {
-		switch event.track {
-		case .hover:
-			lastHoverDispatchUptime = uptime
-		case .drag:
-			lastDragDispatchUptime = uptime
-		}
+	private func cancel(_ state: TrackState) {
+		state.queuedWorkItem?.cancel()
+		state.queuedWorkItem = nil
+		state.queuedEvent = nil
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureHostView.swift
@@ -102,7 +102,7 @@ final class CaptureHostView: NSView {
 		let previousSettings = self.settings
 		let previousMode = self.scene.mode
 		let transitioningToFrozen = previousMode == .live && scene.mode == .frozen
-		let frozenTransformDirtyRect = frozenSelectionTransformDirtyRect(
+		let frozenTransformInvalidation = frozenSelectionTransformInvalidation(
 			previousScene: previousScene,
 			previousChrome: previousChrome,
 			previousSettings: previousSettings,
@@ -188,48 +188,56 @@ final class CaptureHostView: NSView {
 				if previousMode == .live {
 					stopLivePresentationNow()
 				}
-				if let frozenTransformDirtyRect {
-					setNeedsDisplay(frozenTransformDirtyRect)
-				} else {
+				switch frozenTransformInvalidation {
+				case .rect(let dirtyRect):
+					setNeedsDisplay(dirtyRect)
+				case .none:
+					break
+				case .unavailable:
 					needsDisplay = true
 				}
 			}
 		}
 	}
 
-	private func frozenSelectionTransformDirtyRect(
+	private enum FrozenSelectionTransformInvalidation {
+		case unavailable
+		case none
+		case rect(CGRect)
+	}
+
+	private func frozenSelectionTransformInvalidation(
 		previousScene: SceneSnapshot,
 		previousChrome: CaptureChromeState,
 		previousSettings: NativeHostSettings,
 		nextScene: SceneSnapshot,
 		nextChrome: CaptureChromeState,
 		nextSettings: NativeHostSettings
-	) -> CGRect? {
+	) -> FrozenSelectionTransformInvalidation {
 		guard previousScene.mode == .frozen, nextScene.mode == .frozen else {
-			return nil
+			return .unavailable
 		}
 		guard previousSettings == nextSettings else {
-			return nil
+			return .unavailable
 		}
 		guard
 			previousChrome.frozenSelectionInteraction != nil
 				|| nextChrome.frozenSelectionInteraction != nil
 		else {
-			return nil
+			return .unavailable
 		}
 		guard previousChrome.frozenDisplayFrame == nextChrome.frozenDisplayFrame else {
-			return nil
+			return .unavailable
 		}
-		guard
-			let previousSelection = localRect(
-				from: previousChrome.frozenSelectionSnapshot ?? previousScene.frozenSelection),
-			let nextSelection = localRect(
-				from: nextChrome.frozenSelectionSnapshot ?? nextScene.frozenSelection)
-		else {
-			return nil
+		let previousSelection = localRect(
+			from: previousChrome.frozenSelectionSnapshot ?? previousScene.frozenSelection)
+		let nextSelection = localRect(
+			from: nextChrome.frozenSelectionSnapshot ?? nextScene.frozenSelection)
+		guard previousSelection != nil || nextSelection != nil else {
+			return .none
 		}
 
-		var dirtyRect = previousSelection.union(nextSelection)
+		var dirtyRect = previousSelection ?? nextSelection ?? .null
 		if let previousToolbarFrame = frozenToolbarFrame(
 			for: previousSelection,
 			scene: previousScene,
@@ -237,6 +245,9 @@ final class CaptureHostView: NSView {
 			settings: previousSettings
 		) {
 			dirtyRect = dirtyRect.union(previousToolbarFrame)
+		}
+		if let nextSelection {
+			dirtyRect = dirtyRect.union(nextSelection)
 		}
 		if let nextToolbarFrame = frozenToolbarFrame(
 			for: nextSelection,
@@ -247,16 +258,19 @@ final class CaptureHostView: NSView {
 			dirtyRect = dirtyRect.union(nextToolbarFrame)
 		}
 		let clippedDirtyRect = dirtyRect.insetBy(dx: -96, dy: -96).intersection(bounds)
-		return clippedDirtyRect.isNull ? nil : clippedDirtyRect
+		return clippedDirtyRect.isNull ? .none : .rect(clippedDirtyRect)
 	}
 
 	private func frozenToolbarFrame(
-		for selection: CGRect,
+		for selection: CGRect?,
 		scene: SceneSnapshot,
 		chrome: CaptureChromeState,
 		settings: NativeHostSettings
 	) -> CGRect? {
-		FrozenToolbarLayoutPlanner.layout(
+		guard let selection else {
+			return nil
+		}
+		return FrozenToolbarLayoutPlanner.layout(
 			selection: selection,
 			bounds: bounds,
 			prefersTopPlacement: settings.toolbarPlacement == .top,

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+FrozenInteraction.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSessionController+FrozenInteraction.swift
@@ -189,9 +189,14 @@ extension CaptureSessionController {
 			pointerMoved(to: point)
 			return
 		}
-		if updateFrozenSelectionTransform(to: point) {
+		switch updateFrozenSelectionTransform(to: point) {
+		case .changed:
 			refreshOverlay()
 			return
+		case .unchanged:
+			return
+		case .inactive:
+			break
 		}
 		if chromeState.frozenOverlay.update(to: point, selection: selection) {
 			refreshOverlay()
@@ -260,19 +265,27 @@ extension CaptureSessionController {
 		return true
 	}
 
-	func updateFrozenSelectionTransform(to point: CGPoint) -> Bool {
+	private enum FrozenSelectionTransformUpdate {
+		case inactive
+		case unchanged
+		case changed
+	}
+
+	private func updateFrozenSelectionTransform(
+		to point: CGPoint
+	) -> FrozenSelectionTransformUpdate {
 		guard let interaction = chromeState.frozenSelectionInteraction else {
-			return false
+			return .inactive
 		}
 		guard let nextSelection = transformedFrozenSelection(interaction: interaction, point: point)
 		else {
-			return false
+			return .inactive
 		}
 		guard chromeState.frozenSelectionSnapshot != nextSelection else {
-			return true
+			return .unchanged
 		}
 		chromeState.frozenSelectionSnapshot = nextSelection
-		return true
+		return .changed
 	}
 
 	func completeFrozenSelectionTransform(at point: CGPoint) -> Bool {

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -21,6 +21,7 @@ enum RsnapNativeHostKitProbe {
 		assertImmediateInstallGateWaitsForCaptureIdle()
 		assertCaptureHostCursorMapping()
 		assertCaptureHostPointerDispatchSupport()
+		assertCaptureHostPointerDispatchQueueSemantics()
 		assertCaptureHostLivePrimaryInteractionState()
 		assertCaptureHostFrozenFirstDisplayHandoffState()
 		assertCaptureHostScrollToolbarBackdropState()
@@ -195,6 +196,55 @@ enum RsnapNativeHostKitProbe {
 				lastDispatchUptime: 9.50) == 0
 		else {
 			fatalError("capture host pointer dispatch support should preserve throttling")
+		}
+	}
+
+	private static func assertCaptureHostPointerDispatchQueueSemantics() {
+		let recorder = PointerDispatchProbeRecorder()
+		MainActor.assumeIsolated {
+			var scheduledWorkItems: [DispatchWorkItem] = []
+			let queue = CaptureHostPointerDispatchQueue(
+				targetInterval: { 3_600 },
+				dispatchEvent: { recorder.append($0) },
+				schedule: { _, workItem in scheduledWorkItems.append(workItem) }
+			)
+			queue.enqueue(.moved(CGPoint(x: 1, y: 1)))
+			scheduledWorkItems.removeFirst().perform()
+			recorder.removeAll()
+			queue.enqueue(.moved(CGPoint(x: 3, y: 3)))
+			queue.enqueue(.frozenSelectionDragged(CGPoint(x: 2, y: 2)))
+			for workItem in scheduledWorkItems {
+				workItem.perform()
+			}
+		}
+		guard recorder.snapshot() == [.frozenSelectionDragged(CGPoint(x: 2, y: 2))] else {
+			fatalError("drag dispatch should cancel stale queued hover events")
+		}
+
+		recorder.removeAll()
+		MainActor.assumeIsolated {
+			var scheduledWorkItems: [DispatchWorkItem] = []
+			let queue = CaptureHostPointerDispatchQueue(
+				targetInterval: { 3_600 },
+				dispatchEvent: { recorder.append($0) },
+				schedule: { _, workItem in scheduledWorkItems.append(workItem) }
+			)
+			queue.enqueue(.frozenSelectionDragged(CGPoint(x: 3, y: 3)))
+			scheduledWorkItems.removeFirst().perform()
+			recorder.removeAll()
+			queue.enqueue(.frozenSelectionDragged(CGPoint(x: 5, y: 5)))
+			queue.enqueue(.moved(CGPoint(x: 4, y: 4)))
+			for workItem in scheduledWorkItems {
+				workItem.perform()
+			}
+		}
+		guard
+			recorder.snapshot() == [
+				.frozenSelectionDragged(CGPoint(x: 5, y: 5)),
+				.moved(CGPoint(x: 4, y: 4)),
+			]
+		else {
+			fatalError("hover dispatch should not cancel queued drag events")
 		}
 	}
 
@@ -1343,5 +1393,28 @@ enum RsnapNativeHostKitProbe {
 
 	private static func rowIndex(fromBottom y: Int, height: Int) -> Int {
 		max(0, min(height - 1, height - y - 1))
+	}
+}
+
+private final class PointerDispatchProbeRecorder: @unchecked Sendable {
+	private let lock = NSLock()
+	private var events: [CaptureHostPointerDispatchEvent] = []
+
+	func append(_ event: CaptureHostPointerDispatchEvent) {
+		lock.withLock {
+			events.append(event)
+		}
+	}
+
+	func removeAll() {
+		lock.withLock {
+			events.removeAll()
+		}
+	}
+
+	func snapshot() -> [CaptureHostPointerDispatchEvent] {
+		lock.withLock {
+			events
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- avoid unnecessary overlay refreshes and stale hover dispatch during frozen selection transforms
- move existing frozen toolbar Liquid Glass/content views on pure translation instead of synchronously redrawing
- keep transform invalidation window-local without adding cross-screen selection support
- document the frozen transform performance contract and add probe coverage for pointer dispatch queue semantics

## Validation
- swift format lint --strict on touched Swift files
- cargo build -p rsnap-host-ffi
- cargo test -p rsnap-capture-core selection_transform -- --nocapture
- cargo test -p rsnap-capture-core session -- --nocapture
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift run -c release --package-path native/macos-host RsnapNativeHostKitProbe
- decodex docs check
- git diff --check --cached
- VISUAL_CONTRACT_CASES=liquid REPEATED_DRAG_FREEZES=1 REPEATED_CLICK_FREEZES=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/smoke/native-visual-contract-macos.sh
- direct GUI frozen-transform check: drag-region freeze then frozen selection center drag, telemetry frozen_transform_commits=1