### PR TITLE
Release v0.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "color-eyre",
  "directories",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "color-eyre",
  "criterion",
@@ -881,14 +881,14 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "rsnap-capture-core",
 ]
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.11"
+version     = "0.2.12"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -40,8 +40,8 @@ tracing-appender         = { version = "0.2" }
 tracing-subscriber       = { version = "0.3", features = ["env-filter"] }
 ttf-parser               = { version = "0.25" }
 
-rsnap-capture-core = { version = "0.2.11", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.11", path = "packages/rsnap-host-ffi" }
+rsnap-capture-core = { version = "0.2.12", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.12", path = "packages/rsnap-host-ffi" }
 
 [profile.final-release]
 inherits = "release"


### PR DESCRIPTION
## Summary
- bump workspace and internal package versions to 0.2.12
- refresh Cargo.lock package versions for the release tag

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make checks
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-macos-native-host-stage
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-host-reset
- git diff --check

Note: SwiftPM debug builds require Xcode-beta on this macOS 27 environment; CommandLineTools alone misses SwiftUIMacros.