### PR TITLE
Fix frozen Retina selection size badge

### DIFF
--- a/native/macos-host/Sources/RsnapNativeHostKit/LivePreview.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LivePreview.swift
@@ -182,14 +182,7 @@ extension CaptureHostView {
 	}
 
 	func selectionSizeText(for rect: CGRect) -> String {
-		let scale = window?.screen?.backingScaleFactor ?? 1
-		let sizeText = "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))px"
-
-		if abs(scale - 1) <= 0.005 {
-			return sizeText
-		}
-
-		return "\(sizeText) @\(String(format: "%g", Double(scale)))x"
+		SelectionSizeText.displayText(for: rect)
 	}
 
 	private func currentHostLocalFrozenSelectingPreviewSnapshot() -> LivePreviewSnapshot? {

--- a/native/macos-host/Sources/RsnapNativeHostKit/QuickScreenshotController.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/QuickScreenshotController.swift
@@ -773,14 +773,7 @@ private final class QuickScreenshotSelectionView: NSView {
 	}
 
 	private func selectionSizeText(for rect: CGRect) -> String {
-		let scale = window?.screen?.backingScaleFactor ?? 1
-		let sizeText = "\(Int(round(rect.width * scale)))x\(Int(round(rect.height * scale)))px"
-
-		if abs(scale - 1) <= 0.005 {
-			return sizeText
-		}
-
-		return "\(sizeText) @\(String(format: "%g", Double(scale)))x"
+		SelectionSizeText.displayText(for: rect)
 	}
 
 	private func localRect(from globalRect: CGRect) -> CGRect {

--- a/native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift
@@ -1,0 +1,10 @@
+import CoreGraphics
+import Foundation
+
+package enum SelectionSizeText {
+	static func displayText(for rect: CGRect) -> String {
+		let width = Int(round(rect.width))
+		let height = Int(round(rect.height))
+		return "\(width)x\(height)px"
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 
 package enum SelectionSizeText {
-	static func displayText(for rect: CGRect) -> String {
+	package static func displayText(for rect: CGRect) -> String {
 		let width = Int(round(rect.width))
 		let height = Int(round(rect.height))
 		return "\(width)x\(height)px"

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -11,6 +11,7 @@ enum RsnapNativeHostKitProbe {
 		assertScrimExclusionPreservesExistingPixels()
 		assertRoundedExclusionMaskKeepsCornersFilled()
 		assertCaptureFrameEffectExpandsExportCanvas()
+		assertSelectionSizeTextUsesDisplayPointDimensions()
 		assertCaptureOverlayLocalPointKeepsScreenEdgesVisible()
 		assertScrollCaptureViewportPointAcceptsFlippedGlobalMouseCoordinates()
 		assertScrollCaptureObservedInputAcceptsSourceWindowGutter()
@@ -102,6 +103,19 @@ enum RsnapNativeHostKitProbe {
 				automaticallyDownloadsUpdates: true) == "install"
 		else {
 			fatalError("software update mode should treat disabled checks as off")
+		}
+	}
+
+	private static func assertSelectionSizeTextUsesDisplayPointDimensions() {
+		guard
+			SelectionSizeText.displayText(
+				for: CGRect(x: 0, y: 0, width: 3_008, height: 1_692)
+			) == "3008x1692px",
+			SelectionSizeText.displayText(
+				for: CGRect(x: 10, y: 20, width: 12.4, height: 9.6)
+			) == "12x10px"
+		else {
+			fatalError("selection size badge should report display-point dimensions")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- report selection-size badges in display-space dimensions instead of multiplying by Retina backing scale
- share the formatter between live/frozen capture and quick screenshot selection UI
- add a native host probe assertion for the Retina-sized display-point case

## Validation
- swift format lint --strict native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift native/macos-host/Sources/RsnapNativeHostKit/LivePreview.swift native/macos-host/Sources/RsnapNativeHostKit/QuickScreenshotController.swift native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
- swiftc -parse native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift
- cargo make test-macos-native-host (blocked in local CommandLineTools SwiftUI macro loading: SwiftUIMacros.StateMacro plugin not found; Rust FFI build and RsnapHostBridgeProbe completed before failure)