### PR TITLE
Release 0.2.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "color-eyre",
  "directories",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "color-eyre",
  "criterion",
@@ -881,14 +881,14 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "rsnap-capture-core",
 ]
 
 [[package]]
 name = "rsnap-perf"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/rsnap"
-version     = "0.2.12"
+version     = "0.2.13"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -40,8 +40,8 @@ tracing-appender         = { version = "0.2" }
 tracing-subscriber       = { version = "0.3", features = ["env-filter"] }
 ttf-parser               = { version = "0.25" }
 
-rsnap-capture-core = { version = "0.2.12", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.2.12", path = "packages/rsnap-host-ffi" }
+rsnap-capture-core = { version = "0.2.13", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.2.13", path = "packages/rsnap-host-ffi" }
 
 [profile.final-release]
 inherits = "release"


### PR DESCRIPTION
## Summary
- bump Rsnap workspace version to 0.2.13
- refresh Cargo.lock package versions for the release tag

## Validation
- cargo make fmt-toml-check
- cargo metadata --format-version 1 --no-deps
- confirmed v0.2.13 tag is unused locally and remotely

## Release note
After this lands, publish by pushing annotated tag v0.2.13 on main and watching the release workflow.