### PR TITLE
Fix settings shortcut recorder lifecycle

### DIFF
--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -5,7 +5,7 @@ type: "Spec"
 status: active
 authority: normative
 owner: hack-ink/rsnap
-last_verified: 2026-07-07
+last_verified: 2026-07-08
 ---
 # Settings and App Shell Contract
 
@@ -75,6 +75,11 @@ Defines:
   `Option-Shift-X`.
 - Raw event spellings such as `alt+KeyX` must not appear in user-facing shortcut fields,
   summaries, or menu shortcut labels.
+- Shortcut controls must use click-to-listen behavior instead of requiring users to type raw
+  shortcut strings. Clicking a shortcut value arms capture for the next supported key press,
+  commits the canonical platform display string, and persists the result immediately.
+- While a shortcut control is listening, `Esc`, the next mouse-down in Settings, or losing
+  Settings-window focus must cancel listening without changing the stored shortcut.
 - The default capture shortcut is `Option-X`.
 - The default quick screenshot shortcut is `Option-Shift-X`.
 - In live capture, plain `Tab` toggles the loupe on and off. Hold-to-show Tab behavior is not a

--- a/native/macos-host/Sources/RsnapNativeHostKit/CaptureSettingsPanel.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/CaptureSettingsPanel.swift
@@ -69,6 +69,7 @@ private struct LoupeSampleSizePicker: View {
 
 struct CaptureSettingsPanel: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
+	@ObservedObject var shortcutRecorder: SettingsShortcutRecorder
 
 	var body: some View {
 		VStack(spacing: 8) {
@@ -77,7 +78,7 @@ struct CaptureSettingsPanel: View {
 				title: "New Screenshot Shortcut",
 				subtitle: "Current: \(shortcutPresentation.displayTitle)."
 			) {
-				CaptureHotKeyField(model: model)
+				captureHotKeyField
 			}
 
 			SettingsHeroControlTile(
@@ -85,7 +86,7 @@ struct CaptureSettingsPanel: View {
 				title: "Quick Screenshot Shortcut",
 				subtitle: "Current: \(quickScreenshotShortcutPresentation.displayTitle)."
 			) {
-				QuickScreenshotHotKeyField(model: model)
+				quickScreenshotHotKeyField
 			}
 
 			VStack(spacing: 0) {
@@ -150,105 +151,69 @@ struct CaptureSettingsPanel: View {
 		NativeHostSettings.quickScreenshotHotKeyPresentation(
 			for: model.settings.quickScreenshotHotkey)
 	}
-}
 
-private struct CaptureHotKeyField: View {
-	@ObservedObject var model: NativeHostSettingsViewModel
-	@FocusState private var isFocused: Bool
-	@State private var draft = ""
-
-	var body: some View {
-		TextField("Option-X", text: $draft)
-			.font(.system(size: 10.5, weight: .semibold, design: .monospaced))
-			.textFieldStyle(.plain)
-			.padding(.horizontal, 10)
-			.padding(.vertical, 6)
-			.background(Color.primary.opacity(0.070), in: .rect(cornerRadius: 9))
-			.overlay {
-				RoundedRectangle(cornerRadius: 9, style: .continuous)
-					.stroke(Color.primary.opacity(0.075), lineWidth: 1)
-			}
-			.frame(width: SettingsControlLayout.controlColumnWidth)
-			.focused($isFocused)
-			.onAppear(perform: syncDraft)
-			.onSubmit(commitDraft)
-			.onChange(of: isFocused) { _, focused in
-				if focused {
-					syncDraft()
-				} else {
-					commitDraft()
-				}
-			}
-			.onChange(of: model.settings.captureHotkey) { _, _ in
-				if isFocused == false {
-					syncDraft()
-				}
-			}
-	}
-
-	private func syncDraft() {
-		draft =
-			NativeHostSettings.captureHotKeyPresentation(
+	private var captureHotKeyField: some View {
+		ShortcutRecorderField(
+			value: NativeHostSettings.captureHotKeyPresentation(
 				for: model.settings.captureHotkey
-			).displayTitle
+			).displayTitle,
+			isListening: shortcutRecorder.target == .capture
+		) {
+			shortcutRecorder.toggle(.capture) { value in
+				model.update { $0.captureHotkey = value }
+			}
+		}
+		.frame(width: SettingsControlLayout.controlColumnWidth, height: 26)
 	}
 
-	private func commitDraft() {
-		let committed = NativeHostSettings.captureHotKeyPresentation(for: draft).displayTitle
-		if committed != model.settings.captureHotkey {
-			model.update { $0.captureHotkey = committed }
+	private var quickScreenshotHotKeyField: some View {
+		ShortcutRecorderField(
+			value: NativeHostSettings.quickScreenshotHotKeyPresentation(
+				for: model.settings.quickScreenshotHotkey
+			).displayTitle,
+			isListening: shortcutRecorder.target == .quickScreenshot
+		) {
+			shortcutRecorder.toggle(.quickScreenshot) { value in
+				model.update { $0.quickScreenshotHotkey = value }
+			}
 		}
-		draft = committed
+		.frame(width: SettingsControlLayout.controlColumnWidth, height: 26)
 	}
 }
 
-private struct QuickScreenshotHotKeyField: View {
-	@ObservedObject var model: NativeHostSettingsViewModel
-	@FocusState private var isFocused: Bool
-	@State private var draft = ""
+private struct ShortcutRecorderField: View {
+	let value: String
+	let isListening: Bool
+	let onClick: () -> Void
 
 	var body: some View {
-		TextField("Option-Shift-X", text: $draft)
-			.font(.system(size: 10.5, weight: .semibold, design: .monospaced))
-			.textFieldStyle(.plain)
-			.padding(.horizontal, 10)
-			.padding(.vertical, 6)
-			.background(Color.primary.opacity(0.070), in: .rect(cornerRadius: 9))
-			.overlay {
-				RoundedRectangle(cornerRadius: 9, style: .continuous)
-					.stroke(Color.primary.opacity(0.075), lineWidth: 1)
-			}
-			.frame(width: SettingsControlLayout.controlColumnWidth)
-			.focused($isFocused)
-			.onAppear(perform: syncDraft)
-			.onSubmit(commitDraft)
-			.onChange(of: isFocused) { _, focused in
-				if focused {
-					syncDraft()
-				} else {
-					commitDraft()
+		Button(action: onClick) {
+			Text(isListening ? "Listening..." : value)
+				.font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+				.foregroundStyle(isListening ? Color.accentColor : Color.primary)
+				.lineLimit(1)
+				.minimumScaleFactor(0.75)
+				.frame(
+					width: SettingsControlLayout.controlColumnWidth,
+					height: 26,
+					alignment: .center
+				)
+				.background(
+					Color.primary.opacity(isListening ? 0.095 : 0.070),
+					in: .rect(cornerRadius: 9)
+				)
+				.overlay {
+					RoundedRectangle(cornerRadius: 9, style: .continuous)
+						.stroke(
+							isListening
+								? Color.accentColor.opacity(0.45)
+								: Color.primary.opacity(0.075),
+							lineWidth: 1)
 				}
-			}
-			.onChange(of: model.settings.quickScreenshotHotkey) { _, _ in
-				if isFocused == false {
-					syncDraft()
-				}
-			}
-	}
-
-	private func syncDraft() {
-		draft =
-			NativeHostSettings.quickScreenshotHotKeyPresentation(
-				for: model.settings.quickScreenshotHotkey
-			).displayTitle
-	}
-
-	private func commitDraft() {
-		let committed = NativeHostSettings.quickScreenshotHotKeyPresentation(for: draft)
-			.displayTitle
-		if committed != model.settings.quickScreenshotHotkey {
-			model.update { $0.quickScreenshotHotkey = committed }
+				.contentShape(.rect)
 		}
-		draft = committed
+		.buttonStyle(.plain)
+		.frame(width: SettingsControlLayout.controlColumnWidth, height: 26)
+		.accessibilityValue(isListening ? "Listening" : value)
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/GlobalHotKeyCenter.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/GlobalHotKeyCenter.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Carbon
-@preconcurrency import CoreGraphics
 import Foundation
 import RsnapHostBridge
 
@@ -17,29 +16,9 @@ final class GlobalHotKeyCenter {
 	private struct HotKeyDefinition: Equatable {
 		let keyCode: UInt32
 		let modifiers: UInt32
-
-		var eventFlags: CGEventFlags {
-			var flags = CGEventFlags()
-			if modifiers & UInt32(optionKey) != 0 {
-				flags.insert(.maskAlternate)
-			}
-			if modifiers & UInt32(cmdKey) != 0 {
-				flags.insert(.maskCommand)
-			}
-			if modifiers & UInt32(controlKey) != 0 {
-				flags.insert(.maskControl)
-			}
-			if modifiers & UInt32(shiftKey) != 0 {
-				flags.insert(.maskShift)
-			}
-			return flags
-		}
 	}
 
 	private static let signature = OSType(0x5253_4E50)  // RSNP
-	private static let trackedEventFlags: CGEventFlags = [
-		.maskAlternate, .maskCommand, .maskControl, .maskShift,
-	]
 
 	var onCaptureRequested: (() -> Void)?
 	var onQuickScreenshotRequested: (() -> Void)?
@@ -50,37 +29,19 @@ final class GlobalHotKeyCenter {
 	private var handlerRef: EventHandlerRef?
 	private var hotKeyRefs: [Binding: EventHotKeyRef?] = [:]
 	private var registeredDefinitions: [Binding: HotKeyDefinition] = [:]
-	private var quickScreenshotEventTap: CFMachPort?
-	private var quickScreenshotEventTapSource: CFRunLoopSource?
-	private var quickScreenshotEventTapDefinition: HotKeyDefinition?
 
 	init() {
-		var eventType = EventTypeSpec(
-			eventClass: OSType(kEventClassKeyboard),
-			eventKind: UInt32(kEventHotKeyPressed)
-		)
-		InstallEventHandler(
-			GetEventDispatcherTarget(),
-			{ _, eventRef, userData in
-				guard let eventRef, let userData else {
-					return OSStatus(eventNotHandledErr)
-				}
-				let center = Unmanaged<GlobalHotKeyCenter>.fromOpaque(userData)
-					.takeUnretainedValue()
-				return center.handleHotKey(eventRef)
-			},
-			1,
-			&eventType,
-			Unmanaged.passUnretained(self).toOpaque(),
-			&handlerRef
-		)
+		installEventHandlerIfNeeded()
 	}
 
-	func invalidate() {
-		unregisterQuickScreenshotEventTap()
+	func suspendRegisteredHotKeys() {
 		for binding in Binding.allCases {
 			unregister(binding)
 		}
+	}
+
+	func invalidate() {
+		suspendRegisteredHotKeys()
 		if let handlerRef {
 			RemoveEventHandler(handlerRef)
 			self.handlerRef = nil
@@ -92,6 +53,10 @@ final class GlobalHotKeyCenter {
 		quickScreenshotHotKey: String,
 		sceneMode: SceneKind
 	) -> Bool {
+		guard installEventHandlerIfNeeded() else {
+			return false
+		}
+
 		var allRequestedBindingsRegistered = true
 		let captureDefinition = Self.parseCaptureHotKey(captureHotKey) ?? Self.defaultCaptureHotKey
 		allRequestedBindingsRegistered =
@@ -99,13 +64,9 @@ final class GlobalHotKeyCenter {
 
 		let quickScreenshotDefinition =
 			Self.parseCaptureHotKey(quickScreenshotHotKey) ?? Self.defaultQuickScreenshotHotKey
-		if registerQuickScreenshotEventTap(definition: quickScreenshotDefinition) {
-			unregister(.quickScreenshot)
-		} else {
-			allRequestedBindingsRegistered =
-				register(.quickScreenshot, definition: quickScreenshotDefinition)
-				&& allRequestedBindingsRegistered
-		}
+		allRequestedBindingsRegistered =
+			register(.quickScreenshot, definition: quickScreenshotDefinition)
+			&& allRequestedBindingsRegistered
 
 		let wantsCancel = sceneMode != .hidden
 		let wantsLoupe = sceneMode == .live
@@ -136,6 +97,41 @@ final class GlobalHotKeyCenter {
 		}
 
 		return allRequestedBindingsRegistered
+	}
+
+	@discardableResult
+	private func installEventHandlerIfNeeded() -> Bool {
+		guard handlerRef == nil else {
+			return true
+		}
+		var eventType = EventTypeSpec(
+			eventClass: OSType(kEventClassKeyboard),
+			eventKind: UInt32(kEventHotKeyPressed)
+		)
+		let status = InstallEventHandler(
+			GetEventDispatcherTarget(),
+			{ _, eventRef, userData in
+				guard let eventRef, let userData else {
+					return OSStatus(eventNotHandledErr)
+				}
+				let center = Unmanaged<GlobalHotKeyCenter>.fromOpaque(userData)
+					.takeUnretainedValue()
+				return center.handleHotKey(eventRef)
+			},
+			1,
+			&eventType,
+			Unmanaged.passUnretained(self).toOpaque(),
+			&handlerRef
+		)
+		guard status == noErr, handlerRef != nil else {
+			handlerRef = nil
+			NativeHostTelemetry.lifecycleWarning(
+				"native_host.hotkey_handler_install_failed",
+				detail: "status=\(status)"
+			)
+			return false
+		}
+		return true
 	}
 
 	private func register(_ binding: Binding, definition: HotKeyDefinition) -> Bool {
@@ -183,110 +179,6 @@ final class GlobalHotKeyCenter {
 		}
 		hotKeyRefs[binding] = nil
 		registeredDefinitions.removeValue(forKey: binding)
-	}
-
-	private func registerQuickScreenshotEventTap(definition: HotKeyDefinition) -> Bool {
-		if quickScreenshotEventTapDefinition == definition, quickScreenshotEventTap != nil {
-			return true
-		}
-		unregisterQuickScreenshotEventTap()
-
-		let mask = CGEventMask(1) << CGEventType.keyDown.rawValue
-		let callback: CGEventTapCallBack = { _, type, event, userInfo in
-			guard let userInfo else {
-				return Unmanaged.passUnretained(event)
-			}
-			return MainActor.assumeIsolated {
-				let center = Unmanaged<GlobalHotKeyCenter>
-					.fromOpaque(userInfo)
-					.takeUnretainedValue()
-				return center.handleQuickScreenshotEventTap(type: type, event: event)
-			}
-		}
-		guard
-			let eventTap = CGEvent.tapCreate(
-				tap: .cgSessionEventTap,
-				place: .headInsertEventTap,
-				options: .defaultTap,
-				eventsOfInterest: mask,
-				callback: callback,
-				userInfo: Unmanaged.passUnretained(self).toOpaque()
-			)
-		else {
-			NativeHostTelemetry.lifecycleWarning(
-				"native_host.quick_screenshot_event_tap_failed",
-				detail:
-					"keyCode=\(definition.keyCode),modifiers=\(definition.modifiers)"
-			)
-			return false
-		}
-
-		let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
-		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-		CGEvent.tapEnable(tap: eventTap, enable: true)
-		quickScreenshotEventTap = eventTap
-		quickScreenshotEventTapSource = source
-		quickScreenshotEventTapDefinition = definition
-		NativeHostTelemetry.lifecycleEvent(
-			"native_host.quick_screenshot_event_tap_registered",
-			detail:
-				"keyCode=\(definition.keyCode),modifiers=\(definition.modifiers)"
-		)
-		return true
-	}
-
-	private func unregisterQuickScreenshotEventTap() {
-		let activeEventTap = quickScreenshotEventTap
-		let activeEventTapSource = quickScreenshotEventTapSource
-		quickScreenshotEventTap = nil
-		quickScreenshotEventTapSource = nil
-		quickScreenshotEventTapDefinition = nil
-
-		if let activeEventTap {
-			CGEvent.tapEnable(tap: activeEventTap, enable: false)
-		}
-		if let activeEventTapSource {
-			CFRunLoopRemoveSource(CFRunLoopGetMain(), activeEventTapSource, .commonModes)
-		}
-		if let activeEventTap {
-			CFMachPortInvalidate(activeEventTap)
-		}
-	}
-
-	private func handleQuickScreenshotEventTap(type: CGEventType, event: CGEvent)
-		-> Unmanaged<CGEvent>?
-	{
-		switch type {
-		case .tapDisabledByTimeout, .tapDisabledByUserInput:
-			if let quickScreenshotEventTap {
-				CGEvent.tapEnable(tap: quickScreenshotEventTap, enable: true)
-			}
-			return Unmanaged.passUnretained(event)
-		case .keyDown:
-			guard matchesQuickScreenshotEvent(event) else {
-				return Unmanaged.passUnretained(event)
-			}
-			if event.getIntegerValueField(.keyboardEventAutorepeat) == 0 {
-				DispatchQueue.main.async { [weak self] in
-					self?.onQuickScreenshotRequested?()
-				}
-			}
-			return nil
-		default:
-			return Unmanaged.passUnretained(event)
-		}
-	}
-
-	private func matchesQuickScreenshotEvent(_ event: CGEvent) -> Bool {
-		guard let definition = quickScreenshotEventTapDefinition else {
-			return false
-		}
-		let keyCode = UInt32(event.getIntegerValueField(.keyboardEventKeycode))
-		guard keyCode == definition.keyCode else {
-			return false
-		}
-		return event.flags.intersection(Self.trackedEventFlags)
-			== definition.eventFlags.intersection(Self.trackedEventFlags)
 	}
 
 	private func handleHotKey(_ eventRef: EventRef) -> OSStatus {
@@ -366,9 +258,10 @@ final class GlobalHotKeyCenter {
 			"a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7,
 			"c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15, "y": 16,
 			"t": 17, "1": 18, "2": 19, "3": 20, "4": 21, "6": 22, "5": 23, "=": 24,
-			"9": 25, "7": 26, "-": 27, "8": 28, "0": 29, "]": 30, "o": 31, "u": 32,
-			"[": 33, "i": 34, "p": 35, "l": 37, "j": 38, "'": 39, "k": 40, ";": 41,
-			"\\": 42, ",": 43, "/": 44, "n": 45, "m": 46, ".": 47,
+			"9": 25, "7": 26, "-": 27, "minus": 27, "8": 28, "0": 29, "]": 30,
+			"o": 31, "u": 32, "[": 33, "i": 34, "p": 35, "l": 37, "j": 38,
+			"'": 39, "k": 40, ";": 41, "\\": 42, ",": 43, "/": 44, "n": 45,
+			"m": 46, ".": 47,
 		]
 		return letterKeyCodes[key]
 	}

--- a/native/macos-host/Sources/RsnapNativeHostKit/HotKeyBindingCoordinator.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/HotKeyBindingCoordinator.swift
@@ -61,4 +61,9 @@ final class HotKeyBindingCoordinator {
 		hotKeys.invalidate()
 		appliedState = nil
 	}
+
+	func suspendBindings() {
+		hotKeys.suspendRegisteredHotKeys()
+		appliedState = nil
+	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostApp.swift
@@ -116,6 +116,7 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	private var didBootstrap = false
 	private var didPresentLaunchPermissionOnboarding = false
 	private var settingsWindowIsVisible = false
+	private var settingsShortcutRecordingActive = false
 	private var permissionRecoveryGuideIsVisible = false
 	private lazy var softwareUpdater = SoftwareUpdater()
 	@objc public dynamic var window: NSWindow?
@@ -137,6 +138,9 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	private lazy var settingsWindowController = SettingsWindowController(
 		settingsStore: settingsStore,
 		softwareUpdater: softwareUpdater,
+		onShortcutRecordingChanged: { [weak self] isRecording in
+			self?.settingsShortcutRecordingDidChange(isRecording)
+		},
 		onClose: { [weak self] in
 			self?.settingsWindowDidClose()
 		})
@@ -458,6 +462,11 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		guard let captureMenuItem else {
 			return
 		}
+		guard settingsShortcutRecordingActive == false else {
+			captureMenuItem.keyEquivalent = ""
+			captureMenuItem.keyEquivalentModifierMask = []
+			return
+		}
 		let shortcut = NativeHostSettings.captureHotKeyPresentation(
 			for: settingsStore.settings.captureHotkey)
 		captureMenuItem.keyEquivalent = shortcut.keyEquivalent
@@ -468,6 +477,11 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 		guard let quickScreenshotMenuItem else {
 			return
 		}
+		guard settingsShortcutRecordingActive == false else {
+			quickScreenshotMenuItem.keyEquivalent = ""
+			quickScreenshotMenuItem.keyEquivalentModifierMask = []
+			return
+		}
 		let shortcut = NativeHostSettings.quickScreenshotHotKeyPresentation(
 			for: settingsStore.settings.quickScreenshotHotkey)
 		quickScreenshotMenuItem.keyEquivalent = shortcut.keyEquivalent
@@ -475,6 +489,10 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 	}
 
 	private func refreshHotKeyBindings(for mode: SceneKind) {
+		guard settingsShortcutRecordingActive == false else {
+			hotKeyCoordinator.suspendBindings()
+			return
+		}
 		let effectiveMode: SceneKind = sessionController.isCaptureActive ? mode : .hidden
 		hotKeyCoordinator.update(
 			captureHotKey: settingsStore.settings.captureHotkey,
@@ -485,6 +503,13 @@ public final class NativeHostApplicationController: NSObject, NSApplicationDeleg
 
 	@objc
 	private func settingsDidChange() {
+		refreshHotKeyBindings(for: sessionController.currentSceneMode)
+		updateCaptureMenuShortcut()
+		updateQuickScreenshotMenuShortcut()
+	}
+
+	private func settingsShortcutRecordingDidChange(_ isRecording: Bool) {
+		settingsShortcutRecordingActive = isRecording
 		refreshHotKeyBindings(for: sessionController.currentSceneMode)
 		updateCaptureMenuShortcut()
 		updateQuickScreenshotMenuShortcut()

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostPanels.swift
@@ -5,6 +5,8 @@ import RsnapHostBridge
 import SwiftUI
 
 private final class SettingsWindow: NSWindow {
+	weak var shortcutRecorder: SettingsShortcutRecorder?
+
 	override var canBecomeKey: Bool {
 		true
 	}
@@ -14,6 +16,9 @@ private final class SettingsWindow: NSWindow {
 	}
 
 	override func performKeyEquivalent(with event: NSEvent) -> Bool {
+		if shortcutRecorder?.handleKeyEvent(event) == true {
+			return true
+		}
 		if handleCommandShortcut(event) {
 			return true
 		}
@@ -21,10 +26,34 @@ private final class SettingsWindow: NSWindow {
 	}
 
 	override func keyDown(with event: NSEvent) {
+		if shortcutRecorder?.handleKeyEvent(event) == true {
+			return
+		}
 		if handleCommandShortcut(event) {
 			return
 		}
 		super.keyDown(with: event)
+	}
+
+	override func sendEvent(_ event: NSEvent) {
+		if shortcutRecorder?.isRecording == true {
+			switch event.type {
+			case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+				shortcutRecorder?.cancel()
+				return
+			default:
+				break
+			}
+		}
+		super.sendEvent(event)
+	}
+
+	override func cancelOperation(_ sender: Any?) {
+		if shortcutRecorder?.isRecording == true {
+			shortcutRecorder?.cancel()
+			return
+		}
+		super.cancelOperation(sender)
 	}
 
 	private func handleCommandShortcut(_ event: NSEvent) -> Bool {
@@ -53,16 +82,20 @@ private final class SettingsWindow: NSWindow {
 @MainActor
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 	private let viewModel: NativeHostSettingsViewModel
+	let shortcutRecorder = SettingsShortcutRecorder()
 	private let onClose: () -> Void
+	private let onShortcutRecordingChanged: (Bool) -> Void
 
 	init(
 		settingsStore: NativeHostSettingsStore,
 		softwareUpdater: SoftwareUpdater,
+		onShortcutRecordingChanged: @escaping (Bool) -> Void = { _ in },
 		onClose: @escaping () -> Void = {}
 	) {
 		self.viewModel = NativeHostSettingsViewModel(
 			settingsStore: settingsStore,
 			softwareUpdater: softwareUpdater)
+		self.onShortcutRecordingChanged = onShortcutRecordingChanged
 		self.onClose = onClose
 
 		let contentRect = NSRect(
@@ -78,6 +111,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 			defer: false
 		)
 		window.title = "Settings"
+		window.shortcutRecorder = shortcutRecorder
 		window.titleVisibility = .hidden
 		window.titlebarAppearsTransparent = true
 		window.isMovableByWindowBackground = false
@@ -96,11 +130,14 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
 		window.delegate = self
 		let hostingController = NSHostingController(
-			rootView: NativeHostSettingsView(model: viewModel))
+			rootView: NativeHostSettingsView(
+				model: viewModel,
+				shortcutRecorder: shortcutRecorder))
 		hostingController.view.wantsLayer = true
 		hostingController.view.layer?.backgroundColor = NSColor.clear.cgColor
 		window.contentViewController = hostingController
 		window.center()
+		shortcutRecorder.onRecordingChanged = onShortcutRecordingChanged
 		viewModel.refresh()
 	}
 
@@ -129,7 +166,12 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 	}
 
 	func windowWillClose(_: Notification) {
+		shortcutRecorder.cancel()
 		onClose()
+	}
+
+	func windowDidResignKey(_: Notification) {
+		shortcutRecorder.cancel()
 	}
 }
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettings.swift
@@ -147,6 +147,9 @@ final class NativeHostSettingsStore {
 
 struct NativeHostSettings: Equatable {
 	static let defaultQuickScreenshotHotkey = "Option-Shift-X"
+	private static let configurableModifierFlags: NSEvent.ModifierFlags = [
+		.control, .option, .shift, .command,
+	]
 
 	var captureHotkey: String
 	var quickScreenshotHotkey: String
@@ -253,6 +256,31 @@ struct NativeHostSettings: Equatable {
 		hotKeyPresentation(for: raw, fallback: defaultQuickScreenshotHotkey)
 	}
 
+	static func hotKeyDisplayTitle(
+		for modifierFlags: NSEvent.ModifierFlags,
+		keyCode: UInt32
+	) -> String? {
+		guard let key = hotKeyToken(forKeyCode: keyCode) else {
+			return nil
+		}
+		let modifiers = modifierFlags.intersection(configurableModifierFlags)
+		var titleParts: [String] = []
+		if modifiers.contains(.control) {
+			titleParts.append("Control")
+		}
+		if modifiers.contains(.option) {
+			titleParts.append("Option")
+		}
+		if modifiers.contains(.shift) {
+			titleParts.append("Shift")
+		}
+		if modifiers.contains(.command) {
+			titleParts.append("Command")
+		}
+		titleParts.append(key)
+		return titleParts.joined(separator: "-")
+	}
+
 	static func hotKeyPresentation(for raw: String, fallback: String)
 		-> CaptureHotKeyPresentation
 	{
@@ -305,7 +333,7 @@ struct NativeHostSettings: Equatable {
 		if modifiers.contains(.command) {
 			titleParts.append("Command")
 		}
-		titleParts.append(keyEquivalent.uppercased())
+		titleParts.append(displayKeyTitle(for: keyEquivalent))
 		return CaptureHotKeyPresentation(
 			displayTitle: titleParts.joined(separator: "-"),
 			keyEquivalent: keyEquivalent,
@@ -316,10 +344,33 @@ struct NativeHostSettings: Equatable {
 	private static func normalizedMenuKeyEquivalent(for token: String) -> String? {
 		let normalized = token.lowercased()
 		let key = normalized.hasPrefix("key") ? String(normalized.dropFirst(3)) : normalized
+		if key == "minus" {
+			return "-"
+		}
 		guard key.count == 1, key.unicodeScalars.allSatisfy(\.isASCII) else {
 			return nil
 		}
 		return key
+	}
+
+	private static func displayKeyTitle(for keyEquivalent: String) -> String {
+		if keyEquivalent == "-" {
+			return "Minus"
+		}
+		return keyEquivalent.uppercased()
+	}
+
+	private static func hotKeyToken(forKeyCode keyCode: UInt32) -> String? {
+		let keyTokensByCode: [UInt32: String] = [
+			0: "a", 1: "s", 2: "d", 3: "f", 4: "h", 5: "g", 6: "z", 7: "x",
+			8: "c", 9: "v", 11: "b", 12: "q", 13: "w", 14: "e", 15: "r",
+			16: "y", 17: "t", 18: "1", 19: "2", 20: "3", 21: "4", 22: "6",
+			23: "5", 24: "=", 25: "9", 26: "7", 27: "Minus", 28: "8", 29: "0",
+			30: "]", 31: "o", 32: "u", 33: "[", 34: "i", 35: "p", 37: "l",
+			38: "j", 39: "'", 40: "k", 41: ";", 42: "\\", 43: ",", 44: "/",
+			45: "n", 46: "m", 47: ".",
+		]
+		return keyTokensByCode[keyCode]
 	}
 
 	static func captureHotKeyTokens(from raw: String) -> [String] {

--- a/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/NativeHostSettingsView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 enum NativeHostSettingsWindowMetrics {
 	static let width: CGFloat = 620
-	static let minHeight: CGFloat = 332
-	static let idealHeight: CGFloat = 332
+	static let minHeight: CGFloat = 340
+	static let idealHeight: CGFloat = 340
 	static let cornerRadius: CGFloat = 18
 }
 
@@ -76,6 +76,7 @@ final class NativeHostSettingsViewModel: ObservableObject {
 
 struct NativeHostSettingsView: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
+	@ObservedObject var shortcutRecorder: SettingsShortcutRecorder
 	@State private var selectedSection: NativeHostSettingsSection = .appearance
 	private let sidebarWidth: CGFloat = 142
 
@@ -83,21 +84,20 @@ struct NativeHostSettingsView: View {
 		ZStack {
 			SettingsAtmosphere(tintHue: model.settings.hudTintHue)
 
-			HStack(alignment: .top, spacing: 10) {
+			HStack(alignment: .top, spacing: SettingsControlLayout.margin) {
 				SettingsRail(selectedSection: $selectedSection)
 					.frame(width: sidebarWidth)
-					.padding(.top, 24)
+					.padding(.top, SettingsControlLayout.sidebarTitlebarOffset)
 
 				SettingsDashboard(
 					model: model,
+					shortcutRecorder: shortcutRecorder,
 					section: selectedSection,
 					restoreDefaults: model.restoreDefaults
 				)
 				.frame(maxWidth: .infinity, alignment: .topLeading)
 			}
-			.padding(.top, 12)
-			.padding(.horizontal, 14)
-			.padding(.bottom, 12)
+			.padding(SettingsControlLayout.margin)
 		}
 		.ignoresSafeArea(.container, edges: .top)
 		.controlSize(.small)
@@ -131,7 +131,7 @@ private struct SettingsSectionInspector: View {
 		}
 		.padding(14)
 		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-		.settingsGlassSurface(cornerRadius: 18, role: .panel)
+		.settingsGlassSurface(cornerRadius: SettingsControlLayout.panelCornerRadius, role: .panel)
 	}
 }
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/SettingsNavigation.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/SettingsNavigation.swift
@@ -89,7 +89,6 @@ struct SettingsRail: View {
 				}
 			}
 		}
-		.padding(.top, 2)
 	}
 }
 
@@ -186,11 +185,12 @@ private struct SettingsRailButton: View {
 
 struct SettingsDashboard: View {
 	@ObservedObject var model: NativeHostSettingsViewModel
+	@ObservedObject var shortcutRecorder: SettingsShortcutRecorder
 	let section: NativeHostSettingsSection
 	let restoreDefaults: () -> Void
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 6) {
+		VStack(alignment: .leading, spacing: SettingsControlLayout.panelContentSpacing) {
 			SettingsContentHeader(
 				section: section,
 				restoreDefaults: restoreDefaults
@@ -205,16 +205,13 @@ struct SettingsDashboard: View {
 							removal: .opacity.combined(with: .move(edge: .top))
 						)
 					)
-					.padding(.trailing, 8)
-					.padding(.bottom, 2)
 			}
 			.scrollIndicators(.hidden)
 			.frame(maxWidth: .infinity, alignment: .topLeading)
 			.animation(.spring(response: 0.34, dampingFraction: 0.86), value: section)
 		}
-		.padding(.horizontal, 13)
-		.padding(.vertical, 9)
-		.settingsGlassSurface(cornerRadius: 18, role: .panel)
+		.padding(SettingsControlLayout.margin)
+		.settingsGlassSurface(cornerRadius: SettingsControlLayout.panelCornerRadius, role: .panel)
 	}
 
 	@ViewBuilder
@@ -223,7 +220,7 @@ struct SettingsDashboard: View {
 		case .appearance:
 			AppearanceSettingsPanel(model: model)
 		case .capture:
-			CaptureSettingsPanel(model: model)
+			CaptureSettingsPanel(model: model, shortcutRecorder: shortcutRecorder)
 		case .output:
 			OutputSettingsPanel(model: model)
 		case .permissions:
@@ -258,6 +255,5 @@ private struct SettingsContentHeader: View {
 				.controlSize(.small)
 			}
 		}
-		.padding(.bottom, 2)
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKit/SettingsShortcutRecorder.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/SettingsShortcutRecorder.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class SettingsShortcutRecorder: ObservableObject {
+	enum Target {
+		case capture
+		case quickScreenshot
+	}
+
+	@Published private(set) var target: Target?
+
+	var isRecording: Bool {
+		target != nil
+	}
+
+	var onRecordingChanged: ((Bool) -> Void)?
+
+	private var commitHandler: ((String) -> Void)?
+
+	func toggle(_ target: Target, onCommit: @escaping (String) -> Void) {
+		if self.target == target {
+			cancel()
+			return
+		}
+		begin(target, onCommit: onCommit)
+	}
+
+	func cancel() {
+		guard target != nil else {
+			return
+		}
+		target = nil
+		commitHandler = nil
+		onRecordingChanged?(false)
+	}
+
+	func handleKeyEvent(_ event: NSEvent) -> Bool {
+		guard target != nil else {
+			return false
+		}
+		if event.keyCode == 53 {
+			cancel()
+			return true
+		}
+		guard
+			let title = NativeHostSettings.hotKeyDisplayTitle(
+				for: event.modifierFlags,
+				keyCode: UInt32(event.keyCode))
+		else {
+			NSSound.beep()
+			return true
+		}
+
+		let handler = commitHandler
+		target = nil
+		commitHandler = nil
+		onRecordingChanged?(false)
+		DispatchQueue.main.async {
+			handler?(title)
+		}
+		return true
+	}
+
+	private func begin(_ target: Target, onCommit: @escaping (String) -> Void) {
+		let wasRecording = self.target != nil
+		self.target = target
+		self.commitHandler = onCommit
+		if wasRecording == false {
+			onRecordingChanged?(true)
+		}
+	}
+}

--- a/native/macos-host/Sources/RsnapNativeHostKit/SettingsSurface.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/SettingsSurface.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 enum SettingsControlLayout {
+	static let margin: CGFloat = 10
+	static let sidebarTitlebarOffset: CGFloat = 24
+	static let panelContentSpacing: CGFloat = 8
+	static var panelCornerRadius: CGFloat {
+		max(8, NativeHostSettingsWindowMetrics.cornerRadius - margin)
+	}
 	static let controlColumnWidth: CGFloat = 178
 	static let sliderValueWidth: CGFloat = 34
 	static let sliderTrackWidth: CGFloat = 136


### PR DESCRIPTION
## Summary
- Replace raw shortcut text fields with a fixed-size click-to-listen recorder
- Suspend registered hotkeys while recording without tearing down the Carbon handler
- Normalize settings spacing/corner alignment and document shortcut recorder behavior

## Verification
- swift format lint --strict on touched Swift files
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make build-swift-strict
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-macos-native-host
- RSNAP_NATIVE_HOST_FORCE_REBUILD=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer ./scripts/build_and_run.sh --verify
- Manual AX flow: Esc cancel keeps Option-X, record Control-Option-9, record back Option-X, close settings, Option-X triggers ScreenCaptureKit startCapture
