### PR TITLE
Harden macOS tag release automation

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Run Swift tests
         run: cargo make test-swift
 
+      - name: Run release workflow self-check
+        run: cargo make test-release
+
   toml-check:
     name: TOML check
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
@@ -9,6 +9,8 @@ env:
   RUST_BACKTRACE: full
   MACOS_RELEASE_ASSET: rsnap-aarch64-apple-darwin.zip
   MACOS_APPCAST_ASSET: appcast.xml
+  MACOS_CHECKSUM_ASSET: rsnap-aarch64-apple-darwin.zip.sha256
+  SPARKLE_PUBLIC_ED_KEY: X2EaTv6mCzkYxz75Hh+ldMkKlpzNlHRg5l7Kn9ke8Ow=
 
 on:
   push:
@@ -16,32 +18,54 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  build-macos:
-    name: Build signed macOS package
-    runs-on: macos-26
+  validate-release:
+    name: Validate release source
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      sparkle_version: ${{ steps.source.outputs.sparkle_version }}
+      tag_commit: ${{ steps.source.outputs.tag_commit }}
+      version: ${{ steps.source.outputs.version }}
     steps:
-      - name: Fetch latest code
+      - name: Fetch tagged source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Verify release tag and runner
+      - name: Fetch canonical main
+        run: git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+
+      - name: Validate tag, versions, and source commit
+        id: source
+        run: scripts/release/validate-release-source.py
+
+  build-macos:
+    name: Test, sign, and package macOS app
+    needs: validate-release
+    runs-on: macos-26
+    timeout-minutes: 75
+    env:
+      RSNAP_RELEASE_COMMIT: ${{ needs.validate-release.outputs.tag_commit }}
+      RSNAP_RELEASE_TAG: ${{ github.ref_name }}
+      RSNAP_RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+    steps:
+      - name: Fetch validated source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify source and Apple toolchain
         run: |
           set -euo pipefail
-
-          VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' Cargo.toml | head -n 1)"
-          if [[ "v${VERSION}" != "${GITHUB_REF_NAME}" ]]; then
-            echo "Tag ${GITHUB_REF_NAME} does not match Cargo workspace version ${VERSION}" >&2
-            exit 1
-          fi
-
-          if [[ "$(uname -m)" != "arm64" ]]; then
-            echo "The macOS release asset is named for aarch64; expected an arm64 runner." >&2
-            exit 1
-          fi
-
+          test "$(git rev-parse 'HEAD^{commit}')" = "$RSNAP_RELEASE_COMMIT"
+          test "$RUNNER_ARCH" = "ARM64"
+          test "$(uname -m)" = "arm64"
           sw_vers
           swift --version
           xcodebuild -version
@@ -50,20 +74,25 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: true
+          rustflags: ""
 
-      - name: Bundle, sign, optionally notarize, and pack (macOS)
+      - name: Install cargo-make
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-make
+
+      - name: Run release tests
+        run: cargo make test-macos-release
+
+      - name: Build, sign, and validate package
         env:
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-          APPLE_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
-          APPLE_NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
           SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
           set -euo pipefail
-
-          VERSION="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version *= *"\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+          umask 077
 
           for required_secret in \
             APPLE_CERTIFICATE_P12_BASE64 \
@@ -75,119 +104,131 @@ jobs:
               exit 1
             fi
           done
-
-          NOTARY_ENABLED=0
-          if [[ -n "${APPLE_NOTARY_KEY_ID:-}" && -n "${APPLE_NOTARY_KEY_P8:-}" ]]; then
-            NOTARY_ENABLED=1
-          else
-            echo "::warning::Apple notary credentials are incomplete; publishing a signed but unnotarized macOS zip."
+          if [[ "$APPLE_SIGNING_IDENTITY" != "Apple Development: "* ]]; then
+            echo "APPLE_SIGNING_IDENTITY must name the approved Apple Development identity." >&2
+            exit 1
           fi
+          echo "::warning::Personal Team distribution is signed with Apple Development and is not notarized."
 
-          CERT_PATH="${RUNNER_TEMP}/apple-cert.p12"
-          KEYCHAIN_PATH="${RUNNER_TEMP}/build.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
-          NOTARY_KEY_PATH=""
+          CERT_PATH="$RUNNER_TEMP/apple-cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/rsnap-build.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
 
-          CERT_PATH="${CERT_PATH}" python - <<'PY'
+          cleanup() {
+            security delete-keychain "$KEYCHAIN_PATH" >/dev/null 2>&1 || true
+            rm -f "$CERT_PATH"
+          }
+          trap cleanup EXIT
+
+          CERT_PATH="$CERT_PATH" python3 - <<'PY'
           import base64
           import os
           from pathlib import Path
+
           Path(os.environ["CERT_PATH"]).write_bytes(
-              base64.b64decode(os.environ["APPLE_CERTIFICATE_P12_BASE64"])
+              base64.b64decode(
+                  os.environ["APPLE_CERTIFICATE_P12_BASE64"],
+                  validate=True,
+              )
           )
           PY
 
-          if [[ "${NOTARY_ENABLED}" == "1" ]]; then
-            NOTARY_KEY_PATH="${RUNNER_TEMP}/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
-            printf '%s' "${APPLE_NOTARY_KEY_P8}" > "${NOTARY_KEY_PATH}"
-          fi
-
-          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
-          security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
-          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
-          security import "${CERT_PATH}" \
-            -k "${KEYCHAIN_PATH}" \
-            -P "${APPLE_CERTIFICATE_PASSWORD}" \
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
-          security list-keychains -d user -s "${KEYCHAIN_PATH}"
-          security default-keychain -d user -s "${KEYCHAIN_PATH}"
-          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
-          security find-identity -v -p codesigning "${KEYCHAIN_PATH}"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep -F -- "\"$APPLE_SIGNING_IDENTITY\""
 
-          RSNAP_NATIVE_HOST_RUST_PROFILE=final-release \
-          RSNAP_NATIVE_HOST_SWIFT_CONFIGURATION=release \
-          RSNAP_NATIVE_HOST_SIGN_IDENTITY="${APPLE_SIGNING_IDENTITY}" \
-          ./scripts/build_and_run.sh stage
+          printf '%s\n' "$SPARKLE_PRIVATE_ED_KEY" \
+            | swift scripts/release/verify-sparkle-key.swift "$SPARKLE_PUBLIC_ED_KEY"
+
+          RSNAP_NATIVE_HOST_FORCE_REBUILD=1 \
+          RSNAP_NATIVE_HOST_SIGN_IDENTITY="$APPLE_SIGNING_IDENTITY" \
+          RSNAP_NATIVE_HOST_SIGN_KEYCHAIN="$KEYCHAIN_PATH" \
+            ./scripts/build_and_run.sh stage
 
           APP_PATH="target/rsnap-native-host/Rsnap.app"
-          if [[ ! -d "${APP_PATH}" ]]; then
-            echo "Failed to find staged native host app at ${APP_PATH}" >&2
-            exit 1
-          fi
-          ACTUAL_APP_BUNDLE="$(find "target/rsnap-native-host" -maxdepth 1 -type d -iname 'Rsnap.app' -print -quit)"
-          test -n "${ACTUAL_APP_BUNDLE}"
-          test "$(basename "${ACTUAL_APP_BUNDLE}")" = "Rsnap.app"
-          test "$(plutil -extract CFBundleName raw "${APP_PATH}/Contents/Info.plist")" = "Rsnap"
-          test "$(plutil -extract CFBundleDisplayName raw "${APP_PATH}/Contents/Info.plist")" = "Rsnap"
-
-          codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
-          codesign -dv --verbose=4 "${APP_PATH}"
-
-          if [[ "${NOTARY_ENABLED}" == "1" ]]; then
-            NOTARY_ZIP="${RUNNER_TEMP}/Rsnap-notary.zip"
-            ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${NOTARY_ZIP}"
-
-            NOTARY_ARGS=(
-              submit
-              "${NOTARY_ZIP}"
-              --wait
-              --timeout 30m
-              --key "${NOTARY_KEY_PATH}"
-              --key-id "${APPLE_NOTARY_KEY_ID}"
-            )
-            if [[ -n "${APPLE_NOTARY_ISSUER:-}" ]]; then
-              NOTARY_ARGS+=(--issuer "${APPLE_NOTARY_ISSUER}")
-            fi
-            xcrun notarytool "${NOTARY_ARGS[@]}"
-
-            xcrun stapler staple "${APP_PATH}"
-            spctl -a -vvv --type exec "${APP_PATH}"
-          fi
+          test -d "$APP_PATH"
+          test "$(plutil -extract CFBundleName raw "$APP_PATH/Contents/Info.plist")" = "Rsnap"
+          test "$(plutil -extract CFBundleDisplayName raw "$APP_PATH/Contents/Info.plist")" = "Rsnap"
+          test "$(plutil -extract CFBundleIdentifier raw "$APP_PATH/Contents/Info.plist")" = "ink.hack.rsnap"
+          test "$(plutil -extract CFBundleVersion raw "$APP_PATH/Contents/Info.plist")" = "$RSNAP_RELEASE_VERSION"
+          test "$(plutil -extract CFBundleShortVersionString raw "$APP_PATH/Contents/Info.plist")" = "$RSNAP_RELEASE_VERSION"
+          test "$(plutil -extract SUFeedURL raw "$APP_PATH/Contents/Info.plist")" = \
+            "https://github.com/acg-box/rsnap/releases/latest/download/appcast.xml"
+          test "$(plutil -extract SUPublicEDKey raw "$APP_PATH/Contents/Info.plist")" = \
+            "$SPARKLE_PUBLIC_ED_KEY"
+          codesign --verify --deep --strict --verbose=4 "$APP_PATH"
 
           ditto -c -k --sequesterRsrc --keepParent \
-            "${APP_PATH}" \
-            "${MACOS_RELEASE_ASSET}"
-
+            "$APP_PATH" \
+            "$MACOS_RELEASE_ASSET"
           scripts/release/sparkle-appcast.sh \
-            --archive "${MACOS_RELEASE_ASSET}" \
-            --appcast "${MACOS_APPCAST_ASSET}" \
-            --version "${VERSION}" \
-            --tag "${GITHUB_REF_NAME}"
+            --archive "$MACOS_RELEASE_ASSET" \
+            --appcast "$MACOS_APPCAST_ASSET" \
+            --version "$RSNAP_RELEASE_VERSION" \
+            --tag "$RSNAP_RELEASE_TAG"
+          ARCHIVE_SHA256="$(shasum -a 256 "$MACOS_RELEASE_ASSET" | awk '{print $1}')"
+          printf '%s  %s\n' "$ARCHIVE_SHA256" "$MACOS_RELEASE_ASSET" \
+            >"$MACOS_CHECKSUM_ASSET"
+          scripts/release/validate-release-artifacts.py \
+            --archive "$MACOS_RELEASE_ASSET" \
+            --appcast "$MACOS_APPCAST_ASSET" \
+            --checksum "$MACOS_CHECKSUM_ASSET" \
+            --version "$RSNAP_RELEASE_VERSION" \
+            --tag "$RSNAP_RELEASE_TAG" \
+            --repository "$GITHUB_REPOSITORY"
 
-      - name: Upload artifact
+      - name: Upload validated release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rsnap-aarch64-apple-darwin
           path: |
             ${{ env.MACOS_RELEASE_ASSET }}
             ${{ env.MACOS_APPCAST_ASSET }}
+            ${{ env.MACOS_CHECKSUM_ASSET }}
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
-  release:
-    name: Release
+  publish-release:
+    name: Validate draft and publish release
+    needs: [validate-release, build-macos]
     runs-on: ubuntu-latest
-    needs: [build-macos]
+    timeout-minutes: 20
+    environment:
+      name: release
+    permissions:
+      contents: write
+    env:
+      RSNAP_RELEASE_COMMIT: ${{ needs.validate-release.outputs.tag_commit }}
+      RSNAP_RELEASE_TAG: ${{ github.ref_name }}
+      RSNAP_RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
     steps:
-      - name: Download artifacts
+      - name: Fetch validated source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download validated release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rsnap-aarch64-apple-darwin
           path: artifacts
 
-      - name: Publish
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          generate_release_notes: true
-          files: artifacts/*
+      - name: Create, validate, and publish GitHub draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RSNAP_RELEASE_INPUT_DIR: artifacts
+        run: scripts/release/publish-github-release.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition     = "2024"
 homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
-repository  = "https://github.com/acgxv/rsnap"
+repository  = "https://github.com/acg-box/rsnap"
 version     = "0.3.0"
 
 [workspace.dependencies]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -150,6 +150,8 @@ args = [
 	"--recursive",
 	"--parallel",
 	"native/macos-host/Sources",
+	"scripts/release/tests/generate-sparkle-test-keys.swift",
+	"scripts/release/verify-sparkle-key.swift",
 	"scripts/smoke/lib/live-hud-mouse-path.swift",
 	"scripts/smoke/lib/mask-probe-capture.swift",
 	"scripts/smoke/lib/pasteboard-image-info.swift",
@@ -169,6 +171,8 @@ args = [
 	"--strict",
 	"--parallel",
 	"native/macos-host/Sources",
+	"scripts/release/tests/generate-sparkle-test-keys.swift",
+	"scripts/release/verify-sparkle-key.swift",
 	"scripts/smoke/lib/live-hud-mouse-path.swift",
 	"scripts/smoke/lib/mask-probe-capture.swift",
 	"scripts/smoke/lib/pasteboard-image-info.swift",
@@ -306,14 +310,28 @@ args = [
 # | test-host-ffi-header         | command   |     |
 # | test-macos-native-host       | command   |     |
 # | test-macos-native-host-stage | command   |     |
+# | test-macos-release           | script    |     |
+# | test-release                 | script    |     |
 
 [tasks.test]
 clear = true
 workspace = false
 dependencies = [
+	"test-release",
 	"test-rust",
 	"test-swift",
 ]
+
+[tasks.test-release]
+workspace = false
+script = '''
+python3 -m unittest discover \
+  -s scripts/release/tests \
+  -p 'test_*.py'
+for test_script in scripts/release/tests/test-*.sh; do
+  "$test_script"
+done
+'''
 
 [tasks.test-rust]
 workspace = false
@@ -391,8 +409,9 @@ test -x "$APP_PATH/Contents/MacOS/RsnapNativeHost"
 test -f "$APP_PATH/Contents/Info.plist"
 test -f "$APP_PATH/Contents/Resources/AppIcon.icns"
 test -d "$APP_PATH/Contents/Frameworks/Sparkle.framework"
-otool -L "$APP_PATH/Contents/MacOS/RsnapNativeHost" | grep -q '@rpath/Sparkle.framework'
-otool -l "$APP_PATH/Contents/MacOS/RsnapNativeHost" | grep -q '@executable_path/../Frameworks'
+otool -L "$APP_PATH/Contents/MacOS/RsnapNativeHost" | grep '@rpath/Sparkle.framework' >/dev/null
+otool -l "$APP_PATH/Contents/MacOS/RsnapNativeHost" \
+  | grep '@executable_path/../Frameworks' >/dev/null
 if otool -l "$APP_PATH/Contents/MacOS/RsnapNativeHost" \
   | awk '$1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next } in_rpath && $1 == "path" { sub(/^[[:space:]]*path /, ""); sub(/[[:space:]]+\(offset [0-9]+\)$/, ""); print; in_rpath = 0 }' \
   | grep -E '^(/Applications/.*\.app/Contents/Developer/Toolchains/.*/usr/lib/swift[^/]*/macosx|/Library/Developer/CommandLineTools/usr/lib/swift[^/]*/macosx|/Users/.*/Applications/.*\.app/Contents/Developer/Toolchains/.*/usr/lib/swift[^/]*/macosx)$'; then
@@ -403,7 +422,7 @@ plutil -extract CFBundleName raw "$APP_PATH/Contents/Info.plist" | grep -qx 'Rsn
 plutil -extract CFBundleDisplayName raw "$APP_PATH/Contents/Info.plist" | grep -qx 'Rsnap'
 plutil -extract CFBundleIdentifier raw "$APP_PATH/Contents/Info.plist" | grep -qx 'ink.hack.rsnap'
 plutil -extract SUFeedURL raw "$APP_PATH/Contents/Info.plist" \
-  | grep -qx 'https://github.com/acgxv/rsnap/releases/latest/download/appcast.xml'
+  | grep -qx 'https://github.com/acg-box/rsnap/releases/latest/download/appcast.xml'
 plutil -extract SUPublicEDKey raw "$APP_PATH/Contents/Info.plist" \
   | grep -qx 'X2EaTv6mCzkYxz75Hh+ldMkKlpzNlHRg5l7Kn9ke8Ow='
 plutil -extract SUEnableAutomaticChecks raw "$APP_PATH/Contents/Info.plist" | grep -qx 'true'
@@ -413,6 +432,29 @@ if plutil -extract LSUIElement raw "$APP_PATH/Contents/Info.plist" >/dev/null 2>
   echo "LSUIElement must stay unset so Settings is a normal foreground window" >&2
   exit 1
 fi
+'''
+
+[tasks.test-macos-release]
+workspace = false
+dependencies = [
+	"test-release",
+]
+script = '''
+cargo test --workspace --all-targets --all-features --profile final-release
+cargo build -p rsnap-host-ffi --profile final-release
+swift package --package-path native/macos-host clean
+RSNAP_HOST_FFI_LIB_DIR="$PWD/target/final-release" \
+swift run \
+  --package-path native/macos-host \
+  --disable-automatic-resolution \
+  --configuration release \
+  RsnapHostBridgeProbe
+RSNAP_HOST_FFI_LIB_DIR="$PWD/target/final-release" \
+swift run \
+  --package-path native/macos-host \
+  --disable-automatic-resolution \
+  --configuration release \
+  RsnapNativeHostKitProbe
 '''
 
 # Build

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 macOS-first screenshot app built with a native host and Rust core.
 
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Language Checks](https://github.com/acgxv/rsnap/actions/workflows/language.yml/badge.svg?branch=main)](https://github.com/acgxv/rsnap/actions/workflows/language.yml)
-[![Release](https://github.com/acgxv/rsnap/actions/workflows/release.yml/badge.svg)](https://github.com/acgxv/rsnap/actions/workflows/release.yml)
-[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/acgxv/rsnap)](https://github.com/acgxv/rsnap/tags)
-[![GitHub last commit](https://img.shields.io/github/last-commit/acgxv/rsnap?color=red&style=plastic)](https://github.com/acgxv/rsnap)
-[![GitHub code lines](https://tokei.rs/b1/github/acgxv/rsnap)](https://github.com/acgxv/rsnap)
+[![Language Checks](https://github.com/acg-box/rsnap/actions/workflows/language.yml/badge.svg?branch=main)](https://github.com/acg-box/rsnap/actions/workflows/language.yml)
+[![Release](https://github.com/acg-box/rsnap/actions/workflows/release.yml/badge.svg)](https://github.com/acg-box/rsnap/actions/workflows/release.yml)
+[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/acg-box/rsnap)](https://github.com/acg-box/rsnap/tags)
+[![GitHub last commit](https://img.shields.io/github/last-commit/acg-box/rsnap?color=red&style=plastic)](https://github.com/acg-box/rsnap)
+[![GitHub code lines](https://tokei.rs/b1/github/acg-box/rsnap)](https://github.com/acg-box/rsnap)
 
 https://github.com/user-attachments/assets/ff2fe84f-f551-40e8-919c-66ae8a61f8e7
 
@@ -88,7 +88,7 @@ Prototype / in active development.
 
 Download the latest macOS zip:
 
-<https://github.com/acgxv/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip>
+<https://github.com/acg-box/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip>
 
 Unzip it and move `Rsnap.app` to `/Applications`.
 
@@ -99,7 +99,7 @@ with the Sparkle appcast configured.
 #### Build from Source
 
 ```sh
-git clone https://github.com/acgxv/rsnap
+git clone https://github.com/acg-box/rsnap
 cd rsnap
 
 cargo build --workspace
@@ -108,11 +108,14 @@ cargo run -p rsnap
 
 #### macOS Gatekeeper approval for signed but unnotarized builds
 
-Current preview release builds are signed, but may not be notarized by Apple. If macOS blocks
-`Rsnap.app` after you unzip a downloaded build, use the quarantine override only for a bundle you
-built yourself or downloaded from this repository's GitHub Releases page.
+Current preview release builds are signed, but are not notarized by Apple. If macOS blocks
+`Rsnap.app` after you unzip a downloaded build, first try to open it. Then open `System Settings`
+-> `Privacy & Security`, find the message about Rsnap, and select `Open Anyway`. Authenticate and
+confirm `Open` when macOS asks. Do this only for a bundle that you built or downloaded from this
+repository's GitHub Releases page.
 
-Move the app to `/Applications`, then run:
+If `Open Anyway` is not available, move the trusted app to `/Applications`, then use this terminal
+fallback:
 
 ```sh
 xattr -rd com.apple.quarantine /Applications/Rsnap.app

--- a/docs/decisions/annotation-pen-style.md
+++ b/docs/decisions/annotation-pen-style.md
@@ -4,7 +4,7 @@ description: "Annotation Pen Style documentation for Rsnap."
 type: "Decision"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Annotation Pen Style

--- a/docs/decisions/frozen-toolbar-anchor.md
+++ b/docs/decisions/frozen-toolbar-anchor.md
@@ -4,7 +4,7 @@ description: "Frozen Toolbar Stable Anchor documentation for Rsnap."
 type: "Decision"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Frozen Toolbar Stable Anchor

--- a/docs/decisions/native-host-rust-core-reset.md
+++ b/docs/decisions/native-host-rust-core-reset.md
@@ -4,7 +4,7 @@ description: "Native Host / Rust Core Reset documentation for Rsnap."
 type: "Decision"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Native Host / Rust Core Reset

--- a/docs/decisions/scroll-capture-architecture.md
+++ b/docs/decisions/scroll-capture-architecture.md
@@ -4,7 +4,7 @@ description: "Scroll Capture Architecture documentation for Rsnap."
 type: "Decision"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Scroll Capture Architecture

--- a/docs/evidence/legacy-overlay-cleanup-drift-2026-07-06.md
+++ b/docs/evidence/legacy-overlay-cleanup-drift-2026-07-06.md
@@ -4,7 +4,7 @@ description: "Drift audit for removal of the retired Rust overlay UI runtime and
 type: "Drift Audit"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ The active split below is by question type, not by human-versus-agent audience.
   `docs/spec/capture-session.md`
 - Need product display name, macOS app bundle identity, or lower-case identifier exceptions ->
   `docs/spec/app-identity.md`
+- Need tag source, macOS signing, release assets, Sparkle, or publication invariants ->
+  `docs/spec/release-distribution.md`
 - Need Settings, status-menu shortcut display, permission placement, Dock behavior, or Settings
   window semantics -> `docs/spec/settings.md`
 - Need telemetry fields, event names, metric names, or log correlation identifiers ->

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -4,7 +4,7 @@ description: "Documentation Policy documentation for Rsnap."
 type: "Policy"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Documentation Policy

--- a/docs/reference/host-core-reset.md
+++ b/docs/reference/host-core-reset.md
@@ -4,7 +4,7 @@ description: "Host/Core Reset Reference documentation for Rsnap."
 type: "Reference"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Host/Core Reset Reference

--- a/docs/reference/live-sampling.md
+++ b/docs/reference/live-sampling.md
@@ -4,7 +4,7 @@ description: "Live Sampling Reference documentation for Rsnap."
 type: "Reference"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Live Sampling Reference

--- a/docs/reference/smoke-perf-validation-surface.md
+++ b/docs/reference/smoke-perf-validation-surface.md
@@ -4,7 +4,7 @@ description: "Smoke/Perf Validation Surface Reference documentation for Rsnap."
 type: "Reference"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Smoke/Perf Validation Surface Reference

--- a/docs/reference/window-hit-testing.md
+++ b/docs/reference/window-hit-testing.md
@@ -4,7 +4,7 @@ description: "Window Hit-Testing Reference documentation for Rsnap."
 type: "Reference"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Window Hit-Testing Reference

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -4,7 +4,7 @@ description: "Workspace Layout Reference documentation for Rsnap."
 type: "Reference"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-07
 ---
 # Workspace Layout Reference

--- a/docs/research/scroll-capture-prior-art-2026-05-10.md
+++ b/docs/research/scroll-capture-prior-art-2026-05-10.md
@@ -4,7 +4,7 @@ description: "Research contract for the scroll-capture prior-art review complete
 type: "Research Contract"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 

--- a/docs/runbook/architecture-reset-implementation.md
+++ b/docs/runbook/architecture-reset-implementation.md
@@ -4,7 +4,7 @@ description: "Execute Host/Core Reset Slice documentation for Rsnap."
 type: "Runbook"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Execute Host/Core Reset Slice

--- a/docs/runbook/architecture-reset-validation.md
+++ b/docs/runbook/architecture-reset-validation.md
@@ -4,7 +4,7 @@ description: "Validate Host/Core Reset Work documentation for Rsnap."
 type: "Runbook"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Validate Host/Core Reset Work

--- a/docs/runbook/performance-validation.md
+++ b/docs/runbook/performance-validation.md
@@ -4,7 +4,7 @@ description: "Performance Validation Runbook documentation for Rsnap."
 type: "Runbook"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Performance Validation Runbook

--- a/docs/runbook/scroll-capture-benchmarks.md
+++ b/docs/runbook/scroll-capture-benchmarks.md
@@ -4,7 +4,7 @@ description: "Scroll-Capture Benchmark Runbook documentation for Rsnap."
 type: "Runbook"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Scroll-Capture Benchmark Runbook

--- a/docs/runbook/scroll-capture-recovery-plan.md
+++ b/docs/runbook/scroll-capture-recovery-plan.md
@@ -4,7 +4,7 @@ description: "Scroll-Capture Recovery Plan documentation for Rsnap."
 type: "Runbook"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Scroll-Capture Recovery Plan

--- a/docs/runbook/telemetry-debugging.md
+++ b/docs/runbook/telemetry-debugging.md
@@ -4,7 +4,7 @@ description: "Telemetry Debugging documentation for Rsnap."
 type: "Runbook"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Telemetry Debugging

--- a/docs/runbook/validate-release.md
+++ b/docs/runbook/validate-release.md
@@ -4,8 +4,8 @@ description: "Validate Release documentation for Rsnap."
 type: "Runbook"
 status: active
 authority: normative
-owner: acgxv/rsnap
-last_verified: 2026-07-07
+owner: acg-box/rsnap
+last_verified: 2026-07-27
 ---
 # Validate Release
 
@@ -14,36 +14,55 @@ Goal: Execute the final release-candidate checks before publishing a tagged Rsna
 Read this when: You are preparing a formal Rsnap release tag or verifying the published release
 artifacts immediately after the tag workflow completes.
 
-Preconditions: `main` is clean and synced, the intended release version is committed in
-`Cargo.toml`, GitHub Actions macOS signing release secrets are configured, optional Apple notary
-credentials are configured only when a notarized build is required, the Release workflow runs the
-macOS package job on `macos-26` with Apple Swift 6.2 or newer so Liquid Glass API support is
-compiled into the app, and a logged-in macOS desktop session is available for native-host smoke and
-manual checks.
+Preconditions: `main` is clean and synced. The intended release version is committed in
+`Cargo.toml` and `Cargo.lock`. The four required signing and update values are `acg-box`
+organization Actions secrets with visibility `all`. The `release` environment is configured for
+`v*` tags and protects the publish job; it does not store release secrets. The Release workflow
+runs the macOS package job on the standard GitHub-hosted `macos-26` ARM64 runner with Apple Swift
+6.2 or newer so Liquid Glass API support is compiled into the app. A logged-in macOS desktop
+session is available for native-host smoke and manual checks.
 
-Depends on: `docs/spec/app-identity.md`; `docs/spec/settings.md`; `docs/spec/telemetry.md`;
-`docs/runbook/performance-validation.md`; `.github/workflows/release.yml`
+Depends on: `docs/spec/release-distribution.md`; `docs/spec/app-identity.md`;
+`docs/spec/settings.md`; `docs/spec/telemetry.md`; `docs/runbook/performance-validation.md`;
+`.github/workflows/release.yml`
 
-Verification: Local checks, dedicated macOS smoke/perf evidence, release workflow success, signed
-macOS zip acceptance, optional notarization evidence when notary credentials are configured, and
-manual first-run/user-flow validation.
+Verification: Local checks, dedicated macOS smoke/perf evidence, source-provenance validation,
+release workflow success, signed macOS ZIP and Sparkle appcast validation, SHA-256 verification,
+draft-asset validation, and manual first-run/user-flow validation.
 
 ## Before Tagging
 
 1. Confirm the release version:
    - `Cargo.toml` `workspace.package.version` matches the intended tag without a leading `v`.
+   - Rsnap workspace package versions in `Cargo.lock` match the intended version.
+   - `Package.swift` and `Package.resolved` contain the same exact Sparkle version.
    - No existing local or remote tag already uses `v<version>`.
+   - Create an annotated `vX.Y.Z` tag only from a commit that is on `origin/main`. The workflow
+     rejects lightweight tags, mismatched checkouts, and commits that are not reachable from
+     `origin/main`.
+   - Repository tag rulesets restrict `v*` creation to the authorized operator and prevent updates
+     or deletion after creation.
 2. Confirm release credentials:
-   - Apple signing certificate secrets are available to the Release workflow.
+   - These required organization Actions secrets are available to the Release workflow:
+     - `APPLE_CERTIFICATE_P12_BASE64`
+     - `APPLE_CERTIFICATE_PASSWORD`
+     - `APPLE_SIGNING_IDENTITY`
+     - `SPARKLE_PRIVATE_ED_KEY`
    - Sparkle update signing is configured: `SUPublicEDKey` is checked into
      `scripts/build_and_run.sh`, and `SPARKLE_PRIVATE_ED_KEY` is available to the Release workflow
      for signing the published update archive.
-   - Apple notary credentials are optional for current preview releases; when absent, the Release workflow still
-     publishes a signed but unnotarized macOS zip.
+   - The workflow signs the known Rsnap and Sparkle code graph from the inside out with the current
+     Apple Development identity and Hardened Runtime. It does not use `codesign --deep` to sign.
+   - The current Personal Team package is signed with Apple Development and is not notarized.
+     Users can need the Gatekeeper override documented in `README.md`.
+   - The `release` environment contains no secrets and does not replace the organization secret
+     contract. Its reviewer and `v*` deployment policy gate only the final publish job.
 3. Confirm local gates:
    - `cargo make checks`
    - `cargo make test-host-reset`
    - `cargo make test-macos-native-host-stage`
+   - `cargo make test-release`
+   - `actionlint .github/workflows/*.yml`
 4. Confirm dedicated desktop validation:
    - `scripts/smoke/macos.sh`
    - `scripts/perf/macos.sh`
@@ -74,12 +93,12 @@ Validate these user-visible flows:
   fullscreen fallback.
 - Frozen toolbar tools: pointer, pen, arrow, text, mosaic, spotlight, undo, redo, auto-center,
   Recognize Text, Scroll Capture, copy, and save.
-- For the v0.2.5 native-host release, Scroll Capture must stay absent for window-click and
+- Scroll Capture must stay absent for window-click and
   fullscreen freezes, remain available after dragged-region movement or auto-center, start from a
   dragged-region freeze via toolbar or plain `s`, and pass the functional scroll path in
   `docs/runbook/scroll-capture-recovery-plan.md`. Scroll toolbar Liquid Glass cadence, dynamic
   backdrop-change evidence, preview export latency, and cached copy/export timing are part of the
-  v0.2.5 publish gate.
+  publish gate.
 - Light and dark appearance; Classic Glass and Liquid Glass where the OS and current build support
   Liquid Glass.
 - Settings -> About update rows: `Auto Update` and `Release Version` must use Title Case for row
@@ -114,50 +133,57 @@ user-entered annotation text.
 ## Tag And Publish
 
 1. Push the annotated release tag only after local and manual RC validation pass.
-2. Watch the Release workflow for the exact tag.
-3. Treat a build, signing, or packaging failure as a release blocker.
-4. Treat notarization failure as a release blocker only when notary credentials are configured.
-5. The Release workflow publishes the signed macOS zip and `appcast.xml` to the GitHub release.
-   It notarizes and staples the app only when notary credentials are configured. It does not
-   publish crates.io packages or non-macOS desktop archives for current preview releases.
+2. Confirm that the source-validation job accepts the exact stable SemVer tag, Cargo and Sparkle
+   versions, annotated tag object, checked-out commit, event commit, and `origin/main` ancestry.
+3. Confirm that the single `macos-26` job completes release tests, assembly, inside-out signing,
+   recursive signature verification, final ZIP creation, Sparkle appcast generation, and checksum
+   validation.
+4. Confirm that the workflow records the expected signed-but-unnotarized Personal Team warning.
+5. Approve the `release` environment only after the macOS job succeeds. The Ubuntu publisher
+   creates or reuses a draft, uploads exactly the ZIP, appcast, and checksum, validates remote
+   metadata and downloaded bytes, and only then makes the release public. Any pre-publication
+   validation or upload failure leaves the release as a draft.
+6. The workflow does not publish crates.io packages or non-macOS desktop archives.
 
 ## Published Artifact Check
 
 After the Release workflow succeeds:
 
 1. Download `rsnap-aarch64-apple-darwin.zip` from the GitHub release or from:
-   `https://github.com/acgxv/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip`
-2. Unzip it and verify identity:
+   `https://github.com/acg-box/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip`
+   Also download
+   `https://github.com/acg-box/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip.sha256`.
+2. Verify the checksum:
+
+```sh
+shasum -a 256 -c rsnap-aarch64-apple-darwin.zip.sha256
+```
+
+3. Unzip it and verify identity:
    - The app bundle is `Rsnap.app`.
    - `CFBundleName` and `CFBundleDisplayName` are `Rsnap`.
    - `CFBundleIdentifier` is `ink.hack.rsnap`.
    - `SUFeedURL` is
-     `https://github.com/acgxv/rsnap/releases/latest/download/appcast.xml`.
+     `https://github.com/acg-box/rsnap/releases/latest/download/appcast.xml`.
    - `SUPublicEDKey` is present.
    - `Sparkle.framework` is present in `Contents/Frameworks`.
-3. Verify the signature:
+4. Verify the signature:
 
 ```sh
 codesign --verify --deep --strict /path/to/Rsnap.app
 ```
 
-4. For a notarized build, verify Gatekeeper acceptance:
-
-```sh
-spctl -a -vvv --type exec /path/to/Rsnap.app
-```
-
-For a signed but unnotarized build, Gatekeeper may still block a quarantined download. Use the
+5. Gatekeeper can block the signed but unnotarized quarantined download. Use the
 quarantine override documented in `README.md` only for a bundle built locally or downloaded from
 this repository's GitHub Releases page.
 
-5. Confirm the appcast asset was published:
+6. Confirm the appcast asset was published:
 
 ```sh
-curl -fsSL https://github.com/acgxv/rsnap/releases/latest/download/appcast.xml \
+curl -fsSL https://github.com/acg-box/rsnap/releases/latest/download/appcast.xml \
   | grep -q 'sparkle:edSignature'
 ```
 
-6. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, save, and About
+7. Launch the downloaded app and repeat a minimal capture, toolbar, OCR, copy, save, and About
    update check.
-7. Confirm release notes, the macOS zip, and the appcast were published.
+8. Confirm release notes, the macOS ZIP, appcast, and checksum were published.

--- a/docs/spec/annotation-pen.md
+++ b/docs/spec/annotation-pen.md
@@ -4,7 +4,7 @@ description: "Rsnap Annotation Pen Contract documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Rsnap Annotation Pen Contract

--- a/docs/spec/app-identity.md
+++ b/docs/spec/app-identity.md
@@ -4,7 +4,7 @@ description: "Rsnap App Identity Contract documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Rsnap App Identity Contract
@@ -49,7 +49,7 @@ Defines:
 Keep these identifiers lower-case unless a separate migration explicitly changes their technical
 contract:
 
-- Repository slug and URLs: `acgxv/rsnap`.
+- Repository slug and URLs: `acg-box/rsnap`.
 - Cargo package names, crate names, binary package selectors, and source paths such as
   `rsnap`, `rsnap-capture-core`, `rsnap-host-ffi`, and `apps/rsnap/`.
 - Environment variables and build-time constants such as `RSNAP_NATIVE_HOST_STAGE_DIR`.

--- a/docs/spec/capture-session.md
+++ b/docs/spec/capture-session.md
@@ -4,7 +4,7 @@ description: "Rsnap Capture Session Contract documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-07
 ---
 # Rsnap Capture Session Contract

--- a/docs/spec/frozen-toolbar-layout.md
+++ b/docs/spec/frozen-toolbar-layout.md
@@ -4,7 +4,7 @@ description: "Frozen Toolbar Layout Contract documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Frozen Toolbar Layout Contract

--- a/docs/spec/host-core-protocol.md
+++ b/docs/spec/host-core-protocol.md
@@ -4,7 +4,7 @@ description: "Host/Core Protocol documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-07
 ---
 # Host/Core Protocol

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -58,6 +58,8 @@ Then keep the body explicit:
   scroll-capture contract
 - `docs/spec/app-identity.md` for the Rsnap product display name, macOS `Rsnap.app` bundle
   identity, and stable lower-case technical identifiers
+- `docs/spec/release-distribution.md` for tag source, macOS signing, release assets, Sparkle
+  metadata, secret scope, and draft-publication requirements
 - `docs/spec/settings.md` for Settings, status-menu, shortcut, permission, Dock, and Settings
   window behavior
 - `docs/spec/platform-host-boundary.md` for the normative ownership boundary between native hosts

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -4,7 +4,7 @@ description: "Rsnap Performance Contract documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Rsnap Performance Contract

--- a/docs/spec/platform-host-boundary.md
+++ b/docs/spec/platform-host-boundary.md
@@ -4,7 +4,7 @@ description: "Platform Host Boundary documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-07
 ---
 # Platform Host Boundary

--- a/docs/spec/release-distribution.md
+++ b/docs/spec/release-distribution.md
@@ -1,0 +1,108 @@
+---
+title: "Release Distribution Contract"
+description: "Required source, signing, artifact, and publication rules for Rsnap releases."
+type: "Spec"
+status: active
+authority: normative
+owner: acg-box/rsnap
+last_verified: 2026-07-27
+---
+# Release Distribution Contract
+
+Purpose: Define the required trust and integrity properties of an Rsnap tag release.
+
+Status: normative.
+
+Read this when: You change the release workflow, macOS signing, Sparkle metadata, release assets,
+or release credentials.
+
+Not this document: Use `docs/runbook/validate-release.md` for the operator sequence. Use
+`docs/spec/app-identity.md` for product and bundle names.
+
+Defines:
+
+- accepted release source
+- workflow permissions and jobs
+- macOS signing and Personal Team distribution
+- release assets and Sparkle metadata
+- draft publication
+- release secret scope
+
+## Supported workflow shape
+
+- Normal CI runs for pull requests, `main`, and merge queues.
+- A formal release starts only when an authorized operator pushes a stable `vX.Y.Z` tag.
+- The repository does not use a release-preparation, dry-run, or manual-dispatch release workflow.
+- The release workflow must not create a tag.
+
+## Source contract
+
+- The tag is an annotated Git tag that points directly to a commit.
+- The tag name is stable SemVer in the exact form `vX.Y.Z`, without leading zeroes.
+- The tag commit, workflow event commit, and checked-out commit are the same commit.
+- The tag commit is reachable from `origin/main`.
+- The tag version matches `Cargo.toml` and the Rsnap workspace packages in `Cargo.lock`.
+- The declared and resolved Sparkle dependency versions match.
+- The built app `CFBundleVersion` and `CFBundleShortVersionString` match the tag version.
+
+## Permission contract
+
+- The workflow default is `contents: read`.
+- The macOS job does not have repository write permission.
+- Only the Ubuntu publish job has `contents: write`.
+- Checkout steps do not persist GitHub credentials.
+
+## macOS package contract
+
+- The package job runs on the standard GitHub-hosted ARM64 `macos-26` runner.
+- The job runs the release test surface before it creates release assets.
+- The app bundle name is `Rsnap.app`, and its bundle identifier is `ink.hack.rsnap`.
+- The current release identity is the organization-provided Apple Development identity.
+- Signing starts at the innermost Sparkle code and finishes with `Rsnap.app`.
+- Each signed code object uses Hardened Runtime.
+- `codesign --deep` can verify the final bundle. It must not sign the bundle.
+- The Personal Team package is signed but not notarized.
+- Users can need the documented Gatekeeper override after download.
+- The final ZIP is created only after all inside-out signatures verify.
+
+## Update and asset contract
+
+Each release contains exactly these assets:
+
+- `rsnap-aarch64-apple-darwin.zip`
+- `appcast.xml`
+- `rsnap-aarch64-apple-darwin.zip.sha256`
+
+The appcast:
+
+- uses the canonical `acg-box/rsnap` release and download URLs
+- uses the release version from the validated tag
+- records the exact ZIP byte length
+- contains a Sparkle EdDSA signature made with `SPARKLE_PRIVATE_ED_KEY`
+- verifies with the public key embedded in `Rsnap.app`
+
+The checksum file contains the lowercase SHA-256 digest of the final ZIP and the canonical ZIP
+file name.
+
+## Publication contract
+
+- The macOS job must succeed before the Ubuntu publish job starts.
+- The publish job uses the `release` environment as the final deployment approval and audit
+  boundary. The environment stores no release secrets.
+- The publisher validates local assets before it changes GitHub Release state.
+- The publisher creates or reuses a draft and uploads only the three required assets.
+- The publisher validates remote metadata and downloaded remote bytes before publication.
+- The last state-changing operation makes the draft public.
+- A validation or upload failure leaves the release as a draft.
+- The workflow does not publish crates.io packages or non-macOS desktop archives.
+
+## Secret contract
+
+The required GitHub Actions secrets are organization secrets with visibility `all`:
+
+- `APPLE_CERTIFICATE_P12_BASE64`
+- `APPLE_CERTIFICATE_PASSWORD`
+- `APPLE_SIGNING_IDENTITY`
+- `SPARKLE_PRIVATE_ED_KEY`
+
+Repository and environment secrets must not shadow these names.

--- a/docs/spec/settings.md
+++ b/docs/spec/settings.md
@@ -4,7 +4,7 @@ description: "Settings and App Shell Contract documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-08
 ---
 # Settings and App Shell Contract
@@ -154,13 +154,13 @@ Defines:
 - Settings must include an About section.
 - The About section must identify Yvette Cipher as the creator and describe Rsnap as an
   open-source macOS capture tool.
-- The About section must include external links to `https://github.com/acgxv/rsnap` and
+- The About section must include external links to `https://github.com/acg-box/rsnap` and
   `https://x.com/hackink`.
 - The X link may encourage following for ongoing Rsnap updates and may state that follows
   help support future work.
 - Release builds must use Sparkle's standard updater UI and appcast format for macOS self-updates.
   GitHub Releases remains the distribution surface, but the Sparkle appcast at
-  `https://github.com/acgxv/rsnap/releases/latest/download/appcast.xml` is the update-version
+  `https://github.com/acg-box/rsnap/releases/latest/download/appcast.xml` is the update-version
   authority for in-app update checks.
 - The appcast must compare against the running app bundle's `CFBundleVersion`. The user-visible
   version should remain `CFBundleShortVersionString`.

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -4,7 +4,7 @@ description: "Telemetry Schema documentation for Rsnap."
 type: "Spec"
 status: active
 authority: normative
-owner: acgxv/rsnap
+owner: acg-box/rsnap
 last_verified: 2026-07-06
 ---
 # Telemetry Schema

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <span>Rsnap</span>
       </a>
       <nav class="nav-links" aria-label="Site">
-        <a href="https://github.com/acgxv/rsnap" rel="noreferrer">GitHub</a>
+        <a href="https://github.com/acg-box/rsnap" rel="noreferrer">GitHub</a>
       </nav>
     </header>
 
@@ -44,7 +44,7 @@
           <div class="hero-actions" aria-label="Primary actions">
             <a
               class="button button-primary"
-              href="https://github.com/acgxv/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip"
+              href="https://github.com/acg-box/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip"
             >
               Download for macOS
             </a>
@@ -138,7 +138,7 @@
           <h2 id="final-title">Keep the screenshot step invisible.</h2>
           <a
             class="button button-primary"
-            href="https://github.com/acgxv/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip"
+            href="https://github.com/acg-box/rsnap/releases/latest/download/rsnap-aarch64-apple-darwin.zip"
           >
             Download latest macOS zip
           </a>
@@ -148,8 +148,8 @@
 
     <footer class="site-footer">
       <span>Rsnap</span>
-      <a href="https://github.com/acgxv/rsnap/blob/main/LICENSE">GPL-3.0</a>
-      <a href="https://github.com/acgxv/rsnap">acgxv/rsnap</a>
+      <a href="https://github.com/acg-box/rsnap/blob/main/LICENSE">GPL-3.0</a>
+      <a href="https://github.com/acg-box/rsnap">acg-box/rsnap</a>
     </footer>
 
     <noscript>

--- a/native/macos-host/Sources/RsnapNativeHostKit/AboutSettingsPanel.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/AboutSettingsPanel.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 private enum NativeHostAboutLinks {
-	static let source = "https://github.com/acgxv/rsnap"
+	static let source = "https://github.com/acg-box/rsnap"
 	static let creator = "https://x.com/hackink"
 }
 

--- a/native/macos-host/Sources/RsnapNativeHostKit/SoftwareUpdater.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/SoftwareUpdater.swift
@@ -58,7 +58,7 @@ final class SoftwareUpdater: NSObject {
 
 	static let releasePageURL = httpsURL(
 		host: "github.com",
-		path: "/acgxv/rsnap/releases/latest")
+		path: "/acg-box/rsnap/releases/latest")
 
 	var canPerformImmediateInstall: (() -> Bool)?
 

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -26,7 +26,7 @@ APP_ICON_SOURCE="$ROOT_DIR/assets/app-icon/generated/app-icon.icns"
 APP_ICON_NAME="AppIcon.icns"
 STATUS_ICON_SOURCE="$ROOT_DIR/assets/tray-icon/generated/tray-icon-template.png"
 STATUS_ICON_NAME="StatusBarIcon.png"
-SPARKLE_APPCAST_URL="${RSNAP_SPARKLE_APPCAST_URL:-https://github.com/acgxv/rsnap/releases/latest/download/appcast.xml}"
+SPARKLE_APPCAST_URL="${RSNAP_SPARKLE_APPCAST_URL:-https://github.com/acg-box/rsnap/releases/latest/download/appcast.xml}"
 # The public update key is safe to ship in source. The override exists only for
 # local Sparkle smoke tests that generate a disposable key pair and appcast.
 SPARKLE_PUBLIC_ED_KEY="${RSNAP_SPARKLE_PUBLIC_ED_KEY:-$DEFAULT_SPARKLE_PUBLIC_ED_KEY}"
@@ -267,8 +267,8 @@ stage_app_bundle() {
 		chmod +x "$APP_BINARY"
 	fi
 
-	if otool -L "$APP_BINARY" | grep -q 'Sparkle.framework' \
-		&& ! otool -l "$APP_BINARY" | grep -q '@executable_path/../Frameworks'; then
+	if otool -L "$APP_BINARY" | grep 'Sparkle.framework' >/dev/null \
+		&& ! otool -l "$APP_BINARY" | grep '@executable_path/../Frameworks' >/dev/null; then
 		install_name_tool -add_rpath '@executable_path/../Frameworks' "$APP_BINARY"
 		STAGED_APP_DIRTY=1
 	fi
@@ -296,59 +296,52 @@ stage_app_bundle() {
 	stage_sparkle_framework
 
 	local info_plist_contents
-	info_plist_contents="$(cat <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleExecutable</key>
-  <string>$EXECUTABLE_NAME</string>
-  <key>CFBundleIdentifier</key>
-  <string>$BUNDLE_ID</string>
-  <key>CFBundleName</key>
-  <string>$APP_NAME</string>
-  <key>CFBundleDisplayName</key>
-  <string>$APP_NAME</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>CFBundleShortVersionString</key>
-  <string>$APP_VERSION</string>
-  <key>CFBundleVersion</key>
-  <string>$APP_VERSION</string>
-  <key>LSMinimumSystemVersion</key>
-  <string>$MIN_SYSTEM_VERSION</string>
-  <key>NSHighResolutionCapable</key>
-  <true/>
-  <key>NSPrincipalClass</key>
-  <string>NSApplication</string>
-  <key>SUFeedURL</key>
-  <string>$SPARKLE_APPCAST_URL</string>
-  <key>SUEnableAutomaticChecks</key>
-  <true/>
-  <key>SUScheduledCheckInterval</key>
-  <integer>86400</integer>
-  <key>SUAutomaticallyUpdate</key>
-  <true/>
-  <key>SUAllowsAutomaticUpdates</key>
-  <true/>
-  <key>SUPublicEDKey</key>
-  <string>$SPARKLE_PUBLIC_ED_KEY</string>
-PLIST
-)"
+	printf -v info_plist_contents '%s\n' \
+		'<?xml version="1.0" encoding="UTF-8"?>' \
+		'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+		'<plist version="1.0">' \
+		'<dict>' \
+		'  <key>CFBundleExecutable</key>' \
+		"  <string>$EXECUTABLE_NAME</string>" \
+		'  <key>CFBundleIdentifier</key>' \
+		"  <string>$BUNDLE_ID</string>" \
+		'  <key>CFBundleName</key>' \
+		"  <string>$APP_NAME</string>" \
+		'  <key>CFBundleDisplayName</key>' \
+		"  <string>$APP_NAME</string>" \
+		'  <key>CFBundlePackageType</key>' \
+		'  <string>APPL</string>' \
+		'  <key>CFBundleShortVersionString</key>' \
+		"  <string>$APP_VERSION</string>" \
+		'  <key>CFBundleVersion</key>' \
+		"  <string>$APP_VERSION</string>" \
+		'  <key>LSMinimumSystemVersion</key>' \
+		"  <string>$MIN_SYSTEM_VERSION</string>" \
+		'  <key>NSHighResolutionCapable</key>' \
+		'  <true/>' \
+		'  <key>NSPrincipalClass</key>' \
+		'  <string>NSApplication</string>' \
+		'  <key>SUFeedURL</key>' \
+		"  <string>$SPARKLE_APPCAST_URL</string>" \
+		'  <key>SUEnableAutomaticChecks</key>' \
+		'  <true/>' \
+		'  <key>SUScheduledCheckInterval</key>' \
+		'  <integer>86400</integer>' \
+		'  <key>SUAutomaticallyUpdate</key>' \
+		'  <true/>' \
+		'  <key>SUAllowsAutomaticUpdates</key>' \
+		'  <true/>' \
+		'  <key>SUPublicEDKey</key>' \
+		"  <string>$SPARKLE_PUBLIC_ED_KEY</string>"
 
 	if [[ -f "$APP_RESOURCES/$APP_ICON_NAME" ]]; then
-		info_plist_contents+="$(cat <<PLIST
-  <key>CFBundleIconFile</key>
-  <string>${APP_ICON_NAME%.icns}</string>
-PLIST
-)"
+		info_plist_contents+='  <key>CFBundleIconFile</key>'
+		info_plist_contents+=$'\n'"  <string>${APP_ICON_NAME%.icns}</string>"
+		info_plist_contents+=$'\n'
 	fi
 
-	info_plist_contents+="$(cat <<'PLIST'
-</dict>
-</plist>
-PLIST
-)"
+	info_plist_contents+='</dict>'
+	info_plist_contents+=$'\n</plist>'
 
 	if write_if_changed "$INFO_PLIST" "$info_plist_contents"; then
 		STAGED_APP_DIRTY=1
@@ -357,9 +350,14 @@ PLIST
 
 resolve_signing_identity() {
 	local requested_identity identity_list identity
+	local security_args
 
 	requested_identity="${RSNAP_NATIVE_HOST_SIGN_IDENTITY:-$DEFAULT_SIGN_IDENTITY}"
-	identity_list="$(security find-identity -v -p codesigning 2>/dev/null || true)"
+	security_args=(find-identity -v -p codesigning)
+	if [[ -n "${RSNAP_NATIVE_HOST_SIGN_KEYCHAIN:-}" ]]; then
+		security_args+=("$RSNAP_NATIVE_HOST_SIGN_KEYCHAIN")
+	fi
+	identity_list="$(security "${security_args[@]}" 2>/dev/null || true)"
 	if [[ -n "$requested_identity" ]]; then
 		while IFS= read -r line; do
 			identity="${line#*\"}"
@@ -385,27 +383,23 @@ resolve_signing_identity() {
 
 sign_staged_app_bundle() {
 	local requested_identity
+	local signer_args
 	requested_identity="${RSNAP_NATIVE_HOST_SIGN_IDENTITY:-$DEFAULT_SIGN_IDENTITY}"
 	if [[ "$STAGED_APP_DIRTY" != "1" ]] && codesign --verify --deep --strict "$APP_BUNDLE" >/dev/null 2>&1; then
 		return
 	fi
 	if resolve_signing_identity; then
-		if [[ -f "$BUILD_ROOT/$EXECUTABLE_NAME-entitlement.plist" ]]; then
-			codesign \
-				--force \
-				--deep \
-				--options runtime \
-				--sign "$RESOLVED_SIGN_IDENTITY" \
-				--entitlements "$BUILD_ROOT/$EXECUTABLE_NAME-entitlement.plist" \
-				"$APP_BUNDLE"
-		else
-			codesign \
-				--force \
-				--deep \
-				--options runtime \
-				--sign "$RESOLVED_SIGN_IDENTITY" \
-				"$APP_BUNDLE"
+		signer_args=(
+			--app "$APP_BUNDLE"
+			--identity "$RESOLVED_SIGN_IDENTITY"
+		)
+		if [[ -n "${RSNAP_NATIVE_HOST_SIGN_KEYCHAIN:-}" ]]; then
+			signer_args+=(--keychain "$RSNAP_NATIVE_HOST_SIGN_KEYCHAIN")
 		fi
+		if [[ -f "$BUILD_ROOT/$EXECUTABLE_NAME-entitlement.plist" ]]; then
+			signer_args+=(--entitlements "$BUILD_ROOT/$EXECUTABLE_NAME-entitlement.plist")
+		fi
+		"$ROOT_DIR/scripts/release/sign-macos-app.sh" "${signer_args[@]}"
 		return
 	fi
 
@@ -423,7 +417,7 @@ compute_stage_fingerprint() {
 			swift --version
 		} 2>/dev/null | tr '\n' ' '
 	)"
-	python3 - "$ROOT_DIR" "$RUST_PROFILE" "$SWIFT_CONFIGURATION" "$APP_VERSION" "$swift_toolchain" <<'PY'
+	python3 -c '
 import hashlib
 import os
 import sys
@@ -441,6 +435,7 @@ targets = [
 	"packages/rsnap-capture-core",
 	"packages/rsnap-host-ffi",
 	"scripts/build_and_run.sh",
+	"scripts/release/sign-macos-app.sh",
 ]
 skip_dirs = {".git", ".worktrees", "target", ".build"}
 
@@ -471,7 +466,7 @@ for target in targets:
 			update_file(os.path.join(dirpath, filename))
 
 print(hasher.hexdigest())
-PY
+' "$ROOT_DIR" "$RUST_PROFILE" "$SWIFT_CONFIGURATION" "$APP_VERSION" "$swift_toolchain"
 }
 
 write_stage_fingerprint() {

--- a/scripts/release/publish-github-release.sh
+++ b/scripts/release/publish-github-release.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCHIVE_NAME="rsnap-aarch64-apple-darwin.zip"
+APPCAST_NAME="appcast.xml"
+CHECKSUM_NAME="${ARCHIVE_NAME}.sha256"
+CANONICAL_REPOSITORY="acg-box/rsnap"
+
+die() {
+	echo "error: $*" >&2
+	exit 1
+}
+
+for required_variable in \
+	GH_TOKEN \
+	GITHUB_REPOSITORY \
+	GITHUB_SHA \
+	RSNAP_RELEASE_COMMIT \
+	RSNAP_RELEASE_TAG \
+	RSNAP_RELEASE_VERSION \
+	RSNAP_RELEASE_INPUT_DIR; do
+	if [[ -z "${!required_variable:-}" ]]; then
+		die "missing required environment variable: ${required_variable}"
+	fi
+done
+
+if [[ "$GITHUB_REPOSITORY" != "$CANONICAL_REPOSITORY" ]]; then
+	die "GITHUB_REPOSITORY must be ${CANONICAL_REPOSITORY}"
+fi
+if [[ "$GITHUB_SHA" != "$RSNAP_RELEASE_COMMIT" ]]; then
+	die "GITHUB_SHA does not match RSNAP_RELEASE_COMMIT"
+fi
+if [[ ! -d "$RSNAP_RELEASE_INPUT_DIR" ]]; then
+	die "release input directory does not exist: ${RSNAP_RELEASE_INPUT_DIR}"
+fi
+
+input_dir="$(cd "$RSNAP_RELEASE_INPUT_DIR" && pwd -P)"
+archive="${input_dir}/${ARCHIVE_NAME}"
+appcast="${input_dir}/${APPCAST_NAME}"
+checksum="${input_dir}/${CHECKSUM_NAME}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+validator="${RSNAP_RELEASE_VALIDATOR:-${script_dir}/validate-release-artifacts.py}"
+gh_bin="${GH_BIN:-gh}"
+
+if [[ ! -x "$validator" ]]; then
+	die "release validator is not executable: ${validator}"
+fi
+if ! command -v "$gh_bin" >/dev/null 2>&1; then
+	die "GitHub CLI is not available: ${gh_bin}"
+fi
+
+run_validator_for_paths() {
+	local validation_archive="$1"
+	local validation_appcast="$2"
+	local validation_checksum="$3"
+	shift 3
+	"$validator" \
+		--archive "$validation_archive" \
+		--appcast "$validation_appcast" \
+		--checksum "$validation_checksum" \
+		--version "$RSNAP_RELEASE_VERSION" \
+		--tag "$RSNAP_RELEASE_TAG" \
+		--repository "$GITHUB_REPOSITORY" \
+		--verify-appcast-signature \
+		"$@"
+}
+
+run_validator() {
+	run_validator_for_paths "$archive" "$appcast" "$checksum" "$@"
+}
+
+fetch_assets() {
+	local release_id="$1"
+	local output_path="$2"
+	local pages_path="${output_path}.pages"
+	"$gh_bin" api \
+		"repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
+		--paginate \
+		--slurp > "$pages_path"
+	python3 -c '
+import json
+import pathlib
+import sys
+
+pages = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+    raise SystemExit("GitHub paginated assets response must contain arrays")
+json.dump([asset for page in pages for asset in page], sys.stdout)
+	' "$pages_path" > "$output_path"
+}
+
+fetch_releases() {
+	local output_path="$1"
+	local pages_path="${output_path}.pages"
+	"$gh_bin" api \
+		"repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+		--paginate \
+		--slurp > "$pages_path"
+	python3 -c '
+import json
+import pathlib
+import sys
+
+pages = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+    raise SystemExit("GitHub paginated releases response must contain arrays")
+json.dump([release for page in pages for release in page], sys.stdout)
+' "$pages_path" > "$output_path"
+}
+
+json_object_field() {
+	local metadata_path="$1"
+	local field_name="$2"
+	python3 -c '
+import json
+import pathlib
+import sys
+
+value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")).get(sys.argv[2])
+if isinstance(value, bool):
+    print("true" if value else "false")
+elif isinstance(value, (int, str)):
+    print(value)
+else:
+    raise SystemExit(f"invalid JSON metadata field: {sys.argv[2]}")
+' "$metadata_path" "$field_name"
+}
+
+validate_monotonic_version() {
+	local metadata_path="$1"
+	python3 -c '
+import json
+import pathlib
+import re
+import sys
+
+releases = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if not isinstance(releases, list):
+    raise SystemExit("GitHub releases response must be an array")
+
+pattern = re.compile(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)")
+target = tuple(int(part) for part in sys.argv[2].split("."))
+stable_versions = []
+for release in releases:
+    if release.get("draft") is not False or release.get("prerelease") is not False:
+        continue
+    match = pattern.fullmatch(str(release.get("tag_name", "")))
+    if match is not None:
+        stable_versions.append(tuple(int(part) for part in match.groups()))
+
+if stable_versions and target <= max(stable_versions):
+    highest = ".".join(str(part) for part in max(stable_versions))
+    raise SystemExit(
+        f"release version {sys.argv[2]} must be higher than published stable v{highest}"
+    )
+	' "$metadata_path" "$RSNAP_RELEASE_VERSION"
+}
+
+download_assets() {
+	local download_dir="$1"
+	local compare_with_local="$2"
+	local asset_id asset_name local_path
+	mkdir -p "$download_dir"
+	while IFS= read -r -d '' asset_id && IFS= read -r -d '' asset_name; do
+		case "$asset_name" in
+			"$ARCHIVE_NAME")
+				local_path="$archive"
+				;;
+			"$APPCAST_NAME")
+				local_path="$appcast"
+				;;
+			"$CHECKSUM_NAME")
+				local_path="$checksum"
+				;;
+			*)
+				die "unexpected asset in GitHub metadata: ${asset_name}"
+				;;
+		esac
+		"$gh_bin" api \
+			-H "Accept: application/octet-stream" \
+			"repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+			> "${download_dir}/${asset_name}"
+		if [[ "$compare_with_local" == "true" ]] \
+			&& ! cmp -s "$local_path" "${download_dir}/${asset_name}"; then
+			die "downloaded GitHub asset does not match local bytes: ${asset_name}"
+		fi
+	done < <(
+		python3 -c '
+import json
+import pathlib
+import sys
+
+assets = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if not isinstance(assets, list):
+    raise SystemExit("GitHub assets response must be an array")
+for asset in assets:
+    if not isinstance(asset, dict):
+        raise SystemExit("GitHub asset metadata entry must be an object")
+    asset_id = asset.get("id")
+    name = asset.get("name")
+    if not isinstance(asset_id, int) or asset_id <= 0 or not isinstance(name, str):
+        raise SystemExit("GitHub asset metadata has an invalid ID or name")
+    sys.stdout.write(str(asset_id) + "\0" + name + "\0")
+		' "$assets_json"
+	)
+}
+
+for local_artifact in "$archive" "$appcast" "$checksum"; do
+	if [[ ! -f "$local_artifact" ]]; then
+		die "release artifact does not exist: ${local_artifact}"
+	fi
+done
+
+# No GitHub release is created until all local bytes and signatures pass.
+run_validator
+
+temp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/rsnap-release-publish.XXXXXX")"
+trap 'rm -rf "$temp_dir"' EXIT
+release_json="${temp_dir}/release.json"
+assets_json="${temp_dir}/assets.json"
+api_error="${temp_dir}/api-error.txt"
+stable_releases_json="${temp_dir}/stable-releases.json"
+tag_commit_json="${temp_dir}/tag-commit.json"
+
+"$gh_bin" api \
+	"repos/${GITHUB_REPOSITORY}/commits/${RSNAP_RELEASE_TAG}" \
+	> "$tag_commit_json"
+tag_commit="$(json_object_field "$tag_commit_json" sha)"
+if [[ "$tag_commit" != "$RSNAP_RELEASE_COMMIT" ]]; then
+	die "remote release tag does not resolve to RSNAP_RELEASE_COMMIT"
+fi
+
+release_was_created=0
+release_exists=1
+if "$gh_bin" api \
+	"repos/${GITHUB_REPOSITORY}/releases/tags/${RSNAP_RELEASE_TAG}" \
+	> "$release_json" 2> "$api_error"; then
+	:
+elif grep -Eq 'HTTP 404|Not Found' "$api_error"; then
+	release_exists=0
+else
+	cat "$api_error" >&2
+	die "cannot query the GitHub release"
+fi
+
+if [[ "$release_exists" == "1" ]]; then
+	release_is_draft="$(json_object_field "$release_json" draft)"
+else
+	release_is_draft=true
+fi
+
+# A published release with this exact tag is the idempotent exception. New and
+# draft releases must advance the highest visible stable semantic version.
+if [[ "$release_is_draft" == "true" ]]; then
+	fetch_releases "$stable_releases_json"
+	validate_monotonic_version "$stable_releases_json"
+fi
+
+if [[ "$release_exists" == "0" ]]; then
+	"$gh_bin" api \
+		--method POST \
+		"repos/${GITHUB_REPOSITORY}/releases" \
+		-f "tag_name=${RSNAP_RELEASE_TAG}" \
+		-f "target_commitish=${RSNAP_RELEASE_COMMIT}" \
+		-F draft=true \
+		-F prerelease=false \
+		-F generate_release_notes=true > "$release_json"
+	release_was_created=1
+fi
+
+release_id="$(json_object_field "$release_json" id)"
+release_is_draft="$(json_object_field "$release_json" draft)"
+case "$release_is_draft" in
+	true)
+		run_validator \
+			--release-json "$release_json" \
+			--release-state draft
+		;;
+	false)
+		fetch_assets "$release_id" "$assets_json"
+		published_dir="${temp_dir}/published"
+		download_assets "$published_dir" false
+		run_validator_for_paths \
+			"$published_dir/$ARCHIVE_NAME" \
+			"$published_dir/$APPCAST_NAME" \
+			"$published_dir/$CHECKSUM_NAME" \
+			--release-json "$release_json" \
+			--assets-json "$assets_json" \
+			--release-state published
+		echo "GitHub release ${RSNAP_RELEASE_TAG} is already public and its remote assets validate."
+		exit 0
+		;;
+	*)
+		die "GitHub release draft state is invalid"
+		;;
+esac
+
+# A reused draft can contain partial files from an earlier failed attempt. Remove
+# all resolved draft assets, then upload one exact set. A failure still leaves an
+# invisible draft that this script can repair on the next run.
+fetch_assets "$release_id" "$assets_json"
+while IFS= read -r -d '' asset_id; do
+	"$gh_bin" api \
+		--method DELETE \
+		"repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+		--silent
+done < <(
+	python3 -c '
+import json
+import pathlib
+import sys
+
+assets = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+for asset in assets:
+    sys.stdout.write(str(asset["id"]) + "\0")
+	' "$assets_json"
+)
+
+"$gh_bin" release upload "$RSNAP_RELEASE_TAG" \
+	--repo "$GITHUB_REPOSITORY" \
+	"$archive" \
+	"$appcast" \
+	"$checksum"
+
+"$gh_bin" api \
+	"repos/${GITHUB_REPOSITORY}/releases/tags/${RSNAP_RELEASE_TAG}" \
+	> "$release_json"
+fetch_assets "$release_id" "$assets_json"
+run_validator \
+	--release-json "$release_json" \
+	--assets-json "$assets_json" \
+	--release-state draft
+download_assets "${temp_dir}/download" true
+
+if [[ "$release_was_created" == "1" ]]; then
+	echo "Created and validated draft release ${RSNAP_RELEASE_TAG}."
+else
+	echo "Reused and validated draft release ${RSNAP_RELEASE_TAG}."
+fi
+
+# Publishing is the last GitHub operation. All metadata checks and remote byte
+# downloads have completed, so an earlier failure cannot expose a partial release.
+"$gh_bin" api \
+	--method PATCH \
+	"repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+	-F draft=false \
+	-f make_latest=true \
+	--silent
+echo "Published ${RSNAP_RELEASE_TAG} as the latest stable GitHub release."

--- a/scripts/release/sign-macos-app.sh
+++ b/scripts/release/sign-macos-app.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat >&2 <<'USAGE'
+usage: scripts/release/sign-macos-app.sh --app APP --identity IDENTITY [options]
+
+Signs Rsnap and its embedded Sparkle components from the inside out.
+
+Required:
+  --app PATH                         path to Rsnap.app
+  --identity IDENTITY                macOS code-signing identity
+
+Optional:
+  --keychain PATH                    keychain that contains the signing identity
+  --entitlements PATH                entitlements for the outer app
+  --downloader-entitlements PATH     replacement entitlements for Downloader.xpc
+
+If --downloader-entitlements is omitted, Downloader.xpc keeps the entitlements
+from its existing Sparkle signature. Apple Development and ad-hoc signatures
+disable the secure timestamp. Other identities require a secure timestamp.
+USAGE
+}
+
+app=""
+identity=""
+keychain=""
+app_entitlements=""
+downloader_entitlements=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--app)
+			app="${2:-}"
+			shift 2
+			;;
+		--identity)
+			identity="${2:-}"
+			shift 2
+			;;
+		--keychain)
+			keychain="${2:-}"
+			shift 2
+			;;
+		--entitlements)
+			app_entitlements="${2:-}"
+			shift 2
+			;;
+		--downloader-entitlements)
+			downloader_entitlements="${2:-}"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "error: unknown argument: $1" >&2
+			usage
+			exit 2
+			;;
+	esac
+done
+
+if [[ -z "$app" || -z "$identity" ]]; then
+	echo "error: --app and --identity are required" >&2
+	usage
+	exit 2
+fi
+
+if [[ ! -d "$app" ]]; then
+	echo "error: app bundle not found: $app" >&2
+	exit 1
+fi
+
+if [[ -n "$keychain" && ! -f "$keychain" ]]; then
+	echo "error: signing keychain not found: $keychain" >&2
+	exit 1
+fi
+
+for entitlements in "$app_entitlements" "$downloader_entitlements"; do
+	if [[ -n "$entitlements" && ! -f "$entitlements" ]]; then
+		echo "error: entitlements file not found: $entitlements" >&2
+		exit 1
+	fi
+done
+
+codesign_bin="${CODESIGN_BIN:-/usr/bin/codesign}"
+if [[ ! -x "$codesign_bin" ]]; then
+	echo "error: codesign executable not found: $codesign_bin" >&2
+	exit 1
+fi
+
+sparkle_framework="$app/Contents/Frameworks/Sparkle.framework"
+versions_dir="$sparkle_framework/Versions"
+current_link="$versions_dir/Current"
+if [[ ! -d "$sparkle_framework" || ! -d "$versions_dir" || ! -L "$current_link" ]]; then
+	echo "error: Sparkle.framework does not contain a Versions/Current layout" >&2
+	exit 1
+fi
+
+versions_real="$(cd "$versions_dir" && pwd -P)"
+current_real="$(cd "$current_link" && pwd -P)"
+case "$current_real" in
+	"$versions_real"/*)
+		;;
+	*)
+		echo "error: Sparkle.framework Versions/Current resolves outside Versions" >&2
+		exit 1
+		;;
+esac
+
+installer="$current_link/XPCServices/Installer.xpc"
+downloader="$current_link/XPCServices/Downloader.xpc"
+autoupdate="$current_link/Autoupdate"
+updater="$current_link/Updater.app"
+
+for component in "$installer" "$downloader" "$autoupdate" "$updater"; do
+	if [[ ! -e "$component" ]]; then
+		echo "error: required Sparkle signing component not found: $component" >&2
+		exit 1
+	fi
+done
+
+sign_common=(
+	--force
+	--options runtime
+	--sign "$identity"
+)
+
+case "$identity" in
+	Apple\ Development:*|-)
+		sign_common+=(--timestamp=none)
+		;;
+	*)
+		sign_common+=(--timestamp)
+		;;
+esac
+
+if [[ -n "$keychain" ]]; then
+	sign_common+=(--keychain "$keychain")
+fi
+
+sign_component() {
+	local path="$1"
+	shift
+	"$codesign_bin" "${sign_common[@]}" "$@" "$path"
+}
+
+sign_component "$installer"
+
+if [[ -n "$downloader_entitlements" ]]; then
+	sign_component "$downloader" --entitlements "$downloader_entitlements"
+else
+	sign_component "$downloader" --preserve-metadata=entitlements
+fi
+
+sign_component "$autoupdate"
+sign_component "$updater"
+sign_component "$sparkle_framework"
+
+if [[ -n "$app_entitlements" ]]; then
+	sign_component "$app" --entitlements "$app_entitlements"
+else
+	sign_component "$app"
+fi
+
+"$codesign_bin" --verify --deep --strict --verbose=2 "$app"

--- a/scripts/release/sparkle-appcast.sh
+++ b/scripts/release/sparkle-appcast.sh
@@ -12,9 +12,9 @@ Required environment:
 
 Optional environment:
   SPARKLE_SIGN_UPDATE     explicit path to Sparkle's sign_update tool
-  SPARKLE_ARCHIVE_URL     explicit appcast download URL for the release archive
+  SPARKLE_ARCHIVE_URL     canonical acg-box release URL, or a loopback smoke URL
   SPARKLE_RELEASE_NOTES_URL
-                          explicit appcast release notes URL
+                          canonical acg-box release URL, or a loopback smoke URL
 USAGE
 }
 
@@ -61,8 +61,29 @@ for required_value in archive appcast version tag; do
 	fi
 done
 
+semver_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+if [[ ! "$version" =~ $semver_pattern ]]; then
+	echo "error: version must be a stable SemVer value such as 1.2.3" >&2
+	exit 1
+fi
+if [[ "$tag" != "v$version" ]]; then
+	echo "error: release tag $tag does not match version $version" >&2
+	exit 1
+fi
+
 if [[ ! -f "$archive" ]]; then
 	echo "error: release archive not found: $archive" >&2
+	exit 1
+fi
+if [[ ! -s "$archive" ]]; then
+	echo "error: release archive is empty: $archive" >&2
+	exit 1
+fi
+
+archive_name="$(basename "$archive")"
+archive_name_pattern='^[A-Za-z0-9][A-Za-z0-9._-]*$'
+if [[ ! "$archive_name" =~ $archive_name_pattern ]]; then
+	echo "error: release archive name contains unsupported URL characters: $archive_name" >&2
 	exit 1
 fi
 
@@ -89,68 +110,17 @@ if [[ -z "$sign_update" || ! -x "$sign_update" ]]; then
 	exit 1
 fi
 
-signature_fragment="$(
+signature_output="$(
 	printf '%s\n' "$SPARKLE_PRIVATE_ED_KEY" \
 		| "$sign_update" --ed-key-file - "$archive"
 )"
-if [[ "$signature_fragment" != *"sparkle:edSignature="* || "$signature_fragment" != *"length="* ]]; then
-	echo "error: unexpected Sparkle signature fragment: $signature_fragment" >&2
-	exit 1
-fi
 
 VERSION="$version" \
-	TAG="$tag" \
-	ARCHIVE="$(basename "$archive")" \
-	APPCAST="$appcast" \
-	SPARKLE_ARCHIVE_URL="${SPARKLE_ARCHIVE_URL:-}" \
-	SPARKLE_RELEASE_NOTES_URL="${SPARKLE_RELEASE_NOTES_URL:-}" \
-	SPARKLE_SIGNATURE_FRAGMENT="$signature_fragment" \
-	python3 - <<'PY'
-import email.utils
-import os
-from pathlib import Path
-from textwrap import dedent
-from xml.sax.saxutils import escape
-
-version = os.environ["VERSION"]
-tag = os.environ["TAG"]
-archive = os.environ["ARCHIVE"]
-appcast = os.environ["APPCAST"]
-signature_fragment = os.environ["SPARKLE_SIGNATURE_FRAGMENT"].strip()
-archive_url = os.environ["SPARKLE_ARCHIVE_URL"].strip()
-release_notes_url = os.environ["SPARKLE_RELEASE_NOTES_URL"].strip()
-
-download_url = archive_url or f"https://github.com/acgxv/rsnap/releases/download/{tag}/{archive}"
-release_url = release_notes_url or f"https://github.com/acgxv/rsnap/releases/tag/{tag}"
-pub_date = email.utils.formatdate(usegmt=True)
-
-xml = dedent(
-	f"""\
-	<?xml version="1.0" encoding="UTF-8"?>
-	<rss version="2.0"
-	  xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-	  <channel>
-	    <title>Rsnap Updates</title>
-	    <link>https://github.com/acgxv/rsnap/releases</link>
-	    <description>Rsnap macOS app updates.</description>
-	    <language>en</language>
-	    <item>
-	      <title>Version {escape(version)}</title>
-	      <link>{escape(release_url)}</link>
-	      <sparkle:version>{escape(version)}</sparkle:version>
-	      <sparkle:shortVersionString>{escape(version)}</sparkle:shortVersionString>
-	      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-	      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-	      <sparkle:releaseNotesLink>{escape(release_url)}</sparkle:releaseNotesLink>
-	      <pubDate>{escape(pub_date)}</pubDate>
-	      <enclosure
-	        url="{escape(download_url)}"
-	        {signature_fragment}
-	        type="application/octet-stream" />
-	    </item>
-	  </channel>
-	</rss>
-	"""
-)
-Path(appcast).write_text(xml, encoding="utf-8")
-PY
+TAG="$tag" \
+ARCHIVE_PATH="$archive" \
+ARCHIVE_NAME="$archive_name" \
+APPCAST="$appcast" \
+SPARKLE_ARCHIVE_URL="${SPARKLE_ARCHIVE_URL:-}" \
+SPARKLE_RELEASE_NOTES_URL="${SPARKLE_RELEASE_NOTES_URL:-}" \
+SPARKLE_SIGNATURE_OUTPUT="$signature_output" \
+python3 "$repo_root/scripts/release/write-sparkle-appcast.py"

--- a/scripts/release/tests/assert-sparkle-appcast.py
+++ b/scripts/release/tests/assert-sparkle-appcast.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import sys
+import xml.etree.ElementTree as ET
+
+
+path, expected_signature, expected_archive_url, expected_notes_url = sys.argv[1:]
+namespace = {"sparkle": "http://www.andymatuschak.org/xml-namespaces/sparkle"}
+root = ET.parse(path).getroot()
+assert root.tag == "rss"
+channel = root.find("channel")
+assert channel is not None
+assert channel.findtext("link") == "https://github.com/acg-box/rsnap/releases"
+item = channel.find("item")
+assert item is not None
+assert item.findtext("sparkle:version", namespaces=namespace) == "1.2.3"
+assert (
+    item.findtext("sparkle:releaseNotesLink", namespaces=namespace)
+    == expected_notes_url
+)
+enclosure = item.find("enclosure")
+assert enclosure is not None
+assert enclosure.attrib["url"] == expected_archive_url
+assert enclosure.attrib["length"] == "9"
+assert enclosure.attrib[
+    "{http://www.andymatuschak.org/xml-namespaces/sparkle}edSignature"
+] == expected_signature

--- a/scripts/release/tests/generate-sparkle-test-keys.swift
+++ b/scripts/release/tests/generate-sparkle-test-keys.swift
@@ -1,0 +1,25 @@
+#!/usr/bin/env swift
+import CryptoKit
+import Foundation
+
+let firstPrivateKey = Curve25519.Signing.PrivateKey()
+let secondPrivateKey = Curve25519.Signing.PrivateKey()
+
+print(firstPrivateKey.rawRepresentation.base64EncodedString())
+print(firstPrivateKey.publicKey.rawRepresentation.base64EncodedString())
+print(secondPrivateKey.rawRepresentation.base64EncodedString())
+print(secondPrivateKey.publicKey.rawRepresentation.base64EncodedString())
+
+var legacyPrivateKey = Data(SHA512.hash(data: firstPrivateKey.rawRepresentation))
+legacyPrivateKey[legacyPrivateKey.startIndex] &= 248
+legacyPrivateKey[legacyPrivateKey.startIndex + 31] &= 63
+legacyPrivateKey[legacyPrivateKey.startIndex + 31] |= 64
+legacyPrivateKey.append(firstPrivateKey.publicKey.rawRepresentation)
+print(legacyPrivateKey.base64EncodedString())
+
+var mismatchedLegacyPrivateKey = legacyPrivateKey
+mismatchedLegacyPrivateKey.replaceSubrange(
+	mismatchedLegacyPrivateKey.index(mismatchedLegacyPrivateKey.endIndex, offsetBy: -32)...,
+	with: secondPrivateKey.publicKey.rawRepresentation
+)
+print(mismatchedLegacyPrivateKey.base64EncodedString())

--- a/scripts/release/tests/test-sign-macos-app.sh
+++ b/scripts/release/tests/test-sign-macos-app.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SIGNER="$ROOT_DIR/scripts/release/sign-macos-app.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+FAKE_CODESIGN="$TEST_ROOT/codesign"
+CODESIGN_LOG="$TEST_ROOT/codesign.log"
+export CODESIGN_LOG
+
+cat >"$FAKE_CODESIGN" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+	for argument in "$@"; do
+		printf '%q ' "$argument"
+	done
+	printf '\n'
+} >>"$CODESIGN_LOG"
+SH
+chmod +x "$FAKE_CODESIGN"
+
+make_fixture() {
+	local fixture_root="$1"
+	local app="$fixture_root/Rsnap.app"
+	local framework="$app/Contents/Frameworks/Sparkle.framework"
+
+	mkdir -p \
+		"$framework/Versions/B/XPCServices/Installer.xpc" \
+		"$framework/Versions/B/XPCServices/Downloader.xpc" \
+		"$framework/Versions/B/Updater.app"
+	touch "$framework/Versions/B/Autoupdate"
+	ln -s B "$framework/Versions/Current"
+	printf '%s\n' "$app"
+}
+
+assert_contains() {
+	local text="$1"
+	local expected="$2"
+	if [[ "$text" != *"$expected"* ]]; then
+		echo "expected log line to contain: $expected" >&2
+		echo "actual: $text" >&2
+		exit 1
+	fi
+}
+
+app="$(make_fixture "$TEST_ROOT/development")"
+keychain="$TEST_ROOT/test.keychain-db"
+app_entitlements="$TEST_ROOT/app.entitlements"
+downloader_entitlements="$TEST_ROOT/downloader.entitlements"
+touch "$keychain"
+cat >"$app_entitlements" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>app-test</key><true/></dict></plist>
+PLIST
+cat >"$downloader_entitlements" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>downloader-test</key><true/></dict></plist>
+PLIST
+
+: >"$CODESIGN_LOG"
+CODESIGN_BIN="$FAKE_CODESIGN" "$SIGNER" \
+	--app "$app" \
+	--identity "Apple Development: Test" \
+	--keychain "$keychain" \
+	--entitlements "$app_entitlements" \
+	--downloader-entitlements "$downloader_entitlements"
+
+if [[ "$(wc -l <"$CODESIGN_LOG" | tr -d ' ')" != "7" ]]; then
+	echo "expected six signing calls and one verification call" >&2
+	exit 1
+fi
+
+installer_line="$(sed -n '1p' "$CODESIGN_LOG")"
+downloader_line="$(sed -n '2p' "$CODESIGN_LOG")"
+autoupdate_line="$(sed -n '3p' "$CODESIGN_LOG")"
+updater_line="$(sed -n '4p' "$CODESIGN_LOG")"
+framework_line="$(sed -n '5p' "$CODESIGN_LOG")"
+app_line="$(sed -n '6p' "$CODESIGN_LOG")"
+verify_line="$(sed -n '7p' "$CODESIGN_LOG")"
+
+assert_contains "$installer_line" "Installer.xpc"
+assert_contains "$downloader_line" "Downloader.xpc"
+assert_contains "$autoupdate_line" "Autoupdate"
+assert_contains "$updater_line" "Updater.app"
+assert_contains "$framework_line" "Sparkle.framework"
+assert_contains "$app_line" "Rsnap.app"
+assert_contains "$downloader_line" "--entitlements $downloader_entitlements"
+assert_contains "$app_line" "--entitlements $app_entitlements"
+assert_contains "$verify_line" "--verify --deep --strict"
+
+while IFS= read -r signing_line; do
+	assert_contains "$signing_line" "--options runtime"
+	assert_contains "$signing_line" "--timestamp=none"
+	assert_contains "$signing_line" "--keychain $keychain"
+	if [[ "$signing_line" == *"--deep"* ]]; then
+		echo "signing call must not use --deep: $signing_line" >&2
+		exit 1
+	fi
+done < <(sed -n '1,6p' "$CODESIGN_LOG")
+
+preserve_app="$(make_fixture "$TEST_ROOT/preserve")"
+: >"$CODESIGN_LOG"
+CODESIGN_BIN="$FAKE_CODESIGN" "$SIGNER" \
+	--app "$preserve_app" \
+	--identity "Apple Development: Test"
+assert_contains "$(sed -n '2p' "$CODESIGN_LOG")" "--preserve-metadata=entitlements"
+
+distribution_app="$(make_fixture "$TEST_ROOT/distribution")"
+: >"$CODESIGN_LOG"
+CODESIGN_BIN="$FAKE_CODESIGN" "$SIGNER" \
+	--app "$distribution_app" \
+	--identity "Developer ID Application: Test"
+assert_contains "$(sed -n '1p' "$CODESIGN_LOG")" "--timestamp"
+if sed -n '1,6p' "$CODESIGN_LOG" | grep -q -- '--timestamp=none'; then
+	echo "Developer ID signing must request a secure timestamp" >&2
+	exit 1
+fi
+
+outside="$TEST_ROOT/outside"
+mkdir -p "$outside"
+escaped_app="$(make_fixture "$TEST_ROOT/escaped")"
+rm "$escaped_app/Contents/Frameworks/Sparkle.framework/Versions/Current"
+ln -s "$outside" "$escaped_app/Contents/Frameworks/Sparkle.framework/Versions/Current"
+: >"$CODESIGN_LOG"
+if CODESIGN_BIN="$FAKE_CODESIGN" "$SIGNER" \
+	--app "$escaped_app" \
+	--identity "Apple Development: Test" >/dev/null 2>&1; then
+	echo "signer accepted a Versions/Current symlink outside Sparkle.framework" >&2
+	exit 1
+fi
+if [[ -s "$CODESIGN_LOG" ]]; then
+	echo "signer called codesign before rejecting an unsafe framework layout" >&2
+	exit 1
+fi
+
+incomplete_app="$(make_fixture "$TEST_ROOT/incomplete")"
+rm -rf "$incomplete_app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app"
+: >"$CODESIGN_LOG"
+if CODESIGN_BIN="$FAKE_CODESIGN" "$SIGNER" \
+	--app "$incomplete_app" \
+	--identity "Apple Development: Test" >/dev/null 2>&1; then
+	echo "signer accepted a Sparkle framework with a missing nested component" >&2
+	exit 1
+fi
+if [[ -s "$CODESIGN_LOG" ]]; then
+	echo "signer started signing before validating every required component" >&2
+	exit 1
+fi
+
+echo "sign-macos-app tests passed"

--- a/scripts/release/tests/test-sparkle-appcast.sh
+++ b/scripts/release/tests/test-sparkle-appcast.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+APPCAST_TOOL="$ROOT_DIR/scripts/release/sparkle-appcast.sh"
+APPCAST_ASSERTION="$ROOT_DIR/scripts/release/tests/assert-sparkle-appcast.py"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+ARCHIVE="$TEST_ROOT/rsnap-aarch64-apple-darwin.zip"
+APPCAST="$TEST_ROOT/appcast.xml"
+FAKE_SIGN_UPDATE="$TEST_ROOT/sign_update"
+SIGN_UPDATE_LOG="$TEST_ROOT/sign-update.log"
+export SIGN_UPDATE_LOG
+
+printf 'zip-bytes' >"$ARCHIVE"
+cat >"$FAKE_SIGN_UPDATE" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" != "3" || "$1" != "--ed-key-file" || "$2" != "-" ]]; then
+	echo "unexpected sign_update arguments" >&2
+	exit 1
+fi
+read -r private_key
+if [[ "$private_key" != "fake-private-key" ]]; then
+	echo "unexpected private key input" >&2
+	exit 1
+fi
+printf 'called\n' >>"$SIGN_UPDATE_LOG"
+printf '%s\n' "$FAKE_SIGNATURE_OUTPUT"
+SH
+chmod +x "$FAKE_SIGN_UPDATE"
+
+signature="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+valid_output="sparkle:edSignature=\"$signature\" length=\"9\""
+
+run_appcast() {
+	FAKE_SIGNATURE_OUTPUT="$1" \
+	SPARKLE_PRIVATE_ED_KEY="fake-private-key" \
+	SPARKLE_SIGN_UPDATE="$FAKE_SIGN_UPDATE" \
+	SPARKLE_ARCHIVE_URL="${2:-}" \
+	SPARKLE_RELEASE_NOTES_URL="${3:-}" \
+		"$APPCAST_TOOL" \
+		--archive "$ARCHIVE" \
+		--appcast "$APPCAST" \
+		--version "${4:-1.2.3}" \
+		--tag "${5:-v1.2.3}"
+}
+
+: >"$SIGN_UPDATE_LOG"
+run_appcast "$valid_output"
+python3 "$APPCAST_ASSERTION" \
+	"$APPCAST" \
+	"$signature" \
+	"https://github.com/acg-box/rsnap/releases/download/v1.2.3/rsnap-aarch64-apple-darwin.zip" \
+	"https://github.com/acg-box/rsnap/releases/tag/v1.2.3"
+
+loopback_archive_url="http://127.0.0.1:8123/update.zip?one=1&two=2"
+loopback_notes_url="http://localhost:8123/notes.html?one=1&two=2"
+run_appcast "$valid_output" "$loopback_archive_url" "$loopback_notes_url"
+python3 "$APPCAST_ASSERTION" \
+	"$APPCAST" \
+	"$signature" \
+	"$loopback_archive_url" \
+	"$loopback_notes_url"
+
+assert_failure_preserves_appcast() {
+	local label="$1"
+	shift
+	printf 'sentinel' >"$APPCAST"
+	if "$@" >/dev/null 2>&1; then
+		echo "expected failure: $label" >&2
+		exit 1
+	fi
+	if [[ "$(cat "$APPCAST")" != "sentinel" ]]; then
+		echo "failure replaced the existing appcast: $label" >&2
+		exit 1
+	fi
+}
+
+assert_failure_preserves_appcast \
+	"tag mismatch" \
+	run_appcast "$valid_output" "" "" "1.2.3" "v1.2.4"
+
+assert_failure_preserves_appcast \
+	"non-canonical SemVer" \
+	run_appcast "$valid_output" "" "" "01.2.3" "v01.2.3"
+
+assert_failure_preserves_appcast \
+	"wrong signed length" \
+	run_appcast "sparkle:edSignature=\"$signature\" length=\"10\""
+
+assert_failure_preserves_appcast \
+	"extra signer output" \
+	run_appcast "$valid_output
+unexpected"
+
+assert_failure_preserves_appcast \
+	"malformed signature" \
+	run_appcast 'sparkle:edSignature="AAAA" length="9"'
+
+assert_failure_preserves_appcast \
+	"non-canonical archive URL" \
+	run_appcast "$valid_output" "https://example.com/update.zip"
+
+if FAKE_SIGNATURE_OUTPUT="$valid_output" \
+	SPARKLE_PRIVATE_ED_KEY="fake-private-key" \
+	SPARKLE_SIGN_UPDATE="$FAKE_SIGN_UPDATE" \
+		"$APPCAST_TOOL" \
+		--archive "$ARCHIVE" \
+		--appcast "$ARCHIVE" \
+		--version "1.2.3" \
+		--tag "v1.2.3" >/dev/null 2>&1; then
+	echo "appcast generator accepted the archive as its output path" >&2
+	exit 1
+fi
+if [[ "$(cat "$ARCHIVE")" != "zip-bytes" ]]; then
+	echo "appcast generator replaced the signed release archive" >&2
+	exit 1
+fi
+
+printf '' >"$ARCHIVE"
+assert_failure_preserves_appcast \
+	"empty archive" \
+	run_appcast 'sparkle:edSignature="AAAA" length="1"'
+
+echo "sparkle-appcast tests passed"

--- a/scripts/release/tests/test-verify-sparkle-key.sh
+++ b/scripts/release/tests/test-verify-sparkle-key.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+VERIFY_TOOL="$ROOT_DIR/scripts/release/verify-sparkle-key.swift"
+KEY_GENERATOR="$ROOT_DIR/scripts/release/tests/generate-sparkle-test-keys.swift"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+swift "$KEY_GENERATOR" >"$TEST_ROOT/keys"
+
+private_key="$(sed -n '1p' "$TEST_ROOT/keys")"
+public_key="$(sed -n '2p' "$TEST_ROOT/keys")"
+other_public_key="$(sed -n '4p' "$TEST_ROOT/keys")"
+legacy_private_key="$(sed -n '5p' "$TEST_ROOT/keys")"
+mismatched_legacy_private_key="$(sed -n '6p' "$TEST_ROOT/keys")"
+
+printf '%s\n' "$private_key" | swift "$VERIFY_TOOL" "$public_key"
+printf '%s\n' "$legacy_private_key" | swift "$VERIFY_TOOL" "$public_key"
+
+if printf '%s\n' "$private_key" \
+	| swift "$VERIFY_TOOL" "$other_public_key" >/dev/null 2>&1; then
+	echo "key verifier accepted a mismatched public key" >&2
+	exit 1
+fi
+
+if printf '%s\n' "$mismatched_legacy_private_key" \
+	| swift "$VERIFY_TOOL" "$public_key" >/dev/null 2>&1; then
+	echo "key verifier accepted a legacy key with a mismatched public key" >&2
+	exit 1
+fi
+
+if printf '%s\n' "not-base64" \
+	| swift "$VERIFY_TOOL" "$public_key" >/dev/null 2>&1; then
+	echo "key verifier accepted a malformed private key" >&2
+	exit 1
+fi
+
+if printf 'AA==\n' \
+	| swift "$VERIFY_TOOL" "$public_key" >/dev/null 2>&1; then
+	echo "key verifier accepted an unsupported private key length" >&2
+	exit 1
+fi
+
+echo "verify-sparkle-key tests passed"

--- a/scripts/release/tests/test_publish_github_release.py
+++ b/scripts/release/tests/test_publish_github_release.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PUBLISHER_PATH = REPOSITORY_ROOT / "scripts/release/publish-github-release.sh"
+ARCHIVE_NAME = "rsnap-aarch64-apple-darwin.zip"
+APPCAST_NAME = "appcast.xml"
+CHECKSUM_NAME = f"{ARCHIVE_NAME}.sha256"
+COMMIT = "a" * 40
+
+
+FAKE_GH = r"""#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import shutil
+import sys
+
+state_dir = pathlib.Path(os.environ["MOCK_GH_STATE"])
+state_dir.mkdir(parents=True, exist_ok=True)
+release_path = state_dir / "release.json"
+assets_dir = state_dir / "assets"
+assets_dir.mkdir(exist_ok=True)
+log_path = state_dir / "commands.jsonl"
+with log_path.open("a", encoding="utf-8") as log:
+    log.write(json.dumps(sys.argv[1:]) + "\n")
+
+args = sys.argv[1:]
+if not args:
+    raise SystemExit(2)
+
+def release_metadata(draft=True):
+    download_tag = (
+        "untagged-01234567-89ab-cdef-0123-456789abcdef"
+        if draft
+        else "v1.2.3"
+    )
+    return {
+        "id": 42,
+        "tag_name": "v1.2.3",
+        "target_commitish": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "draft": draft,
+        "prerelease": False,
+        "url": "https://api.github.com/repos/acg-box/rsnap/releases/42",
+        "html_url": f"https://github.com/acg-box/rsnap/releases/tag/{download_tag}",
+    }
+
+def load_release():
+    return json.loads(release_path.read_text(encoding="utf-8"))
+
+def write_release(metadata):
+    release_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+def asset_metadata():
+    release = load_release()
+    download_tag = release["html_url"].rsplit("/", 1)[1]
+    result = []
+    for asset_id, path in enumerate(sorted(assets_dir.iterdir()), start=101):
+        result.append({
+            "id": asset_id,
+            "name": path.name,
+            "size": path.stat().st_size,
+            "state": "uploaded",
+            "url": (
+                "https://api.github.com/repos/acg-box/rsnap/releases/assets/"
+                f"{asset_id}"
+            ),
+            "browser_download_url": (
+                f"https://github.com/acg-box/rsnap/releases/download/{download_tag}/"
+                f"{path.name}"
+            ),
+        })
+    return result
+
+if args[0] == "release" and args[1] == "upload":
+    repo_index = args.index("--repo")
+    artifact_args = args[repo_index + 2:]
+    for source in artifact_args:
+        source_path = pathlib.Path(source)
+        shutil.copyfile(source_path, assets_dir / source_path.name)
+    raise SystemExit(0)
+
+if args[0] != "api":
+    raise SystemExit(2)
+
+method = "GET"
+if "--method" in args:
+    method = args[args.index("--method") + 1]
+endpoint = next(
+    value for value in args
+    if value.startswith("repos/")
+)
+
+if endpoint == "repos/acg-box/rsnap/releases/tags/v1.2.3":
+    if not release_path.exists():
+        print("gh: Not Found (HTTP 404)", file=sys.stderr)
+        raise SystemExit(1)
+    print(json.dumps(load_release()))
+elif endpoint == "repos/acg-box/rsnap/commits/v1.2.3":
+    print(json.dumps({"sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}))
+elif endpoint == "repos/acg-box/rsnap/releases?per_page=100":
+    previous = os.environ.get("MOCK_PREVIOUS_VERSION", "1.2.2")
+    releases = []
+    if previous:
+        releases.append({
+            "tag_name": f"v{previous}",
+            "draft": False,
+            "prerelease": False,
+        })
+    pages = [releases]
+    second_page = os.environ.get("MOCK_SECOND_PAGE_VERSION", "")
+    if second_page:
+        pages.append([{
+            "tag_name": f"v{second_page}",
+            "draft": False,
+            "prerelease": False,
+        }])
+    print(json.dumps(pages if "--slurp" in args else releases))
+elif endpoint == "repos/acg-box/rsnap/releases" and method == "POST":
+    metadata = release_metadata()
+    write_release(metadata)
+    print(json.dumps(metadata))
+elif endpoint == "repos/acg-box/rsnap/releases/42/assets?per_page=100":
+    print(json.dumps([asset_metadata()]))
+elif endpoint.startswith("repos/acg-box/rsnap/releases/assets/") and method == "DELETE":
+    asset_id = int(endpoint.rsplit("/", 1)[1])
+    assets = asset_metadata()
+    matching = [asset for asset in assets if asset["id"] == asset_id]
+    if matching:
+        (assets_dir / matching[0]["name"]).unlink()
+elif endpoint.startswith("repos/acg-box/rsnap/releases/assets/"):
+    asset_id = int(endpoint.rsplit("/", 1)[1])
+    matching = [asset for asset in asset_metadata() if asset["id"] == asset_id]
+    if not matching:
+        raise SystemExit(1)
+    data = (assets_dir / matching[0]["name"]).read_bytes()
+    if os.environ.get("MOCK_CORRUPT_DOWNLOAD") == "1" and data:
+        data = bytes([data[0] ^ 1]) + data[1:]
+    sys.stdout.buffer.write(data)
+elif endpoint == "repos/acg-box/rsnap/releases/42" and method == "PATCH":
+    metadata = load_release()
+    metadata["draft"] = False
+    metadata["html_url"] = "https://github.com/acg-box/rsnap/releases/tag/v1.2.3"
+    write_release(metadata)
+else:
+    print(f"unsupported fake gh call: {args}", file=sys.stderr)
+    raise SystemExit(2)
+"""
+
+
+class PublisherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary_directory.name)
+        self.input_dir = self.root / "input"
+        self.input_dir.mkdir()
+        (self.input_dir / ARCHIVE_NAME).write_bytes(b"archive bytes")
+        (self.input_dir / APPCAST_NAME).write_bytes(b"appcast bytes")
+        (self.input_dir / CHECKSUM_NAME).write_bytes(b"checksum bytes")
+
+        self.validator = self.root / "validator"
+        self.validator.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                printf '%s\\n' "$*" >> "$MOCK_VALIDATOR_LOG"
+                if [[ "${MOCK_VALIDATOR_FAIL:-0}" == "1" ]]; then
+                    exit 1
+                fi
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.fake_gh = self.root / "gh"
+        self.fake_gh.write_text(FAKE_GH, encoding="utf-8")
+        for executable in (self.validator, self.fake_gh):
+            executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+        self.state_dir = self.root / "gh-state"
+        self.validator_log = self.root / "validator.log"
+        self.environment = {
+            **os.environ,
+            "GH_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "acg-box/rsnap",
+            "GITHUB_SHA": COMMIT,
+            "RSNAP_RELEASE_COMMIT": COMMIT,
+            "RSNAP_RELEASE_TAG": "v1.2.3",
+            "RSNAP_RELEASE_VERSION": "1.2.3",
+            "RSNAP_RELEASE_INPUT_DIR": str(self.input_dir),
+            "RSNAP_RELEASE_VALIDATOR": str(self.validator),
+            "GH_BIN": str(self.fake_gh),
+            "MOCK_GH_STATE": str(self.state_dir),
+            "MOCK_VALIDATOR_LOG": str(self.validator_log),
+        }
+        self.run_count = 0
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def run_publisher(
+        self,
+        *,
+        extra_environment: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        environment = dict(self.environment)
+        if extra_environment:
+            environment.update(extra_environment)
+        self.run_count += 1
+        stdout_path = self.root / f"publisher-{self.run_count}.stdout"
+        stderr_path = self.root / f"publisher-{self.run_count}.stderr"
+        arguments = ["bash", str(PUBLISHER_PATH)]
+        with stdout_path.open("w", encoding="utf-8") as stdout_file:
+            with stderr_path.open("w", encoding="utf-8") as stderr_file:
+                result = subprocess.run(
+                    arguments,
+                    check=False,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    text=True,
+                    env=environment,
+                )
+        return subprocess.CompletedProcess(
+            arguments,
+            result.returncode,
+            stdout_path.read_text(encoding="utf-8"),
+            stderr_path.read_text(encoding="utf-8"),
+        )
+
+    def commands(self) -> list[list[str]]:
+        log_path = self.state_dir / "commands.jsonl"
+        if not log_path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+        ]
+
+    def test_publishes_only_after_remote_bytes_match(self) -> None:
+        result = self.run_publisher()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        release = json.loads(
+            (self.state_dir / "release.json").read_text(encoding="utf-8")
+        )
+        self.assertFalse(release["draft"])
+        self.assertEqual(
+            {path.name for path in (self.state_dir / "assets").iterdir()},
+            {ARCHIVE_NAME, APPCAST_NAME, CHECKSUM_NAME},
+        )
+        self.assertIn("--assets-json", self.validator_log.read_text(encoding="utf-8"))
+        patch_commands = [
+            command
+            for command in self.commands()
+            if command[0:3] == ["api", "--method", "PATCH"]
+        ]
+        self.assertEqual(len(patch_commands), 1)
+        self.assertIn("make_latest=true", patch_commands[0])
+        self.assertEqual(self.commands()[-1], patch_commands[0])
+
+    def test_local_validation_failure_does_not_create_a_release(self) -> None:
+        result = self.run_publisher(
+            extra_environment={"MOCK_VALIDATOR_FAIL": "1"},
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.state_dir / "release.json").exists())
+        self.assertEqual(self.commands(), [])
+
+    def test_remote_byte_failure_keeps_draft_and_rerun_repairs_it(self) -> None:
+        failed = self.run_publisher(
+            extra_environment={"MOCK_CORRUPT_DOWNLOAD": "1"},
+        )
+        self.assertNotEqual(failed.returncode, 0)
+        release = json.loads(
+            (self.state_dir / "release.json").read_text(encoding="utf-8")
+        )
+        self.assertTrue(release["draft"])
+
+        repaired = self.run_publisher()
+        self.assertEqual(repaired.returncode, 0, repaired.stderr)
+        release = json.loads(
+            (self.state_dir / "release.json").read_text(encoding="utf-8")
+        )
+        self.assertFalse(release["draft"])
+
+    def test_monotonic_gate_fails_before_draft_creation(self) -> None:
+        result = self.run_publisher(
+            extra_environment={"MOCK_PREVIOUS_VERSION": "2.0.0"},
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be higher", result.stderr)
+        self.assertFalse((self.state_dir / "release.json").exists())
+
+    def test_monotonic_gate_reads_all_release_pages(self) -> None:
+        result = self.run_publisher(
+            extra_environment={
+                "MOCK_PREVIOUS_VERSION": "1.0.0",
+                "MOCK_SECOND_PAGE_VERSION": "2.0.0",
+            },
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be higher", result.stderr)
+        self.assertFalse((self.state_dir / "release.json").exists())
+
+    def test_published_release_validates_remote_bytes_independently(self) -> None:
+        self.state_dir.mkdir(parents=True)
+        (self.state_dir / "assets").mkdir()
+        release = {
+            "id": 42,
+            "tag_name": "v1.2.3",
+            "target_commitish": COMMIT,
+            "draft": False,
+            "prerelease": False,
+            "url": "https://api.github.com/repos/acg-box/rsnap/releases/42",
+            "html_url": "https://github.com/acg-box/rsnap/releases/tag/v1.2.3",
+        }
+        (self.state_dir / "release.json").write_text(
+            json.dumps(release),
+            encoding="utf-8",
+        )
+        for name in (ARCHIVE_NAME, APPCAST_NAME, CHECKSUM_NAME):
+            (self.state_dir / "assets" / name).write_bytes(
+                f"published {name}".encode()
+            )
+
+        result = self.run_publisher(
+            extra_environment={"MOCK_PREVIOUS_VERSION": "9.9.9"},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("already public", result.stdout)
+        validator_calls = self.validator_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(validator_calls), 2)
+        self.assertIn("--release-state published", validator_calls[-1])
+        self.assertNotIn(str(self.input_dir), validator_calls[-1])
+        self.assertFalse(
+            any(command[0:3] == ["api", "--method", "PATCH"] for command in self.commands())
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/tests/test_release_artifacts.py
+++ b/scripts/release/tests/test_release_artifacts.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import pathlib
+import plistlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[3]
+VALIDATOR_PATH = REPOSITORY_ROOT / "scripts/release/validate-release-artifacts.py"
+SPEC = importlib.util.spec_from_file_location("rsnap_release_validator", VALIDATOR_PATH)
+assert SPEC is not None and SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = VALIDATOR
+SPEC.loader.exec_module(VALIDATOR)
+DRAFT_TOKEN = "untagged-01234567-89ab-cdef-0123-456789abcdef"
+
+
+class ReleaseFixture:
+    def __init__(
+        self,
+        root: pathlib.Path,
+        *,
+        production_public_key: bool = False,
+    ) -> None:
+        self.root = root
+        self.version = "1.2.3"
+        self.tag = "v1.2.3"
+        self.archive = root / VALIDATOR.ARCHIVE_NAME
+        self.appcast = root / VALIDATOR.APPCAST_NAME
+        self.checksum = root / VALIDATOR.CHECKSUM_NAME
+        self.private_key = root / "sparkle-private.pem"
+
+        if production_public_key:
+            self.public_key_b64 = VALIDATOR.SPARKLE_PUBLIC_ED_KEY
+            self.private_key = None
+        else:
+            subprocess.run(
+                [
+                    "openssl",
+                    "genpkey",
+                    "-algorithm",
+                    "ED25519",
+                    "-out",
+                    str(self.private_key),
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            public_der = subprocess.run(
+                [
+                    "openssl",
+                    "pkey",
+                    "-in",
+                    str(self.private_key),
+                    "-pubout",
+                    "-outform",
+                    "DER",
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            ).stdout
+            self.public_key_b64 = base64.b64encode(public_der[-32:]).decode()
+        self.write_archive()
+        self.write_appcast()
+        self.write_checksum()
+
+    def write_archive(
+        self,
+        *,
+        feed_url: str = VALIDATOR.SPARKLE_FEED_URL,
+        extra_entry: str | None = None,
+    ) -> None:
+        info = {
+            "CFBundleName": "Rsnap",
+            "CFBundleDisplayName": "Rsnap",
+            "CFBundleIdentifier": VALIDATOR.BUNDLE_IDENTIFIER,
+            "CFBundleShortVersionString": self.version,
+            "CFBundleVersion": self.version,
+            "SUFeedURL": feed_url,
+            "SUPublicEDKey": self.public_key_b64,
+        }
+        with zipfile.ZipFile(self.archive, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr(
+                "Rsnap.app/Contents/Info.plist",
+                plistlib.dumps(info),
+            )
+            archive.writestr(
+                "Rsnap.app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle",
+                b"test framework",
+            )
+            archive.writestr(
+                "Rsnap.app/Contents/MacOS/RsnapNativeHost",
+                b"test executable",
+            )
+            if extra_entry is not None:
+                archive.writestr(extra_entry, b"unexpected")
+
+    def signature(self) -> bytes:
+        if self.private_key is None:
+            return bytes(64)
+        signature_path = self.root / "signature.bin"
+        subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-sign",
+                "-inkey",
+                str(self.private_key),
+                "-rawin",
+                "-in",
+                str(self.archive),
+                "-out",
+                str(signature_path),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return signature_path.read_bytes()
+
+    def write_appcast(
+        self,
+        *,
+        signature: bytes | None = None,
+        channel: str = "",
+    ) -> None:
+        signature_text = base64.b64encode(
+            self.signature() if signature is None else signature
+        ).decode()
+        release_url = (
+            f"https://github.com/{VALIDATOR.CANONICAL_REPOSITORY}/"
+            f"releases/tag/{self.tag}"
+        )
+        archive_url = (
+            f"https://github.com/{VALIDATOR.CANONICAL_REPOSITORY}/"
+            f"releases/download/{self.tag}/{VALIDATOR.ARCHIVE_NAME}"
+        )
+        channel_element = (
+            f"<sparkle:channel>{channel}</sparkle:channel>" if channel else ""
+        )
+        self.appcast.write_text(
+            f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:sparkle="{VALIDATOR.SPARKLE_NAMESPACE}">
+  <channel>
+    <title>Rsnap Updates</title>
+    <item>
+      <title>Version {self.version}</title>
+      <link>{release_url}</link>
+      <sparkle:version>{self.version}</sparkle:version>
+      <sparkle:shortVersionString>{self.version}</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>{release_url}</sparkle:releaseNotesLink>
+      {channel_element}
+      <enclosure
+        url="{archive_url}"
+        sparkle:edSignature="{signature_text}"
+        length="{self.archive.stat().st_size}"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+""",
+            encoding="utf-8",
+        )
+
+    def write_checksum(self, *, separator: str = "  ") -> None:
+        digest = hashlib.sha256(self.archive.read_bytes()).hexdigest()
+        self.checksum.write_text(
+            f"{digest}{separator}{VALIDATOR.ARCHIVE_NAME}\n",
+            encoding="ascii",
+        )
+
+    def validate(self, **overrides: object) -> None:
+        arguments: dict[str, object] = {
+            "archive": self.archive,
+            "appcast": self.appcast,
+            "checksum": self.checksum,
+            "version": self.version,
+            "tag": self.tag,
+            "repository": VALIDATOR.CANONICAL_REPOSITORY,
+            "verify_signature": True,
+            "public_key_b64": self.public_key_b64,
+        }
+        arguments.update(overrides)
+        VALIDATOR.validate_artifacts(**arguments)
+
+    def release_metadata(self, *, draft: bool = True) -> dict[str, object]:
+        download_tag = DRAFT_TOKEN if draft else self.tag
+        return {
+            "id": 42,
+            "tag_name": self.tag,
+            "target_commitish": "a" * 40,
+            "draft": draft,
+            "prerelease": False,
+            "url": (
+                f"https://api.github.com/repos/{VALIDATOR.CANONICAL_REPOSITORY}/"
+                "releases/42"
+            ),
+            "html_url": (
+                f"https://github.com/{VALIDATOR.CANONICAL_REPOSITORY}/"
+                f"releases/tag/{download_tag}"
+            ),
+        }
+
+    def asset_metadata(self, *, draft: bool = True) -> list[dict[str, object]]:
+        download_tag = DRAFT_TOKEN if draft else self.tag
+        result = []
+        for asset_id, path in enumerate(
+            (self.archive, self.appcast, self.checksum),
+            start=101,
+        ):
+            result.append(
+                {
+                    "id": asset_id,
+                    "name": path.name,
+                    "size": path.stat().st_size,
+                    "state": "uploaded",
+                    "url": (
+                        f"https://api.github.com/repos/"
+                        f"{VALIDATOR.CANONICAL_REPOSITORY}/releases/assets/{asset_id}"
+                    ),
+                    "browser_download_url": (
+                        f"https://github.com/{VALIDATOR.CANONICAL_REPOSITORY}/"
+                        f"releases/download/{download_tag}/{path.name}"
+                    ),
+                }
+            )
+        return result
+
+
+@unittest.skipUnless(shutil.which("openssl"), "openssl is required")
+class ReleaseArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary_directory.name)
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def test_valid_artifacts_and_signature(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        fixture.validate()
+
+    def test_rejects_second_zip_payload_root(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        fixture.write_archive(extra_entry="README.txt")
+        fixture.write_appcast()
+        fixture.write_checksum()
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "second payload root"):
+            fixture.validate()
+
+    def test_rejects_noncanonical_feed_url(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        fixture.write_archive(feed_url="https://example.invalid/appcast.xml")
+        fixture.write_appcast()
+        fixture.write_checksum()
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "SUFeedURL"):
+            fixture.validate()
+
+    def test_rejects_invalid_signature(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        signature = bytearray(fixture.signature())
+        signature[0] ^= 0x01
+        fixture.write_appcast(signature=bytes(signature))
+        with self.assertRaisesRegex(
+            VALIDATOR.ValidationError,
+            "signature verification failed",
+        ):
+            fixture.validate()
+
+    def test_rejects_noncanonical_checksum_format(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        fixture.write_checksum(separator=" ")
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "exact SHA-256"):
+            fixture.validate()
+
+    def test_rejects_nonstable_appcast_channel(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        fixture.write_appcast(channel="beta")
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "stable channel"):
+            fixture.validate()
+
+    def test_validates_optional_github_metadata(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        release_json = self.root / "release.json"
+        assets_json = self.root / "assets.json"
+        release_json.write_text(json.dumps(fixture.release_metadata()), encoding="utf-8")
+        assets_json.write_text(json.dumps(fixture.asset_metadata()), encoding="utf-8")
+        fixture.validate(
+            release_json=release_json,
+            assets_json=assets_json,
+            release_state="draft",
+        )
+
+        metadata = fixture.asset_metadata()
+        metadata.append(metadata[0])
+        assets_json.write_text(json.dumps(metadata), encoding="utf-8")
+        with self.assertRaisesRegex(
+            VALIDATOR.ValidationError,
+            "exactly three assets",
+        ):
+            fixture.validate(
+                release_json=release_json,
+                assets_json=assets_json,
+                release_state="draft",
+            )
+
+    def test_validates_published_github_urls(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        release_json = self.root / "release.json"
+        assets_json = self.root / "assets.json"
+        release_json.write_text(
+            json.dumps(fixture.release_metadata(draft=False)),
+            encoding="utf-8",
+        )
+        assets_json.write_text(
+            json.dumps(fixture.asset_metadata(draft=False)),
+            encoding="utf-8",
+        )
+        fixture.validate(
+            release_json=release_json,
+            assets_json=assets_json,
+            release_state="published",
+        )
+
+    def test_rejects_draft_asset_from_another_untagged_release(self) -> None:
+        fixture = ReleaseFixture(self.root)
+        release_json = self.root / "release.json"
+        assets_json = self.root / "assets.json"
+        release_json.write_text(json.dumps(fixture.release_metadata()), encoding="utf-8")
+        assets = fixture.asset_metadata()
+        assets[0]["browser_download_url"] = (
+            f"https://github.com/{VALIDATOR.CANONICAL_REPOSITORY}/releases/"
+            f"download/untagged-fedcba98-7654-3210-fedc-ba9876543210/"
+            f"{VALIDATOR.ARCHIVE_NAME}"
+        )
+        assets_json.write_text(json.dumps(assets), encoding="utf-8")
+        with self.assertRaisesRegex(
+            VALIDATOR.ValidationError,
+            "download URL is not canonical",
+        ):
+            fixture.validate(
+                release_json=release_json,
+                assets_json=assets_json,
+                release_state="draft",
+            )
+
+    def test_cli_supports_required_contract(self) -> None:
+        fixture = ReleaseFixture(self.root, production_public_key=True)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR_PATH),
+                "--archive",
+                str(fixture.archive),
+                "--appcast",
+                str(fixture.appcast),
+                "--checksum",
+                str(fixture.checksum),
+                "--version",
+                fixture.version,
+                "--tag",
+                fixture.tag,
+                "--repository",
+                VALIDATOR.CANONICAL_REPOSITORY,
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/tests/test_validate_release_source.py
+++ b/scripts/release/tests/test_validate_release_source.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Tests for the Rsnap release-source validator."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+VALIDATOR = Path(__file__).resolve().parents[1] / "validate-release-source.py"
+
+
+class ReleaseSourceValidatorTests(unittest.TestCase):
+    """Exercise release provenance and version validation in temporary repositories."""
+
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.repo = Path(self.temporary_directory.name)
+        self._write_fixture()
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Rsnap Release Test")
+        self.git("config", "user.email", "release-test@example.invalid")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "tag.gpgsign", "false")
+        self.git("add", ".")
+        self.release_commit = self.commit("release source")
+        self.git("update-ref", "refs/remotes/origin/main", self.release_commit)
+        self.git("tag", "-a", "v1.2.3", "-m", "release v1.2.3")
+
+    def _write_fixture(self) -> None:
+        (self.repo / "apps/rsnap").mkdir(parents=True)
+        (self.repo / "packages/rsnap-core").mkdir(parents=True)
+        (self.repo / "native/macos-host").mkdir(parents=True)
+        (self.repo / "Cargo.toml").write_text(
+            """
+[workspace]
+members = ["apps/*", "packages/*"]
+resolver = "3"
+
+[workspace.package]
+version = "1.2.3"
+""".lstrip(),
+            encoding="utf-8",
+        )
+        for relative_path, name in (
+            ("apps/rsnap/Cargo.toml", "rsnap"),
+            ("packages/rsnap-core/Cargo.toml", "rsnap-core"),
+        ):
+            (self.repo / relative_path).write_text(
+                f"""
+[package]
+name = "{name}"
+version.workspace = true
+""".lstrip(),
+                encoding="utf-8",
+            )
+        (self.repo / "Cargo.lock").write_text(
+            """
+version = 4
+
+[[package]]
+name = "rsnap"
+version = "1.2.3"
+
+[[package]]
+name = "rsnap-core"
+version = "1.2.3"
+""".lstrip(),
+            encoding="utf-8",
+        )
+        (self.repo / "native/macos-host/Package.swift").write_text(
+            """
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "RsnapNativeHost",
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.4"),
+    ]
+)
+""".lstrip(),
+            encoding="utf-8",
+        )
+        (self.repo / "native/macos-host/Package.resolved").write_text(
+            json.dumps(
+                {
+                    "pins": [
+                        {
+                            "identity": "sparkle",
+                            "kind": "remoteSourceControl",
+                            "location": "https://github.com/sparkle-project/Sparkle",
+                            "state": {
+                                "revision": "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+                                "version": "2.9.4",
+                            },
+                        }
+                    ],
+                    "version": 3,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def git(self, *arguments: str) -> str:
+        """Run Git in the temporary repository."""
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def git_with_input(self, content: str, *arguments: str) -> str:
+        """Run Git with text supplied on standard input."""
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=self.repo,
+            input=content,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def commit(self, message: str, parent: str | None = None) -> str:
+        """Create a test commit without invoking repository commit automation."""
+        tree = self.git("write-tree")
+        arguments = ["commit-tree", tree, "-m", message]
+        if parent is not None:
+            arguments.extend(["-p", parent])
+        commit = self.git(*arguments)
+        self.git("update-ref", "HEAD", commit)
+        return commit
+
+    def run_validator(
+        self,
+        *,
+        tag: str = "v1.2.3",
+        repository: str = "acg-box/rsnap",
+    ) -> subprocess.CompletedProcess[str]:
+        """Run the validator with a representative GitHub tag event."""
+        tag_object = self.git("rev-parse", f"refs/tags/{tag}")
+        checkout_commit = self.git("rev-parse", "HEAD^{commit}")
+        event_path = self.repo / "event.json"
+        event_path.write_text(
+            json.dumps(
+                {
+                    "after": tag_object,
+                    "ref": f"refs/tags/{tag}",
+                    "repository": {"full_name": repository},
+                }
+            ),
+            encoding="utf-8",
+        )
+        output_path = self.repo / "github-output.txt"
+        output_path.unlink(missing_ok=True)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_OUTPUT": str(output_path),
+                "GITHUB_REF": f"refs/tags/{tag}",
+                "GITHUB_REF_NAME": tag,
+                "GITHUB_REPOSITORY": repository,
+                "GITHUB_SHA": checkout_commit,
+            }
+        )
+        return subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            cwd=self.repo,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_validation_fails(
+        self, result: subprocess.CompletedProcess[str], message: str
+    ) -> None:
+        """Assert a validation failure contains the expected diagnostic."""
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn(message, result.stderr)
+
+    def test_valid_annotated_tag_writes_trusted_outputs(self) -> None:
+        result = self.run_validator()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outputs = (self.repo / "github-output.txt").read_text(encoding="utf-8")
+        self.assertEqual(
+            outputs.splitlines(),
+            [
+                "version=1.2.3",
+                f"tag_commit={self.release_commit}",
+                "sparkle_version=2.9.4",
+            ],
+        )
+
+    def test_lightweight_tag_is_rejected(self) -> None:
+        self.git("tag", "-d", "v1.2.3")
+        self.git("tag", "v1.2.3")
+
+        result = self.run_validator()
+
+        self.assert_validation_fails(result, "must be an annotated tag")
+
+    def test_annotated_tag_header_name_must_match_ref_name(self) -> None:
+        tag_content = self.git("cat-file", "-p", "refs/tags/v1.2.3")
+        mismatched_content = tag_content.replace(
+            "\ntag v1.2.3\n", "\ntag v9.9.9\n", 1
+        )
+        mismatched_tag_object = self.git_with_input(mismatched_content, "mktag")
+        self.git("update-ref", "refs/tags/v1.2.3", mismatched_tag_object)
+
+        result = self.run_validator()
+
+        self.assert_validation_fails(
+            result,
+            "annotated tag name 'v9.9.9' does not match GITHUB_REF_NAME v1.2.3",
+        )
+
+    def test_tag_and_cargo_version_mismatch_is_rejected(self) -> None:
+        self.git("tag", "-a", "v1.2.4", "-m", "wrong release version")
+
+        result = self.run_validator(tag="v1.2.4")
+
+        self.assert_validation_fails(
+            result, "tag version 1.2.4 does not match Cargo version 1.2.3"
+        )
+
+    def test_tag_commit_outside_origin_main_is_rejected(self) -> None:
+        (self.repo / "side-branch.txt").write_text("not on main\n", encoding="utf-8")
+        self.git("add", "side-branch.txt")
+        self.commit("side branch release", self.git("rev-parse", "HEAD"))
+        self.git("tag", "-d", "v1.2.3")
+        self.git("tag", "-a", "v1.2.3", "-m", "side branch release")
+
+        result = self.run_validator()
+
+        self.assert_validation_fails(result, "is not reachable from origin/main")
+
+    def test_origin_main_can_advance_after_the_tag(self) -> None:
+        (self.repo / "later.txt").write_text("main moved forward\n", encoding="utf-8")
+        self.git("add", "later.txt")
+        later_commit = self.commit("later main commit", self.git("rev-parse", "HEAD"))
+        self.git("update-ref", "refs/remotes/origin/main", later_commit)
+        self.git("checkout", "--detach", self.release_commit)
+
+        result = self.run_validator()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_tag_with_leading_zero_is_rejected(self) -> None:
+        self.git("tag", "-a", "v01.2.3", "-m", "invalid release version")
+
+        result = self.run_validator(tag="v01.2.3")
+
+        self.assert_validation_fails(
+            result, "stable vX.Y.Z SemVer without leading zeroes"
+        )
+
+    def test_mismatched_sparkle_pin_is_rejected(self) -> None:
+        resolved_path = self.repo / "native/macos-host/Package.resolved"
+        resolved = json.loads(resolved_path.read_text(encoding="utf-8"))
+        resolved["pins"][0]["state"]["version"] = "2.9.5"
+        resolved_path.write_text(json.dumps(resolved), encoding="utf-8")
+
+        result = self.run_validator()
+
+        self.assert_validation_fails(
+            result,
+            "Package.resolved Sparkle version does not match Package.swift exact version",
+        )
+
+    def test_sparkle_exact_version_with_leading_zero_is_rejected(self) -> None:
+        package_path = self.repo / "native/macos-host/Package.swift"
+        package_source = package_path.read_text(encoding="utf-8")
+        package_path.write_text(
+            package_source.replace('exact: "2.9.4"', 'exact: "02.9.4"'),
+            encoding="utf-8",
+        )
+
+        result = self.run_validator()
+
+        self.assert_validation_fails(
+            result,
+            "Sparkle exact version must be stable X.Y.Z SemVer without leading zeroes",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/tests/test_workflow_contract.py
+++ b/scripts/release/tests/test_workflow_contract.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Static regression checks for the supported CI and tag-release shape."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class WorkflowContractTests(unittest.TestCase):
+	def test_language_checks_keep_all_supported_lanes_and_triggers(self) -> None:
+		workflow = (ROOT / ".github/workflows/language.yml").read_text(encoding="utf-8")
+		for required in (
+			"push:",
+			"pull_request:",
+			"merge_group:",
+			"rust-check:",
+			"swift-check:",
+			"toml-check:",
+			"runs-on: macos-26",
+			"cargo make test-release",
+		):
+			self.assertIn(required, workflow)
+
+	def test_release_permissions_and_jobs_are_minimal(self) -> None:
+		workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+		self.assertIn("permissions:\n  contents: read", workflow)
+		self.assertEqual(workflow.count("contents: write"), 1)
+		self.assertEqual(workflow.count("runs-on: macos-26"), 1)
+		self.assertNotIn("workflow_dispatch", workflow)
+		self.assertNotIn("Release Preparation", workflow)
+		self.assertNotIn("Release Dry Run", workflow)
+		self.assertIn("needs: [validate-release, build-macos]", workflow)
+		self.assertIn("environment:\n      name: release", workflow)
+		for secret in (
+			"APPLE_CERTIFICATE_P12_BASE64",
+			"APPLE_CERTIFICATE_PASSWORD",
+			"APPLE_SIGNING_IDENTITY",
+			"SPARKLE_PRIVATE_ED_KEY",
+		):
+			self.assertIn(f"secrets.{secret}", workflow)
+		self.assertNotIn("RSNAP_SPARKLE_PRIVATE_ED_KEY", workflow)
+		self.assertNotIn("APPLE_DEVELOPER_ID_APPLICATION", workflow)
+		self.assertNotIn("APPLE_NOTARY_", workflow)
+		self.assertNotIn("notarytool", workflow)
+		self.assertIn("retention-days: 7", workflow)
+
+	def test_canonical_repository_has_no_stale_owner_reference(self) -> None:
+		result = subprocess.run(
+			[
+				"git",
+				"-C",
+				str(ROOT),
+				"grep",
+				"-n",
+				"acgxv/rsnap",
+				"--",
+				":!scripts/release/tests/test_workflow_contract.py",
+			],
+			capture_output=True,
+			text=True,
+		)
+		self.assertEqual(result.returncode, 1, result.stdout)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/release/validate-release-artifacts.py
+++ b/scripts/release/validate-release-artifacts.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Validate the complete Rsnap GitHub release artifact set."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import pathlib
+import plistlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from typing import Any
+from xml.etree import ElementTree
+
+
+ARCHIVE_NAME = "rsnap-aarch64-apple-darwin.zip"
+APPCAST_NAME = "appcast.xml"
+CHECKSUM_NAME = f"{ARCHIVE_NAME}.sha256"
+APP_BUNDLE_NAME = "Rsnap.app"
+BUNDLE_IDENTIFIER = "ink.hack.rsnap"
+CANONICAL_REPOSITORY = "acg-box/rsnap"
+SPARKLE_FEED_URL = (
+    "https://github.com/acg-box/rsnap/releases/latest/download/appcast.xml"
+)
+SPARKLE_PUBLIC_ED_KEY = "X2EaTv6mCzkYxz75Hh+ldMkKlpzNlHRg5l7Kn9ke8Ow="
+SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+SEMVER_PATTERN = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)")
+MAX_METADATA_BYTES = 4 * 1024 * 1024
+
+
+class ValidationError(ValueError):
+    """Report an invalid or inconsistent release artifact."""
+
+
+def require(condition: bool, message: str) -> None:
+    """Raise a release validation error when a condition is false."""
+    if not condition:
+        raise ValidationError(message)
+
+
+def load_json(path: pathlib.Path) -> Any:
+    """Load bounded JSON metadata."""
+    require(path.is_file(), f"metadata file does not exist: {path}")
+    require(
+        path.stat().st_size <= MAX_METADATA_BYTES,
+        f"metadata file is too large: {path}",
+    )
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValidationError(f"cannot read JSON metadata {path}: {error}") from error
+
+
+def validate_identity(
+    archive: pathlib.Path,
+    appcast: pathlib.Path,
+    checksum: pathlib.Path,
+    version: str,
+    tag: str,
+    repository: str,
+) -> None:
+    """Validate fixed names and release identity inputs."""
+    require(repository == CANONICAL_REPOSITORY, "repository must be acg-box/rsnap")
+    require(SEMVER_PATTERN.fullmatch(version) is not None, "version must be X.Y.Z")
+    require(tag == f"v{version}", "tag must be v followed by the release version")
+
+    expected_names = (
+        (archive, ARCHIVE_NAME),
+        (appcast, APPCAST_NAME),
+        (checksum, CHECKSUM_NAME),
+    )
+    for path, expected_name in expected_names:
+        require(path.is_file(), f"release artifact does not exist: {path}")
+        require(
+            path.name == expected_name,
+            f"release artifact must be named {expected_name}: {path}",
+        )
+
+
+def validate_archive(
+    archive: pathlib.Path,
+    version: str,
+    public_key_b64: str,
+) -> None:
+    """Validate the app root and its release identity without extracting the ZIP."""
+    try:
+        with zipfile.ZipFile(archive) as bundle_zip:
+            entries = bundle_zip.infolist()
+            require(entries, "release archive is empty")
+
+            names: set[str] = set()
+            payload_names: list[str] = []
+            for entry in entries:
+                name = entry.filename
+                require(name not in names, f"release archive has duplicate entry: {name}")
+                names.add(name)
+                require("\x00" not in name, "release archive has a NUL in an entry name")
+                require("\\" not in name, f"release archive has a backslash path: {name}")
+                path = pathlib.PurePosixPath(name)
+                require(not path.is_absolute(), f"release archive has an absolute path: {name}")
+                require(
+                    ".." not in path.parts,
+                    f"release archive has a parent path component: {name}",
+                )
+
+                # ditto can add AppleDouble metadata. It is not a second payload root.
+                if path.parts and path.parts[0] == "__MACOSX":
+                    continue
+                require(path.parts, "release archive has an empty entry name")
+                require(
+                    path.parts[0] == APP_BUNDLE_NAME,
+                    f"release archive has a second payload root: {name}",
+                )
+                payload_names.append(name)
+
+            require(payload_names, "release archive does not contain Rsnap.app")
+            info_name = f"{APP_BUNDLE_NAME}/Contents/Info.plist"
+            require(info_name in names, "Rsnap.app does not contain Contents/Info.plist")
+            info_entry = bundle_zip.getinfo(info_name)
+            require(
+                info_entry.file_size <= MAX_METADATA_BYTES,
+                "Info.plist is too large",
+            )
+            try:
+                info = plistlib.loads(bundle_zip.read(info_entry))
+            except (OSError, plistlib.InvalidFileException) as error:
+                raise ValidationError(f"cannot parse Info.plist: {error}") from error
+
+            sparkle_prefix = (
+                f"{APP_BUNDLE_NAME}/Contents/Frameworks/Sparkle.framework/"
+            )
+            require(
+                any(
+                    name.startswith(sparkle_prefix)
+                    and not bundle_zip.getinfo(name).is_dir()
+                    for name in payload_names
+                ),
+                "Rsnap.app does not contain Sparkle.framework",
+            )
+    except (OSError, zipfile.BadZipFile, KeyError) as error:
+        raise ValidationError(f"cannot read release archive: {error}") from error
+
+    require(isinstance(info, dict), "Info.plist root must be a dictionary")
+    expected_values = {
+        "CFBundleName": "Rsnap",
+        "CFBundleDisplayName": "Rsnap",
+        "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+        "CFBundleShortVersionString": version,
+        "CFBundleVersion": version,
+        "SUFeedURL": SPARKLE_FEED_URL,
+        "SUPublicEDKey": public_key_b64,
+    }
+    for key, expected in expected_values.items():
+        require(
+            info.get(key) == expected,
+            f"Info.plist {key} must be {expected!r}",
+        )
+
+
+def decode_signature(signature_text: str) -> bytes:
+    """Decode and validate a Sparkle Ed25519 signature."""
+    try:
+        signature = base64.b64decode(signature_text, validate=True)
+    except (ValueError, binascii.Error) as error:
+        raise ValidationError("appcast Ed25519 signature is not valid base64") from error
+    require(len(signature) == 64, "appcast Ed25519 signature must be 64 bytes")
+    return signature
+
+
+def verify_ed25519_signature(
+    archive: pathlib.Path,
+    signature: bytes,
+    public_key_b64: str,
+) -> None:
+    """Verify an Ed25519 signature with the OpenSSL platform primitive."""
+    openssl = shutil.which("openssl")
+    require(openssl is not None, "openssl is required to verify the appcast signature")
+    try:
+        public_key = base64.b64decode(public_key_b64, validate=True)
+    except (ValueError, binascii.Error) as error:
+        raise ValidationError("checked-in Sparkle public key is not valid base64") from error
+    require(len(public_key) == 32, "checked-in Sparkle public key must be 32 bytes")
+
+    # RFC 8410 SubjectPublicKeyInfo for an Ed25519 raw public key.
+    public_key_der = bytes.fromhex("302a300506032b6570032100") + public_key
+    public_key_pem = (
+        b"-----BEGIN PUBLIC KEY-----\n"
+        + base64.encodebytes(public_key_der)
+        + b"-----END PUBLIC KEY-----\n"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="rsnap-release-signature-") as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
+        public_key_path = temp_path / "sparkle-public.pem"
+        signature_path = temp_path / "sparkle-signature.bin"
+        public_key_path.write_bytes(public_key_pem)
+        signature_path.write_bytes(signature)
+        result = subprocess.run(
+            [
+                openssl,
+                "pkeyutl",
+                "-verify",
+                "-pubin",
+                "-inkey",
+                str(public_key_path),
+                "-rawin",
+                "-in",
+                str(archive),
+                "-sigfile",
+                str(signature_path),
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    require(result.returncode == 0, "appcast Ed25519 signature verification failed")
+
+
+def required_element_text(
+    parent: ElementTree.Element,
+    name: str,
+    description: str,
+) -> str:
+    """Read one required child element as non-empty text."""
+    elements = parent.findall(name)
+    require(len(elements) == 1, f"appcast must contain one {description}")
+    value = elements[0].text
+    require(value is not None and value.strip() != "", f"appcast {description} is empty")
+    return value.strip()
+
+
+def validate_appcast(
+    appcast: pathlib.Path,
+    archive: pathlib.Path,
+    version: str,
+    tag: str,
+    verify_signature: bool,
+    public_key_b64: str,
+) -> None:
+    """Validate the stable Sparkle item and its archive enclosure."""
+    require(appcast.stat().st_size <= MAX_METADATA_BYTES, "appcast.xml is too large")
+    try:
+        appcast_bytes = appcast.read_bytes()
+    except OSError as error:
+        raise ValidationError(f"cannot read appcast.xml: {error}") from error
+    upper_bytes = appcast_bytes.upper()
+    require(b"<!DOCTYPE" not in upper_bytes, "appcast.xml must not contain a DOCTYPE")
+    require(b"<!ENTITY" not in upper_bytes, "appcast.xml must not contain entities")
+    try:
+        root = ElementTree.fromstring(appcast_bytes)
+    except ElementTree.ParseError as error:
+        raise ValidationError(f"cannot parse appcast.xml: {error}") from error
+
+    require(root.tag == "rss", "appcast root must be rss")
+    channels = root.findall("channel")
+    require(len(channels) == 1, "appcast must contain one channel")
+    items = channels[0].findall("item")
+    require(len(items) == 1, "appcast must contain one stable release item")
+    item = items[0]
+
+    channel_name = f"{{{SPARKLE_NAMESPACE}}}channel"
+    require(item.find(channel_name) is None, "appcast release item must use the stable channel")
+    require(
+        required_element_text(
+            item,
+            f"{{{SPARKLE_NAMESPACE}}}version",
+            "sparkle:version",
+        )
+        == version,
+        "appcast sparkle:version does not match the release version",
+    )
+    require(
+        required_element_text(
+            item,
+            f"{{{SPARKLE_NAMESPACE}}}shortVersionString",
+            "sparkle:shortVersionString",
+        )
+        == version,
+        "appcast short version does not match the release version",
+    )
+
+    release_url = f"https://github.com/{CANONICAL_REPOSITORY}/releases/tag/{tag}"
+    require(
+        required_element_text(item, "link", "release link") == release_url,
+        "appcast release link is not canonical",
+    )
+    require(
+        required_element_text(
+            item,
+            f"{{{SPARKLE_NAMESPACE}}}releaseNotesLink",
+            "release notes link",
+        )
+        == release_url,
+        "appcast release notes link is not canonical",
+    )
+
+    enclosures = item.findall("enclosure")
+    require(len(enclosures) == 1, "appcast must contain one enclosure")
+    enclosure = enclosures[0]
+    archive_url = (
+        f"https://github.com/{CANONICAL_REPOSITORY}/releases/download/"
+        f"{tag}/{ARCHIVE_NAME}"
+    )
+    require(enclosure.get("url") == archive_url, "appcast archive URL is not canonical")
+    require(
+        enclosure.get("length") == str(archive.stat().st_size),
+        "appcast archive length does not match the ZIP",
+    )
+    signature_text = enclosure.get(f"{{{SPARKLE_NAMESPACE}}}edSignature")
+    require(signature_text is not None, "appcast enclosure has no Ed25519 signature")
+    signature = decode_signature(signature_text)
+    if verify_signature:
+        verify_ed25519_signature(archive, signature, public_key_b64)
+
+
+def validate_checksum(checksum: pathlib.Path, archive: pathlib.Path) -> None:
+    """Validate the canonical SHA-256 checksum file byte for byte."""
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    expected = f"{digest}  {ARCHIVE_NAME}\n".encode()
+    try:
+        actual = checksum.read_bytes()
+    except OSError as error:
+        raise ValidationError(f"cannot read checksum file: {error}") from error
+    require(
+        actual == expected,
+        f"{CHECKSUM_NAME} must contain the exact SHA-256 line for {ARCHIVE_NAME}",
+    )
+
+
+def validate_release_metadata(
+    metadata: Any,
+    tag: str,
+    repository: str,
+    release_state: str | None,
+) -> tuple[int, str]:
+    """Validate GitHub release metadata and return its ID and download tag."""
+    require(isinstance(metadata, dict), "GitHub release metadata must be an object")
+    release_id = metadata.get("id")
+    require(
+        isinstance(release_id, int) and release_id > 0,
+        "GitHub release ID must be a positive integer",
+    )
+    require(metadata.get("tag_name") == tag, "GitHub release tag does not match")
+    require(metadata.get("prerelease") is False, "GitHub release must not be a prerelease")
+
+    expected_api_url = f"https://api.github.com/repos/{repository}/releases/{release_id}"
+    require(
+        metadata.get("url") == expected_api_url,
+        "GitHub release API URL is not canonical",
+    )
+
+    download_tag = tag
+    if release_state is not None:
+        expected_draft = release_state == "draft"
+        require(
+            metadata.get("draft") is expected_draft,
+            f"GitHub release must be {release_state}",
+        )
+    if release_state == "draft":
+        draft_url_prefix = f"https://github.com/{repository}/releases/tag/"
+        html_url = metadata.get("html_url")
+        require(
+            isinstance(html_url, str) and html_url.startswith(draft_url_prefix),
+            "GitHub draft release URL is not canonical",
+        )
+        download_tag = html_url.removeprefix(draft_url_prefix)
+        require(
+            re.fullmatch(r"untagged-[A-Za-z0-9][A-Za-z0-9._-]*", download_tag)
+            is not None,
+            "GitHub draft release URL has an invalid untagged token",
+        )
+    else:
+        expected_html_url = f"https://github.com/{repository}/releases/tag/{tag}"
+        require(
+            metadata.get("html_url") == expected_html_url,
+            "GitHub release URL is not canonical",
+        )
+    return release_id, download_tag
+
+
+def validate_asset_metadata(
+    metadata: Any,
+    release_id: int,
+    download_tag: str,
+    archive: pathlib.Path,
+    appcast: pathlib.Path,
+    checksum: pathlib.Path,
+    repository: str,
+) -> None:
+    """Validate the exact GitHub release asset metadata set."""
+    require(isinstance(metadata, list), "GitHub asset metadata must be an array")
+    local_paths = {
+        ARCHIVE_NAME: archive,
+        APPCAST_NAME: appcast,
+        CHECKSUM_NAME: checksum,
+    }
+    require(
+        len(metadata) == len(local_paths),
+        "GitHub release must contain exactly three assets",
+    )
+
+    seen_names: set[str] = set()
+    for asset in metadata:
+        require(isinstance(asset, dict), "GitHub asset metadata entry must be an object")
+        asset_id = asset.get("id")
+        name = asset.get("name")
+        require(
+            isinstance(asset_id, int) and asset_id > 0,
+            "GitHub asset ID must be a positive integer",
+        )
+        require(isinstance(name, str), "GitHub asset name must be a string")
+        require(name not in seen_names, f"GitHub release has duplicate asset: {name}")
+        seen_names.add(name)
+        require(name in local_paths, f"GitHub release has unexpected asset: {name}")
+        require(
+            asset.get("size") == local_paths[name].stat().st_size,
+            f"GitHub asset size does not match local file: {name}",
+        )
+        expected_api_url = (
+            f"https://api.github.com/repos/{repository}/releases/assets/{asset_id}"
+        )
+        expected_download_url = (
+            f"https://github.com/{repository}/releases/download/{download_tag}/{name}"
+        )
+        require(
+            asset.get("url") == expected_api_url,
+            f"GitHub asset API URL is not canonical: {name}",
+        )
+        require(
+            asset.get("browser_download_url") == expected_download_url,
+            f"GitHub asset download URL is not canonical: {name}",
+        )
+        require(
+            asset.get("state") == "uploaded",
+            f"GitHub asset is not fully uploaded: {name}",
+        )
+    require(seen_names == set(local_paths), "GitHub release asset set is incomplete")
+
+
+def validate_artifacts(
+    *,
+    archive: pathlib.Path,
+    appcast: pathlib.Path,
+    checksum: pathlib.Path,
+    version: str,
+    tag: str,
+    repository: str,
+    verify_signature: bool = False,
+    public_key_b64: str = SPARKLE_PUBLIC_ED_KEY,
+    release_json: pathlib.Path | None = None,
+    assets_json: pathlib.Path | None = None,
+    release_state: str | None = None,
+) -> None:
+    """Validate local artifacts and optional GitHub metadata."""
+    validate_identity(archive, appcast, checksum, version, tag, repository)
+    validate_archive(archive, version, public_key_b64)
+    validate_appcast(
+        appcast,
+        archive,
+        version,
+        tag,
+        verify_signature,
+        public_key_b64,
+    )
+    validate_checksum(checksum, archive)
+
+    if assets_json is not None:
+        require(release_json is not None, "--assets-json requires --release-json")
+    if release_state is not None:
+        require(release_json is not None, "release metadata options require --release-json")
+    if release_json is not None:
+        release_id, download_tag = validate_release_metadata(
+            load_json(release_json),
+            tag,
+            repository,
+            release_state,
+        )
+        if assets_json is not None:
+            validate_asset_metadata(
+                load_json(assets_json),
+                release_id,
+                download_tag,
+                archive,
+                appcast,
+                checksum,
+                repository,
+            )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse the release validator command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", required=True, type=pathlib.Path)
+    parser.add_argument("--appcast", required=True, type=pathlib.Path)
+    parser.add_argument("--checksum", required=True, type=pathlib.Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument(
+        "--verify-appcast-signature",
+        action="store_true",
+        help="verify the appcast Ed25519 signature with OpenSSL",
+    )
+    parser.add_argument("--release-json", type=pathlib.Path)
+    parser.add_argument("--assets-json", type=pathlib.Path)
+    parser.add_argument("--release-state", choices=("draft", "published"))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release artifact validator."""
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        validate_artifacts(
+            archive=args.archive,
+            appcast=args.appcast,
+            checksum=args.checksum,
+            version=args.version,
+            tag=args.tag,
+            repository=args.repository,
+            verify_signature=args.verify_appcast_signature,
+            release_json=args.release_json,
+            assets_json=args.assets_json,
+            release_state=args.release_state,
+        )
+    except ValidationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(f"validated Rsnap release artifacts for {args.tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release/validate-release-source.py
+++ b/scripts/release/validate-release-source.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Validate that a GitHub tag build comes from an eligible Rsnap source commit."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+CANONICAL_REPOSITORY = "acg-box/rsnap"
+STABLE_VERSION_PATTERN = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+STABLE_TAG_PATTERN = re.compile(
+    r"v((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))"
+)
+SPARKLE_LOCATION = "https://github.com/sparkle-project/Sparkle"
+SPARKLE_EXACT_PATTERN = re.compile(
+    r"""
+    \.package
+    \s*\(
+    \s*url:\s*"https://github\.com/sparkle-project/Sparkle(?:\.git)?"
+    \s*,\s*exact:\s*"([^"]+)"
+    \s*\)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+class ValidationError(RuntimeError):
+    """A release-source validation failure."""
+
+
+def require_environment(name: str) -> str:
+    """Return a required, non-empty environment variable."""
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValidationError(f"{name} is required")
+    return value
+
+
+def git(repo_root: Path, *arguments: str) -> str:
+    """Run a read-only Git command and return its trimmed stdout."""
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+        raise ValidationError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    """Load a TOML document and require a table at its root."""
+    with path.open("rb") as stream:
+        document = tomllib.load(stream)
+    if not isinstance(document, dict):
+        raise ValidationError(f"{path} does not contain a TOML table")
+    return document
+
+
+def validate_github_event(tag: str) -> tuple[dict[str, Any], str]:
+    """Validate canonical GitHub repository and tag event metadata."""
+    repository = require_environment("GITHUB_REPOSITORY")
+    if repository != CANONICAL_REPOSITORY:
+        raise ValidationError(
+            f"GITHUB_REPOSITORY must be {CANONICAL_REPOSITORY}, got {repository}"
+        )
+
+    github_ref = require_environment("GITHUB_REF")
+    expected_ref = f"refs/tags/{tag}"
+    if github_ref != expected_ref:
+        raise ValidationError(f"GITHUB_REF must be {expected_ref}, got {github_ref}")
+
+    event_path = Path(require_environment("GITHUB_EVENT_PATH"))
+    try:
+        event = json.loads(event_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValidationError(f"cannot read GitHub event payload: {error}") from error
+    if not isinstance(event, dict):
+        raise ValidationError("GitHub event payload must be a JSON object")
+
+    if event.get("ref") != expected_ref:
+        raise ValidationError(f"GitHub event ref must be {expected_ref}")
+    event_repository = event.get("repository")
+    if not isinstance(event_repository, dict):
+        raise ValidationError("GitHub event repository metadata is missing")
+    if event_repository.get("full_name") != CANONICAL_REPOSITORY:
+        raise ValidationError(
+            f"GitHub event repository must be {CANONICAL_REPOSITORY}"
+        )
+
+    event_after = event.get("after")
+    if not isinstance(event_after, str) or not event_after:
+        raise ValidationError("GitHub event after object is missing")
+    return event, event_after
+
+
+def validate_tag_and_source(repo_root: Path, tag: str, event_after: str) -> str:
+    """Validate annotated-tag identity and main-branch ancestry."""
+    tag_ref = f"refs/tags/{tag}"
+    if git(repo_root, "cat-file", "-t", tag_ref) != "tag":
+        raise ValidationError(f"{tag} must be an annotated tag")
+
+    tag_object = git(repo_root, "cat-file", "-p", tag_ref)
+    tag_headers = tag_object.partition("\n\n")[0].splitlines()
+    header_values = {
+        key: value
+        for line in tag_headers
+        if " " in line
+        for key, value in [line.split(" ", 1)]
+    }
+    if header_values.get("type") != "commit":
+        raise ValidationError(f"{tag} must point directly to a commit")
+    annotated_tag_name = header_values.get("tag")
+    if annotated_tag_name != tag:
+        raise ValidationError(
+            f"annotated tag name {annotated_tag_name!r} does not match GITHUB_REF_NAME {tag}"
+        )
+
+    direct_target = header_values.get("object", "")
+    tag_commit = git(repo_root, "rev-parse", f"{tag_ref}^{{commit}}")
+    if direct_target != tag_commit:
+        raise ValidationError(f"{tag} does not point directly to its peeled commit")
+
+    head_commit = git(repo_root, "rev-parse", "HEAD^{commit}")
+    github_commit = git(
+        repo_root, "rev-parse", f"{require_environment('GITHUB_SHA')}^{{commit}}"
+    )
+    event_commit = git(repo_root, "rev-parse", f"{event_after}^{{commit}}")
+    source_commits = {
+        "tag": tag_commit,
+        "checkout": head_commit,
+        "GITHUB_SHA": github_commit,
+        "event": event_commit,
+    }
+    if len(set(source_commits.values())) != 1:
+        details = ", ".join(f"{name}={commit}" for name, commit in source_commits.items())
+        raise ValidationError(f"release source commits do not match: {details}")
+
+    origin_main = git(repo_root, "rev-parse", "refs/remotes/origin/main^{commit}")
+    ancestry = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", tag_commit, origin_main],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if ancestry.returncode == 1:
+        raise ValidationError(f"tag commit {tag_commit} is not reachable from origin/main")
+    if ancestry.returncode != 0:
+        detail = ancestry.stderr.strip() or ancestry.stdout.strip() or "unknown Git error"
+        raise ValidationError(f"cannot verify origin/main ancestry: {detail}")
+
+    return tag_commit
+
+
+def workspace_member_manifests(
+    repo_root: Path, workspace: dict[str, Any]
+) -> list[Path]:
+    """Resolve Cargo workspace member patterns to package manifests."""
+    members = workspace.get("members")
+    if not isinstance(members, list) or not members:
+        raise ValidationError("Cargo.toml workspace.members must be a non-empty array")
+
+    manifests: set[Path] = set()
+    for member_pattern in members:
+        if not isinstance(member_pattern, str) or not member_pattern:
+            raise ValidationError("Cargo.toml workspace member patterns must be strings")
+        for match in glob.glob(str(repo_root / member_pattern)):
+            candidate = Path(match)
+            manifest = candidate if candidate.name == "Cargo.toml" else candidate / "Cargo.toml"
+            if manifest.is_file():
+                manifests.add(manifest.resolve())
+    if not manifests:
+        raise ValidationError("Cargo.toml workspace patterns did not resolve any packages")
+    return sorted(manifests)
+
+
+def validate_cargo_versions(repo_root: Path, tag_version: str) -> str:
+    """Validate workspace and locked local package versions."""
+    root_manifest = load_toml(repo_root / "Cargo.toml")
+    workspace = root_manifest.get("workspace")
+    if not isinstance(workspace, dict):
+        raise ValidationError("Cargo.toml is missing [workspace]")
+    workspace_package = workspace.get("package")
+    if not isinstance(workspace_package, dict):
+        raise ValidationError("Cargo.toml is missing [workspace.package]")
+
+    version = workspace_package.get("version")
+    if not isinstance(version, str) or STABLE_VERSION_PATTERN.fullmatch(version) is None:
+        raise ValidationError(
+            "Cargo workspace version must be stable X.Y.Z SemVer without leading zeroes"
+        )
+    if version != tag_version:
+        raise ValidationError(f"tag version {tag_version} does not match Cargo version {version}")
+
+    member_names: set[str] = set()
+    for manifest_path in workspace_member_manifests(repo_root, workspace):
+        manifest = load_toml(manifest_path)
+        package = manifest.get("package")
+        if not isinstance(package, dict):
+            raise ValidationError(f"{manifest_path} is missing [package]")
+        name = package.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValidationError(f"{manifest_path} has no package name")
+        if name in member_names:
+            raise ValidationError(f"duplicate Cargo workspace package name: {name}")
+        member_names.add(name)
+
+        member_version = package.get("version")
+        if isinstance(member_version, dict) and member_version.get("workspace") is True:
+            resolved_version = version
+        elif isinstance(member_version, str):
+            resolved_version = member_version
+        else:
+            raise ValidationError(f"{manifest_path} has no resolvable package version")
+        if resolved_version != version:
+            raise ValidationError(
+                f"Cargo workspace package {name} has version {resolved_version}, expected {version}"
+            )
+
+    lockfile = load_toml(repo_root / "Cargo.lock")
+    locked_packages = lockfile.get("package")
+    if not isinstance(locked_packages, list):
+        raise ValidationError("Cargo.lock is missing package entries")
+    for name in sorted(member_names):
+        candidates = [
+            package
+            for package in locked_packages
+            if isinstance(package, dict)
+            and package.get("name") == name
+            and "source" not in package
+        ]
+        if len(candidates) != 1:
+            raise ValidationError(
+                f"Cargo.lock must contain exactly one local workspace package named {name}"
+            )
+        locked_version = candidates[0].get("version")
+        if locked_version != version:
+            raise ValidationError(
+                f"Cargo.lock workspace package {name} has version {locked_version}, expected {version}"
+            )
+
+    return version
+
+
+def validate_sparkle_pin(repo_root: Path) -> str:
+    """Validate that SwiftPM uses one exact Sparkle version and matching pin."""
+    package_path = repo_root / "native/macos-host/Package.swift"
+    package_source = package_path.read_text(encoding="utf-8")
+    sparkle_mentions = package_source.count("github.com/sparkle-project/Sparkle")
+    exact_matches = SPARKLE_EXACT_PATTERN.findall(package_source)
+    if sparkle_mentions != 1 or len(exact_matches) != 1:
+        raise ValidationError(
+            "Package.swift must declare Sparkle exactly once with an exact version"
+        )
+    sparkle_version = exact_matches[0]
+    if STABLE_VERSION_PATTERN.fullmatch(sparkle_version) is None:
+        raise ValidationError(
+            "Package.swift Sparkle exact version must be stable X.Y.Z SemVer "
+            "without leading zeroes"
+        )
+
+    resolved_path = repo_root / "native/macos-host/Package.resolved"
+    try:
+        resolved = json.loads(resolved_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValidationError(f"cannot read Package.resolved: {error}") from error
+    pins = resolved.get("pins") if isinstance(resolved, dict) else None
+    if not isinstance(pins, list):
+        raise ValidationError("Package.resolved is missing pins")
+    sparkle_pins = [
+        pin
+        for pin in pins
+        if isinstance(pin, dict) and str(pin.get("identity", "")).lower() == "sparkle"
+    ]
+    if len(sparkle_pins) != 1:
+        raise ValidationError("Package.resolved must contain exactly one Sparkle pin")
+
+    sparkle_pin = sparkle_pins[0]
+    location = str(sparkle_pin.get("location", "")).removesuffix(".git")
+    if location != SPARKLE_LOCATION:
+        raise ValidationError(f"Package.resolved Sparkle location is not {SPARKLE_LOCATION}")
+    state = sparkle_pin.get("state")
+    if not isinstance(state, dict):
+        raise ValidationError("Package.resolved Sparkle pin has no state")
+    if state.get("version") != sparkle_version:
+        raise ValidationError(
+            "Package.resolved Sparkle version does not match Package.swift exact version"
+        )
+    revision = state.get("revision")
+    if not isinstance(revision, str) or re.fullmatch(r"[0-9a-fA-F]{40,64}", revision) is None:
+        raise ValidationError("Package.resolved Sparkle pin has no full revision")
+
+    return sparkle_version
+
+
+def write_outputs(version: str, tag_commit: str, sparkle_version: str) -> None:
+    """Write validated values to the GitHub Actions output file."""
+    output_path = Path(require_environment("GITHUB_OUTPUT"))
+    with output_path.open("a", encoding="utf-8") as stream:
+        stream.write(f"version={version}\n")
+        stream.write(f"tag_commit={tag_commit}\n")
+        stream.write(f"sparkle_version={sparkle_version}\n")
+
+
+def main() -> int:
+    """Validate release source state and publish trusted outputs."""
+    tag = require_environment("GITHUB_REF_NAME")
+    tag_match = STABLE_TAG_PATTERN.fullmatch(tag)
+    if tag_match is None:
+        raise ValidationError(
+            "release tag must be stable vX.Y.Z SemVer without leading zeroes"
+        )
+    tag_version = tag_match.group(1)
+
+    repo_root = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    _, event_after = validate_github_event(tag)
+    tag_commit = validate_tag_and_source(repo_root, tag, event_after)
+    version = validate_cargo_versions(repo_root, tag_version)
+    sparkle_version = validate_sparkle_pin(repo_root)
+    write_outputs(version, tag_commit, sparkle_version)
+    print(
+        f"validated release source: version={version} "
+        f"tag_commit={tag_commit} sparkle_version={sparkle_version}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, subprocess.CalledProcessError, tomllib.TOMLDecodeError, ValidationError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/release/verify-sparkle-key.swift
+++ b/scripts/release/verify-sparkle-key.swift
@@ -1,0 +1,53 @@
+#!/usr/bin/env swift
+import CryptoKit
+import Foundation
+
+func fail(_ message: String) -> Never {
+	FileHandle.standardError.write(Data("error: \(message)\n".utf8))
+	exit(1)
+}
+
+guard CommandLine.arguments.count == 2 else {
+	fail("usage: printf PRIVATE_KEY | swift verify-sparkle-key.swift EXPECTED_PUBLIC_KEY")
+}
+
+let privateKeyInput = FileHandle.standardInput.readDataToEndOfFile()
+guard
+	let privateKeyText = String(data: privateKeyInput, encoding: .utf8)?
+		.trimmingCharacters(in: .whitespacesAndNewlines),
+	!privateKeyText.isEmpty,
+	!privateKeyText.contains(where: \.isWhitespace),
+	let privateKeyData = Data(base64Encoded: privateKeyText),
+	[32, 96].contains(privateKeyData.count),
+	privateKeyData.base64EncodedString() == privateKeyText
+else {
+	fail("Sparkle private key is not a canonical supported Sparkle Ed25519 key")
+}
+
+let expectedPublicKeyText = CommandLine.arguments[1]
+guard
+	!expectedPublicKeyText.contains(where: \.isWhitespace),
+	let expectedPublicKeyData = Data(base64Encoded: expectedPublicKeyText),
+	expectedPublicKeyData.count == 32,
+	expectedPublicKeyData.base64EncodedString() == expectedPublicKeyText
+else {
+	fail("expected Sparkle public key is not a canonical Ed25519 public key")
+}
+
+if privateKeyData.count == 32 {
+	do {
+		let privateKey = try Curve25519.Signing.PrivateKey(rawRepresentation: privateKeyData)
+		guard privateKey.publicKey.rawRepresentation == expectedPublicKeyData else {
+			fail("Sparkle private key does not match the expected public key")
+		}
+	} catch {
+		fail("Sparkle private key is invalid")
+	}
+} else {
+	// Sparkle's legacy format is its 64-byte orlp/Ed25519 private key followed
+	// by the corresponding 32-byte public key. The release artifact validator
+	// later verifies the generated signature with this expected public key.
+	guard privateKeyData.suffix(32) == expectedPublicKeyData else {
+		fail("Sparkle private key does not match the expected public key")
+	}
+}

--- a/scripts/release/write-sparkle-appcast.py
+++ b/scripts/release/write-sparkle-appcast.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import base64
+import binascii
+import email.utils
+import os
+import re
+import tempfile
+import urllib.parse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+version = os.environ["VERSION"]
+tag = os.environ["TAG"]
+archive_path = Path(os.environ["ARCHIVE_PATH"])
+archive_name = os.environ["ARCHIVE_NAME"]
+appcast_path = Path(os.environ["APPCAST"])
+signature_output = os.environ["SPARKLE_SIGNATURE_OUTPUT"]
+
+if appcast_path.resolve() == archive_path.resolve():
+    raise SystemExit("error: appcast output must not replace the signed release archive")
+
+signature_match = re.fullmatch(
+    r'sparkle:edSignature="([A-Za-z0-9+/]+={0,2})" length="([1-9][0-9]*)"',
+    signature_output,
+)
+if signature_match is None:
+    raise SystemExit("error: Sparkle sign_update returned an unexpected signature record")
+
+signature, signed_length_text = signature_match.groups()
+try:
+    signature_bytes = base64.b64decode(signature, validate=True)
+except binascii.Error:
+    raise SystemExit("error: Sparkle sign_update returned a malformed EdDSA signature")
+if len(signature_bytes) != 64:
+    raise SystemExit("error: Sparkle sign_update returned an invalid EdDSA signature length")
+
+actual_length = archive_path.stat().st_size
+signed_length = int(signed_length_text)
+if signed_length != actual_length:
+    raise SystemExit(
+        f"error: Sparkle signed length {signed_length} does not match archive length {actual_length}"
+    )
+
+canonical_download_url = (
+    f"https://github.com/acg-box/rsnap/releases/download/{tag}/{archive_name}"
+)
+canonical_release_url = f"https://github.com/acg-box/rsnap/releases/tag/{tag}"
+
+
+def checked_url(value: str, canonical: str, label: str) -> str:
+    if not value:
+        return canonical
+    if value == canonical:
+        return value
+
+    parsed = urllib.parse.urlsplit(value)
+    is_loopback = (
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname in {"127.0.0.1", "::1", "localhost"}
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.fragment
+    )
+    if is_loopback:
+        return value
+    raise SystemExit(f"error: {label} must use the canonical acg-box/rsnap release URL")
+
+
+download_url = checked_url(
+    os.environ["SPARKLE_ARCHIVE_URL"].strip(),
+    canonical_download_url,
+    "SPARKLE_ARCHIVE_URL",
+)
+release_url = checked_url(
+    os.environ["SPARKLE_RELEASE_NOTES_URL"].strip(),
+    canonical_release_url,
+    "SPARKLE_RELEASE_NOTES_URL",
+)
+
+sparkle_namespace = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+ET.register_namespace("sparkle", sparkle_namespace)
+
+rss = ET.Element("rss", {"version": "2.0"})
+channel = ET.SubElement(rss, "channel")
+ET.SubElement(channel, "title").text = "Rsnap Updates"
+ET.SubElement(channel, "link").text = "https://github.com/acg-box/rsnap/releases"
+ET.SubElement(channel, "description").text = "Rsnap macOS app updates."
+ET.SubElement(channel, "language").text = "en"
+
+item = ET.SubElement(channel, "item")
+ET.SubElement(item, "title").text = f"Version {version}"
+ET.SubElement(item, "link").text = release_url
+ET.SubElement(item, f"{{{sparkle_namespace}}}version").text = version
+ET.SubElement(item, f"{{{sparkle_namespace}}}shortVersionString").text = version
+ET.SubElement(item, f"{{{sparkle_namespace}}}minimumSystemVersion").text = "14.0"
+ET.SubElement(item, f"{{{sparkle_namespace}}}hardwareRequirements").text = "arm64"
+ET.SubElement(item, f"{{{sparkle_namespace}}}releaseNotesLink").text = release_url
+ET.SubElement(item, "pubDate").text = email.utils.formatdate(usegmt=True)
+ET.SubElement(
+    item,
+    "enclosure",
+    {
+        "url": download_url,
+        f"{{{sparkle_namespace}}}edSignature": signature,
+        "length": str(actual_length),
+        "type": "application/octet-stream",
+    },
+)
+
+tree = ET.ElementTree(rss)
+ET.indent(tree, space="  ")
+appcast_path.parent.mkdir(parents=True, exist_ok=True)
+temporary_path = None
+try:
+    with tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=appcast_path.parent,
+        prefix=f".{appcast_path.name}.",
+        delete=False,
+    ) as temporary_file:
+        temporary_path = Path(temporary_file.name)
+        tree.write(temporary_file, encoding="utf-8", xml_declaration=True)
+    os.replace(temporary_path, appcast_path)
+finally:
+    if temporary_path is not None and temporary_path.exists():
+        temporary_path.unlink()

--- a/scripts/smoke/sparkle-update-local.sh
+++ b/scripts/smoke/sparkle-update-local.sh
@@ -99,7 +99,7 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 size="$(wc -c <"$file" | tr -d ' ')"
-printf 'sparkle:edSignature="fake-signature" length="%s"\n' "$size"
+printf 'sparkle:edSignature="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==" length="%s"\n' "$size"
 SH
 	chmod +x "$fake_sign_update"
 	SPARKLE_PRIVATE_ED_KEY="fake-private-key" \
@@ -118,7 +118,7 @@ import xml.etree.ElementTree as ET
 path = sys.argv[1]
 text = open(path, encoding="utf-8").read()
 assert "http://127.0.0.1:9/rsnap-aarch64-apple-darwin.zip" in text
-assert 'sparkle:edSignature="fake-signature"' in text
+assert 'sparkle:edSignature="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="' in text
 assert 'length="9"' in text
 assert ET.parse(path).getroot().tag == "rss"
 print("sparkle update local self-check ok")


### PR DESCRIPTION
## Summary

- validate annotated stable tags, Cargo/Sparkle versions, checkout identity, and main ancestry before packaging
- build and test on macos-26, sign Rsnap and embedded Sparkle code inside out with the shared Apple Development identity and Hardened Runtime, then generate a signed appcast and SHA-256 checksum
- publish through a validated GitHub draft with least-privilege permissions and exact remote asset checks
- preserve the Personal Team signed-but-unnotarized distribution contract and document Open Anyway
- migrate stale repository and updater URLs to canonical acg-box/rsnap

This supersedes the closed #500 implementation and uses the four generic acg-box organization secrets. It does not add a manual release-preparation workflow and does not create a tag or release.

## Validation

- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make checks
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-macos-release
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test-macos-native-host-stage
- cargo make test-release (28 Python tests and 3 shell suites)
- actionlint and git diff --check
- independent release/publisher review with all findings resolved

## Boundary

The local Apple Development identity signed the staged app and all Sparkle components with Hardened Runtime. No Git tag, GitHub Release, organization-secret release run, or Apple notarization request was created.