### PR TITLE
Scope the Rsnap Sparkle signing key to its repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.RSNAP_SPARKLE_PRIVATE_ED_KEY }}
         run: |
           set -euo pipefail
           umask 077

--- a/docs/runbook/release.md
+++ b/docs/runbook/release.md
@@ -5,7 +5,7 @@ type: "Runbook"
 status: active
 authority: normative
 owner: acg-box/rsnap
-last_verified: 2026-07-27
+last_verified: 2026-07-28
 ---
 # Release Rsnap
 
@@ -14,8 +14,9 @@ Goal: Publish one stable Rsnap macOS release from an immutable tag.
 Read this when: You are preparing a `vX.Y.Z` release or verifying its published assets.
 
 Preconditions: `main` is clean and synced, the release version is committed, the organization
-secrets and `release` environment defined by `docs/spec/release-distribution.md` are available, and
-a logged-in macOS desktop session is available for smoke checks.
+Apple signing secrets, the Rsnap repository Sparkle secret, and the `release` environment defined
+by `docs/spec/release-distribution.md` are available, and a logged-in macOS desktop session is
+available for smoke checks.
 
 Depends on: `docs/spec/release-distribution.md`; `docs/spec/capture-session.md`;
 `docs/spec/settings.md`; `docs/runbook/performance-validation.md`

--- a/docs/spec/release-distribution.md
+++ b/docs/spec/release-distribution.md
@@ -5,7 +5,7 @@ type: "Spec"
 status: active
 authority: normative
 owner: acg-box/rsnap
-last_verified: 2026-07-27
+last_verified: 2026-07-28
 ---
 # Release Distribution Contract
 
@@ -77,7 +77,8 @@ The appcast:
 - uses the canonical `acg-box/rsnap` release and download URLs
 - uses the release version from the validated tag
 - records the exact ZIP byte length
-- contains a Sparkle EdDSA signature made with `SPARKLE_PRIVATE_ED_KEY`
+- contains a Sparkle EdDSA signature made from the repository secret
+  `RSNAP_SPARKLE_PRIVATE_ED_KEY`, passed to the signer as `SPARKLE_PRIVATE_ED_KEY`
 - verifies with the public key embedded in `Rsnap.app`
 
 The checksum file contains the lowercase SHA-256 digest of the final ZIP and the canonical ZIP
@@ -97,11 +98,15 @@ file name.
 
 ## Secret contract
 
-The required GitHub Actions secrets are organization secrets with visibility `all`:
+The required Apple signing credentials are GitHub organization secrets with visibility `all`:
 
 - `APPLE_CERTIFICATE_P12_BASE64`
 - `APPLE_CERTIFICATE_PASSWORD`
 - `APPLE_SIGNING_IDENTITY`
-- `SPARKLE_PRIVATE_ED_KEY`
 
-Repository and environment secrets must not shadow these names.
+`RSNAP_SPARKLE_PRIVATE_ED_KEY` is an Rsnap repository secret. It contains the private key that
+matches `scripts/release/sparkle-public-ed-key.txt`. The Sparkle private key must not be an
+organization or environment secret.
+
+Repository and environment secrets must not shadow the Apple signing credential names. The
+`release` environment stores no secrets.

--- a/scripts/release/tests/test_workflow_contract.py
+++ b/scripts/release/tests/test_workflow_contract.py
@@ -41,10 +41,13 @@ class WorkflowContractTests(unittest.TestCase):
 			"APPLE_CERTIFICATE_P12_BASE64",
 			"APPLE_CERTIFICATE_PASSWORD",
 			"APPLE_SIGNING_IDENTITY",
-			"SPARKLE_PRIVATE_ED_KEY",
 		):
 			self.assertIn(f"secrets.{secret}", workflow)
-		self.assertNotIn("RSNAP_SPARKLE_PRIVATE_ED_KEY", workflow)
+		self.assertIn(
+			"SPARKLE_PRIVATE_ED_KEY: ${{ secrets.RSNAP_SPARKLE_PRIVATE_ED_KEY }}",
+			workflow,
+		)
+		self.assertNotIn("secrets.SPARKLE_PRIVATE_ED_KEY", workflow)
 		self.assertNotIn("APPLE_DEVELOPER_ID_APPLICATION", workflow)
 		self.assertNotIn("APPLE_NOTARY_", workflow)
 		self.assertNotIn("notarytool", workflow)


### PR DESCRIPTION
## Summary

- read the Sparkle private key from the Rsnap repository secret RSNAP_SPARKLE_PRIVATE_ED_KEY while preserving the signer input contract
- keep the already-shipped Sparkle public key byte-for-byte unchanged so v0.3.0 update compatibility is preserved
- document Apple signing credentials as organization secrets, the Sparkle key as repository-scoped, and the release environment as secret-free
- add workflow contract coverage that rejects the generic organization Sparkle secret

The matching existing private key has been migrated into the repository secret. This change does not create a tag or GitHub Release.

## Validation

- cargo make checks with Xcode beta
- cargo make test-macos-release with Xcode beta
- cargo make test-release: 22 Python tests plus signer and appcast shell suites
- actionlint
- git diff --check
- independent compatibility and secret-scope review with no remaining actionable findings

Keep the legacy organization SPARKLE_PRIVATE_ED_KEY until this PR lands so current main remains releasable; remove it immediately after landing.