### PR TITLE
Prepare Rsnap 0.3.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "color-eyre",
  "directories",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "color-eyre",
  "criterion",
@@ -881,14 +881,14 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rsnap-capture-core",
 ]
 
 [[package]]
 name = "rsnap-perf"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/acg-box/rsnap"
-version     = "0.3.0"
+version     = "0.3.1"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -40,8 +40,8 @@ tracing-appender         = { version = "0.2" }
 tracing-subscriber       = { version = "0.3", features = ["env-filter"] }
 ttf-parser               = { version = "0.25" }
 
-rsnap-capture-core = { version = "0.3.0", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.3.0", path = "packages/rsnap-host-ffi" }
+rsnap-capture-core = { version = "0.3.1", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.3.1", path = "packages/rsnap-host-ffi" }
 
 [profile.final-release]
 inherits = "release"

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -61,7 +61,7 @@ Update the source that owns a claim, then run `openwiki code --update --print` a
 
 - Some migrated current-state references contain filenames that predate the July 2026 Swift file-boundary rename; verify exact source paths before acting.
 - Existing metadata historically marked decisions, references, research, and evidence as `authority: normative` even where their bodies define a weaker authority. The migration preserves provenance but uses lane meaning and page prose when interpreting authority.
-- Some scroll-capture pages still describe v0.2.5 as current while the workspace manifest reports version 0.3.0. Preserve those dated claims as history and use current source for release status.
+- Some scroll-capture pages still describe v0.2.5 as current while the workspace manifest reports version 0.3.1. Preserve those dated claims as history and use current source for release status.
 - The pen-beautification and frozen-toolbar-anchor contracts have reported implementation gaps. Treat their specifications as requirements and validate current code before claiming compliance.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- Bump all Rsnap workspace packages from 0.3.0 to 0.3.1.
- Align local path dependency requirements and the four workspace lockfile entries.
- Correct the current-version claim in the OpenWiki quickstart.

## Verification

- Exact Node 24.18.0 and npm 11.16.0 dependency install
- `cargo make checks`
- Rust clippy and 211 tests passed
- Swift strict build and native bridge probes passed
- 20 TypeScript release tests and 11 release contract tests passed

OpenWiki generation was unavailable because this repository has no reviewed root .infisical.json routing file. The one current-version sentence was corrected directly; no generated workflow or agent files were changed.