### PR TITLE
Harden release state convergence

### DIFF
--- a/openwiki/spec/release-distribution.md
+++ b/openwiki/spec/release-distribution.md
@@ -110,7 +110,8 @@ file name.
 - The publisher reads all bounded release and asset pages. It validates the exact remote asset
   names, states, safe sizes, canonical URLs, SHA-256 digests, and downloaded bytes.
 - Before publication, the publisher rechecks the remote annotated tag, its direct commit target,
-  reachability from `main`, every public stable release, and the exact draft ID.
+  reachability from `main`, every public stable release, and the exact draft ID. Safe reads use
+  bounded convergence when GitHub's release listing temporarily omits a new draft.
 - The last state-changing operation makes the draft public and latest. The publisher does not
   blindly retry this operation. After an unknown result, it reads the release state and validates
   public remote bytes if publication succeeded.

--- a/scripts/release/publish-github-release.ts
+++ b/scripts/release/publish-github-release.ts
@@ -621,6 +621,29 @@ export class Publisher {
 		return matching[0];
 	}
 
+	private async waitForSameTagRelease(
+		expectedId: number | undefined,
+		expectedDraft: boolean,
+		errorMessage: string,
+	): Promise<RemoteRelease> {
+		for (let attempt = 0; attempt <= MAX_SAFE_RETRIES; attempt += 1) {
+			const release = await this.getSameTagRelease();
+			if (release !== undefined) {
+				requireCondition(
+					expectedId === undefined || release.id === expectedId,
+					'release ID changed',
+				);
+				if (release.draft === expectedDraft) {
+					return release;
+				}
+			}
+			if (attempt < MAX_SAFE_RETRIES) {
+				await this.transport.wait(Math.min(MAX_RETRY_DELAY_MS, 1_000 * 2 ** attempt));
+			}
+		}
+		throw new ContractError(errorMessage);
+	}
+
 	private async validateAllStableReleases(allowSameTag: boolean): Promise<void> {
 		for (const release of await this.listAllReleases()) {
 			if (release.draft || release.prerelease) {
@@ -662,12 +685,11 @@ export class Publisher {
 				throw error;
 			}
 			await this.transport.wait(error instanceof HttpError ? error.retryAfterMs : 1_000);
-			const recovered = await this.getSameTagRelease();
-			requireCondition(
-				recovered !== undefined,
+			return await this.waitForSameTagRelease(
+				undefined,
+				true,
 				'draft creation failed without a recoverable release',
 			);
-			return recovered;
 		}
 	}
 
@@ -927,10 +949,7 @@ export class Publisher {
 		const publishedRetry = await this.getPublishedSameTagRelease();
 		if (publishedRetry !== undefined) {
 			this.validateReleaseState(publishedRetry, false);
-			const sameTag = await this.getSameTagRelease();
-			requireCondition(sameTag !== undefined, 'published release disappeared');
-			this.validateReleaseState(sameTag, false, publishedRetry.id);
-			await this.downloadAndValidate(sameTag.id, true, false);
+			await this.downloadAndValidate(publishedRetry.id, true, false);
 			return 'already-public';
 		}
 
@@ -955,8 +974,11 @@ export class Publisher {
 
 		await this.remoteSourceRecheck();
 		await this.validateAllStableReleases(false);
-		const finalDraft = await this.getSameTagRelease();
-		requireCondition(finalDraft !== undefined, 'draft release disappeared before publication');
+		const finalDraft = await this.waitForSameTagRelease(
+			release.id,
+			true,
+			'draft release did not converge before publication',
+		);
 		this.validateReleaseState(finalDraft, true, release.id);
 		await this.downloadAndValidate(release.id, false, true);
 		let publishedValue: unknown;
@@ -971,26 +993,20 @@ export class Publisher {
 			if (error instanceof HttpError && !error.transient) {
 				throw error;
 			}
-			const finalState = await this.getSameTagRelease();
-			requireCondition(
-				finalState !== undefined,
-				'publication result is unknown and release disappeared',
+			const finalState = await this.waitForSameTagRelease(
+				release.id,
+				false,
+				'publication result is unknown and release did not converge to public',
 			);
-			if (!finalState.draft) {
-				this.validateReleaseState(finalState, false, release.id);
-				await this.downloadAndValidate(finalState.id, true, true);
-				return 'published';
-			}
-			this.validateReleaseState(finalState, true, release.id);
-			throw new ContractError(
-				'publication result is unknown; verified release remains a draft',
-			);
+			this.validateReleaseState(finalState, false, release.id);
+			await this.downloadAndValidate(finalState.id, true, true);
+			return 'published';
 		}
 		this.validateReleaseState(parseRelease(publishedValue), false, release.id);
-		const publicRelease = await this.getPublishedSameTagRelease();
-		requireCondition(
-			publicRelease !== undefined,
-			'published release disappeared after publication',
+		const publicRelease = await this.waitForSameTagRelease(
+			release.id,
+			false,
+			'published release did not converge after publication',
 		);
 		this.validateReleaseState(publicRelease, false, release.id);
 		await this.downloadAndValidate(publicRelease.id, true, true);

--- a/scripts/release/tests/publish-github-release.test.ts
+++ b/scripts/release/tests/publish-github-release.test.ts
@@ -63,6 +63,8 @@ class MockTransport implements ReleaseTransport {
 	mutateAssetsAfterFinalSourceCheck = false;
 	mutateAssetsAfterPatch = false;
 	mutateReleaseAfterFinalSourceCheck = false;
+	releaseVisibleAfterListScan = 0;
+	publishedVisibleAfterListScan = 0;
 	nextAssetId = 100;
 	readonly starterAssetIds = new Set<number>();
 
@@ -157,8 +159,16 @@ class MockTransport implements ReleaseTransport {
 				this.releaseListScans += 1;
 			}
 			const releases = [...this.stableReleases];
-			if (this.release !== undefined) {
-				releases.push(this.release);
+			if (
+				this.release !== undefined &&
+				this.releaseListScans > this.releaseVisibleAfterListScan
+			) {
+				releases.push(
+					this.release.draft === false &&
+						this.releaseListScans <= this.publishedVisibleAfterListScan
+						? { ...this.release, draft: true }
+						: this.release,
+				);
 			}
 			if (this.stableRaceVersion !== undefined && this.releaseListScans >= 3) {
 				releases.push(releaseJson(false, `v${this.stableRaceVersion}`));
@@ -315,6 +325,60 @@ void test('draft lookup rejects duplicate releases with the same tag', async () 
 			transport.log.some((entry) => /^(POST|PATCH|DELETE|UPLOAD) /.test(entry)),
 			false,
 		);
+	} finally {
+		await rm(fixtureValue.root, { recursive: true, force: true });
+	}
+});
+
+void test('known draft ID survives delayed release-list visibility', async () => {
+	const fixtureValue = await fixture();
+	const transport = new MockTransport();
+	const calls: ExecRequest[] = [];
+	try {
+		transport.releaseVisibleAfterListScan = 4;
+		const result = await (await publisher(fixtureValue, transport, calls)).publish();
+		assert.equal(result, 'published');
+		assert.equal(transport.release?.draft, false);
+		assert.equal(transport.log.filter((entry) => entry.startsWith('POST ')).length, 1);
+		assert.equal(transport.log.filter((entry) => entry.startsWith('PATCH ')).length, 1);
+		assert.equal(transport.releaseListScans, 6);
+	} finally {
+		await rm(fixtureValue.root, { recursive: true, force: true });
+	}
+});
+
+void test('draft list visibility that exceeds the bound remains private', async () => {
+	const fixtureValue = await fixture();
+	const transport = new MockTransport();
+	const calls: ExecRequest[] = [];
+	try {
+		transport.releaseVisibleAfterListScan = Number.MAX_SAFE_INTEGER;
+		await assert.rejects(
+			(await publisher(fixtureValue, transport, calls)).publish(),
+			/draft release did not converge before publication/,
+		);
+		assert.equal(transport.release?.draft, true);
+		assert.equal(
+			transport.log.some((entry) => entry.startsWith('PATCH ')),
+			false,
+		);
+	} finally {
+		await rm(fixtureValue.root, { recursive: true, force: true });
+	}
+});
+
+void test('published state survives delayed release-list visibility', async () => {
+	const fixtureValue = await fixture();
+	const transport = new MockTransport();
+	const calls: ExecRequest[] = [];
+	try {
+		transport.release = releaseJson(true);
+		transport.publishedVisibleAfterListScan = 5;
+		const result = await (await publisher(fixtureValue, transport, calls)).publish();
+		assert.equal(result, 'published');
+		assert.equal(transport.release?.draft, false);
+		assert.equal(transport.log.filter((entry) => entry.startsWith('PATCH ')).length, 1);
+		assert.equal(transport.releaseListScans, 6);
 	} finally {
 		await rm(fixtureValue.root, { recursive: true, force: true });
 	}
@@ -512,7 +576,7 @@ void test('a successful PATCH is followed by exact public byte validation', asyn
 		assert.equal(
 			transport.log
 				.slice(transport.log.findIndex((entry) => entry.startsWith('PATCH ')) + 1)
-				.some((entry) => entry.includes('/releases/tags/v1.2.3')),
+				.some((entry) => entry.includes('/releases?per_page=100&page=1')),
 			true,
 		);
 	} finally {


### PR DESCRIPTION
Prevent a newly created GitHub draft from appearing to disappear when the release listing is briefly stale.

- Converge bounded safe reads for draft visibility and post-PATCH public state.
- Preserve exact release ID validation and a single non-retried publication PATCH.
- Add delayed-visibility success, exhaustion/fail-closed, and delayed-public-state regressions.
- Align the release distribution contract.

Validation:
- cargo make checks
- npm run check
- cargo make test-release
- git diff --check