### PR TITLE
Align routine CI with the Linux-only policy

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -129,50 +129,6 @@ jobs:
       - name: Run Rust tests
         run: cargo make test-rust
 
-  swift-check:
-    name: Swift check
-    runs-on: macos-26
-    steps:
-      - name: Fetch latest code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Print Apple toolchain
-        run: |
-          sw_vers
-          swift --version
-          xcodebuild -version
-
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          cache: true
-          rustflags: ''
-
-      - name: Install cargo-make
-        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
-        with:
-          tool: cargo-make
-
-      - name: Run Swift format check
-        run: cargo make fmt-swift-check
-
-      - name: Run Swift style check
-        uses: hack-ink/vibe-style@567174c977a3fc09229c81aacf10bf93edc4fd70 # v0.2.3
-        with:
-          language: swift
-          workspace: true
-          args: --all-features
-          version: v0.2.3
-
-      - name: Run SwiftLint and strict build
-        run: cargo make check-swift
-
-      - name: Run Swift tests
-        run: cargo make test-swift
-
-      - name: Test Sparkle key verification
-        run: scripts/release/tests/test-verify-sparkle-key.sh
-
   toml-check:
     name: TOML check
     runs-on: ubuntu-latest

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-28T05:22:15.658Z",
-  "command": "init",
-  "gitHead": "96f2c6e31987fe599ef0fbbe520e26276f237cfc",
+  "updatedAt": "2026-07-29T08:01:42.776Z",
+  "command": "update",
+  "gitHead": "72f0aab37b87dca49ae89a47041f7044e80c6e13",
   "model": "gpt-5.6-sol-nosystem"
 }

--- a/openwiki/spec/release-distribution.md
+++ b/openwiki/spec/release-distribution.md
@@ -5,7 +5,7 @@ type: "Spec"
 status: active
 authority: normative
 owner: acg-box/rsnap
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 ---
 # Release Distribution Contract
 
@@ -30,7 +30,10 @@ Defines:
 
 ## Supported workflow shape
 
-- Normal CI runs for pull requests, `main`, and merge queues.
+- Normal CI runs Rust, TOML, TypeScript, and release-contract checks on Ubuntu for pull requests,
+  `main`, and merge queues.
+- Swift/AppKit format, lint, build, and test checks remain local development gates. A formal tag
+  release runs the release-mode native tests and build on macOS before it can package or publish.
 - A formal release starts only when an authorized operator pushes a stable `vX.Y.Z` tag.
 - The repository does not use a release-preparation, dry-run, or manual-dispatch release workflow.
 - The release workflow must not create a tag.
@@ -111,7 +114,8 @@ file name.
   names, states, safe sizes, canonical URLs, SHA-256 digests, and downloaded bytes.
 - Before publication, the publisher rechecks the remote annotated tag, its direct commit target,
   reachability from `main`, every public stable release, and the exact draft ID. Safe reads use
-  bounded convergence when GitHub's release listing temporarily omits a new draft.
+  bounded convergence when GitHub's release listing temporarily omits the expected draft or public
+  same-tag state; failure to converge before publication leaves the release private.
 - The last state-changing operation makes the draft public and latest. The publisher does not
   blindly retry this operation. After an unknown result, it reads the release state and validates
   public remote bytes if publication succeeded.

--- a/scripts/release/tests/test_workflow_contract.py
+++ b/scripts/release/tests/test_workflow_contract.py
@@ -19,12 +19,9 @@ class WorkflowContractTests(unittest.TestCase):
 			"pull_request:",
 			"merge_group:",
 			"rust-check:",
-			"swift-check:",
 			"toml-check:",
 			"typescript-check:",
-			"runs-on: macos-26",
 			"cargo make test-release",
-			"scripts/release/tests/test-verify-sparkle-key.sh",
 			"npm ci --ignore-scripts",
 			"npm run format:check",
 			"npm run typecheck",
@@ -32,6 +29,10 @@ class WorkflowContractTests(unittest.TestCase):
 			"npm test",
 		):
 			self.assertIn(required, workflow)
+		self.assertEqual(workflow.count("runs-on:"), 3)
+		self.assertEqual(workflow.count("runs-on: ubuntu-latest"), 3)
+		self.assertNotIn("swift-check:", workflow)
+		self.assertNotIn("runs-on: macos-26", workflow)
 
 	def test_release_permissions_and_jobs_are_minimal(self) -> None:
 		workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
@@ -59,6 +60,7 @@ class WorkflowContractTests(unittest.TestCase):
 		self.assertNotIn("APPLE_NOTARY_", workflow)
 		self.assertNotIn("notarytool", workflow)
 		self.assertIn("retention-days: 7", workflow)
+		self.assertIn("cargo make test-macos-release", workflow)
 		self.assertIn("scripts/release/package-macos.sh", workflow)
 		self.assertEqual(
 			workflow.count("node scripts/release/validate-release-source.ts"),


### PR DESCRIPTION
## Summary

- Remove the routine macOS Swift job from Language Checks so Rsnap and DeskHelm use three Ubuntu lanes.
- Keep local Swift/AppKit gates and the tagged macos-26 release test, build, signing, and Sparkle path unchanged.
- Update the workflow contract test and release specification for the Linux-only routine CI boundary.

## Verification

- `actionlint .github/workflows/language.yml .github/workflows/release.yml`
- `python3 -m unittest scripts.release.tests.test_workflow_contract`
- `cargo make test-release`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make checks` with Node 24.18.0 and npm 11.16.0
- OpenWiki update and generated diff review
- Independent read-only review; no remaining findings