### PR TITLE
Prepare Rsnap v0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "color-eyre",
  "directories",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "color-eyre",
  "criterion",
@@ -880,14 +880,14 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "rsnap-capture-core",
 ]
 
 [[package]]
 name = "rsnap-perf"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/acg-box/rsnap"
-version     = "0.3.3"
+version     = "0.3.4"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -40,8 +40,8 @@ tracing-appender         = { version = "0.2" }
 tracing-subscriber       = { version = "0.3", features = ["env-filter"] }
 ttf-parser               = { version = "0.25" }
 
-rsnap-capture-core = { version = "0.3.3", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.3.3", path = "packages/rsnap-host-ffi" }
+rsnap-capture-core = { version = "0.3.4", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.3.4", path = "packages/rsnap-host-ffi" }
 
 [profile.final-release]
 inherits = "release"

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -118,11 +118,24 @@ enum RsnapNativeHostKitProbe {
 
 	private static func assertTextRecognitionNeuralEngineSelection() {
 		let request = VNRecognizeTextRequest()
-		guard TextRecognitionHelper.configureNeuralEngine(for: request),
-			let device = request.computeDevice(for: .main),
-			case .neuralEngine = device
-		else {
-			fatalError("text recognition should assign its main stage to the Neural Engine")
+		let supportedDevices = try? request.supportedComputeStageDevices
+		let exposesNeuralEngine =
+			supportedDevices?[.main]?.contains { device in
+				if case .neuralEngine = device {
+					return true
+				}
+				return false
+			} == true
+		let configured = TextRecognitionHelper.configureNeuralEngine(for: request)
+		if exposesNeuralEngine {
+			guard configured,
+				let device = request.computeDevice(for: .main),
+				case .neuralEngine = device
+			else {
+				fatalError("text recognition should assign its main stage to the Neural Engine")
+			}
+		} else if configured {
+			fatalError("text recognition should fail closed when the Neural Engine is unavailable")
 		}
 		guard
 			TextRecognitionHelper.isE5RecompileRequired(

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-08-03T05:43:31.244Z",
+  "updatedAt": "2026-08-03T06:41:14.437Z",
   "command": "update",
-  "gitHead": "3ddf85f34d46bf0499ea6a3d2a7b6e1b4237f5a1",
+  "gitHead": "edb7a7f465ee9e458b4e33421610bd4038e5fae9",
   "model": "gpt-5.6-sol-nosystem"
 }

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -61,7 +61,7 @@ Update the source that owns a claim, then run `openwiki code --update --print` a
 
 - Some migrated current-state references contain filenames that predate the July 2026 Swift file-boundary rename; verify exact source paths before acting.
 - Existing metadata historically marked decisions, references, research, and evidence as `authority: normative` even where their bodies define a weaker authority. The migration preserves provenance but uses lane meaning and page prose when interpreting authority.
-- Some scroll-capture pages still describe v0.2.5 as current while the workspace manifest reports version 0.3.3. Preserve those dated claims as history and use current source for release status.
+- Some scroll-capture pages still describe v0.2.5 as current while the workspace manifest reports version 0.3.4. Preserve those dated claims as history and use current source for release status.
 - The pen-beautification and frozen-toolbar-anchor contracts have reported implementation gaps. Treat their specifications as requirements and validate current code before claiming compliance.
 
 ## Backlog

--- a/openwiki/reference/workspace-layout.md
+++ b/openwiki/reference/workspace-layout.md
@@ -404,13 +404,17 @@ sequenceDiagram
     participant PB as Pasteboard
     CS->>TE: Submit prepared frozen image
     TE->>WK: Send versioned RGBA frame
-    WK->>VS: Run accurate OCR on Neural Engine
-    alt Worker transport failure or E5RT code 13
-        WK-->>TE: Return failure or close channel
-        TE->>WK: Restart process and retry once
-        WK->>VS: Run OCR with fresh model state
+    alt Vision advertises Neural Engine
+        WK->>VS: Run accurate OCR on Neural Engine
+        alt Worker transport failure or E5RT code 13
+            WK-->>TE: Return failure or close channel
+            TE->>WK: Restart process and retry once
+            WK->>VS: Run OCR with fresh model state
+        end
+        VS-->>WK: Return observations or failure
+    else Neural Engine unavailable
+        WK-->>TE: Return capability failure
     end
-    VS-->>WK: Return observations or failure
     WK-->>TE: Return versioned result
     TE-->>CS: Complete on main actor
     CS->>PB: Publish nonempty recognized text
@@ -421,8 +425,9 @@ The diagram shows healthy worker reuse and the single fresh-process recovery att
 The engine keeps one worker warm across healthy requests. It invalidates that process after channel
 or protocol errors and explicitly restarts it before retrying an E5RT code `13` recompile signal;
 other Vision failures return without retry. The capture session still owns stale-job rejection, user
-status, pasteboard publication, and teardown. `RsnapNativeHostKitProbe/main.swift` checks Neural
-Engine selection, frame boundaries, healthy-process reuse, and explicit restart behavior.
+status, pasteboard publication, and teardown. `RsnapNativeHostKitProbe/main.swift` checks that Neural
+Engine selection succeeds when Vision advertises the device and fails closed otherwise, along with
+frame boundaries, healthy-process reuse, and explicit restart behavior.
 
 It depends on:
 


### PR DESCRIPTION
## Summary

- make the Neural Engine probe validate both supported hosts and fail-closed hosts
- preserve Neural Engine-only OCR behavior with no CPU fallback
- bump the workspace release version to 0.3.4
- update generated OpenWiki release and architecture evidence

## Context

The protected v0.3.3 release tag reached a GitHub macOS virtual runner that does not expose a Neural Engine. The application already returned a capability failure correctly, but the probe incorrectly required every host to expose Neural Engine hardware. This changes only the probe contract: if Vision advertises Neural Engine, selection must succeed and resolve to it; otherwise configuration must fail closed.

## Validation

- cargo make checks
- cargo make test-macos-release
- cargo audit --json (0 vulnerabilities; existing informational unmaintained ttf-parser advisory remains)
- actionlint
- OpenWiki generator and diff checks