### PR TITLE
Restore HiDPI selection indicator and prepare v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsnap"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "color-eyre",
  "directories",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "rsnap-capture-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "color-eyre",
  "criterion",
@@ -880,14 +880,14 @@ dependencies = [
 
 [[package]]
 name = "rsnap-host-ffi"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "rsnap-capture-core",
 ]
 
 [[package]]
 name = "rsnap-perf"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "color-eyre",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage    = "https://hack.ink/rsnap"
 license     = "GPL-3.0"
 readme      = "README.md"
 repository  = "https://github.com/acg-box/rsnap"
-version     = "0.3.4"
+version     = "0.3.5"
 
 [workspace.dependencies]
 arboard                  = { version = "3.6" }
@@ -40,8 +40,8 @@ tracing-appender         = { version = "0.2" }
 tracing-subscriber       = { version = "0.3", features = ["env-filter"] }
 ttf-parser               = { version = "0.25" }
 
-rsnap-capture-core = { version = "0.3.4", path = "packages/rsnap-capture-core" }
-rsnap-host-ffi     = { version = "0.3.4", path = "packages/rsnap-host-ffi" }
+rsnap-capture-core = { version = "0.3.5", path = "packages/rsnap-capture-core" }
+rsnap-host-ffi     = { version = "0.3.5", path = "packages/rsnap-host-ffi" }
 
 [profile.final-release]
 inherits = "release"

--- a/native/macos-host/Sources/RsnapNativeHostKit/LivePreview.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/LivePreview.swift
@@ -182,7 +182,10 @@ extension CaptureHostView {
 	}
 
 	func selectionSizeText(for rect: CGRect) -> String {
-		SelectionSizeText.displayText(for: rect)
+		SelectionSizeText.displayText(
+			for: rect,
+			scale: window?.screen?.backingScaleFactor ?? 1
+		)
 	}
 
 	private func currentHostLocalFrozenSelectingPreviewSnapshot() -> LivePreviewSnapshot? {

--- a/native/macos-host/Sources/RsnapNativeHostKit/QuickScreenshotController.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/QuickScreenshotController.swift
@@ -773,7 +773,10 @@ private final class QuickScreenshotSelectionView: NSView {
 	}
 
 	private func selectionSizeText(for rect: CGRect) -> String {
-		SelectionSizeText.displayText(for: rect)
+		SelectionSizeText.displayText(
+			for: rect,
+			scale: window?.screen?.backingScaleFactor ?? 1
+		)
 	}
 
 	private func localRect(from globalRect: CGRect) -> CGRect {

--- a/native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKit/SelectionSizeText.swift
@@ -2,9 +2,16 @@ import CoreGraphics
 import Foundation
 
 package enum SelectionSizeText {
-	package static func displayText(for rect: CGRect) -> String {
-		let width = Int(round(rect.width))
-		let height = Int(round(rect.height))
-		return "\(width)x\(height)px"
+	package static func displayText(for rect: CGRect, scale: CGFloat) -> String {
+		let resolvedScale = scale.isFinite && scale > 0 ? scale : 1
+		let width = Int(round(rect.width * resolvedScale))
+		let height = Int(round(rect.height * resolvedScale))
+		let sizeText = "\(width)x\(height)px"
+
+		if abs(resolvedScale - 1) <= 0.005 {
+			return sizeText
+		}
+
+		return "\(sizeText) @\(String(format: "%g", Double(resolvedScale)))x"
 	}
 }

--- a/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
+++ b/native/macos-host/Sources/RsnapNativeHostKitProbe/main.swift
@@ -18,7 +18,7 @@ enum RsnapNativeHostKitProbe {
 		assertScrimExclusionPreservesExistingPixels()
 		assertRoundedExclusionMaskKeepsCornersFilled()
 		assertCaptureFrameEffectExpandsExportCanvas()
-		assertSelectionSizeTextUsesDisplayPointDimensions()
+		assertSelectionSizeTextUsesBackingScaleFactor()
 		assertCaptureOverlayLocalPointKeepsScreenEdgesVisible()
 		assertScrollCaptureViewportPointAcceptsFlippedGlobalMouseCoordinates()
 		assertScrollCaptureObservedInputAcceptsSourceWindowGutter()
@@ -237,16 +237,22 @@ enum RsnapNativeHostKitProbe {
 		return true
 	}
 
-	private static func assertSelectionSizeTextUsesDisplayPointDimensions() {
+	private static func assertSelectionSizeTextUsesBackingScaleFactor() {
 		guard
 			SelectionSizeText.displayText(
-				for: CGRect(x: 0, y: 0, width: 3_008, height: 1_692)
+				for: CGRect(x: 0, y: 0, width: 3_008, height: 1_692),
+				scale: 1
 			) == "3008x1692px",
 			SelectionSizeText.displayText(
-				for: CGRect(x: 10, y: 20, width: 12.4, height: 9.6)
-			) == "12x10px"
+				for: CGRect(x: 0, y: 0, width: 800, height: 450),
+				scale: 2
+			) == "1600x900px @2x",
+			SelectionSizeText.displayText(
+				for: CGRect(x: 10, y: 20, width: 12.4, height: 9.6),
+				scale: 1.5
+			) == "19x14px @1.5x"
 		else {
-			fatalError("selection size badge should report display-point dimensions")
+			fatalError("selection size badge should report physical pixels and display scale")
 		}
 	}
 

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -61,7 +61,7 @@ Update the source that owns a claim, then run `openwiki code --update --print` a
 
 - Some migrated current-state references contain filenames that predate the July 2026 Swift file-boundary rename; verify exact source paths before acting.
 - Existing metadata historically marked decisions, references, research, and evidence as `authority: normative` even where their bodies define a weaker authority. The migration preserves provenance but uses lane meaning and page prose when interpreting authority.
-- Some scroll-capture pages still describe v0.2.5 as current while the workspace manifest reports version 0.3.4. Preserve those dated claims as history and use current source for release status.
+- Some scroll-capture pages still describe v0.2.5 as current while the workspace manifest reports version 0.3.5. Preserve those dated claims as history and use current source for release status.
 - The pen-beautification and frozen-toolbar-anchor contracts have reported implementation gaps. Treat their specifications as requirements and validate current code before claiming compliance.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- restore physical-pixel selection dimensions and the `@2x`/`@1.5x` indicator on Retina displays
- use the active screen backing scale in both live preview and quick screenshot selection overlays
- add native probe coverage and prepare workspace metadata for Rsnap v0.3.5

## Verification

- `cargo make test-macos-release`
- `npm run check` with Node 26.5.1 and npm 12.0.2
- `swift format lint --strict --parallel` on changed Swift files
- signed commit verified locally